### PR TITLE
feat: gispulse triggers — Mode 1 headless runtime + YAML loader + watch daemon (closes #2)

### DIFF
--- a/gispulse/cli.py
+++ b/gispulse/cli.py
@@ -1526,6 +1526,15 @@ def workflow_execute(
     typer.echo(f"Workflow '{name}' terminé. Résultat: {len(result.layers)} couches.")
 
 
+# ---------------------------------------------------------------------------
+# triggers sub-group (Mode 1 headless runtime — see cli_triggers.py)
+# ---------------------------------------------------------------------------
+
+from gispulse.cli_triggers import triggers_app  # noqa: E402
+
+app.add_typer(triggers_app, name="triggers")
+
+
 def main() -> None:
     app()
 

--- a/gispulse/cli_triggers.py
+++ b/gispulse/cli_triggers.py
@@ -128,20 +128,50 @@ def cmd_run(
     once: bool = typer.Option(
         False,
         "--once",
-        help="Run a single tick then exit (default off requires --once today; "
-        "daemon `--watch` mode lands in a follow-up story).",
+        help="Run a single tick then exit. Mutually exclusive with --watch.",
+    ),
+    watch: bool = typer.Option(
+        False,
+        "--watch",
+        help="Run as a daemon: poll the change-log every "
+        "``--poll-interval-ms`` until SIGINT/SIGTERM.",
+    ),
+    poll_interval_ms: int | None = typer.Option(
+        None,
+        "--poll-interval-ms",
+        help="Override the YAML ``runtime.poll_interval_ms`` for daemon "
+        "mode. CLI flag wins over YAML when both are set. Ignored under "
+        "--once.",
+        min=10,
+        max=60_000,
     ),
 ) -> None:
     """Execute the trigger pipeline against a GPKG.
 
-    Currently only ``--once`` is supported: a single watcher tick is
-    driven, every change-log row is acked, then the process exits 0.
-    Daemon mode (``--watch``) is reserved for the next story.
+    Two modes:
+
+    - ``--once``  — a single tick, exit 0. The watcher's daemon thread
+                    is *not* started; the change-log is drained
+                    synchronously then the runtime closes.
+    - ``--watch`` — block on a tick → wait → tick loop until
+                    SIGINT/SIGTERM. The YAML config is checked for
+                    mtime changes every tick so an operator can edit
+                    triggers without restarting the daemon. Broken
+                    YAML is logged and ignored (the previous valid
+                    config stays active).
+
+    The flags are mutually exclusive; passing neither (or both) exits 2.
     """
-    if not once:
+    if once and watch:
         _human(
-            "[!] Daemon mode is not available yet. Pass --once for a single "
-            "tick. ('--watch' lands in the follow-up story.)",
+            "[!] --once and --watch are mutually exclusive.",
+            err=True,
+            style="yellow",
+        )
+        raise typer.Exit(2)
+    if not once and not watch:
+        _human(
+            "[!] Pass either --once (single tick) or --watch (daemon).",
             err=True,
             style="yellow",
         )
@@ -175,12 +205,20 @@ def cmd_run(
     _maybe_warn_network_fs(gpkg_path)
 
     triggers_obj = to_triggers(cfg)
+    # Brief: "défaut 1000ms, surchargeable YAML > flag" — the flag, when
+    # set, wins over the YAML value. The YAML value is itself optional
+    # (defaults to 1000 ms in :class:`RuntimeConfigModel`).
+    effective_poll_ms = (
+        poll_interval_ms if poll_interval_ms is not None else cfg.runtime.poll_interval_ms
+    )
+
     _log_event(
         "runtime_starting",
         gpkg=str(gpkg_path),
         triggers=len(triggers_obj),
-        poll_interval_ms=cfg.runtime.poll_interval_ms,
+        poll_interval_ms=effective_poll_ms,
         max_batch=cfg.runtime.max_batch,
+        mode="watch" if watch else "once",
     )
 
     try:
@@ -188,7 +226,7 @@ def cmd_run(
             gpkg_path=gpkg_path,
             triggers=triggers_obj,
             webhook_allowlist=cfg.security.webhook_allowlist or None,
-            poll_interval=cfg.runtime.poll_interval_ms / 1000.0,
+            poll_interval=effective_poll_ms / 1000.0,
             batch_limit=cfg.runtime.max_batch,
             dataset_id="__cli__",
         )
@@ -197,6 +235,48 @@ def cmd_run(
         _human(f"[red]Runtime build failed:[/red] {exc}", err=True)
         raise typer.Exit(1)
 
+    if watch:
+        # Hand the runtime over to the daemon loop. Signal handlers
+        # set ``stop_event``; the loop closes the runtime on its own
+        # ``finally`` block.
+        from gispulse.cli_triggers_watch import (
+            install_signal_handlers,
+            run_watch_loop,
+        )
+        import threading as _threading
+
+        stop_event = _threading.Event()
+        restore_signals = install_signal_handlers(stop_event)
+
+        _human(
+            f"[bold cyan]gispulse watch[/bold cyan] [green]ON[/green]  "
+            f"gpkg=[bold]{gpkg_path.name}[/bold]  triggers="
+            f"[bold]{len(triggers_obj)}[/bold]  "
+            f"poll={effective_poll_ms}ms — Ctrl-C to stop."
+        )
+
+        try:
+            exit_code = run_watch_loop(
+                initial_runtime=runtime,
+                initial_cfg=cfg,
+                config_path=Path(config).resolve(),
+                gpkg_override=gpkg,
+                poll_interval=effective_poll_ms / 1000.0,
+                stop_event=stop_event,
+            )
+        finally:
+            restore_signals()
+
+        if exit_code != 0:
+            _human(
+                f"[red]Daemon aborted after consecutive tick failures.[/red]",
+                err=True,
+            )
+            raise typer.Exit(exit_code)
+        _human("[green]Daemon stopped cleanly.[/green]")
+        return
+
+    # ``--once`` path
     try:
         with runtime as rt:
             processed = rt.run_once()

--- a/gispulse/cli_triggers.py
+++ b/gispulse/cli_triggers.py
@@ -1,0 +1,331 @@
+"""``gispulse triggers ...`` CLI subapp.
+
+Three sub-commands (Mode 1 MVP scope):
+
+    gispulse triggers run --config FILE [--gpkg PATH] [--once]
+    gispulse triggers validate --config FILE [--gpkg PATH]
+    gispulse triggers list --gpkg PATH
+
+Logging convention
+------------------
+- Human-friendly Rich output → stdout (UI surface).
+- Structured JSON events     → stderr (machine-readable for log shippers).
+
+The ``--watch`` daemon mode is intentionally **not** included in this PR;
+it lands in S5 along with signal handling, restart-on-change, and
+backoff. ``--once`` is the only execution mode shipped here.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+import warnings
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import typer
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from gispulse.runtime.config_loader import GISPulseConfig
+
+
+triggers_app = typer.Typer(
+    name="triggers",
+    help="Run YAML-configured triggers against a GeoPackage (Mode 1, headless).",
+    add_completion=False,
+    no_args_is_help=True,
+)
+
+
+# ---------------------------------------------------------------------------
+# Logging helpers
+# ---------------------------------------------------------------------------
+
+
+def _log_event(event: str, **fields: Any) -> None:
+    """Emit a single-line JSON log record on stderr.
+
+    Stays decoupled from the project's structlog config so the CLI works
+    even when the user has not bootstrapped the structured logger.
+    """
+    record = {"event": event, **fields}
+    try:
+        line = json.dumps(record, default=str, separators=(",", ":"))
+    except Exception:  # pragma: no cover - extreme defensive
+        line = json.dumps({"event": event, "format_error": True})
+    print(line, file=sys.stderr, flush=True)
+
+
+def _human(message: str, *, err: bool = False, style: str | None = None) -> None:
+    """Pretty-print to stdout (or stderr) using Rich if available."""
+    try:
+        from rich.console import Console
+
+        console = Console(stderr=err)
+        if style:
+            console.print(f"[{style}]{message}[/{style}]")
+        else:
+            console.print(message)
+    except ImportError:  # pragma: no cover - Rich is a hard dep, but be safe
+        stream = sys.stderr if err else sys.stdout
+        print(message, file=stream)
+
+
+# ---------------------------------------------------------------------------
+# Network FS detection (warn, do not refuse — see brief)
+# ---------------------------------------------------------------------------
+
+
+def _maybe_warn_network_fs(path: Path) -> None:
+    """Emit a warning when ``path`` lives on a probable network filesystem.
+
+    Heuristic only: GISPulse change-tracking relies on SQLite WAL +
+    triggers, which are unsafe on NFS/SMB shares. Beta requested a hard
+    refusal but we ship this as a warning first to gather telemetry on
+    real-world false positives. A P0 follow-up will tighten this gate.
+    """
+    p = str(path).lower()
+    network_signals = ("/mnt/", "/net/", "//", "/cifs", "/smb")
+    if any(sig in p for sig in network_signals):
+        msg = (
+            f"GPKG path {path} looks like a network filesystem. SQLite WAL "
+            "+ triggers are not safe on NFS / SMB shares. Copy the GPKG to "
+            "a local disk before running triggers."
+        )
+        _log_event("network_fs_warning", path=str(path))
+        warnings.warn(msg, RuntimeWarning, stacklevel=2)
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+
+@triggers_app.command("run")
+def cmd_run(
+    config: Path = typer.Option(
+        ...,
+        "--config",
+        "-c",
+        help="Path to the YAML triggers config file.",
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+    ),
+    gpkg: Path | None = typer.Option(
+        None,
+        "--gpkg",
+        help="Override the gpkg path declared in the config.",
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+    ),
+    once: bool = typer.Option(
+        False,
+        "--once",
+        help="Run a single tick then exit (default off requires --once today; "
+        "daemon `--watch` mode lands in a follow-up story).",
+    ),
+) -> None:
+    """Execute the trigger pipeline against a GPKG.
+
+    Currently only ``--once`` is supported: a single watcher tick is
+    driven, every change-log row is acked, then the process exits 0.
+    Daemon mode (``--watch``) is reserved for the next story.
+    """
+    if not once:
+        _human(
+            "[!] Daemon mode is not available yet. Pass --once for a single "
+            "tick. ('--watch' lands in the follow-up story.)",
+            err=True,
+            style="yellow",
+        )
+        raise typer.Exit(2)
+
+    # Lazy import — keeps `gispulse --help` fast even with the heavy
+    # geopandas + duckdb stack underneath.
+    from gispulse.runtime.config_loader import (
+        ConfigError,
+        load_config,
+        to_triggers,
+        validate_against_gpkg,
+    )
+    from gispulse.runtime.headless_runtime import build_runtime
+
+    try:
+        cfg = load_config(config, gpkg_override=gpkg)
+    except ConfigError as exc:
+        _log_event("config_error", error=str(exc))
+        _human(f"[red]Config error:[/red] {exc}", err=True)
+        raise typer.Exit(1)
+
+    schema_errors = validate_against_gpkg(cfg)
+    if schema_errors:
+        for err in schema_errors:
+            _log_event("schema_error", message=err)
+            _human(f"[red]Schema error:[/red] {err}", err=True)
+        raise typer.Exit(1)
+
+    gpkg_path = Path(cfg.gpkg)
+    _maybe_warn_network_fs(gpkg_path)
+
+    triggers_obj = to_triggers(cfg)
+    _log_event(
+        "runtime_starting",
+        gpkg=str(gpkg_path),
+        triggers=len(triggers_obj),
+        poll_interval_ms=cfg.runtime.poll_interval_ms,
+        max_batch=cfg.runtime.max_batch,
+    )
+
+    try:
+        runtime = build_runtime(
+            gpkg_path=gpkg_path,
+            triggers=triggers_obj,
+            webhook_allowlist=cfg.security.webhook_allowlist or None,
+            poll_interval=cfg.runtime.poll_interval_ms / 1000.0,
+            batch_limit=cfg.runtime.max_batch,
+            dataset_id="__cli__",
+        )
+    except Exception as exc:
+        _log_event("runtime_build_failed", error=str(exc))
+        _human(f"[red]Runtime build failed:[/red] {exc}", err=True)
+        raise typer.Exit(1)
+
+    try:
+        with runtime as rt:
+            processed = rt.run_once()
+    except Exception as exc:
+        _log_event("tick_failed", error=str(exc))
+        _human(f"[red]Tick failed:[/red] {exc}", err=True)
+        raise typer.Exit(1)
+
+    _log_event("tick_done", processed=processed)
+    _human(
+        f"[green]OK[/green] one tick processed [bold]{processed}[/bold] "
+        f"change-log row(s) on [cyan]{gpkg_path.name}[/cyan]."
+    )
+
+
+@triggers_app.command("validate")
+def cmd_validate(
+    config: Path = typer.Option(
+        ...,
+        "--config",
+        "-c",
+        help="Path to the YAML triggers config file.",
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+    ),
+    gpkg: Path | None = typer.Option(
+        None,
+        "--gpkg",
+        help="Override the gpkg path declared in the config.",
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+    ),
+) -> None:
+    """Validate the YAML config (syntax + schema + GPKG layer references).
+
+    Exits 0 on success, 1 on any error.
+    """
+    from gispulse.runtime.config_loader import (
+        ConfigError,
+        load_config,
+        validate_against_gpkg,
+    )
+
+    try:
+        cfg = load_config(config, gpkg_override=gpkg)
+    except ConfigError as exc:
+        _log_event("config_error", error=str(exc))
+        _human(f"[red]Config error:[/red] {exc}", err=True)
+        raise typer.Exit(1)
+
+    errors = validate_against_gpkg(cfg)
+    if errors:
+        for err in errors:
+            _log_event("schema_error", message=err)
+            _human(f"  [red]FAIL[/red]  {err}", err=True)
+        _human("\nValidation failed.", err=True, style="red bold")
+        raise typer.Exit(1)
+
+    _log_event("validate_ok", triggers=len(cfg.triggers), gpkg=cfg.gpkg)
+    _human(
+        f"[green]OK[/green] {len(cfg.triggers)} trigger(s) valid against "
+        f"[cyan]{Path(cfg.gpkg).name}[/cyan]."
+    )
+
+
+@triggers_app.command("list")
+def cmd_list(
+    gpkg: Path = typer.Option(
+        ...,
+        "--gpkg",
+        help="GeoPackage to inspect.",
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+    ),
+) -> None:
+    """List the native SQLite triggers GISPulse has installed in the GPKG.
+
+    These are the ``_gispulse_trg_<table>_<op>`` triggers wired by the
+    engine when ``enable_change_tracking()`` runs. Empty list = the GPKG
+    is not yet tracked.
+    """
+    try:
+        conn = sqlite3.connect(str(gpkg))
+        try:
+            cur = conn.execute(
+                """
+                SELECT name, tbl_name
+                FROM sqlite_master
+                WHERE type = 'trigger'
+                  AND name LIKE '\\_gispulse\\_trg\\_%' ESCAPE '\\'
+                ORDER BY tbl_name, name
+                """,
+            )
+            rows = cur.fetchall()
+        finally:
+            conn.close()
+    except sqlite3.Error as exc:
+        _log_event("gpkg_open_failed", error=str(exc))
+        _human(f"[red]Cannot open GPKG:[/red] {exc}", err=True)
+        raise typer.Exit(1)
+
+    if not rows:
+        _human(
+            "[yellow]No GISPulse triggers installed in this GPKG.[/yellow]\n"
+            "Use the upload / enable-tracking endpoint or run a config that "
+            "calls `engine.enable_change_tracking(...)`."
+        )
+        _log_event("list_empty", gpkg=str(gpkg))
+        return
+
+    # Group: one (table, [ops]) per row.
+    by_table: dict[str, list[str]] = {}
+    for name, tbl in rows:
+        # name is `_gispulse_trg_<table>_<op>` — pull the op suffix.
+        op = name.rsplit("_", 1)[-1].upper()
+        by_table.setdefault(tbl, []).append(op)
+
+    _human(f"[bold]{len(by_table)} tracked table(s) in {gpkg.name}:[/bold]\n")
+    for tbl, ops in sorted(by_table.items()):
+        ops_str = ", ".join(sorted(set(ops)))
+        _human(f"  - [cyan]{tbl}[/cyan]: {ops_str}")
+
+    _log_event("list_ok", gpkg=str(gpkg), tables=len(by_table))
+
+
+__all__ = ["triggers_app"]

--- a/gispulse/cli_triggers_watch.py
+++ b/gispulse/cli_triggers_watch.py
@@ -1,0 +1,472 @@
+"""Daemon loop for ``gispulse triggers run --watch``.
+
+Extracted from ``cli_triggers.py`` so the loop is unit-testable without
+spawning a subprocess. The CLI command thin-wraps :func:`run_watch_loop`
+and only owns argument parsing + signal binding.
+
+Design
+------
+- The loop drives :meth:`HeadlessRuntime.run_once` itself rather than
+  starting :meth:`HeadlessRuntime.start` (which would spawn the watcher's
+  daemon thread). Reasons:
+
+  * The brief mandates a per-tick structured JSON log line on stderr,
+    with metrics (``fired``, ``skipped_predicate``, ``errors``,
+    ``duration_ms``, ``sqlite_busy_retries``) that the watcher does not
+    expose today.
+  * The brief mandates "10 consecutive failed ticks → exit 1". That
+    policy lives at the CLI level, not in the persistence layer.
+  * The loop also re-validates the YAML config on mtime change, which
+    requires CLI ownership of the trigger list anyway.
+
+- Cancellation flows through a single :class:`threading.Event` injected
+  by the CLI. SIGINT / SIGTERM handlers ``set()`` it, the loop breaks
+  on the next ``Event.wait`` boundary.
+
+- ``Sleeper`` is a callable ``(timeout: float) -> bool`` (returns True
+  on cancellation) so tests can mock time without freezing the event
+  loop.
+
+- The runtime is rebuilt from scratch on every successful YAML reload.
+  This is heavier than mutating ``runtime.triggers`` in place, but it
+  guarantees that ``poll_interval``, ``webhook_allowlist`` and other
+  build-time decisions stay coherent with the on-disk config.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable
+
+if TYPE_CHECKING:  # pragma: no cover
+    from gispulse.runtime.config_loader import GISPulseConfig
+    from gispulse.runtime.headless_runtime import HeadlessRuntime
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Brief: "Si 10 ticks consécutifs échouent → exit 1".
+MAX_CONSECUTIVE_TICK_FAILURES: int = 10
+
+# Brief: "sleep backoff exponentiel (cap 30s)".
+TICK_ERROR_BACKOFF_INITIAL: float = 1.0
+TICK_ERROR_BACKOFF_CAP: float = 30.0
+TICK_ERROR_BACKOFF_MULTIPLIER: float = 2.0
+
+
+# ---------------------------------------------------------------------------
+# Counters
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TickMetrics:
+    """Per-tick counters surfaced in the structured JSON log."""
+
+    fired: int = 0
+    skipped_predicate: int = 0
+    errors: int = 0
+    duration_ms: float = 0.0
+    sqlite_busy_retries: int = 0
+    rows_processed: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Sleeper protocol
+# ---------------------------------------------------------------------------
+
+
+class CancellableSleeper:
+    """Callable wrapper around a :class:`threading.Event`.
+
+    Called as ``sleeper(timeout) -> bool`` where the return value is
+    ``True`` if the event was set (cancellation requested) and ``False``
+    on natural timeout. Tests can swap the underlying implementation by
+    passing a different callable to :func:`run_watch_loop`.
+    """
+
+    def __init__(self, event: threading.Event) -> None:
+        self._event = event
+
+    def __call__(self, timeout: float) -> bool:
+        # ``Event.wait`` already returns True on set / False on timeout —
+        # exactly the contract we need.
+        return self._event.wait(timeout=timeout)
+
+
+# ---------------------------------------------------------------------------
+# Config reload state
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _ConfigSnapshot:
+    """Last successfully-loaded config + the file mtime that produced it.
+
+    Stored across ticks so we can short-circuit when the YAML hasn't
+    changed and so we keep the *previous* runtime alive when a reload
+    fails (broken YAML must not crash the daemon).
+    """
+
+    cfg: "GISPulseConfig"
+    mtime_ns: int
+    runtime: "HeadlessRuntime"
+    # We close the previous runtime after the new one is built so a
+    # failed reload doesn't leave us with a closed engine.
+    closed: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def emit_json(event: str, **fields: Any) -> None:
+    """Emit a single JSON record on stderr (one tick = one line).
+
+    Mirrors :func:`gispulse.cli_triggers._log_event` but exposed at
+    module scope so the watch loop can use it without circular imports.
+    """
+    record: dict[str, Any] = {"event": event, **fields}
+    try:
+        line = json.dumps(record, default=str, separators=(",", ":"))
+    except Exception:  # pragma: no cover - extreme defensive
+        line = json.dumps({"event": event, "format_error": True})
+    print(line, file=sys.stderr, flush=True)
+
+
+def install_signal_handlers(stop_event: threading.Event) -> Callable[[], None]:
+    """Wire SIGINT / SIGTERM to set ``stop_event``.
+
+    Returns a callable that restores the previous handlers — invoke it
+    on exit so other code (pytest, embedders) sees the original
+    behaviour.
+
+    Windows only ships SIGINT (no SIGTERM). We skip SIGTERM there
+    silently rather than blowing up at install time.
+    """
+    import signal
+
+    previous: list[tuple[int, Any]] = []
+
+    def _handler(signum: int, frame: Any) -> None:
+        emit_json("watch_signal_received", signum=int(signum))
+        stop_event.set()
+
+    signums: list[int] = [signal.SIGINT]
+    sigterm = getattr(signal, "SIGTERM", None)
+    if sigterm is not None:
+        signums.append(int(sigterm))
+
+    for sig in signums:
+        try:
+            previous.append((sig, signal.signal(sig, _handler)))
+        except (ValueError, OSError):
+            # Outside main thread (signal.signal() requires main) or
+            # signal not supported on this platform. Tests run inside
+            # threads — we silently skip and they fall back to setting
+            # ``stop_event`` directly.
+            continue
+
+    def _restore() -> None:
+        for sig, prev in previous:
+            try:
+                signal.signal(sig, prev)
+            except (ValueError, OSError):
+                pass
+
+    return _restore
+
+
+def _stat_mtime_ns(path: Path) -> int:
+    """Return ``path.stat().st_mtime_ns`` or 0 if the file is gone.
+
+    Used as the "has the YAML changed?" key. We fall back to 0 on
+    failure so a transiently-missing file (operator's editor swap-file
+    flicker) does not crash the daemon — the next stat will pick up
+    the real mtime.
+    """
+    try:
+        return path.stat().st_mtime_ns
+    except OSError:
+        return 0
+
+
+def _build_runtime_from_config(
+    cfg: "GISPulseConfig",
+    *,
+    gpkg_override: Path | None,
+) -> "HeadlessRuntime":
+    """Wire a fresh :class:`HeadlessRuntime` from ``cfg``.
+
+    Mirrors the logic in :func:`gispulse.cli_triggers.cmd_run`. Imported
+    locally to keep ``cli_triggers_watch`` import-light.
+    """
+    from gispulse.runtime.config_loader import to_triggers
+    from gispulse.runtime.headless_runtime import build_runtime
+
+    triggers = to_triggers(cfg)
+    return build_runtime(
+        gpkg_path=Path(cfg.gpkg) if gpkg_override is None else gpkg_override,
+        triggers=triggers,
+        webhook_allowlist=cfg.security.webhook_allowlist or None,
+        poll_interval=cfg.runtime.poll_interval_ms / 1000.0,
+        batch_limit=cfg.runtime.max_batch,
+        dataset_id="__cli__",
+    )
+
+
+def _maybe_reload(
+    snapshot: _ConfigSnapshot,
+    *,
+    config_path: Path,
+    gpkg_override: Path | None,
+) -> _ConfigSnapshot:
+    """If the YAML mtime changed, reload + revalidate. On failure, keep
+    the previous snapshot alive and emit an ERROR event."""
+    from gispulse.runtime.config_loader import (
+        ConfigError,
+        load_config,
+        validate_against_gpkg,
+    )
+
+    new_mtime = _stat_mtime_ns(config_path)
+    if new_mtime == snapshot.mtime_ns or new_mtime == 0:
+        return snapshot
+
+    emit_json("watch_config_reload_attempt", path=str(config_path))
+    try:
+        cfg = load_config(config_path, gpkg_override=gpkg_override)
+        errors = validate_against_gpkg(cfg)
+        if errors:
+            for err in errors:
+                emit_json("watch_config_reload_schema_error", message=err)
+            return _ConfigSnapshot(
+                cfg=snapshot.cfg,
+                mtime_ns=new_mtime,  # don't keep retrying the same broken file
+                runtime=snapshot.runtime,
+                closed=snapshot.closed,
+            )
+    except ConfigError as exc:
+        emit_json("watch_config_reload_failed", error=str(exc))
+        return _ConfigSnapshot(
+            cfg=snapshot.cfg,
+            mtime_ns=new_mtime,
+            runtime=snapshot.runtime,
+            closed=snapshot.closed,
+        )
+
+    # Build the new runtime *before* closing the old one so a build
+    # failure does not leave the daemon without an engine.
+    try:
+        new_runtime = _build_runtime_from_config(cfg, gpkg_override=gpkg_override)
+    except Exception as exc:
+        emit_json("watch_config_reload_build_failed", error=str(exc))
+        return _ConfigSnapshot(
+            cfg=snapshot.cfg,
+            mtime_ns=new_mtime,
+            runtime=snapshot.runtime,
+            closed=snapshot.closed,
+        )
+
+    # Successful swap.
+    try:
+        snapshot.runtime.close()
+    except Exception as exc:
+        log.warning("watch_old_runtime_close_failed: %s", exc)
+    emit_json("watch_config_reloaded", triggers=len(cfg.triggers))
+    return _ConfigSnapshot(
+        cfg=cfg, mtime_ns=new_mtime, runtime=new_runtime, closed=False
+    )
+
+
+# ---------------------------------------------------------------------------
+# The loop itself
+# ---------------------------------------------------------------------------
+
+
+def run_watch_loop(
+    *,
+    initial_runtime: "HeadlessRuntime",
+    initial_cfg: "GISPulseConfig",
+    config_path: Path,
+    gpkg_override: Path | None,
+    poll_interval: float,
+    stop_event: threading.Event | None = None,
+    sleeper: Callable[[float], bool] | None = None,
+    clock: Callable[[], float] = time.monotonic,
+    max_ticks: int | None = None,
+) -> int:
+    """Drive ticks until ``stop_event`` is set.
+
+    Args:
+        initial_runtime:    Already-built runtime (so the caller can fail
+                            loudly on the first build before entering the
+                            loop). The loop owns it from this point and
+                            will :meth:`HeadlessRuntime.close` on exit /
+                            on every successful reload.
+        initial_cfg:        Validated config that produced
+                            ``initial_runtime``. Used as the snapshot
+                            seed for reload-on-mtime-change.
+        config_path:        Absolute path to the YAML file. Polled with
+                            ``stat().st_mtime_ns`` each tick.
+        gpkg_override:      ``--gpkg`` override (forwarded on reload).
+        poll_interval:      Seconds between successful ticks. Independent
+                            of the watcher's own ``poll_interval`` (we
+                            drive ``run_once`` ourselves; the watcher's
+                            daemon thread is never started).
+        stop_event:         External cancellation primitive. When omitted
+                            a fresh :class:`Event` is created — typical
+                            CLI usage installs signal handlers that set
+                            it.
+        sleeper:            Cancellable sleep ``(timeout) -> bool`` (True
+                            on cancel). Defaults to a wrapper around
+                            ``stop_event.wait``.
+        clock:              Monotonic time source for the per-tick
+                            duration metric. Test injection point.
+        max_ticks:          When set, exit after this many ticks
+                            regardless of ``stop_event`` — handy for
+                            integration tests that want a finite run.
+
+    Returns:
+        Process exit code: ``0`` on clean shutdown, ``1`` when the
+        consecutive-failure budget is exhausted.
+    """
+    if stop_event is None:
+        stop_event = threading.Event()
+    if sleeper is None:
+        sleeper = CancellableSleeper(stop_event)
+    if poll_interval <= 0:
+        raise ValueError("poll_interval must be > 0")
+
+    snapshot = _ConfigSnapshot(
+        cfg=initial_cfg,
+        mtime_ns=_stat_mtime_ns(config_path),
+        runtime=initial_runtime,
+    )
+
+    consecutive_failures = 0
+    error_backoff = TICK_ERROR_BACKOFF_INITIAL
+    tick_count = 0
+
+    emit_json(
+        "watch_started",
+        config=str(config_path),
+        gpkg=str(initial_runtime.gpkg_path),
+        poll_interval_ms=int(poll_interval * 1000),
+        triggers=len(initial_runtime.triggers),
+    )
+
+    try:
+        while not stop_event.is_set():
+            tick_count += 1
+            metrics = TickMetrics()
+            t0 = clock()
+
+            # Reload-on-config-change check — happens before every tick so
+            # we never run a tick against a stale YAML for longer than
+            # ``poll_interval`` seconds.
+            try:
+                snapshot = _maybe_reload(
+                    snapshot,
+                    config_path=config_path,
+                    gpkg_override=gpkg_override,
+                )
+            except Exception as exc:
+                # Defensive: _maybe_reload swallows known errors. An
+                # unexpected exception here means a bug, not a transient
+                # — log loudly and fall through.
+                emit_json("watch_reload_unexpected_error", error=str(exc))
+
+            # Snapshot the busy-retry counter before the tick so we can
+            # diff after.
+            retries_before = (
+                snapshot.runtime.retrying_sql.snapshot_retries()
+                if snapshot.runtime.retrying_sql is not None
+                else 0
+            )
+
+            try:
+                metrics.rows_processed = snapshot.runtime.run_once()
+                consecutive_failures = 0
+                error_backoff = TICK_ERROR_BACKOFF_INITIAL
+            except Exception as exc:
+                metrics.errors += 1
+                consecutive_failures += 1
+                emit_json(
+                    "watch_tick_failed",
+                    error=str(exc),
+                    consecutive_failures=consecutive_failures,
+                )
+                if consecutive_failures >= MAX_CONSECUTIVE_TICK_FAILURES:
+                    emit_json(
+                        "watch_aborted_after_failures",
+                        consecutive_failures=consecutive_failures,
+                        max=MAX_CONSECUTIVE_TICK_FAILURES,
+                    )
+                    return 1
+                # Sleep on the cancellable sleeper so SIGINT during
+                # backoff is honoured. Cap exponential growth.
+                if sleeper(error_backoff):
+                    break
+                error_backoff = min(
+                    error_backoff * TICK_ERROR_BACKOFF_MULTIPLIER,
+                    TICK_ERROR_BACKOFF_CAP,
+                )
+                continue
+
+            retries_after = (
+                snapshot.runtime.retrying_sql.snapshot_retries()
+                if snapshot.runtime.retrying_sql is not None
+                else 0
+            )
+            metrics.sqlite_busy_retries = retries_after - retries_before
+            metrics.duration_ms = (clock() - t0) * 1000.0
+
+            emit_json(
+                "watch_tick",
+                tick=tick_count,
+                rows_processed=metrics.rows_processed,
+                fired=metrics.fired,
+                skipped_predicate=metrics.skipped_predicate,
+                errors=metrics.errors,
+                duration_ms=round(metrics.duration_ms, 3),
+                sqlite_busy_retries=metrics.sqlite_busy_retries,
+            )
+
+            if max_ticks is not None and tick_count >= max_ticks:
+                break
+
+            if sleeper(poll_interval):
+                break
+    finally:
+        try:
+            snapshot.runtime.close()
+        except Exception as exc:
+            log.warning("watch_runtime_close_failed: %s", exc)
+        emit_json("watch_stopped", ticks=tick_count)
+
+    return 0
+
+
+__all__ = [
+    "MAX_CONSECUTIVE_TICK_FAILURES",
+    "TICK_ERROR_BACKOFF_CAP",
+    "TICK_ERROR_BACKOFF_INITIAL",
+    "TICK_ERROR_BACKOFF_MULTIPLIER",
+    "CancellableSleeper",
+    "TickMetrics",
+    "emit_json",
+    "install_signal_handlers",
+    "run_watch_loop",
+]

--- a/gispulse/runtime/__init__.py
+++ b/gispulse/runtime/__init__.py
@@ -1,0 +1,26 @@
+"""GISPulse headless runtime.
+
+Provides a FastAPI-free wiring of the trigger pipeline so the CLI
+(``gispulse triggers run``) and embedded integrations (QGIS / ArcGIS /
+SDK) can drive the same plumbing as the HTTP server without booting
+uvicorn.
+
+The runtime mirrors the lifespan wiring at ``adapters/http/app.py``
+(``ChangeLogWatcher`` + ``ActionDispatcher`` + a no-op ``EventHub``)
+so behaviour stays identical between modes.
+
+Public API:
+    - :func:`build_runtime`        — factory that wires everything.
+    - :class:`HeadlessRuntime`     — handle returned by the factory.
+    - :class:`NullEventHub`        — drop-in EventHub stub for headless mode.
+"""
+
+from __future__ import annotations
+
+from gispulse.runtime.headless_runtime import (
+    HeadlessRuntime,
+    NullEventHub,
+    build_runtime,
+)
+
+__all__ = ["HeadlessRuntime", "NullEventHub", "build_runtime"]

--- a/gispulse/runtime/__init__.py
+++ b/gispulse/runtime/__init__.py
@@ -29,14 +29,32 @@ from gispulse.runtime.headless_runtime import (
     NullEventHub,
     build_runtime,
 )
+from gispulse.runtime.predicate_dsl import (
+    PredicateDepthError,
+    PredicateError,
+    PredicateEvalError,
+    PredicateNode,
+    PredicateSyntaxError,
+    build_update_payload,
+    evaluate_predicate,
+    parse_predicate,
+)
 
 __all__ = [
     "ConfigError",
     "GISPulseConfig",
     "HeadlessRuntime",
     "NullEventHub",
+    "PredicateDepthError",
+    "PredicateError",
+    "PredicateEvalError",
+    "PredicateNode",
+    "PredicateSyntaxError",
     "build_runtime",
+    "build_update_payload",
+    "evaluate_predicate",
     "load_config",
+    "parse_predicate",
     "to_triggers",
     "validate_against_gpkg",
 ]

--- a/gispulse/runtime/__init__.py
+++ b/gispulse/runtime/__init__.py
@@ -39,9 +39,17 @@ from gispulse.runtime.predicate_dsl import (
     evaluate_predicate,
     parse_predicate,
 )
+from gispulse.runtime.sqlite_retry import (
+    DEFAULT_BACKOFF_SCHEDULE,
+    DEFAULT_JITTER_PCT,
+    RetryingSqlExecutor,
+    is_busy_error,
+)
 
 __all__ = [
     "ConfigError",
+    "DEFAULT_BACKOFF_SCHEDULE",
+    "DEFAULT_JITTER_PCT",
     "GISPulseConfig",
     "HeadlessRuntime",
     "NullEventHub",
@@ -50,9 +58,11 @@ __all__ = [
     "PredicateEvalError",
     "PredicateNode",
     "PredicateSyntaxError",
+    "RetryingSqlExecutor",
     "build_runtime",
     "build_update_payload",
     "evaluate_predicate",
+    "is_busy_error",
     "load_config",
     "parse_predicate",
     "to_triggers",

--- a/gispulse/runtime/__init__.py
+++ b/gispulse/runtime/__init__.py
@@ -17,10 +17,26 @@ Public API:
 
 from __future__ import annotations
 
+from gispulse.runtime.config_loader import (
+    ConfigError,
+    GISPulseConfig,
+    load_config,
+    to_triggers,
+    validate_against_gpkg,
+)
 from gispulse.runtime.headless_runtime import (
     HeadlessRuntime,
     NullEventHub,
     build_runtime,
 )
 
-__all__ = ["HeadlessRuntime", "NullEventHub", "build_runtime"]
+__all__ = [
+    "ConfigError",
+    "GISPulseConfig",
+    "HeadlessRuntime",
+    "NullEventHub",
+    "build_runtime",
+    "load_config",
+    "to_triggers",
+    "validate_against_gpkg",
+]

--- a/gispulse/runtime/config_loader.py
+++ b/gispulse/runtime/config_loader.py
@@ -1,0 +1,468 @@
+"""YAML config loader for ``gispulse triggers``.
+
+Schema (version 1, strict)::
+
+    version: 1
+    gpkg: ./layer.gpkg          # surchargeable par --gpkg
+    triggers:
+      - name: enrich_parcels
+        table: parcels
+        pk_col: fid
+        when: [INSERT, UPDATE]
+        predicate: "status == 'pending'"   # AttrPredicate expression
+        actions:
+          - type: webhook
+            url: https://example.com/hook
+          - type: set_field
+            field: enriched_at
+            value: 2026-04-27
+          - type: run_sql
+            expression: "UPDATE parcels SET status='ok' WHERE fid=NEW.fid"
+    security:
+      webhook_allowlist:
+        - example.com
+    runtime:
+      poll_interval_ms: 1000
+      max_batch: 200
+
+Security guarantees
+-------------------
+- ``yaml.safe_load`` only — never ``yaml.load`` (CVE class).
+- Config path is canonicalised with ``Path.resolve(strict=True)`` and
+  rejected if it escapes the user's ``$HOME`` and the current working
+  directory (path traversal guard, e.g. ``../../etc/passwd``).
+- The referenced GPKG path is canonicalised the same way and is checked
+  against the same anchor set.
+- Trigger ``table`` is validated against the actual GPKG layer list at
+  ``validate_against_gpkg`` time so a typo is reported by
+  ``gispulse triggers validate`` before any tick runs.
+- Strict pydantic v2 models (``extra="forbid"``) so unknown keys raise
+  loudly instead of being silently ignored.
+
+The loader does **not** evaluate predicates or open the GPKG by itself —
+that's the runtime's job. ``validate_against_gpkg(config, engine)`` is
+called explicitly by the CLI before ``build_runtime()`` so config errors
+surface as exit-code 1 from ``triggers validate``.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Iterable, Literal
+from uuid import uuid4
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+if TYPE_CHECKING:  # pragma: no cover
+    from core.models import ActionDef, Trigger
+
+
+CONFIG_VERSION = 1
+
+# Action types the loader recognises in YAML. Subset of the full
+# ``ActionType`` enum: only the ones a Mode 1 user can actually
+# meaningfully express in a flat YAML file. Other action types
+# (RUN_JOB, RUN_GRAPH, ENQUEUE, ...) require infrastructure the
+# headless runtime does not boot.
+_SUPPORTED_ACTION_TYPES: tuple[str, ...] = (
+    "webhook",
+    "set_field",
+    "run_sql",
+    "log_event",
+    "notify",
+)
+
+# DML operations the watcher emits.
+_SUPPORTED_DML_OPS: tuple[str, ...] = ("INSERT", "UPDATE", "DELETE")
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models (strict)
+# ---------------------------------------------------------------------------
+
+
+class ActionConfigModel(BaseModel):
+    """One action under a trigger.
+
+    The ``type`` field is closed (Literal) so unknown action types are
+    rejected at parse time. Type-specific keys are validated by the
+    field validator below.
+    """
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    type: Literal["webhook", "set_field", "run_sql", "log_event", "notify"]
+    # webhook
+    url: str | None = None
+    # set_field
+    field: str | None = Field(default=None, alias="field")
+    value: Any = None
+    # run_sql
+    expression: str | None = None
+    # notify
+    channel: str | None = None
+    payload_template: dict[str, Any] | str | None = None
+
+    @field_validator("url")
+    @classmethod
+    def _validate_url(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        v = v.strip()
+        if not (v.startswith("http://") or v.startswith("https://")):
+            raise ValueError(
+                f"webhook url must start with http:// or https://, got {v!r}"
+            )
+        return v
+
+
+class TriggerConfigModel(BaseModel):
+    """One trigger entry in the YAML config."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    name: str = Field(min_length=1, max_length=120)
+    table: str = Field(min_length=1, max_length=120)
+    pk_col: str = Field(default="fid", min_length=1, max_length=64)
+    when: list[Literal["INSERT", "UPDATE", "DELETE"]] = Field(
+        default_factory=lambda: list(_SUPPORTED_DML_OPS),
+    )
+    predicate: str | None = None
+    actions: list[ActionConfigModel] = Field(default_factory=list)
+    enabled: bool = True
+
+    @field_validator("when")
+    @classmethod
+    def _no_empty_when(cls, v: list[str]) -> list[str]:
+        if not v:
+            raise ValueError("when must list at least one of INSERT/UPDATE/DELETE")
+        # Deduplicate while preserving order.
+        seen: list[str] = []
+        for op in v:
+            if op not in seen:
+                seen.append(op)
+        return seen
+
+
+class SecurityConfigModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    webhook_allowlist: list[str] = Field(default_factory=list)
+
+
+class RuntimeConfigModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    poll_interval_ms: int = Field(default=1000, ge=10, le=60_000)
+    max_batch: int = Field(default=200, ge=1, le=10_000)
+
+
+class GISPulseConfig(BaseModel):
+    """Top-level config schema."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    version: Literal[1] = 1
+    gpkg: str
+    triggers: list[TriggerConfigModel] = Field(default_factory=list)
+    security: SecurityConfigModel = Field(default_factory=SecurityConfigModel)
+    runtime: RuntimeConfigModel = Field(default_factory=RuntimeConfigModel)
+
+
+# ---------------------------------------------------------------------------
+# Loader
+# ---------------------------------------------------------------------------
+
+
+class ConfigError(ValueError):
+    """Raised when the YAML config is invalid or violates the safety policy."""
+
+
+def _safe_anchors() -> list[Path]:
+    """Return the directories under which user-controlled paths are
+    accepted. Anything resolved outside of these roots is rejected.
+
+    We accept ``cwd`` and ``$HOME``. Operators wanting a hardened deploy
+    can ``cd`` into the project root before running the CLI, and the
+    ``--gpkg`` override goes through the same check.
+    """
+    anchors: list[Path] = []
+    try:
+        anchors.append(Path.cwd().resolve())
+    except OSError:
+        pass
+    try:
+        anchors.append(Path.home().resolve())
+    except (OSError, RuntimeError):
+        pass
+    return anchors
+
+
+def _check_within_anchors(path: Path, anchors: Iterable[Path]) -> None:
+    """Raise :class:`ConfigError` if ``path`` is not under any anchor."""
+    for anchor in anchors:
+        try:
+            path.relative_to(anchor)
+        except ValueError:
+            continue
+        return
+    raise ConfigError(
+        f"path {path!s} escapes the allowed roots ("
+        + ", ".join(str(a) for a in anchors)
+        + "). Refusing to load (path traversal guard)."
+    )
+
+
+def _resolve_safe(raw: str | os.PathLike[str], *, anchors: list[Path], must_exist: bool = True) -> Path:
+    """Canonicalise ``raw`` and ensure it is under one of the anchors.
+
+    Args:
+        raw:        Path string from the YAML (or CLI flag).
+        anchors:    List of allowed root directories.
+        must_exist: When *True*, use ``resolve(strict=True)`` so a
+                    missing target also fails.
+
+    Raises:
+        ConfigError: Missing path (when ``must_exist``) or escapes roots.
+    """
+    p = Path(raw).expanduser()
+    if not p.is_absolute():
+        # Anchor relative paths to cwd before resolution.
+        p = (Path.cwd() / p)
+    try:
+        resolved = p.resolve(strict=must_exist)
+    except FileNotFoundError as exc:
+        raise ConfigError(f"path does not exist: {raw!s}") from exc
+    except OSError as exc:  # pragma: no cover - defensive
+        raise ConfigError(f"cannot resolve path {raw!s}: {exc}") from exc
+
+    _check_within_anchors(resolved, anchors)
+    return resolved
+
+
+def load_config(
+    config_path: str | os.PathLike[str],
+    *,
+    gpkg_override: str | os.PathLike[str] | None = None,
+) -> GISPulseConfig:
+    """Load + validate a YAML config file.
+
+    Args:
+        config_path:   Path to the ``triggers.yaml`` file.
+        gpkg_override: Optional ``--gpkg`` value that wins over the
+                       ``gpkg:`` key. Subject to the same path-traversal
+                       guard.
+
+    Returns:
+        A validated :class:`GISPulseConfig` with absolute resolved paths.
+
+    Raises:
+        ConfigError:        Path traversal, missing file, or schema violation.
+        pydantic.ValidationError: Invalid YAML schema (re-raised as-is so
+                                  callers can format detailed messages).
+    """
+    anchors = _safe_anchors()
+    cfg_path = _resolve_safe(config_path, anchors=anchors, must_exist=True)
+
+    if not cfg_path.is_file():
+        raise ConfigError(f"config path is not a file: {cfg_path}")
+
+    # SECURITY: never use yaml.load — only safe_load. This is the single
+    # most important guard in this module.
+    text = cfg_path.read_text(encoding="utf-8")
+    try:
+        raw = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise ConfigError(f"invalid YAML in {cfg_path}: {exc}") from exc
+
+    if raw is None:
+        raise ConfigError(f"empty config file: {cfg_path}")
+    if not isinstance(raw, dict):
+        raise ConfigError(
+            f"config root must be a mapping, got {type(raw).__name__}"
+        )
+
+    # Resolve the GPKG path (override wins). We do this *before*
+    # pydantic validation so the schema sees an absolute path string.
+    gpkg_raw = gpkg_override if gpkg_override is not None else raw.get("gpkg")
+    if not gpkg_raw:
+        raise ConfigError("missing 'gpkg' key (no --gpkg override either)")
+    gpkg_resolved = _resolve_safe(gpkg_raw, anchors=anchors, must_exist=True)
+    raw["gpkg"] = str(gpkg_resolved)
+
+    # Pydantic validation (strict, extra=forbid).
+    try:
+        config = GISPulseConfig.model_validate(raw)
+    except Exception as exc:  # ValidationError or others
+        raise ConfigError(f"invalid config schema: {exc}") from exc
+
+    return config
+
+
+# ---------------------------------------------------------------------------
+# Mapping into domain dataclasses
+# ---------------------------------------------------------------------------
+
+
+def to_triggers(config: GISPulseConfig) -> list["Trigger"]:
+    """Convert YAML trigger entries into domain :class:`Trigger` objects.
+
+    Maps:
+        - ``type: webhook`` ─▶ ``ActionType.WEBHOOK``
+        - ``type: set_field`` ─▶ ``ActionType.SET_FIELD``
+        - ``type: run_sql`` ─▶ ``ActionType.RUN_SQL``
+        - ``type: log_event`` ─▶ ``ActionType.LOG_EVENT``
+        - ``type: notify`` ─▶ ``ActionType.NOTIFY``
+
+    Predicate strings are stored verbatim under
+    ``Trigger.conditions["predicate"]`` for now — full parsing into
+    :class:`AttrPredicate` is deferred to S4 (predicate DSL story). The
+    current evaluator falls back to ``matched=True`` when no
+    :class:`Trigger.predicates` are set, so trigger actions still fire
+    on every change while we wait for the DSL.
+    """
+    from core.graph import ActionDef, ActionType
+    from core.enums import TriggerEvent, TriggerType, TriggerCategory
+    from core.models import Trigger
+
+    type_map = {
+        "webhook": ActionType.WEBHOOK,
+        "set_field": ActionType.SET_FIELD,
+        "run_sql": ActionType.RUN_SQL,
+        "log_event": ActionType.LOG_EVENT,
+        "notify": ActionType.NOTIFY,
+    }
+
+    triggers: list[Trigger] = []
+    for entry in config.triggers:
+        actions: list[ActionDef] = []
+        for ac in entry.actions:
+            cfg: dict[str, Any] = {}
+            if ac.type == "webhook":
+                cfg["url"] = ac.url or ""
+            elif ac.type == "set_field":
+                cfg["field"] = ac.field or ""
+                cfg["value"] = ac.value
+            elif ac.type == "run_sql":
+                cfg["expression"] = ac.expression or ""
+            elif ac.type == "notify":
+                cfg["channel"] = ac.channel or "gispulse_events"
+                if ac.payload_template is not None:
+                    cfg["payload_template"] = ac.payload_template
+            # log_event takes no required config
+
+            actions.append(
+                ActionDef(action_type=type_map[ac.type], config=cfg),
+            )
+
+        # Stash the user-friendly metadata on the trigger so log lines
+        # and validate output can reference the YAML name.
+        conditions: dict[str, Any] = {
+            "yaml_name": entry.name,
+            "table": entry.table,
+            "pk_col": entry.pk_col,
+            "when": list(entry.when),
+        }
+        if entry.predicate:
+            conditions["predicate"] = entry.predicate
+
+        trigger = Trigger(
+            name=entry.name,
+            description=f"Loaded from YAML config (table={entry.table})",
+            event=TriggerEvent.DATA_CHANGED,
+            trigger_type=TriggerType.DML,
+            category=TriggerCategory.DATA,
+            conditions=conditions,
+            actions=actions,
+            enabled=entry.enabled,
+        )
+        triggers.append(trigger)
+
+    return triggers
+
+
+# ---------------------------------------------------------------------------
+# Validation against the GPKG
+# ---------------------------------------------------------------------------
+
+
+def validate_against_gpkg(config: GISPulseConfig) -> list[str]:
+    """Open the GPKG and check every trigger references a real layer.
+
+    This is a *separate* step from :func:`load_config` because opening
+    the GPKG is comparatively expensive and the bare schema validation
+    is enough for ``--validate`` shape checks. Callers who want full
+    structural validation chain ``load_config`` then this function.
+
+    Args:
+        config: A validated :class:`GISPulseConfig`.
+
+    Returns:
+        List of human-readable error strings. Empty list = valid.
+    """
+    from persistence.gpkg_engine import GeoPackageEngine
+
+    errors: list[str] = []
+
+    gpkg_path = Path(config.gpkg)
+    if not gpkg_path.exists():
+        return [f"gpkg file not found: {gpkg_path}"]
+
+    engine = GeoPackageEngine(path=gpkg_path)
+    try:
+        engine.open()
+    except Exception as exc:
+        return [f"cannot open gpkg {gpkg_path}: {exc}"]
+
+    try:
+        try:
+            layers = set(engine.list_layers() or [])
+        except Exception as exc:
+            errors.append(f"cannot list layers in {gpkg_path}: {exc}")
+            return errors
+
+        # Internal GPKG metadata tables are also valid trigger targets
+        # (they show up in _gispulse_change_log too) but we don't
+        # encourage that path. We just don't reject them.
+        for entry in config.triggers:
+            if entry.table not in layers:
+                errors.append(
+                    f"trigger {entry.name!r}: table {entry.table!r} not "
+                    f"found in {gpkg_path.name} (available: "
+                    f"{', '.join(sorted(layers)) or 'none'})"
+                )
+            for ac in entry.actions:
+                if ac.type == "webhook" and not ac.url:
+                    errors.append(
+                        f"trigger {entry.name!r}: webhook action requires url"
+                    )
+                if ac.type == "set_field" and not ac.field:
+                    errors.append(
+                        f"trigger {entry.name!r}: set_field action requires field"
+                    )
+                if ac.type == "run_sql" and not ac.expression:
+                    errors.append(
+                        f"trigger {entry.name!r}: run_sql action requires expression"
+                    )
+
+    finally:
+        try:
+            engine.close()
+        except Exception:  # pragma: no cover - defensive
+            pass
+
+    return errors
+
+
+__all__ = [
+    "CONFIG_VERSION",
+    "ActionConfigModel",
+    "ConfigError",
+    "GISPulseConfig",
+    "RuntimeConfigModel",
+    "SecurityConfigModel",
+    "TriggerConfigModel",
+    "load_config",
+    "to_triggers",
+    "validate_against_gpkg",
+]

--- a/gispulse/runtime/config_loader.py
+++ b/gispulse/runtime/config_loader.py
@@ -153,6 +153,33 @@ class TriggerConfigModel(BaseModel):
                 seen.append(op)
         return seen
 
+    @field_validator("predicate")
+    @classmethod
+    def _validate_predicate_dsl(cls, v: str | None) -> str | None:
+        """Compile the predicate string at config-load time.
+
+        We only call ``parse_predicate`` for its side effect — the
+        compiled AST is recomputed in :func:`to_triggers` so the
+        pydantic model stays a pure data carrier (frozen-friendly,
+        JSON-serialisable for ``triggers validate --json``). Surfacing
+        DSL errors here means ``triggers validate`` can flag them as
+        config errors instead of letting them blow up the first tick.
+        """
+        if v is None:
+            return None
+        # Local import keeps the module import-light; the DSL only
+        # matters when there's a predicate to compile.
+        from gispulse.runtime.predicate_dsl import (
+            PredicateError,
+            parse_predicate,
+        )
+
+        try:
+            parse_predicate(v)
+        except PredicateError as exc:
+            raise ValueError(f"predicate parse failed: {exc}") from exc
+        return v
+
 
 class SecurityConfigModel(BaseModel):
     model_config = ConfigDict(extra="forbid")
@@ -353,16 +380,20 @@ def to_triggers(config: GISPulseConfig) -> list["Trigger"]:
         - ``type: log_event`` ─▶ ``ActionType.LOG_EVENT``
         - ``type: notify`` ─▶ ``ActionType.NOTIFY``
 
-    Predicate strings are stored verbatim under
-    ``Trigger.conditions["predicate"]`` for now — full parsing into
-    :class:`AttrPredicate` is deferred to S4 (predicate DSL story). The
-    current evaluator falls back to ``matched=True`` when no
-    :class:`Trigger.predicates` are set, so trigger actions still fire
-    on every change while we wait for the DSL.
+    Predicate handling (S4)
+    -----------------------
+    When ``predicate:`` is set on the YAML entry, the DSL string is
+    parsed into a :class:`PredicateNode` AST and stored under
+    ``Trigger.conditions["predicate_ast"]``. The verbatim source stays
+    in ``conditions["predicate"]`` for round-trip / observability. The
+    headless runtime evaluates the AST against the row payload before
+    dispatching any action; trigger entries without a predicate keep
+    the pre-S4 always-fire behaviour.
     """
     from core.graph import ActionDef, ActionType
     from core.enums import TriggerEvent, TriggerType, TriggerCategory
     from core.models import Trigger
+    from gispulse.runtime.predicate_dsl import parse_predicate
 
     type_map = {
         "webhook": ActionType.WEBHOOK,
@@ -404,6 +435,12 @@ def to_triggers(config: GISPulseConfig) -> list["Trigger"]:
         }
         if entry.predicate:
             conditions["predicate"] = entry.predicate
+            # Compile the DSL and stash the AST. The pydantic validator
+            # already parsed it once for early error surfacing; we
+            # re-parse here so the runtime path holds an AST object
+            # rather than a string. This is a few µs and keeps the
+            # config model JSON-serialisable.
+            conditions["predicate_ast"] = parse_predicate(entry.predicate)
 
         trigger = Trigger(
             name=entry.name,

--- a/gispulse/runtime/config_loader.py
+++ b/gispulse/runtime/config_loader.py
@@ -52,11 +52,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterable, Literal
 from uuid import uuid4
 
-import yaml
+import yaml  # type: ignore[import-untyped]
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 if TYPE_CHECKING:  # pragma: no cover
-    from core.models import ActionDef, Trigger
+    from core.graph import ActionDef
+    from core.models import Trigger
 
 
 CONFIG_VERSION = 1
@@ -127,7 +128,14 @@ class TriggerConfigModel(BaseModel):
     table: str = Field(min_length=1, max_length=120)
     pk_col: str = Field(default="fid", min_length=1, max_length=64)
     when: list[Literal["INSERT", "UPDATE", "DELETE"]] = Field(
-        default_factory=lambda: list(_SUPPORTED_DML_OPS),
+        # mypy can't widen ``list[str]`` into the Literal[...] union mode
+        # the BaseModel field expects; the runtime values are perfectly
+        # fine because pydantic re-validates them at construction time.
+        default_factory=lambda: [  # type: ignore[arg-type]
+            "INSERT",
+            "UPDATE",
+            "DELETE",
+        ],
     )
     predicate: str | None = None
     actions: list[ActionConfigModel] = Field(default_factory=list)
@@ -182,10 +190,19 @@ def _safe_anchors() -> list[Path]:
     """Return the directories under which user-controlled paths are
     accepted. Anything resolved outside of these roots is rejected.
 
-    We accept ``cwd`` and ``$HOME``. Operators wanting a hardened deploy
-    can ``cd`` into the project root before running the CLI, and the
-    ``--gpkg`` override goes through the same check.
+    We accept:
+      * ``cwd``                — the canonical operator location.
+      * ``$HOME``              — typical config locations under ``~``.
+      * ``tempfile.gettempdir()`` — CI runners and ephemeral pipelines.
+
+    Operators wanting a hardened deploy can ``cd`` into the project
+    root before running the CLI, and the ``--gpkg`` override goes
+    through the same check. The ``GISPULSE_CONFIG_ALLOW_ROOTS`` env
+    var can extend the list at runtime (colon-separated).
     """
+    import os as _os
+    import tempfile
+
     anchors: list[Path] = []
     try:
         anchors.append(Path.cwd().resolve())
@@ -195,7 +212,29 @@ def _safe_anchors() -> list[Path]:
         anchors.append(Path.home().resolve())
     except (OSError, RuntimeError):
         pass
-    return anchors
+    try:
+        anchors.append(Path(tempfile.gettempdir()).resolve())
+    except OSError:  # pragma: no cover - defensive
+        pass
+
+    extra = _os.environ.get("GISPULSE_CONFIG_ALLOW_ROOTS", "")
+    for raw in extra.split(":"):
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            anchors.append(Path(raw).expanduser().resolve())
+        except OSError:  # pragma: no cover - defensive
+            continue
+
+    # Deduplicate while preserving order.
+    seen: set[Path] = set()
+    unique: list[Path] = []
+    for a in anchors:
+        if a not in seen:
+            seen.add(a)
+            unique.append(a)
+    return unique
 
 
 def _check_within_anchors(path: Path, anchors: Iterable[Path]) -> None:

--- a/gispulse/runtime/headless_runtime.py
+++ b/gispulse/runtime/headless_runtime.py
@@ -1,0 +1,345 @@
+"""Headless trigger runtime for GISPulse Mode 1 (CLI/SDK).
+
+This module is the FastAPI-free counterpart of the lifespan-bound
+trigger wiring at ``gispulse/adapters/http/app.py:309-391``. The HTTP
+server reproduces the same plumbing inside an ``@asynccontextmanager``
+because it also needs uvicorn and the WebSocket fan-out; here we only
+need a single tick (``run_once``) or a daemon-friendly start/stop pair.
+
+Architecture (Mode 1, GPKG):
+
+    GPKG SQLite triggers ──▶ _gispulse_change_log
+                                    │
+                                    │  (poll)
+                                    ▼
+                          ChangeLogWatcher._tick()
+                                    │
+                                    ├──▶ NullEventHub.broadcast(...)  (no-op)
+                                    │
+                                    ├──▶ TriggerEvaluator.evaluate(...)
+                                    │
+                                    └──▶ ActionDispatcher.dispatch_all(
+                                            WEBHOOK / SET_FIELD / RUN_SQL / ...
+                                        )
+
+Thread safety
+-------------
+``ChangeLogWatcher`` runs the polling loop on a daemon thread.
+:meth:`HeadlessRuntime.run_once` does **not** start that thread — it
+manually drives a single ``_tick()`` for ``--once`` mode so the CLI can
+exit cleanly. :meth:`HeadlessRuntime.start` / :meth:`stop` are exposed
+for future ``--watch`` mode (S5) but stay unused this PR.
+
+AGPL note
+---------
+Imports are restricted to the public OSS tree (``gispulse.*``,
+``persistence.*``, ``rules.*``, ``core.*``, ``capabilities.*``). The
+runtime never reaches into ``gispulse-enterprise``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import warnings
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Sequence
+
+from core.logging import get_logger
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from core.models import Trigger
+    from gispulse.adapters.esb.action_dispatcher import ActionDispatcher
+    from persistence.change_log_watcher import ChangeLogWatcher
+    from persistence.gpkg_engine import GeoPackageEngine
+
+log = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# NullEventHub — no-op stand-in for adapters/http/event_hub.EventHub
+# ---------------------------------------------------------------------------
+
+
+class NullEventHub:
+    """Drop-in :class:`EventHub` replacement that swallows every broadcast.
+
+    The watcher and the dispatcher both call ``hub.broadcast(event_type,
+    data)``. In Mode 1 we have no WebSocket fan-out — those events are
+    not observed, so we accept and discard them.
+
+    The HTTP ``EventHub`` also exposes ``bind_loop`` and a coroutine
+    ``subscribe`` API; we deliberately do **not** implement those here
+    because the headless path is single-threaded from the dispatcher's
+    point of view (the watcher thread broadcasts, the hub no-ops).
+    """
+
+    def broadcast(  # pragma: no cover - trivial stub
+        self,
+        event_type: str,
+        data: dict[str, Any] | None = None,
+    ) -> None:
+        """No-op: discard the event payload."""
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Runtime handle
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class HeadlessRuntime:
+    """Bundle of objects returned by :func:`build_runtime`.
+
+    Lifecycle:
+        - ``run_once()``  — drive a single watcher tick, then return
+                            (used by ``gispulse triggers run --once``).
+        - ``start()`` / ``stop()`` — start the polling daemon thread
+                            (reserved for ``--watch``, not exposed yet).
+        - ``close()``     — close the underlying GPKG engine.
+    """
+
+    engine: "GeoPackageEngine"
+    event_hub: NullEventHub
+    action_dispatcher: "ActionDispatcher"
+    watcher: "ChangeLogWatcher"
+    triggers: list["Trigger"] = field(default_factory=list)
+    gpkg_path: Path = field(default_factory=Path)
+
+    def run_once(self) -> int:
+        """Run one polling tick. Returns the number of change-log rows
+        processed.
+
+        Notes:
+            - The watcher's daemon thread is **not** started; we drive
+              ``_tick()`` directly so the CLI can exit cleanly without
+              relying on ``stop()`` join semantics.
+            - ``_tick()`` swallows broadcast / dispatch failures
+              internally (per-row try/except), so a single bad webhook
+              does not abort the batch.
+        """
+        # ``_tick`` is "private" but documented as the unit of work and
+        # is safe to call directly: the public ``start()`` / ``stop()``
+        # only adds the daemon thread + sleep loop on top.
+        return self.watcher._tick()  # noqa: SLF001 - intentional
+
+    def start(self) -> None:
+        """Start the polling daemon thread (reserved for ``--watch``)."""
+        self.watcher.start()
+
+    def stop(self) -> None:
+        """Stop the polling daemon thread (reserved for ``--watch``)."""
+        self.watcher.stop()
+
+    def close(self) -> None:
+        """Release the underlying GPKG engine."""
+        try:
+            self.engine.close()
+        except Exception as exc:  # pragma: no cover - defensive
+            log.warning("headless_runtime_close_failed", error=str(exc))
+
+    # Context manager sugar so callers can ``with build_runtime(...) as rt:``
+    def __enter__(self) -> "HeadlessRuntime":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # noqa: D401, ANN001
+        self.close()
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+def _check_pragmas(engine: "GeoPackageEngine") -> None:
+    """Verify the GPKG opened in WAL mode with a sensible busy timeout.
+
+    The engine sets ``journal_mode=WAL`` + ``busy_timeout=5000`` in
+    ``_open_conn``. We re-check at runtime startup so an externally
+    re-created GPKG (or one opened in DELETE mode by a rogue tool) is
+    surfaced loudly instead of silently bottlenecking the watcher.
+    """
+    conn = engine._get_conn()  # noqa: SLF001 - documented internal accessor
+
+    journal_mode = ""
+    busy_timeout = 0
+    try:
+        cur = conn.execute("PRAGMA journal_mode")
+        row = cur.fetchone()
+        if row is not None:
+            journal_mode = str(row[0]).lower()
+        cur = conn.execute("PRAGMA busy_timeout")
+        row = cur.fetchone()
+        if row is not None:
+            busy_timeout = int(row[0])
+    except sqlite3.Error as exc:  # pragma: no cover - defensive
+        log.warning("pragma_check_failed", error=str(exc))
+        return
+
+    if journal_mode != "wal":
+        warnings.warn(
+            f"GPKG journal_mode is {journal_mode!r}, not 'wal'. Concurrent "
+            "writers may block the trigger watcher.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+    if busy_timeout < 5000:
+        warnings.warn(
+            f"GPKG busy_timeout is {busy_timeout} ms (< 5000 ms). The watcher "
+            "may raise SQLITE_BUSY under load.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
+
+def build_runtime(
+    gpkg_path: str | Path,
+    triggers: Sequence["Trigger"],
+    *,
+    webhook_allowlist: Iterable[str] | None = None,
+    poll_interval: float = 1.0,
+    batch_limit: int = 200,
+    dataset_id: str = "__cli__",
+    sql_executor: Callable[..., Any] | None = None,
+    webhook_client: Callable[[str, dict[str, Any]], None] | None = None,
+) -> HeadlessRuntime:
+    """Wire a headless trigger runtime over a single GPKG file.
+
+    This reproduces the FastAPI lifespan wiring at
+    ``adapters/http/app.py:309-391`` minus the HTTP server, the job
+    worker, and the scheduler.
+
+    Args:
+        gpkg_path:         Path to the project GPKG. Must already be a
+                           valid GeoPackage (the engine bootstraps the
+                           internal tables on open).
+        triggers:          List of :class:`Trigger` instances to evaluate.
+                           Stored at runtime build time (snapshot).
+                           ``--watch`` will re-poll this list each tick
+                           via the embedded ``triggers_provider``.
+        webhook_allowlist: When provided, restrict outbound webhook URLs
+                           to hosts in this set. Empty/None disables the
+                           filter (default ``HttpWebhookClient`` SSRF
+                           policy still applies).
+        poll_interval:     Seconds between two ``_tick`` calls when the
+                           daemon thread is started (``--watch``). The
+                           ``run_once`` path ignores this value.
+        batch_limit:       Max change-log rows pulled per tick.
+        dataset_id:        Synthetic id stamped onto every broadcast
+                           payload. Mandatory non-empty per the watcher
+                           contract.
+        sql_executor:      Optional ``(sql, params) -> Any`` callable
+                           injected into the dispatcher. Defaults to
+                           ``engine.execute`` if available.
+        webhook_client:    Optional ``(url, payload) -> None`` callable
+                           injected into the dispatcher. Defaults to
+                           :class:`HttpWebhookClient`.
+
+    Returns:
+        A :class:`HeadlessRuntime` ready for ``run_once()`` or daemon
+        ``start()`` / ``stop()``.
+
+    Raises:
+        ValueError:    Empty ``dataset_id`` or non-positive intervals.
+        FileNotFoundError: ``gpkg_path`` does not exist.
+    """
+    # Lazy imports keep CLI startup snappy: we only need rules / esb
+    # when the user actually runs ``triggers``.
+    from gispulse.adapters.esb.action_dispatcher import ActionDispatcher
+    from gispulse.adapters.webhooks import HttpWebhookClient
+    from persistence.change_log_watcher import ChangeLogWatcher
+    from persistence.gpkg_engine import GeoPackageEngine
+
+    if poll_interval <= 0:
+        raise ValueError("poll_interval must be > 0")
+    if batch_limit <= 0:
+        raise ValueError("batch_limit must be > 0")
+    if not isinstance(dataset_id, str) or not dataset_id:
+        raise ValueError("dataset_id must be a non-empty string")
+
+    gpkg = Path(gpkg_path).expanduser()
+    if not gpkg.exists():
+        raise FileNotFoundError(f"GPKG not found: {gpkg}")
+
+    # ---- Engine -------------------------------------------------------
+    engine = GeoPackageEngine(path=gpkg)
+    engine.open()
+    _check_pragmas(engine)
+
+    # ---- EventHub (no-op) --------------------------------------------
+    hub = NullEventHub()
+
+    # ---- ActionDispatcher --------------------------------------------
+    # Match app.py wiring: sql_executor falls back to engine.execute,
+    # webhook_client to HttpWebhookClient.post (SSRF-safe by default).
+    if sql_executor is None:
+        sql_executor = getattr(engine, "execute", None)
+
+    if webhook_client is None:
+        # Optional allowlist: when set, wrap the SSRF-safe client with
+        # an extra host check so operators can pin outbound traffic to
+        # specific destinations even on local fixtures (where the SSRF
+        # blocklist alone would refuse RFC1918).
+        from urllib.parse import urlparse
+
+        base_client = HttpWebhookClient()
+        allowlist = (
+            {host.strip().lower() for host in webhook_allowlist if host.strip()}
+            if webhook_allowlist
+            else None
+        )
+
+        def _post_with_allowlist(url: str, payload: dict[str, Any]) -> None:
+            if allowlist:
+                host = (urlparse(url).hostname or "").lower()
+                if host not in allowlist:
+                    raise PermissionError(
+                        f"Webhook host {host!r} not in allowlist {sorted(allowlist)!r}"
+                    )
+            base_client.post(url, payload)
+
+        webhook_client = _post_with_allowlist
+
+    dispatcher = ActionDispatcher(
+        event_hub=hub,
+        sql_executor=sql_executor,
+        webhook_client=webhook_client,
+    )
+
+    # ---- ChangeLogWatcher --------------------------------------------
+    trigger_list = list(triggers)
+
+    def _triggers_provider() -> list["Trigger"]:
+        # Snapshot reference: callers can mutate the original list and
+        # pick up changes on the next tick (matches the API behaviour).
+        return [t for t in trigger_list if getattr(t, "enabled", True)]
+
+    watcher = ChangeLogWatcher(
+        engine=engine,
+        event_hub=hub,
+        dataset_id=dataset_id,
+        poll_interval=poll_interval,
+        batch_limit=batch_limit,
+        triggers_provider=_triggers_provider,
+        action_dispatcher=dispatcher,
+    )
+
+    log.info(
+        "headless_runtime_built",
+        gpkg=str(gpkg),
+        triggers=len(trigger_list),
+        webhook_allowlist=sorted(allowlist) if webhook_allowlist else None,
+    )
+
+    return HeadlessRuntime(
+        engine=engine,
+        event_hub=hub,
+        action_dispatcher=dispatcher,
+        watcher=watcher,
+        triggers=trigger_list,
+        gpkg_path=gpkg,
+    )
+
+
+__all__ = ["HeadlessRuntime", "NullEventHub", "build_runtime"]

--- a/gispulse/runtime/headless_runtime.py
+++ b/gispulse/runtime/headless_runtime.py
@@ -50,6 +50,7 @@ from core.logging import get_logger
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from core.models import Trigger
     from gispulse.adapters.esb.action_dispatcher import ActionDispatcher
+    from gispulse.runtime.sqlite_retry import RetryingSqlExecutor
     from persistence.change_log_watcher import ChangeLogWatcher
     from persistence.gpkg_engine import GeoPackageEngine
 
@@ -106,6 +107,12 @@ class HeadlessRuntime:
     watcher: "ChangeLogWatcher"
     triggers: list["Trigger"] = field(default_factory=list)
     gpkg_path: Path = field(default_factory=Path)
+    # When the caller did not inject a custom ``sql_executor``, this
+    # holds the :class:`RetryingSqlExecutor` wrapper installed around
+    # ``engine.execute`` (S5). The CLI ``--watch`` mode reads
+    # ``.snapshot_retries()`` per tick to populate the JSON log.
+    # ``None`` when no executor is configured at all.
+    retrying_sql: "RetryingSqlExecutor | None" = None
 
     def run_once(self) -> int:
         """Run one polling tick. Returns the number of change-log rows
@@ -253,6 +260,7 @@ def build_runtime(
     # when the user actually runs ``triggers``.
     from gispulse.adapters.esb.action_dispatcher import ActionDispatcher
     from gispulse.adapters.webhooks import HttpWebhookClient
+    from gispulse.runtime.sqlite_retry import RetryingSqlExecutor
     from persistence.change_log_watcher import ChangeLogWatcher
     from persistence.gpkg_engine import GeoPackageEngine
 
@@ -278,8 +286,20 @@ def build_runtime(
     # ---- ActionDispatcher --------------------------------------------
     # Match app.py wiring: sql_executor falls back to engine.execute,
     # webhook_client to HttpWebhookClient.post (SSRF-safe by default).
+    #
+    # S5: wrap whatever executor we end up with in a
+    # :class:`RetryingSqlExecutor` so transient ``SQLITE_BUSY`` errors
+    # (concurrent QGIS save, peer GISPulse tick) get up to 5 backoff
+    # retries instead of failing the action on first lock contention.
+    # Permanent errors (no such table, syntax) bypass the retry and
+    # surface immediately. The wrapper exposes ``snapshot_retries`` so
+    # the CLI ``--watch`` daemon can include the count in its tick log.
     if sql_executor is None:
         sql_executor = getattr(engine, "execute", None)
+    retrying_sql: RetryingSqlExecutor | None = None
+    if sql_executor is not None:
+        retrying_sql = RetryingSqlExecutor(sql_executor)
+        sql_executor = retrying_sql
 
     # Build the allowlist once (used both for logging and as the
     # default-client wrapper). When the caller injects an explicit
@@ -350,6 +370,7 @@ def build_runtime(
         watcher=watcher,
         triggers=trigger_list,
         gpkg_path=gpkg,
+        retrying_sql=retrying_sql,
     )
 
 

--- a/gispulse/runtime/headless_runtime.py
+++ b/gispulse/runtime/headless_runtime.py
@@ -143,7 +143,12 @@ class HeadlessRuntime:
     def __enter__(self) -> "HeadlessRuntime":
         return self
 
-    def __exit__(self, exc_type, exc, tb) -> None:  # noqa: D401, ANN001
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: Any,
+    ) -> None:
         self.close()
 
 
@@ -276,6 +281,16 @@ def build_runtime(
     if sql_executor is None:
         sql_executor = getattr(engine, "execute", None)
 
+    # Build the allowlist once (used both for logging and as the
+    # default-client wrapper). When the caller injects an explicit
+    # ``webhook_client`` we still keep the allowlist around for
+    # observability without enforcing it on the injected callable.
+    allowlist: set[str] | None = (
+        {host.strip().lower() for host in webhook_allowlist if host.strip()}
+        if webhook_allowlist
+        else None
+    )
+
     if webhook_client is None:
         # Optional allowlist: when set, wrap the SSRF-safe client with
         # an extra host check so operators can pin outbound traffic to
@@ -284,18 +299,14 @@ def build_runtime(
         from urllib.parse import urlparse
 
         base_client = HttpWebhookClient()
-        allowlist = (
-            {host.strip().lower() for host in webhook_allowlist if host.strip()}
-            if webhook_allowlist
-            else None
-        )
 
         def _post_with_allowlist(url: str, payload: dict[str, Any]) -> None:
             if allowlist:
                 host = (urlparse(url).hostname or "").lower()
                 if host not in allowlist:
                     raise PermissionError(
-                        f"Webhook host {host!r} not in allowlist {sorted(allowlist)!r}"
+                        f"Webhook host {host!r} not in allowlist "
+                        f"{sorted(allowlist)!r}"
                     )
             base_client.post(url, payload)
 
@@ -329,7 +340,7 @@ def build_runtime(
         "headless_runtime_built",
         gpkg=str(gpkg),
         triggers=len(trigger_list),
-        webhook_allowlist=sorted(allowlist) if webhook_allowlist else None,
+        webhook_allowlist=sorted(allowlist) if allowlist else None,
     )
 
     return HeadlessRuntime(

--- a/gispulse/runtime/predicate_dsl.py
+++ b/gispulse/runtime/predicate_dsl.py
@@ -1,0 +1,925 @@
+"""Predicate DSL parser for ``gispulse triggers`` (S4).
+
+Why a dedicated parser
+----------------------
+The trigger YAML config (Mode 1) lets the operator filter rows with a
+human-readable predicate string::
+
+    triggers:
+      - name: high_value_parcels
+        table: parcels
+        predicate: "valeur > 100 AND status == 'pending'"
+
+The HTTP path uses *structured* predicates (``AttrPredicate`` /
+``CompoundPredicate`` dataclasses defined in ``core/predicates.py``). The
+in-memory evaluator in ``rules/predicates.py`` already knows how to walk
+that AST against a row payload. This module bridges the two: it turns
+the DSL string into the same structured AST so the runtime reuses the
+existing evaluator without parallel logic.
+
+Grammar (LL(1), recursive-descent)
+----------------------------------
+
+::
+
+    predicate  := or_expr
+    or_expr    := and_expr ("OR" and_expr)*
+    and_expr   := not_expr ("AND" not_expr)*
+    not_expr   := "NOT" not_expr | comparison
+    comparison := attr op literal
+                | attr "IS" "NOT"? "NULL"
+                | attr ("NOT" "IN" | "IN") list_literal
+                | "(" or_expr ")"
+    attr       := identifier ("." identifier)*
+    op         := "==" | "!=" | ">" | ">=" | "<" | "<="
+    literal    := number | string | boolean | "null"
+    list_literal := "[" literal ("," literal)* "]"
+
+Security guarantees
+-------------------
+* No ``eval`` / ``exec`` / ``compile`` / ``simpleeval`` — the parser is
+  100% explicit, hand-written recursive descent.
+* Operator alphabet is a closed whitelist. Unknown tokens raise
+  ``PredicateSyntaxError`` with line/column context.
+* Right-hand side of comparisons is *literal only*. Function calls,
+  attribute access on RHS, and dunder identifiers are rejected.
+* Identifiers are restricted to ``[A-Za-z_][A-Za-z0-9_]*`` segments
+  joined by dots. Dunder names (``__class__`` etc.) are refused.
+* Maximum nesting depth (default 32) protects against stack-blowing
+  payloads. Configurable via ``MAX_DEPTH``.
+* NUL bytes and non-printable control characters in the input are
+  rejected before parsing.
+
+UPDATE row semantics
+--------------------
+For UPDATE rows, the runtime supplies a payload that exposes both the
+old and new values:
+
+* Bare attributes (``status``)        → ``new.status`` (familiar SQL feel).
+* Explicit ``new.status``             → new row column.
+* Explicit ``old.status``             → old row column.
+
+INSERT and DELETE rows expose only one snapshot; ``old.*`` on INSERT
+returns ``None`` (and therefore comparisons fail unless the operator is
+``is_null``).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Iterable
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from core.predicates import AnyPredicate
+
+log = logging.getLogger(__name__)
+
+# Maximum recursion depth allowed during parsing AND evaluation. The
+# parser nests once per left-paren / NOT / binary-op; 32 covers any
+# reasonable hand-written predicate while safely rejecting adversarial
+# 1000-deep payloads in <1 ms.
+MAX_DEPTH = 32
+
+# Reserved keywords (case-insensitive). They cannot appear as bare
+# identifiers, so a column literally called ``and`` would have to be
+# quoted — fine for a YAML config DSL.
+_KEYWORDS: frozenset[str] = frozenset(
+    {"AND", "OR", "NOT", "IN", "IS", "NULL", "TRUE", "FALSE"}
+)
+
+# Identifier segment ([A-Za-z_][A-Za-z0-9_]*). We also reject any segment
+# starting OR ending with double-underscore to keep dunders out (defense
+# in depth — even though we never call getattr on the row dict).
+_IDENT_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class PredicateError(ValueError):
+    """Base class for DSL errors (parsing or evaluation)."""
+
+
+class PredicateSyntaxError(PredicateError):
+    """Raised when the DSL source is syntactically invalid.
+
+    Carries ``line``/``col`` so CLI callers can format a
+    ``triggers validate`` style error message.
+    """
+
+    def __init__(self, message: str, *, line: int = 1, col: int = 1) -> None:
+        super().__init__(f"line {line}, col {col}: {message}")
+        self.line = line
+        self.col = col
+
+
+class PredicateDepthError(PredicateError):
+    """Raised when the parser/evaluator detects unsafe nesting."""
+
+
+class PredicateEvalError(PredicateError):
+    """Raised at evaluation time (e.g. type mismatch with ``WARN`` policy
+    disabled)."""
+
+
+# ---------------------------------------------------------------------------
+# Token model
+# ---------------------------------------------------------------------------
+
+
+class _TokenKind(str, Enum):
+    LPAREN = "("
+    RPAREN = ")"
+    LBRACKET = "["
+    RBRACKET = "]"
+    COMMA = ","
+    OP = "op"          # ==, !=, >, >=, <, <=
+    IDENT = "ident"    # bare identifier or attribute path
+    NUMBER = "num"
+    STRING = "str"
+    KEYWORD = "kw"     # AND/OR/NOT/IN/IS/NULL/TRUE/FALSE
+    EOF = "eof"
+
+
+@dataclass(frozen=True)
+class _Token:
+    kind: _TokenKind
+    value: Any
+    line: int
+    col: int
+
+
+# ---------------------------------------------------------------------------
+# Lexer
+# ---------------------------------------------------------------------------
+
+
+_OP_TWO_CHAR = {"==", "!=", ">=", "<="}
+_OP_ONE_CHAR = {">", "<"}
+
+
+class _Lexer:
+    """Hand-rolled tokenizer for the DSL.
+
+    Drops whitespace and ``#`` line comments. Tracks line/column for
+    diagnostic messages.
+    """
+
+    def __init__(self, source: str) -> None:
+        self._src = source
+        self._n = len(source)
+        self._i = 0
+        self._line = 1
+        self._col = 1
+
+    def tokenize(self) -> list[_Token]:
+        """Return the full token list (including a trailing EOF)."""
+        # Hard guard: NUL byte / non-printable control chars are a
+        # smell (binary smuggle, copy-paste from PDF, etc.).
+        for ch in self._src:
+            if ch == "\x00":
+                raise PredicateSyntaxError("NUL byte in predicate")
+            if ord(ch) < 32 and ch not in ("\n", "\r", "\t"):
+                raise PredicateSyntaxError(
+                    f"non-printable control char U+{ord(ch):04X}"
+                )
+
+        tokens: list[_Token] = []
+        while self._i < self._n:
+            self._skip_ws_and_comments()
+            if self._i >= self._n:
+                break
+            ch = self._src[self._i]
+            if ch == "(":
+                tokens.append(self._emit(_TokenKind.LPAREN, "("))
+                self._advance()
+            elif ch == ")":
+                tokens.append(self._emit(_TokenKind.RPAREN, ")"))
+                self._advance()
+            elif ch == "[":
+                tokens.append(self._emit(_TokenKind.LBRACKET, "["))
+                self._advance()
+            elif ch == "]":
+                tokens.append(self._emit(_TokenKind.RBRACKET, "]"))
+                self._advance()
+            elif ch == ",":
+                tokens.append(self._emit(_TokenKind.COMMA, ","))
+                self._advance()
+            elif ch in ("'", '"'):
+                tokens.append(self._read_string(ch))
+            elif ch.isdigit() or (
+                ch in ("-", "+")
+                and self._i + 1 < self._n
+                and self._src[self._i + 1].isdigit()
+                and self._can_start_number(tokens)
+            ):
+                tokens.append(self._read_number())
+            elif self._starts_with_two(ch):
+                tokens.append(self._emit(_TokenKind.OP, self._src[self._i : self._i + 2]))
+                self._advance()
+                self._advance()
+            elif ch in _OP_ONE_CHAR:
+                tokens.append(self._emit(_TokenKind.OP, ch))
+                self._advance()
+            elif _IDENT_RE.match(self._src, self._i):
+                tokens.append(self._read_ident_or_keyword())
+            else:
+                raise PredicateSyntaxError(
+                    f"unexpected character {ch!r}", line=self._line, col=self._col
+                )
+
+        tokens.append(_Token(_TokenKind.EOF, None, self._line, self._col))
+        return tokens
+
+    # -- helpers -----------------------------------------------------------
+
+    def _emit(self, kind: _TokenKind, value: Any) -> _Token:
+        return _Token(kind, value, self._line, self._col)
+
+    def _advance(self) -> None:
+        if self._i < self._n and self._src[self._i] == "\n":
+            self._line += 1
+            self._col = 1
+        else:
+            self._col += 1
+        self._i += 1
+
+    def _skip_ws_and_comments(self) -> None:
+        while self._i < self._n:
+            ch = self._src[self._i]
+            if ch in " \t\r\n":
+                self._advance()
+            elif ch == "#":
+                # Line comment: skip until newline.
+                while self._i < self._n and self._src[self._i] != "\n":
+                    self._advance()
+            else:
+                return
+
+    def _starts_with_two(self, ch: str) -> bool:
+        if self._i + 1 >= self._n:
+            return False
+        two = self._src[self._i : self._i + 2]
+        return two in _OP_TWO_CHAR
+
+    def _can_start_number(self, tokens: list[_Token]) -> bool:
+        """Return True when a leading ``-``/``+`` belongs to a numeric
+        literal (after an op/comma/lparen/lbracket) rather than being
+        part of a (currently unsupported) arithmetic expression.
+        """
+        if not tokens:
+            return True
+        last = tokens[-1]
+        return last.kind in (
+            _TokenKind.OP,
+            _TokenKind.COMMA,
+            _TokenKind.LPAREN,
+            _TokenKind.LBRACKET,
+            _TokenKind.KEYWORD,
+        )
+
+    def _read_string(self, quote: str) -> _Token:
+        start_line, start_col = self._line, self._col
+        self._advance()  # skip opening quote
+        buf: list[str] = []
+        while self._i < self._n:
+            ch = self._src[self._i]
+            if ch == "\\":
+                # Minimal escape support: \\, \', \", \n, \t, \r
+                self._advance()
+                if self._i >= self._n:
+                    raise PredicateSyntaxError(
+                        "unterminated escape", line=start_line, col=start_col
+                    )
+                esc = self._src[self._i]
+                buf.append({"n": "\n", "t": "\t", "r": "\r"}.get(esc, esc))
+                self._advance()
+                continue
+            if ch == quote:
+                self._advance()
+                return _Token(_TokenKind.STRING, "".join(buf), start_line, start_col)
+            buf.append(ch)
+            self._advance()
+        raise PredicateSyntaxError(
+            "unterminated string literal", line=start_line, col=start_col
+        )
+
+    def _read_number(self) -> _Token:
+        start_line, start_col = self._line, self._col
+        start = self._i
+        if self._src[self._i] in ("-", "+"):
+            self._advance()
+        while self._i < self._n and (
+            self._src[self._i].isdigit() or self._src[self._i] in "._eE+-"
+        ):
+            # We accept '.', 'e', 'E' and signed exponents; we'll let
+            # ``float()`` validate. Keep the loop conservative so we
+            # don't swallow a trailing comma.
+            ch = self._src[self._i]
+            if ch in "+-":
+                # Only accept after exponent char.
+                prev = self._src[self._i - 1]
+                if prev not in "eE":
+                    break
+            self._advance()
+        text = self._src[start : self._i]
+        try:
+            if any(c in text for c in ".eE"):
+                value: Any = float(text)
+            else:
+                value = int(text)
+        except ValueError as exc:
+            raise PredicateSyntaxError(
+                f"invalid number {text!r}", line=start_line, col=start_col
+            ) from exc
+        return _Token(_TokenKind.NUMBER, value, start_line, start_col)
+
+    def _read_ident_or_keyword(self) -> _Token:
+        start_line, start_col = self._line, self._col
+        start = self._i
+        # Identifiers may be dotted: foo.bar.baz
+        while self._i < self._n:
+            m = _IDENT_RE.match(self._src, self._i)
+            if not m:
+                break
+            seg = m.group(0)
+            # Reject dunder segments (defense in depth).
+            if seg.startswith("__") or seg.endswith("__"):
+                raise PredicateSyntaxError(
+                    f"dunder identifier rejected: {seg!r}",
+                    line=start_line,
+                    col=start_col,
+                )
+            self._i = m.end()
+            self._col += len(seg)
+            if self._i < self._n and self._src[self._i] == ".":
+                self._advance()
+                continue
+            break
+        text = self._src[start : self._i]
+        upper = text.upper()
+        if upper in _KEYWORDS:
+            return _Token(_TokenKind.KEYWORD, upper, start_line, start_col)
+        # ``true``/``false``/``null`` (lowercase) get folded into keywords too.
+        if upper in {"TRUE", "FALSE", "NULL"}:
+            return _Token(_TokenKind.KEYWORD, upper, start_line, start_col)
+        return _Token(_TokenKind.IDENT, text, start_line, start_col)
+
+
+# ---------------------------------------------------------------------------
+# AST nodes (independent of core.predicates so the parser stays self-contained
+# and core remains domain-only). We compile to core dataclasses lazily.
+# ---------------------------------------------------------------------------
+
+
+class _NodeKind(str, Enum):
+    AND = "and"
+    OR = "or"
+    NOT = "not"
+    CMP = "cmp"
+    IS_NULL = "is_null"
+    IS_NOT_NULL = "is_not_null"
+    IN = "in"
+    NOT_IN = "not_in"
+
+
+@dataclass(frozen=True)
+class PredicateNode:
+    """Compiled, immutable AST node."""
+
+    kind: _NodeKind
+    # For CMP/IS_NULL/IN: the attribute path (e.g. ['new', 'status']).
+    attr: tuple[str, ...] = ()
+    # For CMP: the comparison operator (``==``/``!=``/``>``/...).
+    op: str = ""
+    # For CMP: literal (scalar). For IN: tuple of literals.
+    value: Any = None
+    # For AND/OR: child predicates.
+    children: tuple["PredicateNode", ...] = ()
+    # For NOT: single child wrapped in children[0].
+
+    # ---- evaluation --------------------------------------------------
+
+    def evaluate(
+        self, payload: dict[str, Any], *, _depth: int = 0
+    ) -> bool:
+        """Evaluate this node against a payload row dict.
+
+        ``payload`` is expected to expose:
+            * bare column keys (``"status": "pending"``)
+            * ``new.<col>`` keys for UPDATE rows (handled by the runtime)
+            * ``old.<col>`` keys for UPDATE rows (handled by the runtime)
+        """
+        if _depth > MAX_DEPTH:
+            raise PredicateDepthError(
+                f"evaluation depth exceeded {MAX_DEPTH}"
+            )
+
+        if self.kind == _NodeKind.AND:
+            return all(c.evaluate(payload, _depth=_depth + 1) for c in self.children)
+        if self.kind == _NodeKind.OR:
+            return any(c.evaluate(payload, _depth=_depth + 1) for c in self.children)
+        if self.kind == _NodeKind.NOT:
+            return not self.children[0].evaluate(payload, _depth=_depth + 1)
+
+        # Leaf: pull the attribute value once.
+        attr_value = _resolve_attr(self.attr, payload)
+
+        if self.kind == _NodeKind.IS_NULL:
+            return attr_value is None
+        if self.kind == _NodeKind.IS_NOT_NULL:
+            return attr_value is not None
+        if self.kind == _NodeKind.IN:
+            return attr_value in self.value
+        if self.kind == _NodeKind.NOT_IN:
+            return attr_value not in self.value
+        if self.kind == _NodeKind.CMP:
+            return _compare(attr_value, self.op, self.value)
+
+        raise PredicateEvalError(f"unknown node kind: {self.kind!r}")  # pragma: no cover
+
+    # ---- introspection (for tests / round-trip) ----------------------
+
+    def to_dict(self) -> dict[str, Any]:
+        """Stable dict representation, used for golden tests / debug."""
+        out: dict[str, Any] = {"kind": self.kind.value}
+        if self.attr:
+            out["attr"] = list(self.attr)
+        if self.kind == _NodeKind.CMP:
+            out["op"] = self.op
+            out["value"] = self.value
+        if self.kind in (_NodeKind.IN, _NodeKind.NOT_IN):
+            out["value"] = list(self.value)
+        if self.children:
+            out["children"] = [c.to_dict() for c in self.children]
+        return out
+
+
+def _resolve_attr(path: tuple[str, ...], payload: dict[str, Any]) -> Any:
+    """Walk a dotted attribute path against the payload.
+
+    The runtime exposes ``new.*`` / ``old.*`` keys as flat strings
+    (``"new.status"``) for UPDATE rows. We try both shapes:
+        1. Flat key: ``payload["new.status"]``.
+        2. Nested:    ``payload["new"]["status"]``.
+
+    Returns ``None`` when the attribute is missing — the evaluator
+    then makes that a fail-safe non-match for value comparisons (and a
+    *match* for ``IS NULL``).
+    """
+    if not path:
+        return None
+
+    # Flat dotted key first (the runtime builds this for old.*/new.*).
+    flat = ".".join(path)
+    if flat in payload:
+        return payload[flat]
+
+    # Nested fallback. Stops as soon as a level is missing or non-mapping.
+    cursor: Any = payload
+    for seg in path:
+        if isinstance(cursor, dict) and seg in cursor:
+            cursor = cursor[seg]
+        else:
+            return None
+    return cursor
+
+
+def _compare(left: Any, op: str, right: Any) -> bool:
+    """Evaluate ``left op right`` with type-tolerant comparison.
+
+    A ``None`` on either side resolves to a non-match (mirrors SQL
+    ``NULL`` semantics where ``NULL = anything`` is unknown). The only
+    exception is ``==`` between two ``None`` values, which is True.
+    """
+    if op == "==":
+        return left == right
+    if op == "!=":
+        return left != right
+
+    if left is None or right is None:
+        return False
+
+    try:
+        if op == ">":
+            return left > right
+        if op == ">=":
+            return left >= right
+        if op == "<":
+            return left < right
+        if op == "<=":
+            return left <= right
+    except TypeError:
+        # Mixed types (e.g. str > int) — log once at WARN level and
+        # treat as a non-match. Callers downstream (CLI / API) flag
+        # this with a counter but never crash the tick.
+        log.warning("predicate_type_mismatch op=%s left=%r right=%r", op, left, right)
+        return False
+
+    raise PredicateEvalError(f"unknown comparison operator: {op!r}")  # pragma: no cover
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+
+_VALID_OPS = {"==", "!=", ">", ">=", "<", "<="}
+
+
+class _Parser:
+    """Recursive-descent parser. One instance per ``parse_predicate`` call."""
+
+    def __init__(self, tokens: list[_Token]) -> None:
+        self._tokens = tokens
+        self._pos = 0
+        self._depth = 0
+
+    # ---- public ---------------------------------------------------------
+
+    def parse(self) -> PredicateNode:
+        node = self._parse_or()
+        if self._peek().kind != _TokenKind.EOF:
+            tok = self._peek()
+            raise PredicateSyntaxError(
+                f"unexpected token {tok.value!r} after predicate",
+                line=tok.line,
+                col=tok.col,
+            )
+        return node
+
+    # ---- helpers --------------------------------------------------------
+
+    def _peek(self) -> _Token:
+        return self._tokens[self._pos]
+
+    def _consume(self) -> _Token:
+        tok = self._tokens[self._pos]
+        self._pos += 1
+        return tok
+
+    def _expect_keyword(self, kw: str) -> _Token:
+        tok = self._peek()
+        if tok.kind != _TokenKind.KEYWORD or tok.value != kw:
+            raise PredicateSyntaxError(
+                f"expected {kw!r}, got {tok.value!r}", line=tok.line, col=tok.col
+            )
+        return self._consume()
+
+    def _enter(self) -> None:
+        self._depth += 1
+        if self._depth > MAX_DEPTH:
+            tok = self._peek()
+            raise PredicateDepthError(
+                f"max nesting depth {MAX_DEPTH} exceeded at line {tok.line}, col {tok.col}"
+            )
+
+    def _exit(self) -> None:
+        self._depth -= 1
+
+    # ---- grammar --------------------------------------------------------
+
+    def _parse_or(self) -> PredicateNode:
+        self._enter()
+        try:
+            left = self._parse_and()
+            terms = [left]
+            while (
+                self._peek().kind == _TokenKind.KEYWORD and self._peek().value == "OR"
+            ):
+                self._consume()
+                terms.append(self._parse_and())
+            if len(terms) == 1:
+                return left
+            return PredicateNode(kind=_NodeKind.OR, children=tuple(terms))
+        finally:
+            self._exit()
+
+    def _parse_and(self) -> PredicateNode:
+        self._enter()
+        try:
+            left = self._parse_not()
+            terms = [left]
+            while (
+                self._peek().kind == _TokenKind.KEYWORD and self._peek().value == "AND"
+            ):
+                self._consume()
+                terms.append(self._parse_not())
+            if len(terms) == 1:
+                return left
+            return PredicateNode(kind=_NodeKind.AND, children=tuple(terms))
+        finally:
+            self._exit()
+
+    def _parse_not(self) -> PredicateNode:
+        if (
+            self._peek().kind == _TokenKind.KEYWORD
+            and self._peek().value == "NOT"
+            # Disambiguate from ``NOT IN`` / ``NOT NULL`` which are
+            # part of comparison productions.
+            and not self._lookahead_is_in_or_null()
+        ):
+            self._consume()
+            self._enter()
+            try:
+                child = self._parse_not()
+            finally:
+                self._exit()
+            return PredicateNode(kind=_NodeKind.NOT, children=(child,))
+        return self._parse_comparison()
+
+    def _lookahead_is_in_or_null(self) -> bool:
+        """``NOT`` is part of ``NOT IN`` / ``IS NOT NULL`` only when an
+        ``IN``/``NULL`` keyword follows. Pure ``NOT <expr>`` does not.
+        """
+        # We're on a NOT token. The previous token is either start, OR, AND,
+        # LPAREN, NOT — never an IDENT — so prefix ``NOT IN`` is impossible
+        # at this position. Safe to always treat as standalone NOT.
+        return False
+
+    def _parse_comparison(self) -> PredicateNode:
+        tok = self._peek()
+        # Parenthesised sub-expression
+        if tok.kind == _TokenKind.LPAREN:
+            self._consume()
+            self._enter()
+            try:
+                inner = self._parse_or()
+            finally:
+                self._exit()
+            close = self._consume()
+            if close.kind != _TokenKind.RPAREN:
+                raise PredicateSyntaxError(
+                    "expected ')'", line=close.line, col=close.col
+                )
+            return inner
+
+        # Comparison: attr op literal | attr IS [NOT] NULL | attr [NOT] IN list
+        attr_path = self._parse_attr_path()
+
+        nxt = self._peek()
+        if nxt.kind == _TokenKind.OP:
+            op = self._consume().value
+            if op not in _VALID_OPS:
+                raise PredicateSyntaxError(
+                    f"unknown operator {op!r}", line=nxt.line, col=nxt.col
+                )
+            value = self._parse_literal()
+            return PredicateNode(
+                kind=_NodeKind.CMP, attr=attr_path, op=op, value=value
+            )
+
+        if nxt.kind == _TokenKind.KEYWORD and nxt.value == "IS":
+            self._consume()
+            negated = False
+            if self._peek().kind == _TokenKind.KEYWORD and self._peek().value == "NOT":
+                self._consume()
+                negated = True
+            self._expect_keyword("NULL")
+            return PredicateNode(
+                kind=_NodeKind.IS_NOT_NULL if negated else _NodeKind.IS_NULL,
+                attr=attr_path,
+            )
+
+        if nxt.kind == _TokenKind.KEYWORD and nxt.value in {"IN", "NOT"}:
+            negated = False
+            if nxt.value == "NOT":
+                self._consume()
+                self._expect_keyword("IN")
+                negated = True
+            else:
+                self._consume()  # IN
+            values = self._parse_list_literal()
+            return PredicateNode(
+                kind=_NodeKind.NOT_IN if negated else _NodeKind.IN,
+                attr=attr_path,
+                value=values,
+            )
+
+        raise PredicateSyntaxError(
+            f"expected comparison operator after attribute, got {nxt.value!r}",
+            line=nxt.line,
+            col=nxt.col,
+        )
+
+    def _parse_attr_path(self) -> tuple[str, ...]:
+        tok = self._peek()
+        if tok.kind != _TokenKind.IDENT:
+            raise PredicateSyntaxError(
+                f"expected attribute identifier, got {tok.value!r}",
+                line=tok.line,
+                col=tok.col,
+            )
+        self._consume()
+        # The lexer already handles dotted segments inside one IDENT
+        # token, so we just split.
+        segments = tuple(str(tok.value).split("."))
+        for seg in segments:
+            if not seg or seg.startswith("__") or seg.endswith("__"):
+                raise PredicateSyntaxError(
+                    f"invalid attribute segment {seg!r}",
+                    line=tok.line,
+                    col=tok.col,
+                )
+        return segments
+
+    def _parse_literal(self) -> Any:
+        tok = self._peek()
+        if tok.kind == _TokenKind.NUMBER or tok.kind == _TokenKind.STRING:
+            self._consume()
+            return tok.value
+        if tok.kind == _TokenKind.KEYWORD and tok.value in {"TRUE", "FALSE", "NULL"}:
+            self._consume()
+            if tok.value == "TRUE":
+                return True
+            if tok.value == "FALSE":
+                return False
+            return None
+        raise PredicateSyntaxError(
+            f"expected literal, got {tok.value!r}", line=tok.line, col=tok.col
+        )
+
+    def _parse_list_literal(self) -> tuple[Any, ...]:
+        tok = self._consume()
+        if tok.kind != _TokenKind.LBRACKET:
+            raise PredicateSyntaxError(
+                f"expected '[' after IN, got {tok.value!r}",
+                line=tok.line,
+                col=tok.col,
+            )
+        items: list[Any] = []
+        if self._peek().kind == _TokenKind.RBRACKET:
+            self._consume()
+            return tuple(items)
+        while True:
+            items.append(self._parse_literal())
+            nxt = self._consume()
+            if nxt.kind == _TokenKind.COMMA:
+                continue
+            if nxt.kind == _TokenKind.RBRACKET:
+                break
+            raise PredicateSyntaxError(
+                f"expected ',' or ']' in list literal, got {nxt.value!r}",
+                line=nxt.line,
+                col=nxt.col,
+            )
+        return tuple(items)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+# Hard cap on input size — we never expect a 10 KB predicate string,
+# rejecting upfront protects us from pathological inputs.
+_MAX_SOURCE_LEN = 4096
+
+
+def parse_predicate(source: str) -> PredicateNode:
+    """Parse a DSL string into a compiled :class:`PredicateNode`.
+
+    Raises :class:`PredicateSyntaxError` on malformed input,
+    :class:`PredicateDepthError` on adversarially-deep nesting.
+
+    The returned node is immutable (``frozen=True`` on the dataclass)
+    and safe to share across threads.
+    """
+    if not isinstance(source, str):
+        raise PredicateSyntaxError(
+            f"predicate source must be a string, got {type(source).__name__}"
+        )
+    if len(source) > _MAX_SOURCE_LEN:
+        raise PredicateSyntaxError(
+            f"predicate source exceeds {_MAX_SOURCE_LEN} characters"
+        )
+    if not source.strip():
+        raise PredicateSyntaxError("predicate source is empty")
+
+    tokens = _Lexer(source).tokenize()
+    return _Parser(tokens).parse()
+
+
+def evaluate_predicate(
+    node: PredicateNode | None, payload: dict[str, Any]
+) -> bool:
+    """Evaluate a compiled predicate against a payload row.
+
+    A ``None`` predicate is treated as *always-true* — this preserves the
+    pre-S4 behaviour where missing predicates fall through to
+    ``matched=True`` in the runtime.
+    """
+    if node is None:
+        return True
+    return node.evaluate(payload)
+
+
+def build_update_payload(
+    *,
+    new_values: dict[str, Any],
+    old_values: dict[str, Any] | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the payload dict consumed by :func:`evaluate_predicate`.
+
+    For UPDATE rows we expose three views::
+
+        {
+            "status": ...,           # bare = new.<col> for SQL-feel
+            "new.status": ...,
+            "old.status": ...,
+        }
+
+    INSERT rows have no ``old`` snapshot; we still emit ``new.*`` so
+    explicit predicates work the same way across all DML ops.
+    """
+    payload: dict[str, Any] = {}
+    if extra:
+        payload.update(extra)
+    # Bare keys: new wins (familiar SQL convention).
+    payload.update(new_values)
+    for k, v in new_values.items():
+        payload[f"new.{k}"] = v
+    if old_values:
+        for k, v in old_values.items():
+            payload[f"old.{k}"] = v
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Bridge to ``core.predicates`` AST (so the structured PredicateEvaluator
+# in rules/predicates.py can consume the parsed tree). Currently used by
+# tests / introspection — the runtime path uses ``evaluate_predicate``
+# directly because it knows how to feed ``old.*``/``new.*`` payloads.
+# ---------------------------------------------------------------------------
+
+
+def to_core_predicate(node: PredicateNode) -> "AnyPredicate":
+    """Best-effort conversion to ``core.predicates`` dataclasses.
+
+    Limitation: dotted attribute paths (``new.status``) get flattened
+    into the ``field`` string because ``AttrPredicate.field`` is a
+    plain identifier. The structured evaluator doesn't traverse dots,
+    so this only round-trips cleanly for *bare* attributes.
+    """
+    from core.predicates import AttrPredicate, CompoundPredicate
+
+    if node.kind == _NodeKind.AND:
+        return CompoundPredicate(
+            logic="AND",
+            predicates=[to_core_predicate(c) for c in node.children],
+        )
+    if node.kind == _NodeKind.OR:
+        return CompoundPredicate(
+            logic="OR",
+            predicates=[to_core_predicate(c) for c in node.children],
+        )
+    if node.kind == _NodeKind.NOT:
+        return CompoundPredicate(
+            logic="NOT",
+            predicates=[to_core_predicate(node.children[0])],
+        )
+
+    field = ".".join(node.attr)
+    if node.kind == _NodeKind.IS_NULL:
+        return AttrPredicate(field=field, op="is_null")
+    if node.kind == _NodeKind.IS_NOT_NULL:
+        return AttrPredicate(field=field, op="not_null")
+    if node.kind == _NodeKind.IN:
+        return AttrPredicate(field=field, op="in", value=list(node.value))
+    if node.kind == _NodeKind.NOT_IN:
+        return CompoundPredicate(
+            logic="NOT",
+            predicates=[
+                AttrPredicate(field=field, op="in", value=list(node.value))
+            ],
+        )
+    if node.kind == _NodeKind.CMP:
+        op_map = {"==": "eq", "!=": "neq", ">": "gt", ">=": "gte", "<": "lt", "<=": "lte"}
+        # ``AttrPredicate.op`` is a closed Literal[…]; the map values
+        # are statically inside that set, but mypy can't prove it from
+        # a dict lookup. We narrow with ``cast``.
+        from typing import cast
+        from typing import Any as _Any  # local alias to avoid TYPE_CHECKING shuffle
+
+        return AttrPredicate(field=field, op=cast(_Any, op_map[node.op]), value=node.value)
+    raise PredicateError(f"cannot convert node kind {node.kind!r}")  # pragma: no cover
+
+
+__all__ = [
+    "MAX_DEPTH",
+    "PredicateDepthError",
+    "PredicateError",
+    "PredicateEvalError",
+    "PredicateNode",
+    "PredicateSyntaxError",
+    "build_update_payload",
+    "evaluate_predicate",
+    "parse_predicate",
+    "to_core_predicate",
+]

--- a/gispulse/runtime/sqlite_retry.py
+++ b/gispulse/runtime/sqlite_retry.py
@@ -1,0 +1,182 @@
+"""Exponential-backoff retry wrapper for SQLite executors.
+
+Why
+---
+When a GPKG is opened in WAL mode (``journal_mode=WAL`` + a generous
+``busy_timeout``), reads do not block writes and vice versa. But SET_FIELD
+/ RUN_SQL actions still issue write transactions, and a concurrent QGIS
+save (or another GISPulse tick on the same file) can hold the writer
+lock long enough to push us past the engine-level ``busy_timeout``.
+``sqlite3`` then raises ``OperationalError("database is locked")`` and
+the action fails — even though a 100 ms retry would have succeeded.
+
+Scope
+-----
+The wrapper retries only on transient lock errors (``database is locked``
+/ ``database is busy``). Any other ``OperationalError`` (typo in SQL,
+missing table, syntax error, …) is re-raised on the first attempt so we
+do not mask real bugs by spinning.
+
+Counters
+--------
+The CLI ``--watch`` mode wants to expose ``sqlite_busy_retries`` per tick
+in its structured log. The wrapper keeps a process-local counter
+accessible via :meth:`RetryingSqlExecutor.snapshot_retries` so the
+caller can ``before/after`` diff per tick without a global.
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+import sqlite3
+import time
+from typing import Any, Callable
+
+log = logging.getLogger(__name__)
+
+
+# Default backoff schedule (seconds). 5 attempts total: 100 ms → 250 ms
+# → 500 ms → 1 s → 2 s. Cumulative ~3.85 s before final failure, which
+# is the right order of magnitude for a QGIS save under typical load.
+DEFAULT_BACKOFF_SCHEDULE: tuple[float, ...] = (0.1, 0.25, 0.5, 1.0, 2.0)
+DEFAULT_JITTER_PCT: float = 0.2  # ±20 %
+
+# Lower-cased substrings that mark a recoverable lock error. SQLite's
+# message text is the public contract here — there is no error code on
+# the Python side until ``sqlite3.OperationalError.sqlite_errorcode``
+# (3.11+) is universally available, and we ship 3.10 still.
+_BUSY_MARKERS: tuple[str, ...] = (
+    "database is locked",
+    "database is busy",
+)
+
+
+def is_busy_error(exc: BaseException) -> bool:
+    """Return True when ``exc`` is a SQLite busy/locked error.
+
+    Centralised so test code and the wrapper agree on the predicate.
+    """
+    if not isinstance(exc, sqlite3.OperationalError):
+        return False
+    msg = str(exc).lower()
+    return any(marker in msg for marker in _BUSY_MARKERS)
+
+
+class RetryingSqlExecutor:
+    """Callable wrapper that retries the inner executor on SQLITE_BUSY.
+
+    Wraps any ``(sql, params) -> Any`` callable (typically
+    :meth:`GeoPackageEngine.execute` or a user-supplied stub) and
+    re-raises immediately on non-busy errors.
+
+    The wrapper is callable so it can be dropped in wherever the
+    dispatcher expects ``sql_executor``::
+
+        retrying = RetryingSqlExecutor(engine.execute)
+        dispatcher = ActionDispatcher(sql_executor=retrying, ...)
+
+    Args:
+        inner:        The wrapped executor.
+        backoff:      Tuple of sleep durations (seconds) between attempts.
+                      The number of attempts equals ``len(backoff) + 1``
+                      (one initial try, then one retry per slot).
+        jitter_pct:   Fractional jitter applied to each sleep (uniform
+                      distribution in ``[1-pct, 1+pct]``).
+        sleeper:      Injection point for tests — defaults to
+                      :func:`time.sleep`.
+    """
+
+    def __init__(
+        self,
+        inner: Callable[..., Any],
+        *,
+        backoff: tuple[float, ...] = DEFAULT_BACKOFF_SCHEDULE,
+        jitter_pct: float = DEFAULT_JITTER_PCT,
+        sleeper: Callable[[float], None] | None = None,
+    ) -> None:
+        if inner is None:
+            raise ValueError("inner executor cannot be None")
+        if not backoff:
+            raise ValueError("backoff schedule must not be empty")
+        if jitter_pct < 0 or jitter_pct > 1:
+            raise ValueError("jitter_pct must be between 0 and 1")
+
+        self._inner = inner
+        self._backoff = tuple(backoff)
+        self._jitter = float(jitter_pct)
+        self._sleep: Callable[[float], None] = sleeper or time.sleep
+        # Total number of busy retries that actually fired (i.e. excludes
+        # the first successful attempt). Read via :meth:`snapshot_retries`.
+        self._retries = 0
+
+    # ------------------------------------------------------------------
+    # Counter API
+    # ------------------------------------------------------------------
+
+    def snapshot_retries(self) -> int:
+        """Return the cumulative retry count since wrapper creation."""
+        return self._retries
+
+    def reset_retries(self) -> None:
+        """Reset the counter (used by tests; the CLI prefers diff'ing)."""
+        self._retries = 0
+
+    # ------------------------------------------------------------------
+    # Call site
+    # ------------------------------------------------------------------
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        """Invoke the wrapped executor with retry-on-busy semantics.
+
+        Signature matches ``Callable[..., Any]`` so we transparently
+        forward whatever shape the dispatcher uses (positional ``(sql,
+        params)`` or keyword variants).
+        """
+        last_exc: BaseException | None = None
+        attempts = len(self._backoff) + 1
+        for attempt in range(attempts):
+            try:
+                return self._inner(*args, **kwargs)
+            except sqlite3.OperationalError as exc:
+                if not is_busy_error(exc):
+                    # Permanent error (no such table, syntax, …): fail fast.
+                    raise
+                last_exc = exc
+                if attempt >= len(self._backoff):
+                    # Exhausted retry budget — re-raise so the dispatcher's
+                    # try/except logs and the change-log row is NOT acked
+                    # (handled at the watcher tick level).
+                    log.error(
+                        "sqlite_busy_retry_exhausted attempts=%d err=%s",
+                        attempts,
+                        exc,
+                    )
+                    raise
+                # Compute jittered sleep for this slot.
+                base = self._backoff[attempt]
+                jitter_factor = 1.0 + random.uniform(-self._jitter, self._jitter)
+                sleep_for = max(0.0, base * jitter_factor)
+                self._retries += 1
+                log.warning(
+                    "sqlite_busy_retry attempt=%d/%d sleep=%.3fs err=%s",
+                    attempt + 1,
+                    attempts,
+                    sleep_for,
+                    exc,
+                )
+                self._sleep(sleep_for)
+        # Defensive: the loop always either returns, raises busy after
+        # exhaustion, or raises a non-busy OperationalError. Reaching
+        # here would mean a logic error in the loop above.
+        if last_exc is not None:  # pragma: no cover - unreachable
+            raise last_exc
+        raise RuntimeError("RetryingSqlExecutor: unreachable")  # pragma: no cover
+
+
+__all__ = [
+    "DEFAULT_BACKOFF_SCHEDULE",
+    "DEFAULT_JITTER_PCT",
+    "RetryingSqlExecutor",
+    "is_busy_error",
+]

--- a/persistence/change_log_watcher.py
+++ b/persistence/change_log_watcher.py
@@ -42,7 +42,6 @@ from __future__ import annotations
 
 import logging
 import threading
-import time
 from typing import Any, Callable, Protocol
 
 from core.models import ChangeOperation, ChangeRecord, Trigger
@@ -195,6 +194,11 @@ class ChangeLogWatcher:
 
         self._running = False
         self._thread: threading.Thread | None = None
+        # S5: replace bare ``time.sleep(self._poll_interval)`` with an
+        # :class:`Event` so :meth:`stop` (and the CLI ``--watch`` daemon's
+        # SIGINT handler) can interrupt the wait immediately rather than
+        # waiting up to ``poll_interval`` seconds before the loop notices.
+        self._stop_event = threading.Event()
         # Backoff window when get_pending_changes raises.
         self._error_backoff = 1.0
 
@@ -207,6 +211,8 @@ class ChangeLogWatcher:
         if self._running:
             return
         self._running = True
+        # Re-arm in case the watcher is being restarted after a stop().
+        self._stop_event.clear()
         self._thread = threading.Thread(
             target=self._run,
             name=f"gispulse-change-log-watcher-{getattr(self._engine, 'backend_name', '?')}",
@@ -220,8 +226,16 @@ class ChangeLogWatcher:
         )
 
     def stop(self) -> None:
-        """Stop the polling thread and join (2 s timeout)."""
+        """Stop the polling thread and join (2 s timeout).
+
+        S5: signals the internal :class:`Event` so a thread sleeping
+        inside ``Event.wait(poll_interval)`` returns immediately. With
+        the prior ``time.sleep()`` an operator pressing Ctrl-C against
+        a watcher configured for ``poll_interval=5s`` would wait up to
+        a full poll window before the loop noticed.
+        """
         self._running = False
+        self._stop_event.set()
         thread = self._thread
         if thread is not None:
             thread.join(timeout=2.0)
@@ -234,6 +248,13 @@ class ChangeLogWatcher:
         """Return True when the polling thread is active."""
         return self._running and self._thread is not None and self._thread.is_alive()
 
+    @property
+    def stop_event(self) -> threading.Event:
+        """Expose the cancel event so external loops (CLI ``--watch``)
+        can wait on the same primitive when they drive ``_tick`` directly
+        instead of starting the daemon thread."""
+        return self._stop_event
+
     # ------------------------------------------------------------------
     # Internals
     # ------------------------------------------------------------------
@@ -241,28 +262,47 @@ class ChangeLogWatcher:
     def _run(self) -> None:
         """Polling loop — runs in the daemon thread.
 
-        ``sleep -> tick`` so that on restart with un-acked rows, the WS
+        ``wait -> tick`` so that on restart with un-acked rows, the WS
         subscriber has a chance to (re)connect before the watcher consumes
         and acks the backlog (otherwise replay events are broadcast to no
         subscribers and lost).
+
+        S5: the wait uses :class:`threading.Event` instead of ``time.sleep``
+        so :meth:`stop` returns control immediately (no poll-interval-sized
+        latency on Ctrl-C).
         """
         while self._running:
-            time.sleep(self._poll_interval)
+            # ``wait`` returns True when the event is set (stop) or False
+            # when it timed out (next tick). Either way we re-check
+            # ``_running`` afterwards to honour external state changes.
+            if self._stop_event.wait(timeout=self._poll_interval):
+                break
             if not self._running:
                 break
             try:
                 self._tick()
             except Exception as exc:  # pragma: no cover — defensive
                 logger.exception("change_log_watcher_tick_failed: %s", exc)
-                time.sleep(self._error_backoff)
+                # Use the same cancellable wait so error backoff also
+                # respects stop().
+                if self._stop_event.wait(timeout=self._error_backoff):
+                    break
 
     def _tick(self) -> int:
-        """One polling cycle. Returns the number of rows processed."""
+        """One polling cycle. Returns the number of rows processed.
+
+        S5: when the engine raises while listing pending changes (typical
+        cause: a transient SQLite lock during a concurrent QGIS save) we
+        sleep on :attr:`_stop_event` rather than ``time.sleep`` so the
+        external stop signal is honoured without an extra poll.
+        """
         try:
             rows = self._engine.get_pending_changes(self._batch_limit)
         except Exception as exc:
             logger.warning("change_log_get_pending_failed: %s", exc)
-            time.sleep(self._error_backoff)
+            # Cancellable backoff: ``wait`` returns immediately when the
+            # event is set (stop), otherwise after ``_error_backoff`` s.
+            self._stop_event.wait(timeout=self._error_backoff)
             return 0
 
         if not rows:

--- a/persistence/change_log_watcher.py
+++ b/persistence/change_log_watcher.py
@@ -352,11 +352,37 @@ class ChangeLogWatcher:
                 except ValueError:
                     operation = ChangeOperation.INSERT
 
+                # When any active trigger carries a DSL predicate
+                # (S4: ``conditions["predicate_ast"]``), fetch the
+                # row attributes from the underlying table so the
+                # evaluator can match against real values. This is
+                # opt-in per trigger — triggers without predicates
+                # never pay the SELECT cost.
+                #
+                # We guard with table+pk presence: DELETE rows have
+                # no row to load (``new_values`` stays empty, the
+                # predicate then evaluates over what amounts to
+                # NULLs everywhere, which is the documented semantics
+                # for DSL on DELETE).
+                new_values: dict[str, Any] = {}
+                if (
+                    op != "DELETE"
+                    and fid is not None
+                    and table
+                    and any(
+                        (getattr(t, "conditions", None) or {}).get("predicate_ast")
+                        is not None
+                        for t in active_triggers
+                    )
+                ):
+                    new_values = self._load_row_values(table, fid) or {}
+
                 record = ChangeRecord(
                     session_id="",
                     table_name=table,
                     feature_id=fid,
                     operation=operation,
+                    new_values=new_values,
                 )
 
                 try:
@@ -433,6 +459,67 @@ class ChangeLogWatcher:
                 logger.warning("change_log_mark_processed_failed: %s", exc)
 
         return len(rows)
+
+    # ------------------------------------------------------------------
+    # Row materialisation for DSL predicate evaluation (S4)
+    # ------------------------------------------------------------------
+
+    def _load_row_values(self, table: str, fid: str) -> dict[str, Any] | None:
+        """Read the current row from the underlying table.
+
+        Used only when at least one active trigger carries a DSL
+        ``predicate_ast`` (no overhead otherwise). The row is fetched
+        through the engine's GPKG connection and returned as a flat
+        ``dict``. Geometry columns are kept as raw blobs / WKT (the
+        evaluator currently only matches on attributes — geometry
+        predicates remain on the structured ``GeomPredicate`` path).
+
+        Returns ``None`` when the table or row no longer exists; the
+        evaluator then sees an empty payload and the predicate
+        resolves to a non-match (fail-safe). Identifier validation
+        prevents SQL injection via the trigger config.
+        """
+        from core.sql_safety import validate_identifier as _validate_ident
+
+        try:
+            safe_table = _validate_ident(table)
+        except Exception as exc:  # ValueError from validator
+            logger.warning(
+                "change_log_load_row_invalid_table table=%r err=%s", table, exc
+            )
+            return None
+
+        # Default GPKG primary key is "fid". We fall back to a generic
+        # ``id``/``rowid`` lookup so non-GPKG layers still resolve.
+        pk_candidates = ("fid", "id", "rowid")
+        get_conn = getattr(self._engine, "_get_conn", None)
+        if get_conn is None:
+            return None
+        try:
+            conn = get_conn()
+        except Exception:
+            return None
+
+        try:
+            for pk in pk_candidates:
+                try:
+                    cur = conn.execute(
+                        f'SELECT * FROM "{safe_table}" WHERE "{pk}" = ? LIMIT 1',
+                        (fid,),
+                    )
+                except Exception:
+                    continue
+                row = cur.fetchone()
+                if row is not None:
+                    return {k: row[k] for k in row.keys()}
+        except Exception as exc:
+            logger.warning(
+                "change_log_load_row_failed table=%s fid=%s err=%s",
+                table,
+                fid,
+                exc,
+            )
+        return None
 
     # ------------------------------------------------------------------
     # Action dispatch bridge (#458)

--- a/rules/trigger_evaluator.py
+++ b/rules/trigger_evaluator.py
@@ -178,6 +178,43 @@ class TriggerEvaluator:
         if not handler(self, record, trigger, typed_cond):
             return False
 
+        # DSL predicate AST (Mode 1 / CLI triggers — S4).
+        # Compiled by ``runtime.config_loader.to_triggers`` and stashed
+        # on ``conditions["predicate_ast"]``. We evaluate it against a
+        # payload that exposes both ``old.*`` and ``new.*`` so DSL
+        # authors can reference either snapshot on UPDATE.
+        ast_node = (trigger.conditions or {}).get("predicate_ast")
+        if ast_node is not None:
+            try:
+                from gispulse.runtime.predicate_dsl import (
+                    PredicateError,
+                    build_update_payload,
+                    evaluate_predicate,
+                )
+
+                ast_payload = build_update_payload(
+                    new_values=record.new_values or {},
+                    old_values=record.old_values or {},
+                    extra=(
+                        {"geom": record.new_geom_wkt}
+                        if record.new_geom_wkt
+                        else None
+                    ),
+                )
+                if not evaluate_predicate(ast_node, ast_payload):
+                    return False
+            except PredicateError as exc:
+                # Fail-safe: a runtime predicate error must not crash
+                # the watcher tick. Log + skip the row.
+                import logging as _logging
+
+                _logging.getLogger(__name__).warning(
+                    "trigger_predicate_eval_failed trigger=%r error=%s",
+                    getattr(trigger, "name", trigger.id),
+                    exc,
+                )
+                return False
+
         # Structured predicates (if any)
         if trigger.predicates:
             payload = {**record.new_values}

--- a/tests/cli/test_triggers_command.py
+++ b/tests/cli/test_triggers_command.py
@@ -115,17 +115,30 @@ def test_run_once_succeeds_and_marks_change_processed(
     assert unprocessed == 0, "watcher should have acked every pending row"
 
 
-def test_run_without_once_exits_2_with_helpful_message(
+def test_run_without_mode_flag_exits_2_with_helpful_message(
     runner: CliRunner, fixture_yaml: Path
 ) -> None:
-    """Daemon mode is reserved — the CLI must refuse rather than hang."""
+    """No mode chosen → exit 2 with usage hint (rather than blocking
+    on a daemon the operator did not explicitly opt into)."""
     result = runner.invoke(
         triggers_app,
         ["run", "--config", str(fixture_yaml)],
     )
     assert result.exit_code == 2
     combined = result.output
-    assert "--once" in combined or "watch" in combined.lower()
+    assert "--once" in combined or "--watch" in combined
+
+
+def test_run_with_once_and_watch_is_rejected(
+    runner: CliRunner, fixture_yaml: Path
+) -> None:
+    """``--once`` and ``--watch`` are mutually exclusive."""
+    result = runner.invoke(
+        triggers_app,
+        ["run", "--config", str(fixture_yaml), "--once", "--watch"],
+    )
+    assert result.exit_code == 2
+    assert "mutually exclusive" in result.output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_triggers_command.py
+++ b/tests/cli/test_triggers_command.py
@@ -1,0 +1,301 @@
+"""Tests for ``gispulse triggers`` CLI sub-commands.
+
+Strategy
+--------
+We use Typer's ``CliRunner`` to drive the subapp directly (no
+subprocess), then inspect ``result.exit_code`` and ``result.output``.
+
+Three flows covered:
+- ``run --once`` against a real GPKG fixture: exit 0, change-log drained.
+- ``validate`` on a broken YAML: exit 1.
+- ``list`` on an untracked GPKG: exit 0 with empty-table message.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import textwrap
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from gispulse.cli_triggers import triggers_app
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    """A Typer ``CliRunner``. Newer Click versions dropped the legacy
+    ``mix_stderr`` flag; both stdout and stderr land in ``result.output``
+    by default, which is fine for our assertions."""
+    return CliRunner()
+
+
+@pytest.fixture()
+def fixture_gpkg(tmp_path: Path) -> Path:
+    """GPKG with a tracked ``parcels`` table + a single pending change."""
+    from persistence.gpkg_engine import GeoPackageEngine
+
+    gpkg = tmp_path / "fixture.gpkg"
+    engine = GeoPackageEngine(path=gpkg)
+    engine.open()
+    try:
+        conn = engine._get_conn()  # noqa: SLF001
+        conn.execute(
+            'CREATE TABLE "parcels" '
+            '(fid INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)'
+        )
+        conn.commit()
+        engine.enable_change_tracking("parcels")
+    finally:
+        engine.close()
+
+    # External writer to fire the trigger and seed _gispulse_change_log.
+    ext = sqlite3.connect(str(gpkg))
+    try:
+        ext.execute('INSERT INTO "parcels"(name) VALUES (?)', ("alpha",))
+        ext.commit()
+    finally:
+        ext.close()
+
+    return gpkg
+
+
+@pytest.fixture()
+def fixture_yaml(fixture_gpkg: Path, tmp_path: Path) -> Path:
+    cfg = tmp_path / "triggers.yaml"
+    cfg.write_text(
+        textwrap.dedent(
+            f"""
+            version: 1
+            gpkg: {fixture_gpkg}
+            triggers:
+              - name: log_only
+                table: parcels
+                actions:
+                  - type: log_event
+            runtime:
+              poll_interval_ms: 100
+              max_batch: 10
+            """,
+        ).strip(),
+        encoding="utf-8",
+    )
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# `gispulse triggers run`
+# ---------------------------------------------------------------------------
+
+
+def test_run_once_succeeds_and_marks_change_processed(
+    runner: CliRunner, fixture_yaml: Path, fixture_gpkg: Path
+) -> None:
+    result = runner.invoke(
+        triggers_app,
+        ["run", "--config", str(fixture_yaml), "--once"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "OK" in result.stdout
+
+    # The change_log row should now be marked processed (id <= max_id_acked).
+    conn = sqlite3.connect(str(fixture_gpkg))
+    try:
+        unprocessed = conn.execute(
+            "SELECT COUNT(*) FROM _gispulse_change_log WHERE processed = 0"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert unprocessed == 0, "watcher should have acked every pending row"
+
+
+def test_run_without_once_exits_2_with_helpful_message(
+    runner: CliRunner, fixture_yaml: Path
+) -> None:
+    """Daemon mode is reserved — the CLI must refuse rather than hang."""
+    result = runner.invoke(
+        triggers_app,
+        ["run", "--config", str(fixture_yaml)],
+    )
+    assert result.exit_code == 2
+    combined = result.output
+    assert "--once" in combined or "watch" in combined.lower()
+
+
+# ---------------------------------------------------------------------------
+# `gispulse triggers validate`
+# ---------------------------------------------------------------------------
+
+
+def test_validate_exits_0_on_valid_config(
+    runner: CliRunner, fixture_yaml: Path
+) -> None:
+    result = runner.invoke(
+        triggers_app,
+        ["validate", "--config", str(fixture_yaml)],
+    )
+    assert result.exit_code == 0, result.output
+
+
+def test_validate_exits_1_on_broken_yaml(
+    runner: CliRunner, fixture_gpkg: Path, tmp_path: Path
+) -> None:
+    bad = tmp_path / "broken.yaml"
+    bad.write_text(
+        f"version: 1\ngpkg: {fixture_gpkg}\ntriggers: [\n - foo: bar\n",
+        encoding="utf-8",
+    )
+    result = runner.invoke(
+        triggers_app,
+        ["validate", "--config", str(bad)],
+    )
+    assert result.exit_code == 1
+    combined = result.output
+    assert "Config error" in combined or "invalid YAML" in combined
+
+
+def test_validate_exits_1_on_missing_table(
+    runner: CliRunner, fixture_gpkg: Path, tmp_path: Path
+) -> None:
+    bad = tmp_path / "missing_table.yaml"
+    bad.write_text(
+        textwrap.dedent(
+            f"""
+            version: 1
+            gpkg: {fixture_gpkg}
+            triggers:
+              - name: typo
+                table: parcells
+                actions:
+                  - type: log_event
+            """,
+        ).strip(),
+        encoding="utf-8",
+    )
+    result = runner.invoke(
+        triggers_app,
+        ["validate", "--config", str(bad)],
+    )
+    assert result.exit_code == 1
+    combined = result.output
+    assert "parcells" in combined
+
+
+# ---------------------------------------------------------------------------
+# `gispulse triggers list`
+# ---------------------------------------------------------------------------
+
+
+def test_list_reports_tracked_tables(
+    runner: CliRunner, fixture_gpkg: Path
+) -> None:
+    result = runner.invoke(
+        triggers_app,
+        ["list", "--gpkg", str(fixture_gpkg)],
+    )
+    assert result.exit_code == 0, result.output
+    # Tracked table should appear with its DML ops
+    assert "parcels" in result.stdout
+    # All three CRUD ops are wired by enable_change_tracking
+    for op in ("INSERT", "UPDATE", "DELETE"):
+        assert op in result.stdout
+
+
+def test_list_handles_untracked_gpkg(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """An empty GPKG (no GISPulse triggers installed) must exit 0 with
+    a clear "not tracked" message rather than crashing."""
+    from persistence.gpkg_engine import GeoPackageEngine
+
+    raw = tmp_path / "untracked.gpkg"
+    eng = GeoPackageEngine(path=raw)
+    eng.open()
+    try:
+        conn = eng._get_conn()  # noqa: SLF001
+        conn.execute('CREATE TABLE "parcels"(fid INTEGER PRIMARY KEY)')
+        conn.commit()
+    finally:
+        eng.close()
+
+    result = runner.invoke(
+        triggers_app,
+        ["list", "--gpkg", str(raw)],
+    )
+    assert result.exit_code == 0
+    assert "No GISPulse triggers" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Error path coverage
+# ---------------------------------------------------------------------------
+
+
+def test_run_exits_1_on_config_error(
+    runner: CliRunner, fixture_gpkg: Path, tmp_path: Path
+) -> None:
+    """`gispulse triggers run --once` should exit 1 (not 2) when YAML is
+    syntactically broken. Distinct from exit 2 (missing --once flag)."""
+    bad = tmp_path / "broken.yaml"
+    bad.write_text(
+        f"version: 1\ngpkg: {fixture_gpkg}\ntriggers: [\n - foo: bar\n",
+        encoding="utf-8",
+    )
+    result = runner.invoke(
+        triggers_app,
+        ["run", "--config", str(bad), "--once"],
+    )
+    assert result.exit_code == 1
+    assert "Config error" in result.output or "invalid YAML" in result.output
+
+
+def test_run_exits_1_on_schema_error_after_load(
+    runner: CliRunner, fixture_gpkg: Path, tmp_path: Path
+) -> None:
+    """If load_config succeeds but validate_against_gpkg fails (e.g. typo
+    in trigger.table) the runtime must refuse to start."""
+    cfg = tmp_path / "bad_table.yaml"
+    cfg.write_text(
+        textwrap.dedent(
+            f"""
+            version: 1
+            gpkg: {fixture_gpkg}
+            triggers:
+              - name: typo
+                table: parcells   # typo
+                actions:
+                  - type: log_event
+            """,
+        ).strip(),
+        encoding="utf-8",
+    )
+    result = runner.invoke(
+        triggers_app,
+        ["run", "--config", str(cfg), "--once"],
+    )
+    assert result.exit_code == 1
+    assert "parcells" in result.output
+
+
+def test_list_exits_1_when_gpkg_is_corrupt(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """Hand a path that exists but is not a SQLite file. We bypass
+    Typer's file existence check by creating a real file first; sqlite3
+    will fail to open it with a clean error."""
+    not_sqlite = tmp_path / "not_a_db.gpkg"
+    not_sqlite.write_bytes(b"definitely not sqlite")
+
+    result = runner.invoke(
+        triggers_app,
+        ["list", "--gpkg", str(not_sqlite)],
+    )
+    # sqlite3.connect() succeeds on any path, then the SELECT fails.
+    assert result.exit_code == 1
+    assert "Cannot open GPKG" in result.output

--- a/tests/cli/test_triggers_watch.py
+++ b/tests/cli/test_triggers_watch.py
@@ -1,0 +1,569 @@
+"""Integration tests for ``gispulse triggers run --watch``.
+
+Strategy
+--------
+The watch loop is split between :func:`gispulse.cli_triggers.cmd_run`
+(arg parsing + signal binding) and :func:`gispulse.cli_triggers_watch
+.run_watch_loop` (the actual tick → wait → tick body). We test:
+
+1. The loop body **directly** for fast deterministic coverage of:
+   - Reload-on-mtime-change (added trigger picked up without restart).
+   - Broken YAML on reload kept the previous valid config.
+   - ``poll_interval`` is respected — i.e. ``max_ticks=N`` produces
+     N tick events.
+2. The full CLI command via ``subprocess.Popen`` for the SIGINT
+   round-trip (cannot use ``CliRunner`` because Typer's runner does
+   not deliver real signals to the process).
+
+All ``time.sleep`` in the loop is replaced by an injected sleeper that
+either no-ops or sets the stop event after a configurable number of
+calls — keeps every test under 1 s.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import sqlite3
+import subprocess
+import sys
+import textwrap
+import threading
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+import pytest
+
+from gispulse.cli_triggers_watch import run_watch_loop
+from gispulse.runtime.config_loader import load_config, validate_against_gpkg
+from gispulse.runtime.headless_runtime import build_runtime
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def gpkg_with_parcels(tmp_path: Path) -> Path:
+    from persistence.gpkg_engine import GeoPackageEngine
+
+    gpkg = tmp_path / "watch.gpkg"
+    eng = GeoPackageEngine(path=gpkg)
+    eng.open()
+    try:
+        conn = eng._get_conn()  # noqa: SLF001
+        conn.execute(
+            'CREATE TABLE "parcels" '
+            '(fid INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, status TEXT)'
+        )
+        conn.commit()
+        eng.enable_change_tracking("parcels")
+    finally:
+        eng.close()
+    return gpkg
+
+
+@pytest.fixture()
+def yaml_one_trigger(gpkg_with_parcels: Path, tmp_path: Path) -> Path:
+    cfg = tmp_path / "triggers.yaml"
+    cfg.write_text(
+        textwrap.dedent(
+            f"""
+            version: 1
+            gpkg: {gpkg_with_parcels}
+            triggers:
+              - name: log_only
+                table: parcels
+                actions:
+                  - type: log_event
+            runtime:
+              poll_interval_ms: 50
+              max_batch: 10
+            """,
+        ).strip(),
+        encoding="utf-8",
+    )
+    return cfg
+
+
+def _insert_row(gpkg: Path, name: str = "alpha") -> None:
+    conn = sqlite3.connect(str(gpkg))
+    try:
+        conn.execute(
+            'INSERT INTO "parcels"(name, status) VALUES (?, ?)',
+            (name, "pending"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Sleeper helpers
+# ---------------------------------------------------------------------------
+
+
+class _CountingSleeper:
+    """Sleeper double that records calls and optionally cancels after N."""
+
+    def __init__(self, stop_after: int | None = None, stop_event: threading.Event | None = None) -> None:
+        self.calls: list[float] = []
+        self._stop_after = stop_after
+        self._stop_event = stop_event
+
+    def __call__(self, timeout: float) -> bool:
+        self.calls.append(timeout)
+        if self._stop_after is not None and len(self.calls) >= self._stop_after:
+            if self._stop_event is not None:
+                self._stop_event.set()
+            return True
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Direct loop tests
+# ---------------------------------------------------------------------------
+
+
+def test_watch_loop_runs_three_ticks_then_stops(
+    yaml_one_trigger: Path,
+    gpkg_with_parcels: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``max_ticks=3`` lets us assert deterministic tick count.
+
+    No real sleeping happens (sleeper no-ops), so the wall time stays
+    well under the brief's 5 s budget.
+    """
+    cfg = load_config(yaml_one_trigger)
+    assert validate_against_gpkg(cfg) == []
+    runtime = build_runtime(
+        gpkg_path=gpkg_with_parcels,
+        triggers=[],  # we only care that ticks fire, not their content
+        webhook_client=lambda url, payload: None,
+        sql_executor=lambda *a, **kw: None,
+        poll_interval=cfg.runtime.poll_interval_ms / 1000.0,
+        batch_limit=cfg.runtime.max_batch,
+        dataset_id="test",
+    )
+
+    sleeper = _CountingSleeper()
+    stop_event = threading.Event()
+
+    t0 = time.monotonic()
+    exit_code = run_watch_loop(
+        initial_runtime=runtime,
+        initial_cfg=cfg,
+        config_path=yaml_one_trigger,
+        gpkg_override=None,
+        poll_interval=0.05,
+        stop_event=stop_event,
+        sleeper=sleeper,
+        max_ticks=3,
+    )
+    elapsed = time.monotonic() - t0
+
+    assert exit_code == 0
+    assert elapsed < 1.0, f"loop took {elapsed:.2f}s — should be near-instant"
+
+    # Inspect the JSON event stream on stderr.
+    captured = capsys.readouterr()
+    events = [json.loads(line) for line in captured.err.splitlines() if line.strip()]
+    tick_events = [e for e in events if e["event"] == "watch_tick"]
+    assert len(tick_events) == 3, (
+        f"expected exactly 3 tick events, got {len(tick_events)}: {tick_events!r}"
+    )
+    # Each tick log carries the contract fields.
+    for ev in tick_events:
+        assert "rows_processed" in ev
+        assert "duration_ms" in ev
+        assert "sqlite_busy_retries" in ev
+
+
+def test_watch_loop_reloads_on_yaml_change(
+    yaml_one_trigger: Path,
+    gpkg_with_parcels: Path,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """Modifier le YAML pendant le run → trigger ajoute actif au tick suivant.
+
+    We start with a 1-trigger config, run a tick, then rewrite the YAML
+    with 2 triggers. The next tick must reload and the next-but-one
+    ``watch_started``-or-``watch_tick`` block should reflect 2 active
+    triggers.
+    """
+    cfg = load_config(yaml_one_trigger)
+    runtime = build_runtime(
+        gpkg_path=gpkg_with_parcels,
+        triggers=[],
+        webhook_client=lambda url, payload: None,
+        sql_executor=lambda *a, **kw: None,
+        poll_interval=cfg.runtime.poll_interval_ms / 1000.0,
+        batch_limit=cfg.runtime.max_batch,
+        dataset_id="test",
+    )
+
+    # Sleeper that, on the 2nd call, mutates the YAML so the 3rd tick
+    # picks up the change.
+    sleep_count = {"n": 0}
+
+    def hook_sleeper(timeout: float) -> bool:
+        sleep_count["n"] += 1
+        if sleep_count["n"] == 2:
+            # Bump mtime explicitly: some filesystems have second-level
+            # mtime resolution and a write within the same second may
+            # not change ``st_mtime_ns``.
+            new_yaml = textwrap.dedent(
+                f"""
+                version: 1
+                gpkg: {gpkg_with_parcels}
+                triggers:
+                  - name: log_only
+                    table: parcels
+                    actions:
+                      - type: log_event
+                  - name: extra_one
+                    table: parcels
+                    actions:
+                      - type: log_event
+                runtime:
+                  poll_interval_ms: 50
+                  max_batch: 10
+                """,
+            ).strip()
+            yaml_one_trigger.write_text(new_yaml, encoding="utf-8")
+            # Force mtime advance.
+            future = time.time() + 2
+            os.utime(yaml_one_trigger, (future, future))
+        return False
+
+    exit_code = run_watch_loop(
+        initial_runtime=runtime,
+        initial_cfg=cfg,
+        config_path=yaml_one_trigger,
+        gpkg_override=None,
+        poll_interval=0.05,
+        sleeper=hook_sleeper,
+        max_ticks=4,
+    )
+
+    assert exit_code == 0
+
+    captured = capsys.readouterr()
+    events = [json.loads(line) for line in captured.err.splitlines() if line.strip()]
+    reloaded = [e for e in events if e["event"] == "watch_config_reloaded"]
+    assert reloaded, (
+        "expected at least one watch_config_reloaded event — got: "
+        f"{[e['event'] for e in events]}"
+    )
+    # The reload event reports the new trigger count (2).
+    assert reloaded[0]["triggers"] == 2
+
+
+def test_watch_loop_keeps_old_config_on_broken_yaml(
+    yaml_one_trigger: Path,
+    gpkg_with_parcels: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """YAML cassé après reload → ancien config reste actif, log ERROR émis."""
+    cfg = load_config(yaml_one_trigger)
+    runtime = build_runtime(
+        gpkg_path=gpkg_with_parcels,
+        triggers=[],
+        webhook_client=lambda url, payload: None,
+        sql_executor=lambda *a, **kw: None,
+        poll_interval=cfg.runtime.poll_interval_ms / 1000.0,
+        batch_limit=cfg.runtime.max_batch,
+        dataset_id="test",
+    )
+
+    sleep_count = {"n": 0}
+
+    def break_yaml_on_2nd_call(timeout: float) -> bool:
+        sleep_count["n"] += 1
+        if sleep_count["n"] == 2:
+            yaml_one_trigger.write_text(
+                "this is: not [valid yaml: at all\n",
+                encoding="utf-8",
+            )
+            future = time.time() + 2
+            os.utime(yaml_one_trigger, (future, future))
+        return False
+
+    exit_code = run_watch_loop(
+        initial_runtime=runtime,
+        initial_cfg=cfg,
+        config_path=yaml_one_trigger,
+        gpkg_override=None,
+        poll_interval=0.05,
+        sleeper=break_yaml_on_2nd_call,
+        max_ticks=4,
+    )
+
+    # Daemon must NOT abort on config error — only on tick failure budget.
+    assert exit_code == 0
+
+    captured = capsys.readouterr()
+    events = [json.loads(line) for line in captured.err.splitlines() if line.strip()]
+    failures = [e for e in events if e["event"] == "watch_config_reload_failed"]
+    reloaded = [e for e in events if e["event"] == "watch_config_reloaded"]
+
+    assert failures, (
+        "expected at least one watch_config_reload_failed event when the "
+        f"YAML is mutated to garbage: events={[e['event'] for e in events]}"
+    )
+    assert not reloaded, (
+        "broken YAML must not produce watch_config_reloaded — the previous "
+        "config stays active"
+    )
+
+    # And ticks kept firing — the daemon stayed up.
+    ticks = [e for e in events if e["event"] == "watch_tick"]
+    assert len(ticks) >= 2
+
+
+def test_watch_loop_keeps_old_config_on_schema_error(
+    yaml_one_trigger: Path,
+    gpkg_with_parcels: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Reload où le YAML est syntaxiquement valide mais reference une
+    table inexistante dans le GPKG → schema error, ancienne config
+    reste active."""
+    cfg = load_config(yaml_one_trigger)
+    runtime = build_runtime(
+        gpkg_path=gpkg_with_parcels,
+        triggers=[],
+        webhook_client=lambda url, payload: None,
+        sql_executor=lambda *a, **kw: None,
+        poll_interval=cfg.runtime.poll_interval_ms / 1000.0,
+        batch_limit=cfg.runtime.max_batch,
+        dataset_id="test",
+    )
+
+    sleep_count = {"n": 0}
+
+    def hook_sleeper(timeout: float) -> bool:
+        sleep_count["n"] += 1
+        if sleep_count["n"] == 2:
+            yaml_one_trigger.write_text(
+                textwrap.dedent(
+                    f"""
+                    version: 1
+                    gpkg: {gpkg_with_parcels}
+                    triggers:
+                      - name: typo
+                        table: parcells
+                        actions:
+                          - type: log_event
+                    runtime:
+                      poll_interval_ms: 50
+                      max_batch: 10
+                    """,
+                ).strip(),
+                encoding="utf-8",
+            )
+            future = time.time() + 2
+            os.utime(yaml_one_trigger, (future, future))
+        return False
+
+    exit_code = run_watch_loop(
+        initial_runtime=runtime,
+        initial_cfg=cfg,
+        config_path=yaml_one_trigger,
+        gpkg_override=None,
+        poll_interval=0.05,
+        sleeper=hook_sleeper,
+        max_ticks=4,
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    events = [json.loads(line) for line in captured.err.splitlines() if line.strip()]
+    schema_errs = [
+        e for e in events if e["event"] == "watch_config_reload_schema_error"
+    ]
+    assert schema_errs, (
+        f"expected at least one schema_error event; events={[e['event'] for e in events]}"
+    )
+    # Daemon kept ticking.
+    assert sum(1 for e in events if e["event"] == "watch_tick") >= 2
+
+
+def test_install_signal_handlers_returns_restore_callable(
+    tmp_path: Path,
+) -> None:
+    """``install_signal_handlers`` must return a noop-safe restore
+    callable even when called in a thread (where ``signal.signal``
+    raises ``ValueError``)."""
+    from gispulse.cli_triggers_watch import install_signal_handlers
+
+    stop = threading.Event()
+    captured: list[Callable[[], None]] = []
+
+    def runner() -> None:
+        # signal.signal() outside main thread raises ValueError on
+        # CPython — install_signal_handlers swallows that and returns
+        # an empty restore callable. We only assert no crash.
+        captured.append(install_signal_handlers(stop))
+
+    t = threading.Thread(target=runner)
+    t.start()
+    t.join(timeout=2.0)
+    assert captured, "install_signal_handlers should return even from thread"
+    captured[0]()  # restore — should also be a no-op, not raise
+
+
+def test_poll_interval_flag_is_respected(
+    yaml_one_trigger: Path,
+    gpkg_with_parcels: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The sleeper receives the configured ``poll_interval`` as its
+    timeout. We assert the values it was called with rather than the
+    wall clock so the test is hermetic."""
+    cfg = load_config(yaml_one_trigger)
+    runtime = build_runtime(
+        gpkg_path=gpkg_with_parcels,
+        triggers=[],
+        webhook_client=lambda url, payload: None,
+        sql_executor=lambda *a, **kw: None,
+        poll_interval=cfg.runtime.poll_interval_ms / 1000.0,
+        batch_limit=cfg.runtime.max_batch,
+        dataset_id="test",
+    )
+
+    sleeper = _CountingSleeper()
+    run_watch_loop(
+        initial_runtime=runtime,
+        initial_cfg=cfg,
+        config_path=yaml_one_trigger,
+        gpkg_override=None,
+        poll_interval=0.05,
+        sleeper=sleeper,
+        max_ticks=3,
+    )
+    # max_ticks=3 → 2 sleeps between ticks (the 3rd tick is followed by
+    # a max_ticks break before any post-tick sleep). All sleeps must
+    # carry the configured 50 ms timeout.
+    assert all(abs(t - 0.05) < 1e-9 for t in sleeper.calls), (
+        f"sleeper got unexpected timeouts: {sleeper.calls!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# SIGINT integration via subprocess
+# ---------------------------------------------------------------------------
+
+
+def _python_with_pythonpath() -> dict[str, str]:
+    """Return an env dict that includes the project source in PYTHONPATH.
+
+    When running ``python -m gispulse.cli ...`` from a subprocess,
+    PYTHONPATH must include the project root for editable-install
+    resolution (the test runner has it implicitly, the child does not).
+    """
+    env = os.environ.copy()
+    project_root = Path(__file__).resolve().parents[2]
+    existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = (
+        f"{project_root}:{existing}" if existing else str(project_root)
+    )
+    # Stay in the same conda env / venv as the test runner.
+    return env
+
+
+def test_subprocess_watch_exits_cleanly_on_sigint(
+    yaml_one_trigger: Path,
+    gpkg_with_parcels: Path,
+    tmp_path: Path,
+) -> None:
+    """The brief: ``--watch`` lance la boucle, après 3 ticks et SIGINT
+    exit 0 propre.
+
+    We launch the CLI in a subprocess so signal delivery is real, wait
+    for at least 3 ``watch_tick`` JSON lines on stderr, then send
+    SIGINT and expect a clean exit 0 within 5 seconds.
+
+    Skipped on Windows: SIGINT under WSL/POSIX is reliable, on Win
+    Python the semantics around signal.SIGINT and CTRL_C_EVENT differ
+    enough that this would need a separate test path.
+    """
+    if sys.platform == "win32":
+        pytest.skip("SIGINT subprocess delivery is not reliable on Windows")
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "gispulse.cli",
+        "triggers",
+        "run",
+        "--config",
+        str(yaml_one_trigger),
+        "--watch",
+        "--poll-interval-ms",
+        "50",
+    ]
+
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=_python_with_pythonpath(),
+        text=True,
+        bufsize=1,
+    )
+
+    # Read stderr line-by-line in a thread and accumulate parsed events
+    # until we see >= 3 watch_tick events or hit the 4 s soft budget.
+    events: list[dict[str, Any]] = []
+    seen_ticks = threading.Event()
+
+    def reader() -> None:
+        assert proc.stderr is not None
+        for raw in proc.stderr:
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                ev = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            events.append(ev)
+            if ev.get("event") == "watch_tick" and (
+                sum(1 for e in events if e.get("event") == "watch_tick") >= 3
+            ):
+                seen_ticks.set()
+
+    t = threading.Thread(target=reader, daemon=True)
+    t.start()
+
+    # Wait up to 4 s for 3 ticks to land.
+    assert seen_ticks.wait(timeout=4.0), (
+        f"did not observe 3 watch_tick events in 4 s — got: "
+        f"{[e.get('event') for e in events]}"
+    )
+
+    # Send SIGINT and expect prompt clean exit.
+    proc.send_signal(signal.SIGINT)
+    try:
+        rc = proc.wait(timeout=5.0)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=2.0)
+        pytest.fail("watch daemon did not exit within 5 s of SIGINT")
+
+    t.join(timeout=1.0)
+
+    assert rc == 0, (
+        f"clean SIGINT must exit 0; got rc={rc}, last events: "
+        f"{[e.get('event') for e in events[-5:]]}"
+    )
+    # And the daemon emitted its stop marker.
+    assert any(e.get("event") == "watch_stopped" for e in events), (
+        "expected a watch_stopped event before exit"
+    )

--- a/tests/cli/test_triggers_watch_resilience.py
+++ b/tests/cli/test_triggers_watch_resilience.py
@@ -1,0 +1,374 @@
+"""Resilience integration tests for ``gispulse triggers run --watch``.
+
+Three scenarios from the brief:
+
+1. Une exception générique levée par un tick → daemon catch + sleep
+   backoff (cancellable) + retry (consecutive_failures < 10).
+2. 10 ticks consécutifs foirent d'affilée → exit 1 avec message clair.
+3. Le sleeper de backoff respecte la cap exponentielle (1 → 2 → 4 → ...
+   → 30 s).
+
+We monkey-patch :meth:`HeadlessRuntime.run_once` to inject failures
+deterministically, and inject a sleeper that records timeouts so we can
+assert the backoff schedule without real waits.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import textwrap
+import threading
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from gispulse.cli_triggers_watch import (
+    MAX_CONSECUTIVE_TICK_FAILURES,
+    TICK_ERROR_BACKOFF_CAP,
+    TICK_ERROR_BACKOFF_INITIAL,
+    TICK_ERROR_BACKOFF_MULTIPLIER,
+    run_watch_loop,
+)
+from gispulse.runtime.config_loader import load_config
+from gispulse.runtime.headless_runtime import HeadlessRuntime, build_runtime
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (shared with test_triggers_watch but kept local for clarity)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def gpkg_with_parcels(tmp_path: Path) -> Path:
+    from persistence.gpkg_engine import GeoPackageEngine
+
+    gpkg = tmp_path / "resilience.gpkg"
+    eng = GeoPackageEngine(path=gpkg)
+    eng.open()
+    try:
+        conn = eng._get_conn()  # noqa: SLF001
+        conn.execute(
+            'CREATE TABLE "parcels" '
+            '(fid INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)'
+        )
+        conn.commit()
+        eng.enable_change_tracking("parcels")
+    finally:
+        eng.close()
+    return gpkg
+
+
+@pytest.fixture()
+def yaml_one_trigger(gpkg_with_parcels: Path, tmp_path: Path) -> Path:
+    cfg = tmp_path / "triggers.yaml"
+    cfg.write_text(
+        textwrap.dedent(
+            f"""
+            version: 1
+            gpkg: {gpkg_with_parcels}
+            triggers:
+              - name: log_only
+                table: parcels
+                actions:
+                  - type: log_event
+            runtime:
+              poll_interval_ms: 50
+              max_batch: 10
+            """,
+        ).strip(),
+        encoding="utf-8",
+    )
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+class _RecordingSleeper:
+    """Sleeper that records every timeout it received."""
+
+    def __init__(self) -> None:
+        self.calls: list[float] = []
+
+    def __call__(self, timeout: float) -> bool:
+        self.calls.append(timeout)
+        return False
+
+
+class _ThenSucceedRunOnce:
+    """Programmable ``run_once`` that fails N times then succeeds.
+
+    Patched onto the runtime instance so we can simulate a transient
+    error without touching the engine.
+    """
+
+    def __init__(self, fail_first_n: int) -> None:
+        self.fail_first_n = fail_first_n
+        self.calls = 0
+
+    def __call__(self, *args: Any, **kwargs: Any) -> int:
+        self.calls += 1
+        if self.calls <= self.fail_first_n:
+            raise RuntimeError(f"simulated tick failure #{self.calls}")
+        return 0
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_single_tick_failure_triggers_backoff_and_retry(
+    yaml_one_trigger: Path,
+    gpkg_with_parcels: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """One tick raises → daemon logs ``watch_tick_failed``, sleeps on
+    the backoff sleeper, then succeeds on the next tick.
+
+    Verifies: counter resets on success, backoff timeout matches the
+    initial value, daemon does NOT exit.
+    """
+    cfg = load_config(yaml_one_trigger)
+    runtime = build_runtime(
+        gpkg_path=gpkg_with_parcels,
+        triggers=[],
+        webhook_client=lambda url, payload: None,
+        sql_executor=lambda *a, **kw: None,
+        poll_interval=0.05,
+        batch_limit=10,
+        dataset_id="test",
+    )
+
+    fail_then_ok = _ThenSucceedRunOnce(fail_first_n=1)
+    sleeper = _RecordingSleeper()
+
+    with patch.object(HeadlessRuntime, "run_once", fail_then_ok):
+        exit_code = run_watch_loop(
+            initial_runtime=runtime,
+            initial_cfg=cfg,
+            config_path=yaml_one_trigger,
+            gpkg_override=None,
+            poll_interval=0.05,
+            sleeper=sleeper,
+            max_ticks=3,
+        )
+
+    assert exit_code == 0
+    assert fail_then_ok.calls == 3
+
+    captured = capsys.readouterr()
+    events = [json.loads(line) for line in captured.err.splitlines() if line.strip()]
+    failed = [e for e in events if e["event"] == "watch_tick_failed"]
+    succeeded = [e for e in events if e["event"] == "watch_tick"]
+    assert len(failed) == 1
+    assert failed[0]["consecutive_failures"] == 1
+    # 3 ticks total, 1 failed, 2 succeeded.
+    assert len(succeeded) == 2
+
+    # The sleeper saw the initial backoff timeout once on the failure path,
+    # then the regular poll_interval on success-path waits.
+    assert TICK_ERROR_BACKOFF_INITIAL in sleeper.calls, (
+        f"expected initial backoff timeout in sleeper calls: {sleeper.calls!r}"
+    )
+
+
+def test_ten_consecutive_failures_exits_one(
+    yaml_one_trigger: Path,
+    gpkg_with_parcels: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The brief: 10 ticks consécutifs foirent → exit 1 avec message."""
+    cfg = load_config(yaml_one_trigger)
+    runtime = build_runtime(
+        gpkg_path=gpkg_with_parcels,
+        triggers=[],
+        webhook_client=lambda url, payload: None,
+        sql_executor=lambda *a, **kw: None,
+        poll_interval=0.05,
+        batch_limit=10,
+        dataset_id="test",
+    )
+
+    always_fail = _ThenSucceedRunOnce(fail_first_n=1_000)
+    sleeper = _RecordingSleeper()
+
+    t0 = time.monotonic()
+    with patch.object(HeadlessRuntime, "run_once", always_fail):
+        exit_code = run_watch_loop(
+            initial_runtime=runtime,
+            initial_cfg=cfg,
+            config_path=yaml_one_trigger,
+            gpkg_override=None,
+            poll_interval=0.05,
+            sleeper=sleeper,
+            # Don't bound by max_ticks — let the failure budget enforce exit.
+            max_ticks=None,
+            stop_event=threading.Event(),
+        )
+    elapsed = time.monotonic() - t0
+
+    assert exit_code == 1
+    # Brief budget: tests must run < 5 s. With a no-op sleeper this is
+    # near-instant, but we assert the bound to catch regressions.
+    assert elapsed < 3.0, f"daemon shutdown took {elapsed:.2f}s — sleeper not honoured?"
+
+    # Exactly MAX_CONSECUTIVE_TICK_FAILURES failed run_once calls before exit.
+    assert always_fail.calls == MAX_CONSECUTIVE_TICK_FAILURES
+
+    captured = capsys.readouterr()
+    events = [json.loads(line) for line in captured.err.splitlines() if line.strip()]
+    aborts = [e for e in events if e["event"] == "watch_aborted_after_failures"]
+    assert len(aborts) == 1
+    assert aborts[0]["consecutive_failures"] == MAX_CONSECUTIVE_TICK_FAILURES
+    assert aborts[0]["max"] == MAX_CONSECUTIVE_TICK_FAILURES
+
+
+def test_backoff_grows_exponentially_then_caps(
+    yaml_one_trigger: Path,
+    gpkg_with_parcels: Path,
+) -> None:
+    """The sleeper should see backoff timeouts following the
+    ``initial * multiplier**n`` schedule, clamped at ``cap``.
+
+    With ``initial=1.0``, ``multiplier=2.0``, ``cap=30.0`` we expect:
+        attempt 1 → 1.0
+        attempt 2 → 2.0
+        attempt 3 → 4.0
+        attempt 4 → 8.0
+        attempt 5 → 16.0
+        attempt 6 → 30.0  (capped, would be 32)
+        attempt 7 → 30.0
+        attempt 8 → 30.0
+        attempt 9 → 30.0
+    Then attempt 10 → exit 1 (no further sleep — the budget triggers
+    BEFORE the post-failure sleep).
+    """
+    cfg = load_config(yaml_one_trigger)
+    runtime = build_runtime(
+        gpkg_path=gpkg_with_parcels,
+        triggers=[],
+        webhook_client=lambda url, payload: None,
+        sql_executor=lambda *a, **kw: None,
+        poll_interval=0.05,
+        batch_limit=10,
+        dataset_id="test",
+    )
+
+    always_fail = _ThenSucceedRunOnce(fail_first_n=1_000)
+    sleeper = _RecordingSleeper()
+
+    with patch.object(HeadlessRuntime, "run_once", always_fail):
+        run_watch_loop(
+            initial_runtime=runtime,
+            initial_cfg=cfg,
+            config_path=yaml_one_trigger,
+            gpkg_override=None,
+            poll_interval=0.05,
+            sleeper=sleeper,
+        )
+
+    # Compute expected schedule.
+    expected: list[float] = []
+    cur = TICK_ERROR_BACKOFF_INITIAL
+    for _ in range(MAX_CONSECUTIVE_TICK_FAILURES - 1):
+        expected.append(cur)
+        cur = min(cur * TICK_ERROR_BACKOFF_MULTIPLIER, TICK_ERROR_BACKOFF_CAP)
+
+    assert sleeper.calls == expected, (
+        f"backoff schedule mismatch: expected {expected!r}, got {sleeper.calls!r}"
+    )
+    # And the final value did hit the cap (proves the clamp works).
+    assert TICK_ERROR_BACKOFF_CAP in sleeper.calls
+
+
+def test_cancellable_backoff_breaks_immediately(
+    yaml_one_trigger: Path,
+    gpkg_with_parcels: Path,
+) -> None:
+    """When the sleeper returns True (cancellation requested), the
+    daemon must break out of the backoff and exit 0 — even mid-failure
+    streak. This is the SIGINT-during-backoff path."""
+    cfg = load_config(yaml_one_trigger)
+    runtime = build_runtime(
+        gpkg_path=gpkg_with_parcels,
+        triggers=[],
+        webhook_client=lambda url, payload: None,
+        sql_executor=lambda *a, **kw: None,
+        poll_interval=0.05,
+        batch_limit=10,
+        dataset_id="test",
+    )
+
+    always_fail = _ThenSucceedRunOnce(fail_first_n=1_000)
+
+    # Sleeper that cancels on its first call.
+    def cancel_first_call(timeout: float) -> bool:
+        return True
+
+    with patch.object(HeadlessRuntime, "run_once", always_fail):
+        exit_code = run_watch_loop(
+            initial_runtime=runtime,
+            initial_cfg=cfg,
+            config_path=yaml_one_trigger,
+            gpkg_override=None,
+            poll_interval=0.05,
+            sleeper=cancel_first_call,
+        )
+
+    # Clean exit 0 — the consecutive-failure budget is NOT exhausted
+    # because the cancellation broke the loop after the first failure.
+    assert exit_code == 0
+    assert always_fail.calls == 1
+
+
+def test_run_once_failure_does_not_close_runtime_prematurely(
+    yaml_one_trigger: Path,
+    gpkg_with_parcels: Path,
+) -> None:
+    """A failed tick must not close the runtime — the next tick reuses
+    the same engine and dispatcher. Verified by asserting we can still
+    insert + drain after recovery."""
+    cfg = load_config(yaml_one_trigger)
+    runtime = build_runtime(
+        gpkg_path=gpkg_with_parcels,
+        triggers=[],
+        webhook_client=lambda url, payload: None,
+        sql_executor=lambda *a, **kw: None,
+        poll_interval=0.05,
+        batch_limit=10,
+        dataset_id="test",
+    )
+
+    fail_then_ok = _ThenSucceedRunOnce(fail_first_n=2)
+    sleeper = _RecordingSleeper()
+
+    # Insert a row before kicking off the loop so the post-recovery
+    # tick has something to drain.
+    conn = sqlite3.connect(str(gpkg_with_parcels))
+    try:
+        conn.execute('INSERT INTO "parcels"(name) VALUES (?)', ("alpha",))
+        conn.commit()
+    finally:
+        conn.close()
+
+    with patch.object(HeadlessRuntime, "run_once", fail_then_ok):
+        exit_code = run_watch_loop(
+            initial_runtime=runtime,
+            initial_cfg=cfg,
+            config_path=yaml_one_trigger,
+            gpkg_override=None,
+            poll_interval=0.05,
+            sleeper=sleeper,
+            max_ticks=4,
+        )
+
+    # 2 fails + 2 successes = 4 calls.
+    assert fail_then_ok.calls == 4
+    assert exit_code == 0

--- a/tests/runtime/test_action_dispatcher_retry.py
+++ b/tests/runtime/test_action_dispatcher_retry.py
@@ -1,0 +1,343 @@
+"""Tests for the SQLITE_BUSY retry wrapper used by the headless runtime.
+
+Strategy
+--------
+Drive :class:`RetryingSqlExecutor` directly with a stub ``inner`` that we
+can program to raise / succeed on demand. Time is mocked via the
+``sleeper`` injection point so the suite stays sub-second.
+
+The wrapper sits between :class:`ActionDispatcher` and the actual GPKG
+``execute`` callable. We exercise three flows that the brief calls out:
+
+1. First attempt fails with ``database is locked``, second succeeds →
+   action returns the inner's result, retry counter == 1.
+2. Five attempts in a row fail with ``database is locked`` → wrapper
+   re-raises ``OperationalError``, dispatcher's outer try/except logs,
+   change-log row is NOT acked (verified at the watcher layer in the
+   CLI integration suite).
+3. Non-busy ``OperationalError`` (``no such table``) → fail immediately
+   with **zero** retries (we must not mask real bugs by spinning).
+
+The fourth axiom — that the dispatcher itself wires the wrapper
+transparently when ``build_runtime`` is called without a custom
+``sql_executor`` — is checked via the public
+``HeadlessRuntime.retrying_sql`` handle in the existing
+``test_headless_runtime`` suite.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+import pytest
+
+from gispulse.runtime.sqlite_retry import (
+    DEFAULT_BACKOFF_SCHEDULE,
+    RetryingSqlExecutor,
+    is_busy_error,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _ProgrammableInner:
+    """Stub SQL executor whose behaviour is driven by a queue of outcomes.
+
+    Each call pops one item from ``self.outcomes``:
+
+    * an ``Exception`` instance → re-raised
+    * anything else → returned as-is
+
+    Tracks every ``(args, kwargs)`` tuple in ``self.calls`` for assertions.
+    """
+
+    def __init__(self, outcomes: list[Any]) -> None:
+        self.outcomes = list(outcomes)
+        self.calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        self.calls.append((args, kwargs))
+        if not self.outcomes:
+            raise RuntimeError("test outcome queue exhausted")
+        result = self.outcomes.pop(0)
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+
+def _busy() -> sqlite3.OperationalError:
+    return sqlite3.OperationalError("database is locked")
+
+
+def _busy_other_phrasing() -> sqlite3.OperationalError:
+    return sqlite3.OperationalError("database is busy")
+
+
+def _no_such_table() -> sqlite3.OperationalError:
+    return sqlite3.OperationalError("no such table: parcels")
+
+
+# ---------------------------------------------------------------------------
+# is_busy_error
+# ---------------------------------------------------------------------------
+
+
+def test_is_busy_error_recognises_both_phrasings() -> None:
+    assert is_busy_error(_busy()) is True
+    assert is_busy_error(_busy_other_phrasing()) is True
+
+
+def test_is_busy_error_rejects_other_operational_errors() -> None:
+    assert is_busy_error(_no_such_table()) is False
+    assert is_busy_error(sqlite3.OperationalError("syntax error")) is False
+
+
+def test_is_busy_error_rejects_non_sqlite_exceptions() -> None:
+    assert is_busy_error(RuntimeError("database is locked")) is False
+    assert is_busy_error(ValueError()) is False
+
+
+# ---------------------------------------------------------------------------
+# RetryingSqlExecutor — happy path / retry / exhaustion
+# ---------------------------------------------------------------------------
+
+
+def test_first_attempt_succeeds_no_retry() -> None:
+    inner = _ProgrammableInner([42])
+    sleeps: list[float] = []
+    wrapper = RetryingSqlExecutor(inner, sleeper=sleeps.append)
+
+    result = wrapper("SELECT 1", [])
+
+    assert result == 42
+    assert wrapper.snapshot_retries() == 0
+    assert sleeps == [], "no retries → no sleep"
+    assert len(inner.calls) == 1
+
+
+def test_one_busy_then_success_reports_one_retry() -> None:
+    """First call raises 'database is locked', second returns OK."""
+    inner = _ProgrammableInner([_busy(), "ok"])
+    sleeps: list[float] = []
+    wrapper = RetryingSqlExecutor(inner, sleeper=sleeps.append)
+
+    result = wrapper("UPDATE parcels SET x=1 WHERE fid=?", [1])
+
+    assert result == "ok"
+    assert wrapper.snapshot_retries() == 1
+    assert len(sleeps) == 1
+    # Jitter is ±20 %: the slot is 0.1 s so we land in [0.08, 0.12].
+    assert 0.08 - 1e-9 <= sleeps[0] <= 0.12 + 1e-9
+    assert len(inner.calls) == 2
+
+
+def test_busy_alternative_phrasing_also_retried() -> None:
+    inner = _ProgrammableInner([_busy_other_phrasing(), "ok"])
+    wrapper = RetryingSqlExecutor(inner, sleeper=lambda _t: None)
+
+    assert wrapper("x") == "ok"
+    assert wrapper.snapshot_retries() == 1
+
+
+def test_five_busy_in_a_row_exhausts_and_reraises() -> None:
+    """Default schedule has 5 slots: 6 calls (1 initial + 5 retries) all
+    fail busy → the final one re-raises ``OperationalError``."""
+    schedule = DEFAULT_BACKOFF_SCHEDULE  # 5 slots
+    n_attempts = len(schedule) + 1  # 6 total
+    inner = _ProgrammableInner([_busy() for _ in range(n_attempts)])
+    sleeps: list[float] = []
+    wrapper = RetryingSqlExecutor(inner, sleeper=sleeps.append)
+
+    with pytest.raises(sqlite3.OperationalError) as ei:
+        wrapper("UPDATE parcels SET x=1")
+
+    assert is_busy_error(ei.value)
+    # Counter increments only for retries that actually fired (not the
+    # final exhaustion → it's the 5th retry that raised after sleeping).
+    # Specifically: attempts 0..4 sleep + retry, attempt 5 raises.
+    assert wrapper.snapshot_retries() == len(schedule)
+    assert len(sleeps) == len(schedule)
+    assert len(inner.calls) == n_attempts
+
+
+def test_non_busy_operational_error_fails_immediately() -> None:
+    """Any non-busy ``OperationalError`` (no such table, syntax error,
+    …) must NOT be retried. Spinning here would mask real bugs."""
+    inner = _ProgrammableInner([_no_such_table(), "would_succeed"])
+    sleeps: list[float] = []
+    wrapper = RetryingSqlExecutor(inner, sleeper=sleeps.append)
+
+    with pytest.raises(sqlite3.OperationalError, match="no such table"):
+        wrapper("SELECT * FROM parcels")
+
+    assert wrapper.snapshot_retries() == 0
+    assert sleeps == [], "no retry on permanent error"
+    assert len(inner.calls) == 1
+
+
+def test_non_operational_exception_propagates_unchanged() -> None:
+    """``IntegrityError``, ``ValueError`` etc. should bypass the retry."""
+    err = sqlite3.IntegrityError("UNIQUE constraint failed")
+    inner = _ProgrammableInner([err])
+    wrapper = RetryingSqlExecutor(inner, sleeper=lambda _t: None)
+
+    with pytest.raises(sqlite3.IntegrityError):
+        wrapper("INSERT ...")
+
+    assert wrapper.snapshot_retries() == 0
+
+
+# ---------------------------------------------------------------------------
+# Counter / reset semantics
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_retries_is_cumulative_across_calls() -> None:
+    """The CLI tick log relies on ``snapshot_retries()`` returning the
+    running total so it can diff per tick."""
+    inner = _ProgrammableInner([
+        _busy(), "ok",          # call 1: 1 retry
+        _busy(), _busy(), "ok"  # call 2: 2 retries
+    ])
+    wrapper = RetryingSqlExecutor(inner, sleeper=lambda _t: None)
+
+    wrapper("a")
+    assert wrapper.snapshot_retries() == 1
+    wrapper("b")
+    assert wrapper.snapshot_retries() == 3
+
+
+def test_reset_retries_zeroes_the_counter() -> None:
+    inner = _ProgrammableInner([_busy(), "ok"])
+    wrapper = RetryingSqlExecutor(inner, sleeper=lambda _t: None)
+    wrapper("x")
+    assert wrapper.snapshot_retries() == 1
+    wrapper.reset_retries()
+    assert wrapper.snapshot_retries() == 0
+
+
+# ---------------------------------------------------------------------------
+# Constructor validation
+# ---------------------------------------------------------------------------
+
+
+def test_constructor_rejects_none_inner() -> None:
+    with pytest.raises(ValueError, match="inner"):
+        RetryingSqlExecutor(None)  # type: ignore[arg-type]
+
+
+def test_constructor_rejects_empty_backoff() -> None:
+    with pytest.raises(ValueError, match="backoff"):
+        RetryingSqlExecutor(lambda *a, **k: None, backoff=())
+
+
+def test_constructor_rejects_invalid_jitter() -> None:
+    with pytest.raises(ValueError, match="jitter"):
+        RetryingSqlExecutor(lambda *a, **k: None, jitter_pct=1.5)
+    with pytest.raises(ValueError, match="jitter"):
+        RetryingSqlExecutor(lambda *a, **k: None, jitter_pct=-0.1)
+
+
+# ---------------------------------------------------------------------------
+# Custom backoff schedule
+# ---------------------------------------------------------------------------
+
+
+def test_custom_short_schedule_respected() -> None:
+    """A 2-slot schedule means at most 3 attempts."""
+    inner = _ProgrammableInner([_busy(), _busy(), _busy()])
+    sleeps: list[float] = []
+    wrapper = RetryingSqlExecutor(
+        inner, backoff=(0.001, 0.002), jitter_pct=0.0, sleeper=sleeps.append
+    )
+
+    with pytest.raises(sqlite3.OperationalError):
+        wrapper("x")
+    assert len(inner.calls) == 3
+    assert sleeps == [0.001, 0.002]
+    assert wrapper.snapshot_retries() == 2
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher integration via build_runtime: the wrapper is wired by
+# default and surfaces on the runtime handle.
+# ---------------------------------------------------------------------------
+
+
+def test_build_runtime_skips_wrapper_when_engine_has_no_executor(
+    tmp_path: Any,
+) -> None:
+    """The default :class:`GeoPackageEngine` does not expose ``execute``;
+    when no ``sql_executor=`` is injected and no fallback is found,
+    ``retrying_sql`` stays ``None`` (no-op wiring, matches today's
+    HTTP-side wiring at ``app.py:339``)."""
+    from persistence.gpkg_engine import GeoPackageEngine
+
+    from gispulse.runtime import build_runtime
+
+    gpkg = tmp_path / "fixture.gpkg"
+    eng = GeoPackageEngine(path=gpkg)
+    eng.open()
+    try:
+        conn = eng._get_conn()  # noqa: SLF001
+        conn.execute('CREATE TABLE "x"(id INTEGER PRIMARY KEY)')
+        conn.commit()
+    finally:
+        eng.close()
+
+    runtime = build_runtime(
+        gpkg_path=gpkg,
+        triggers=[],
+        webhook_client=lambda url, payload: None,
+        dataset_id="test",
+    )
+    try:
+        # Engine.execute does not exist on GeoPackageEngine today.
+        assert runtime.retrying_sql is None
+    finally:
+        runtime.close()
+
+
+def test_build_runtime_also_wraps_user_supplied_executor(
+    tmp_path: Any,
+) -> None:
+    """When the caller injects a stub, we still wrap it — so a user's
+    integration test that simulates SQLITE_BUSY benefits from the same
+    retry policy as production."""
+    from persistence.gpkg_engine import GeoPackageEngine
+
+    from gispulse.runtime import build_runtime
+
+    gpkg = tmp_path / "fixture.gpkg"
+    eng = GeoPackageEngine(path=gpkg)
+    eng.open()
+    try:
+        conn = eng._get_conn()  # noqa: SLF001
+        conn.execute('CREATE TABLE "x"(id INTEGER PRIMARY KEY)')
+        conn.commit()
+    finally:
+        eng.close()
+
+    captured: list[tuple[str, Any]] = []
+
+    def stub(sql: str, params: Any = None) -> None:
+        captured.append((sql, params))
+
+    runtime = build_runtime(
+        gpkg_path=gpkg,
+        triggers=[],
+        sql_executor=stub,
+        webhook_client=lambda url, payload: None,
+        dataset_id="test",
+    )
+    try:
+        assert runtime.retrying_sql is not None
+        # Passing through the wrapper should still reach the stub.
+        runtime.retrying_sql("SELECT 1", [])
+        assert captured == [("SELECT 1", [])]
+    finally:
+        runtime.close()

--- a/tests/runtime/test_config_loader.py
+++ b/tests/runtime/test_config_loader.py
@@ -315,6 +315,94 @@ def test_yaml_root_must_be_mapping(tmp_path: Path) -> None:
         load_config(bad)
 
 
+def test_predicate_dsl_compiled_into_ast(
+    tracked_gpkg: Path, tmp_path: Path
+) -> None:
+    """A YAML predicate gets parsed eagerly and the compiled AST is
+    stashed on the domain trigger's ``conditions``.
+    """
+    from gispulse.runtime.predicate_dsl import PredicateNode
+
+    cfg_path = tmp_path / "with_predicate.yaml"
+    cfg_path.write_text(
+        textwrap.dedent(
+            f"""
+            version: 1
+            gpkg: {tracked_gpkg}
+            triggers:
+              - name: high_value
+                table: parcels
+                predicate: "name == 'parcelle_1'"
+                actions:
+                  - type: log_event
+            """,
+        ).strip(),
+        encoding="utf-8",
+    )
+    cfg = load_config(cfg_path)
+    triggers = to_triggers(cfg)
+    assert len(triggers) == 1
+    cond = triggers[0].conditions
+    # Verbatim source is preserved for observability.
+    assert cond["predicate"] == "name == 'parcelle_1'"
+    # Compiled AST is ready for the runtime.
+    ast = cond.get("predicate_ast")
+    assert isinstance(ast, PredicateNode)
+
+
+def test_predicate_with_invalid_dsl_rejected(
+    tracked_gpkg: Path, tmp_path: Path
+) -> None:
+    """A broken DSL string surfaces as a config error with a clear
+    pointer to the offending trigger."""
+    cfg_path = tmp_path / "bad_predicate.yaml"
+    cfg_path.write_text(
+        textwrap.dedent(
+            f"""
+            version: 1
+            gpkg: {tracked_gpkg}
+            triggers:
+              - name: broken
+                table: parcels
+                predicate: "1; DROP TABLE users"
+                actions:
+                  - type: log_event
+            """,
+        ).strip(),
+        encoding="utf-8",
+    )
+    with pytest.raises(ConfigError) as excinfo:
+        load_config(cfg_path)
+    msg = str(excinfo.value)
+    assert "predicate parse failed" in msg
+
+
+def test_predicate_optional_keeps_legacy_behaviour(
+    tracked_gpkg: Path, tmp_path: Path
+) -> None:
+    """A YAML config without a ``predicate:`` key must continue to
+    work — no AST set on conditions, runtime falls back to always-match."""
+    cfg_path = tmp_path / "no_predicate.yaml"
+    cfg_path.write_text(
+        textwrap.dedent(
+            f"""
+            version: 1
+            gpkg: {tracked_gpkg}
+            triggers:
+              - name: legacy_no_predicate
+                table: parcels
+                actions:
+                  - type: log_event
+            """,
+        ).strip(),
+        encoding="utf-8",
+    )
+    cfg = load_config(cfg_path)
+    triggers = to_triggers(cfg)
+    assert "predicate" not in triggers[0].conditions
+    assert "predicate_ast" not in triggers[0].conditions
+
+
 def test_when_dedupes_and_rejects_empty(tracked_gpkg: Path, tmp_path: Path) -> None:
     # Empty when -> error
     bad = tmp_path / "empty_when.yaml"

--- a/tests/runtime/test_config_loader.py
+++ b/tests/runtime/test_config_loader.py
@@ -1,0 +1,355 @@
+"""Tests for ``gispulse.runtime.config_loader``.
+
+Coverage targets:
+- valid YAML round-trip through pydantic v2 strict schema
+- ``yaml.load`` (unsafe) is never used by the module (static grep test)
+- Path traversal escapes (``../../etc/passwd``) are rejected
+- Schema typos surface clear errors
+- ``validate_against_gpkg`` catches non-existent tables
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from gispulse.runtime.config_loader import (
+    ConfigError,
+    GISPulseConfig,
+    load_config,
+    to_triggers,
+    validate_against_gpkg,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def tracked_gpkg(tmp_path: Path) -> Path:
+    """Create a real GPKG with a ``parcels`` table tracked by triggers."""
+    from persistence.gpkg_engine import GeoPackageEngine
+
+    gpkg = tmp_path / "fixture.gpkg"
+    engine = GeoPackageEngine(path=gpkg)
+    engine.open()
+    try:
+        conn = engine._get_conn()  # noqa: SLF001
+        conn.execute(
+            'CREATE TABLE "parcels" '
+            '(fid INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)'
+        )
+        conn.execute(
+            'CREATE TABLE "buildings" '
+            '(fid INTEGER PRIMARY KEY AUTOINCREMENT, height REAL)'
+        )
+        conn.commit()
+        engine.enable_change_tracking("parcels")
+        engine.enable_change_tracking("buildings")
+    finally:
+        engine.close()
+    return gpkg
+
+
+@pytest.fixture()
+def valid_yaml(tracked_gpkg: Path, tmp_path: Path) -> Path:
+    cfg = tmp_path / "triggers.yaml"
+    cfg.write_text(
+        textwrap.dedent(
+            f"""
+            version: 1
+            gpkg: {tracked_gpkg}
+            triggers:
+              - name: enrich
+                table: parcels
+                pk_col: fid
+                when: [INSERT, UPDATE]
+                actions:
+                  - type: webhook
+                    url: https://hook.example.com/parcels
+                  - type: set_field
+                    field: status
+                    value: enriched
+                  - type: run_sql
+                    expression: "SELECT 1"
+            security:
+              webhook_allowlist:
+                - hook.example.com
+            runtime:
+              poll_interval_ms: 500
+              max_batch: 50
+            """,
+        ).strip(),
+        encoding="utf-8",
+    )
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_load_config_valid_yaml(valid_yaml: Path, tracked_gpkg: Path) -> None:
+    cfg = load_config(valid_yaml)
+    assert isinstance(cfg, GISPulseConfig)
+    assert cfg.version == 1
+    assert Path(cfg.gpkg) == tracked_gpkg.resolve()
+    assert len(cfg.triggers) == 1
+    t = cfg.triggers[0]
+    assert t.name == "enrich"
+    assert t.table == "parcels"
+    assert t.when == ["INSERT", "UPDATE"]
+    assert len(t.actions) == 3
+    assert t.actions[0].type == "webhook"
+    assert cfg.runtime.poll_interval_ms == 500
+    assert cfg.runtime.max_batch == 50
+    assert cfg.security.webhook_allowlist == ["hook.example.com"]
+
+
+def test_to_triggers_maps_into_domain(valid_yaml: Path) -> None:
+    from core.graph import ActionType
+
+    cfg = load_config(valid_yaml)
+    triggers = to_triggers(cfg)
+    assert len(triggers) == 1
+    trig = triggers[0]
+    assert trig.name == "enrich"
+    assert trig.enabled is True
+    assert {a.action_type for a in trig.actions} == {
+        ActionType.WEBHOOK,
+        ActionType.SET_FIELD,
+        ActionType.RUN_SQL,
+    }
+    # YAML metadata stashed on conditions for downstream introspection.
+    assert trig.conditions["yaml_name"] == "enrich"
+    assert trig.conditions["table"] == "parcels"
+    assert trig.conditions["when"] == ["INSERT", "UPDATE"]
+
+
+def test_validate_against_gpkg_passes_when_tables_exist(valid_yaml: Path) -> None:
+    cfg = load_config(valid_yaml)
+    errors = validate_against_gpkg(cfg)
+    assert errors == []
+
+
+def test_gpkg_override_wins_over_config_value(
+    valid_yaml: Path, tracked_gpkg: Path
+) -> None:
+    # Build a second GPKG and pass it via override.
+    other = tracked_gpkg.parent / "other.gpkg"
+    from persistence.gpkg_engine import GeoPackageEngine
+
+    eng = GeoPackageEngine(path=other)
+    eng.open()
+    try:
+        conn = eng._get_conn()  # noqa: SLF001
+        conn.execute('CREATE TABLE "parcels"(fid INTEGER PRIMARY KEY)')
+        conn.commit()
+    finally:
+        eng.close()
+
+    cfg = load_config(valid_yaml, gpkg_override=other)
+    assert Path(cfg.gpkg) == other.resolve()
+
+
+# ---------------------------------------------------------------------------
+# Failure modes
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_yaml_syntax_rejected(tracked_gpkg: Path, tmp_path: Path) -> None:
+    bad = tmp_path / "bad.yaml"
+    bad.write_text("version: 1\ngpkg: ./fixture.gpkg\ntriggers: [\n - foo: bar\n", encoding="utf-8")
+    with pytest.raises(ConfigError, match="invalid YAML"):
+        load_config(bad)
+
+
+def test_unknown_top_level_key_rejected(tracked_gpkg: Path, tmp_path: Path) -> None:
+    bad = tmp_path / "extra.yaml"
+    bad.write_text(
+        f"version: 1\ngpkg: {tracked_gpkg}\ntriggers: []\nunknown_key: 1\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ConfigError, match="invalid config schema"):
+        load_config(bad)
+
+
+def test_unknown_action_type_rejected(tracked_gpkg: Path, tmp_path: Path) -> None:
+    bad = tmp_path / "bad_action.yaml"
+    bad.write_text(
+        textwrap.dedent(
+            f"""
+            version: 1
+            gpkg: {tracked_gpkg}
+            triggers:
+              - name: t
+                table: parcels
+                actions:
+                  - type: send_email_to_mars
+            """,
+        ).strip(),
+        encoding="utf-8",
+    )
+    with pytest.raises(ConfigError):
+        load_config(bad)
+
+
+def test_path_traversal_in_gpkg_rejected(valid_yaml: Path, tracked_gpkg: Path) -> None:
+    """An override path that escapes cwd ∪ $HOME is refused.
+
+    /etc/passwd is outside any plausible anchor on a CI runner.
+    """
+    with pytest.raises(ConfigError, match="path traversal|escapes"):
+        load_config(valid_yaml, gpkg_override="/etc/passwd")
+
+
+def test_webhook_url_must_be_http_or_https(tracked_gpkg: Path, tmp_path: Path) -> None:
+    bad = tmp_path / "scheme.yaml"
+    bad.write_text(
+        textwrap.dedent(
+            f"""
+            version: 1
+            gpkg: {tracked_gpkg}
+            triggers:
+              - name: t
+                table: parcels
+                actions:
+                  - type: webhook
+                    url: file:///etc/passwd
+            """,
+        ).strip(),
+        encoding="utf-8",
+    )
+    with pytest.raises(ConfigError):
+        load_config(bad)
+
+
+def test_validate_against_gpkg_reports_missing_table(
+    tracked_gpkg: Path, tmp_path: Path
+) -> None:
+    cfg = tmp_path / "missing.yaml"
+    cfg.write_text(
+        textwrap.dedent(
+            f"""
+            version: 1
+            gpkg: {tracked_gpkg}
+            triggers:
+              - name: typo
+                table: parcells   # <- typo
+                actions:
+                  - type: log_event
+            """,
+        ).strip(),
+        encoding="utf-8",
+    )
+    config = load_config(cfg)
+    errors = validate_against_gpkg(config)
+    assert errors
+    assert any("parcells" in e and "not found" in e for e in errors), errors
+
+
+def test_validate_reports_webhook_without_url(
+    tracked_gpkg: Path, tmp_path: Path
+) -> None:
+    """A webhook action without a URL must surface a clear error.
+
+    URL is optional in the pydantic model (so a `webhook` action can
+    co-exist with other types in the YAML without requiring the field
+    on every type), but `validate_against_gpkg` enforces it.
+    """
+    cfg = tmp_path / "noweb.yaml"
+    cfg.write_text(
+        textwrap.dedent(
+            f"""
+            version: 1
+            gpkg: {tracked_gpkg}
+            triggers:
+              - name: incomplete
+                table: parcels
+                actions:
+                  - type: webhook
+            """,
+        ).strip(),
+        encoding="utf-8",
+    )
+    config = load_config(cfg)
+    errors = validate_against_gpkg(config)
+    assert any("webhook action requires url" in e for e in errors), errors
+
+
+# ---------------------------------------------------------------------------
+# Static guarantee: yaml.load (unsafe) is never used
+# ---------------------------------------------------------------------------
+
+
+def test_module_does_not_call_unsafe_yaml_load() -> None:
+    """Static grep: ensure the module never reaches for ``yaml.load``."""
+    src = Path(__file__).resolve().parents[2] / "gispulse" / "runtime" / "config_loader.py"
+    text = src.read_text(encoding="utf-8")
+    # Reject ``yaml.load(`` exactly. ``yaml.safe_load`` is fine.
+    bad_patterns = ["yaml.load(", "yaml.unsafe_load(", "yaml.full_load("]
+    for pat in bad_patterns:
+        assert pat not in text, (
+            f"config_loader.py uses {pat!r} which is unsafe. "
+            "Only yaml.safe_load is allowed."
+        )
+
+
+def test_empty_yaml_rejected(tmp_path: Path) -> None:
+    empty = tmp_path / "empty.yaml"
+    empty.write_text("", encoding="utf-8")
+    with pytest.raises(ConfigError, match="empty config file"):
+        load_config(empty)
+
+
+def test_yaml_root_must_be_mapping(tmp_path: Path) -> None:
+    bad = tmp_path / "list.yaml"
+    bad.write_text("- one\n- two\n", encoding="utf-8")
+    with pytest.raises(ConfigError, match="must be a mapping"):
+        load_config(bad)
+
+
+def test_when_dedupes_and_rejects_empty(tracked_gpkg: Path, tmp_path: Path) -> None:
+    # Empty when -> error
+    bad = tmp_path / "empty_when.yaml"
+    bad.write_text(
+        textwrap.dedent(
+            f"""
+            version: 1
+            gpkg: {tracked_gpkg}
+            triggers:
+              - name: t
+                table: parcels
+                when: []
+                actions: []
+            """,
+        ).strip(),
+        encoding="utf-8",
+    )
+    with pytest.raises(ConfigError):
+        load_config(bad)
+
+    # Duplicates collapsed
+    dup = tmp_path / "dup.yaml"
+    dup.write_text(
+        textwrap.dedent(
+            f"""
+            version: 1
+            gpkg: {tracked_gpkg}
+            triggers:
+              - name: t
+                table: parcels
+                when: [INSERT, INSERT, UPDATE]
+                actions: []
+            """,
+        ).strip(),
+        encoding="utf-8",
+    )
+    cfg = load_config(dup)
+    assert cfg.triggers[0].when == ["INSERT", "UPDATE"]

--- a/tests/runtime/test_headless_runtime.py
+++ b/tests/runtime/test_headless_runtime.py
@@ -1,0 +1,294 @@
+"""Tests for ``gispulse.runtime.headless_runtime``.
+
+Strategy
+--------
+Build a real GPKG in ``tmp_path``, install ``enable_change_tracking``
+on a parcels table, then exercise three trigger flavours end-to-end via
+``HeadlessRuntime.run_once()``:
+
+1. ``ActionType.RUN_SQL`` — the dispatcher calls a captured SQL executor.
+2. ``ActionType.WEBHOOK`` — a fake webhook callable receives the payload.
+3. ``ActionType.SET_FIELD`` — the SQL executor writes back into the table.
+
+We deliberately bypass :class:`HttpWebhookClient` (which would refuse the
+fake URL via SSRF policy) and inject a plain stub via ``webhook_client=``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from core.enums import TriggerCategory, TriggerEvent, TriggerType
+from core.graph import ActionDef, ActionType
+from core.models import Trigger
+from gispulse.runtime import build_runtime
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def gpkg_with_parcels(tmp_path: Path) -> Path:
+    """Create a real GPKG with a tracked ``parcels`` table.
+
+    We use ``GeoPackageEngine`` directly so the boot path is identical
+    to what the runtime will see (bootstrap_gpkg_project, native
+    triggers, etc.). The engine is closed after setup so the runtime
+    can open it cleanly.
+    """
+    from persistence.gpkg_engine import GeoPackageEngine
+
+    gpkg_path = tmp_path / "fixture.gpkg"
+    engine = GeoPackageEngine(path=gpkg_path)
+    engine.open()
+    try:
+        conn = engine._get_conn()  # noqa: SLF001
+        conn.execute(
+            'CREATE TABLE IF NOT EXISTS "parcels" '
+            '(fid INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, status TEXT)'
+        )
+        conn.commit()
+        engine.enable_change_tracking("parcels")
+    finally:
+        engine.close()
+    return gpkg_path
+
+
+def _make_trigger(*, action: ActionDef, name: str = "t1") -> Trigger:
+    return Trigger(
+        id=uuid4(),
+        name=name,
+        description="test trigger",
+        event=TriggerEvent.DATA_CHANGED,
+        trigger_type=TriggerType.DML,
+        category=TriggerCategory.DATA,
+        actions=[action],
+        enabled=True,
+    )
+
+
+def _insert_row(gpkg: Path, name: str = "alpha") -> None:
+    """Open a *separate* sqlite connection to fire the native triggers."""
+    conn = sqlite3.connect(str(gpkg))
+    try:
+        conn.execute('INSERT INTO "parcels"(name, status) VALUES (?, ?)', (name, "pending"))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_run_once_executes_run_sql_action(gpkg_with_parcels: Path) -> None:
+    """An INSERT in the GPKG fires the native trigger, the watcher reads
+    the change-log and the dispatcher runs our RUN_SQL action."""
+    captured: list[tuple[str, Any]] = []
+
+    def fake_sql(sql: str, params: Any = None) -> None:
+        captured.append((sql, params))
+
+    trigger = _make_trigger(
+        action=ActionDef(
+            action_type=ActionType.RUN_SQL,
+            config={"expression": "SELECT 1"},
+        ),
+        name="run_sql_test",
+    )
+
+    _insert_row(gpkg_with_parcels)
+
+    runtime = build_runtime(
+        gpkg_path=gpkg_with_parcels,
+        triggers=[trigger],
+        sql_executor=fake_sql,
+        # Plain stub so we never reach HttpWebhookClient / SSRF policy.
+        webhook_client=lambda url, payload: None,
+        dataset_id="test",
+    )
+    try:
+        processed = runtime.run_once()
+    finally:
+        runtime.close()
+
+    assert processed >= 1, "watcher should have read at least one change-log row"
+    # The RUN_SQL handler validates expression then calls fake_sql once.
+    assert any("SELECT 1" in sql for sql, _ in captured), (
+        f"RUN_SQL handler should have called the executor with our expression. "
+        f"captured={captured!r}"
+    )
+
+
+def test_run_once_invokes_webhook_with_correct_payload(gpkg_with_parcels: Path) -> None:
+    """WEBHOOK action fires the injected client with a structured payload."""
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    def fake_webhook(url: str, payload: dict[str, Any]) -> None:
+        calls.append((url, payload))
+
+    trigger = _make_trigger(
+        action=ActionDef(
+            action_type=ActionType.WEBHOOK,
+            config={"url": "https://hook.example.com/parcels"},
+        ),
+        name="webhook_test",
+    )
+
+    _insert_row(gpkg_with_parcels, name="beta")
+
+    runtime = build_runtime(
+        gpkg_path=gpkg_with_parcels,
+        triggers=[trigger],
+        webhook_client=fake_webhook,
+        sql_executor=lambda *a, **kw: None,
+        dataset_id="test",
+    )
+    try:
+        runtime.run_once()
+    finally:
+        runtime.close()
+
+    assert calls, "webhook callable should have been invoked"
+    url, payload = calls[0]
+    assert url == "https://hook.example.com/parcels"
+    # Contract from action_dispatcher._webhook
+    assert payload["event_type"] == "trigger_fired"
+    assert payload["table"] == "parcels"
+    assert payload["operation"] == "INSERT"
+    assert payload["matched"] is True
+    assert payload["trigger_name"] == "webhook_test"
+
+
+def test_run_once_set_field_writes_value(gpkg_with_parcels: Path) -> None:
+    """SET_FIELD action calls the SQL executor with an UPDATE that targets
+    the right table + field. We verify the captured SQL shape (the real
+    GPKG executor isn't wired in this test, the dispatcher only emits
+    the SQL via our stub)."""
+    captured: list[tuple[str, Any]] = []
+
+    def fake_sql(sql: str, params: Any = None) -> None:
+        captured.append((sql, params))
+
+    trigger = _make_trigger(
+        action=ActionDef(
+            action_type=ActionType.SET_FIELD,
+            config={"field": "status", "value": "ok"},
+        ),
+        name="set_field_test",
+    )
+
+    _insert_row(gpkg_with_parcels, name="gamma")
+
+    runtime = build_runtime(
+        gpkg_path=gpkg_with_parcels,
+        triggers=[trigger],
+        sql_executor=fake_sql,
+        webhook_client=lambda url, payload: None,
+        dataset_id="test",
+    )
+    try:
+        runtime.run_once()
+    finally:
+        runtime.close()
+
+    assert captured, f"SET_FIELD should produce one SQL call, got {captured!r}"
+    sql, params = captured[0]
+    # The handler builds: UPDATE "parcels" SET "status" = %s WHERE id = %s
+    assert 'UPDATE "parcels"' in sql
+    assert '"status"' in sql
+    assert params[0] == "ok"
+
+
+def test_build_runtime_rejects_missing_gpkg(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        build_runtime(
+            gpkg_path=tmp_path / "does_not_exist.gpkg",
+            triggers=[],
+        )
+
+
+def test_build_runtime_rejects_invalid_dataset_id(gpkg_with_parcels: Path) -> None:
+    with pytest.raises(ValueError, match="dataset_id"):
+        build_runtime(
+            gpkg_path=gpkg_with_parcels,
+            triggers=[],
+            dataset_id="",
+        )
+
+
+def test_run_once_with_no_triggers_just_acks(gpkg_with_parcels: Path) -> None:
+    """Insert without configured triggers: watcher still drains and acks."""
+    _insert_row(gpkg_with_parcels)
+
+    runtime = build_runtime(
+        gpkg_path=gpkg_with_parcels,
+        triggers=[],
+        sql_executor=lambda *a, **kw: None,
+        webhook_client=lambda url, payload: None,
+        dataset_id="test",
+    )
+    try:
+        processed = runtime.run_once()
+        # Second tick: nothing left to process.
+        leftover = runtime.run_once()
+    finally:
+        runtime.close()
+
+    assert processed >= 1
+    assert leftover == 0
+
+
+def test_null_event_hub_swallows_broadcasts() -> None:
+    """Smoke test for the no-op hub used in headless mode."""
+    from gispulse.runtime import NullEventHub
+
+    hub = NullEventHub()
+    # Must not raise no matter what we throw at it.
+    hub.broadcast("any.event", {"a": 1, "b": [1, 2, 3]})
+    hub.broadcast("empty", None)
+    hub.broadcast("nodata")  # type: ignore[call-arg]
+
+
+def test_webhook_allowlist_blocks_off_list_host(gpkg_with_parcels: Path) -> None:
+    """When ``webhook_allowlist`` is provided and the trigger URL is not
+    on it, the dispatcher's per-action try/except logs but doesn't crash
+    — and our test ensures the wrapped HttpWebhookClient is never reached
+    (no network call)."""
+    from urllib.parse import urlparse
+
+    # Build a runtime with the default webhook_client wrapping
+    # HttpWebhookClient, but with an allowlist that excludes the
+    # webhook host. The dispatcher's try/except catches the
+    # PermissionError so the run does not raise.
+    trigger = _make_trigger(
+        action=ActionDef(
+            action_type=ActionType.WEBHOOK,
+            config={"url": "https://blocked.example.com/x"},
+        ),
+        name="blocked_webhook",
+    )
+
+    _insert_row(gpkg_with_parcels)
+
+    runtime = build_runtime(
+        gpkg_path=gpkg_with_parcels,
+        triggers=[trigger],
+        webhook_allowlist=["allowed.example.com"],
+        sql_executor=lambda *a, **kw: None,
+        dataset_id="test",
+    )
+    # The dispatcher swallows action errors, so run_once must succeed.
+    try:
+        processed = runtime.run_once()
+    finally:
+        runtime.close()
+    assert processed >= 1

--- a/tests/runtime/test_headless_runtime.py
+++ b/tests/runtime/test_headless_runtime.py
@@ -258,6 +258,195 @@ def test_null_event_hub_swallows_broadcasts() -> None:
     hub.broadcast("nodata")  # type: ignore[call-arg]
 
 
+def _insert_with_value(
+    gpkg: Path, *, name: str, status: str, valeur: int | None = None
+) -> None:
+    """Helper to insert a parcel with a numeric ``valeur`` column.
+
+    The base fixture ``parcels`` table only has ``name``/``status``;
+    predicate tests need a numeric column so we add it on demand. The
+    ALTER is idempotent.
+    """
+    conn = sqlite3.connect(str(gpkg))
+    try:
+        try:
+            conn.execute('ALTER TABLE "parcels" ADD COLUMN valeur INTEGER')
+        except sqlite3.OperationalError:
+            pass  # column already exists
+        conn.execute(
+            'INSERT INTO "parcels"(name, status, valeur) VALUES (?, ?, ?)',
+            (name, status, valeur),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_predicate_filters_rows_below_threshold(
+    gpkg_with_parcels: Path,
+) -> None:
+    """A trigger with ``predicate: 'valeur > 100'`` must skip rows
+    where ``valeur <= 100``.
+
+    We insert two rows (valeur=50 and valeur=200) and verify that the
+    webhook fires exactly once with the high-value payload.
+    """
+    from gispulse.runtime import parse_predicate
+
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    def fake_webhook(url: str, payload: dict[str, Any]) -> None:
+        calls.append((url, payload))
+
+    trigger = _make_trigger(
+        action=ActionDef(
+            action_type=ActionType.WEBHOOK,
+            config={"url": "https://hook.example.com/x"},
+        ),
+        name="threshold_filter",
+    )
+    # Inject the AST manually — this is the same shape ``to_triggers``
+    # builds from a YAML config.
+    trigger.conditions["predicate_ast"] = parse_predicate("valeur > 100")
+
+    _insert_with_value(gpkg_with_parcels, name="lo", status="x", valeur=50)
+    _insert_with_value(gpkg_with_parcels, name="hi", status="x", valeur=200)
+
+    runtime = build_runtime(
+        gpkg_path=gpkg_with_parcels,
+        triggers=[trigger],
+        sql_executor=lambda *a, **kw: None,
+        webhook_client=fake_webhook,
+        dataset_id="test",
+    )
+    try:
+        runtime.run_once()
+    finally:
+        runtime.close()
+
+    # Exactly one fire: only the row with valeur=200 matches.
+    assert len(calls) == 1, f"expected 1 webhook call, got {len(calls)}: {calls!r}"
+    _, payload = calls[0]
+    # The webhook payload exposes the change-record metadata; the row
+    # values themselves are not leaked over the wire (security choice
+    # documented in change_log_watcher.py:318-320). The fact that the
+    # webhook fired exactly once is the test contract — a non-matching
+    # predicate would have produced zero calls.
+    assert payload["table"] == "parcels"
+    assert payload["operation"] == "INSERT"
+    assert payload["matched"] is True
+
+
+def test_predicate_compound_and_or(gpkg_with_parcels: Path) -> None:
+    """A compound DSL predicate ``A AND (B OR C)`` filters rows correctly."""
+    from gispulse.runtime import parse_predicate
+
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    trigger = _make_trigger(
+        action=ActionDef(
+            action_type=ActionType.WEBHOOK,
+            config={"url": "https://hook.example.com/y"},
+        ),
+        name="compound_filter",
+    )
+    trigger.conditions["predicate_ast"] = parse_predicate(
+        "valeur > 100 AND (status == 'pending' OR status == 'review')"
+    )
+
+    # 4 rows × cartesian: only (valeur>100 AND status in {pending,review}) should match
+    _insert_with_value(gpkg_with_parcels, name="r1", status="pending", valeur=50)
+    _insert_with_value(gpkg_with_parcels, name="r2", status="pending", valeur=200)
+    _insert_with_value(gpkg_with_parcels, name="r3", status="ok", valeur=200)
+    _insert_with_value(gpkg_with_parcels, name="r4", status="review", valeur=300)
+
+    runtime = build_runtime(
+        gpkg_path=gpkg_with_parcels,
+        triggers=[trigger],
+        sql_executor=lambda *a, **kw: None,
+        webhook_client=lambda url, payload: calls.append((url, payload)),
+        dataset_id="test",
+    )
+    try:
+        runtime.run_once()
+    finally:
+        runtime.close()
+
+    # r2 + r4 match — 2 fires expected.
+    assert len(calls) == 2, f"expected 2 webhook calls, got {len(calls)}: {calls!r}"
+
+
+def test_predicate_missing_attr_skips_silently(
+    gpkg_with_parcels: Path,
+) -> None:
+    """A predicate that references a non-existent attribute resolves to
+    a non-match (fail-safe). The watcher tick must not raise."""
+    from gispulse.runtime import parse_predicate
+
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    trigger = _make_trigger(
+        action=ActionDef(
+            action_type=ActionType.WEBHOOK,
+            config={"url": "https://hook.example.com/z"},
+        ),
+        name="ghost_attr",
+    )
+    trigger.conditions["predicate_ast"] = parse_predicate(
+        "no_such_field == 42"
+    )
+
+    _insert_row(gpkg_with_parcels, name="any")
+
+    runtime = build_runtime(
+        gpkg_path=gpkg_with_parcels,
+        triggers=[trigger],
+        sql_executor=lambda *a, **kw: None,
+        webhook_client=lambda url, payload: calls.append((url, payload)),
+        dataset_id="test",
+    )
+    try:
+        processed = runtime.run_once()
+    finally:
+        runtime.close()
+
+    assert processed >= 1
+    assert calls == [], "predicate over missing attr should suppress the action"
+
+
+def test_no_predicate_keeps_legacy_always_match(
+    gpkg_with_parcels: Path,
+) -> None:
+    """When no DSL predicate is set, the trigger must keep firing for
+    every change-log row (pre-S4 behaviour)."""
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    trigger = _make_trigger(
+        action=ActionDef(
+            action_type=ActionType.WEBHOOK,
+            config={"url": "https://hook.example.com/legacy"},
+        ),
+        name="no_predicate",
+    )
+    # No predicate_ast on conditions — equivalent to pre-S4 wiring.
+
+    _insert_row(gpkg_with_parcels, name="always_fires")
+
+    runtime = build_runtime(
+        gpkg_path=gpkg_with_parcels,
+        triggers=[trigger],
+        sql_executor=lambda *a, **kw: None,
+        webhook_client=lambda url, payload: calls.append((url, payload)),
+        dataset_id="test",
+    )
+    try:
+        runtime.run_once()
+    finally:
+        runtime.close()
+
+    assert len(calls) == 1
+
+
 def test_webhook_allowlist_blocks_off_list_host(gpkg_with_parcels: Path) -> None:
     """When ``webhook_allowlist`` is provided and the trigger URL is not
     on it, the dispatcher's per-action try/except logs but doesn't crash

--- a/tests/runtime/test_predicate_parser.py
+++ b/tests/runtime/test_predicate_parser.py
@@ -1,0 +1,465 @@
+"""Tests for ``gispulse.runtime.predicate_dsl``.
+
+Coverage targets
+----------------
+* Parsing: every operator + AND/OR/NOT, parentheses, dotted attrs,
+  IN list, IS [NOT] NULL, numeric / string / boolean / null literals.
+* Evaluation: each operator on representative payloads.
+* Errors: missing attr, invalid syntax, unknown ops, EOF mid-expression.
+* Security: SQL injection attempts, dunder attrs, deep nesting,
+  oversized input, NUL bytes, unicode control chars.
+* Round-trip: AST ``to_dict`` is stable so YAML → AST → introspection
+  stays deterministic.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gispulse.runtime.predicate_dsl import (
+    MAX_DEPTH,
+    PredicateDepthError,
+    PredicateError,
+    PredicateNode,
+    PredicateSyntaxError,
+    build_update_payload,
+    evaluate_predicate,
+    parse_predicate,
+    to_core_predicate,
+)
+
+
+# ---------------------------------------------------------------------------
+# Parsing — happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestParseScalarComparisons:
+    """Each scalar comparison op produces the expected CMP node."""
+
+    @pytest.mark.parametrize(
+        "src,op,value",
+        [
+            ("x == 1", "==", 1),
+            ("x != 1", "!=", 1),
+            ("x > 1", ">", 1),
+            ("x >= 1", ">=", 1),
+            ("x < 1", "<", 1),
+            ("x <= 1", "<=", 1),
+            ("x == 'foo'", "==", "foo"),
+            ('x == "foo"', "==", "foo"),
+            ("x == 3.14", "==", 3.14),
+            ("x == -5", "==", -5),
+            ("x == 1e3", "==", 1000.0),
+            ("x == true", "==", True),
+            ("x == FALSE", "==", False),
+            ("x == null", "==", None),
+        ],
+    )
+    def test_parse_cmp(self, src: str, op: str, value: object) -> None:
+        node = parse_predicate(src)
+        d = node.to_dict()
+        assert d == {"kind": "cmp", "attr": ["x"], "op": op, "value": value}
+
+
+class TestParseBoolean:
+    def test_and_chain(self) -> None:
+        node = parse_predicate("a > 1 AND b < 2 AND c == 3")
+        d = node.to_dict()
+        assert d["kind"] == "and"
+        assert len(d["children"]) == 3
+
+    def test_or_chain(self) -> None:
+        node = parse_predicate("a == 1 OR a == 2 OR a == 3")
+        d = node.to_dict()
+        assert d["kind"] == "or"
+        assert len(d["children"]) == 3
+
+    def test_precedence_and_over_or(self) -> None:
+        # AND binds tighter than OR.
+        node = parse_predicate("a == 1 OR b == 2 AND c == 3")
+        d = node.to_dict()
+        assert d["kind"] == "or"
+        # right child is AND
+        right = d["children"][1]
+        assert right["kind"] == "and"
+
+    def test_parens_override_precedence(self) -> None:
+        node = parse_predicate("(a == 1 OR b == 2) AND c == 3")
+        d = node.to_dict()
+        assert d["kind"] == "and"
+        left = d["children"][0]
+        assert left["kind"] == "or"
+
+    def test_not_unary(self) -> None:
+        node = parse_predicate("NOT (a == 1)")
+        d = node.to_dict()
+        assert d["kind"] == "not"
+        assert len(d["children"]) == 1
+        assert d["children"][0]["kind"] == "cmp"
+
+    def test_nested_not(self) -> None:
+        node = parse_predicate("NOT NOT (a == 1)")
+        # double-NOT collapses into nested ``not`` nodes — evaluation
+        # gives us back True/True idempotently.
+        assert evaluate_predicate(node, {"a": 1}) is True
+        assert evaluate_predicate(node, {"a": 2}) is False
+
+
+class TestParseNullAndIn:
+    def test_is_null(self) -> None:
+        node = parse_predicate("reviewer IS NULL")
+        assert node.to_dict() == {"kind": "is_null", "attr": ["reviewer"]}
+
+    def test_is_not_null(self) -> None:
+        node = parse_predicate("reviewer IS NOT NULL")
+        assert node.to_dict() == {"kind": "is_not_null", "attr": ["reviewer"]}
+
+    def test_in_list(self) -> None:
+        node = parse_predicate("status IN ['pending', 'draft', 'review']")
+        d = node.to_dict()
+        assert d == {
+            "kind": "in",
+            "attr": ["status"],
+            "value": ["pending", "draft", "review"],
+        }
+
+    def test_not_in_list(self) -> None:
+        node = parse_predicate("status NOT IN ['x', 'y']")
+        d = node.to_dict()
+        assert d == {"kind": "not_in", "attr": ["status"], "value": ["x", "y"]}
+
+    def test_in_empty_list(self) -> None:
+        node = parse_predicate("status IN []")
+        assert evaluate_predicate(node, {"status": "anything"}) is False
+
+    def test_in_mixed_types(self) -> None:
+        node = parse_predicate("score IN [1, 2.5, 'NA']")
+        assert evaluate_predicate(node, {"score": 1}) is True
+        assert evaluate_predicate(node, {"score": 2.5}) is True
+        assert evaluate_predicate(node, {"score": "NA"}) is True
+        assert evaluate_predicate(node, {"score": 3}) is False
+
+
+class TestParseDottedAttrs:
+    def test_dotted_attr(self) -> None:
+        node = parse_predicate("new.status == 'pending'")
+        assert node.to_dict()["attr"] == ["new", "status"]
+
+    def test_deep_dotted_attr(self) -> None:
+        # Three-level path must round-trip.
+        node = parse_predicate("a.b.c == 1")
+        assert node.to_dict()["attr"] == ["a", "b", "c"]
+
+
+# ---------------------------------------------------------------------------
+# Evaluation
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluation:
+    def test_eq_str(self) -> None:
+        n = parse_predicate("status == 'pending'")
+        assert evaluate_predicate(n, {"status": "pending"}) is True
+        assert evaluate_predicate(n, {"status": "ok"}) is False
+
+    def test_gt_int(self) -> None:
+        n = parse_predicate("valeur > 100")
+        assert evaluate_predicate(n, {"valeur": 150}) is True
+        assert evaluate_predicate(n, {"valeur": 100}) is False
+        assert evaluate_predicate(n, {"valeur": 50}) is False
+
+    def test_ge_float(self) -> None:
+        n = parse_predicate("price >= 9.99")
+        assert evaluate_predicate(n, {"price": 9.99}) is True
+        assert evaluate_predicate(n, {"price": 10.0}) is True
+        assert evaluate_predicate(n, {"price": 9.50}) is False
+
+    def test_eq_bool(self) -> None:
+        n = parse_predicate("active == true")
+        assert evaluate_predicate(n, {"active": True}) is True
+        assert evaluate_predicate(n, {"active": False}) is False
+
+    def test_compound_and_or(self) -> None:
+        n = parse_predicate(
+            "valeur > 100 AND (status == 'pending' OR status == 'review')"
+        )
+        assert evaluate_predicate(n, {"valeur": 150, "status": "pending"}) is True
+        assert evaluate_predicate(n, {"valeur": 150, "status": "review"}) is True
+        assert evaluate_predicate(n, {"valeur": 150, "status": "ok"}) is False
+        assert evaluate_predicate(n, {"valeur": 50, "status": "pending"}) is False
+
+    def test_not_compound(self) -> None:
+        n = parse_predicate("NOT (status == 'archived')")
+        assert evaluate_predicate(n, {"status": "live"}) is True
+        assert evaluate_predicate(n, {"status": "archived"}) is False
+
+    def test_null_evaluation(self) -> None:
+        n_null = parse_predicate("reviewer IS NULL")
+        assert evaluate_predicate(n_null, {"reviewer": None}) is True
+        assert evaluate_predicate(n_null, {"reviewer": "simon"}) is False
+        assert evaluate_predicate(n_null, {}) is True  # missing == None
+
+        n_not_null = parse_predicate("reviewer IS NOT NULL")
+        assert evaluate_predicate(n_not_null, {"reviewer": "simon"}) is True
+        assert evaluate_predicate(n_not_null, {"reviewer": None}) is False
+
+    def test_eq_none_both_sides(self) -> None:
+        n = parse_predicate("reviewer == null")
+        assert evaluate_predicate(n, {"reviewer": None}) is True
+        assert evaluate_predicate(n, {"reviewer": "x"}) is False
+
+    def test_missing_attr_logs_warn_and_skips(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Comparing a missing attr with a non-null op resolves to False."""
+        n = parse_predicate("missing_field > 100")
+        with caplog.at_level("DEBUG"):
+            result = evaluate_predicate(n, {"valeur": 200})
+        assert result is False  # fail-safe non-match
+
+    def test_type_mismatch_logs_warn(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """``str > int`` is a type mismatch — log WARN and treat as no-match."""
+        n = parse_predicate("valeur > 100")
+        with caplog.at_level("WARNING"):
+            result = evaluate_predicate(n, {"valeur": "abc"})
+        assert result is False
+        assert any(
+            "predicate_type_mismatch" in rec.message for rec in caplog.records
+        )
+
+    def test_none_predicate_is_always_true(self) -> None:
+        """The runtime treats ``None`` as 'no predicate set' which matches
+        everything (preserving pre-S4 behaviour)."""
+        assert evaluate_predicate(None, {"any": "value"}) is True
+        assert evaluate_predicate(None, {}) is True
+
+
+class TestUpdatePayloadSemantics:
+    """Verify ``old.*`` / ``new.*`` exposure for UPDATE rows."""
+
+    def test_bare_attr_resolves_to_new(self) -> None:
+        n = parse_predicate("status == 'final'")
+        payload = build_update_payload(
+            new_values={"status": "final"},
+            old_values={"status": "draft"},
+        )
+        assert evaluate_predicate(n, payload) is True
+
+    def test_explicit_new_namespace(self) -> None:
+        n = parse_predicate("new.status == 'final'")
+        payload = build_update_payload(
+            new_values={"status": "final"},
+            old_values={"status": "draft"},
+        )
+        assert evaluate_predicate(n, payload) is True
+
+    def test_explicit_old_namespace(self) -> None:
+        n = parse_predicate("old.status == 'draft'")
+        payload = build_update_payload(
+            new_values={"status": "final"},
+            old_values={"status": "draft"},
+        )
+        assert evaluate_predicate(n, payload) is True
+
+    def test_old_without_old_values_is_null(self) -> None:
+        """INSERT exposes only ``new.*``; ``old.x`` should be None."""
+        n = parse_predicate("old.status IS NULL")
+        payload = build_update_payload(new_values={"status": "live"})
+        assert evaluate_predicate(n, payload) is True
+
+
+# ---------------------------------------------------------------------------
+# Round-trip / introspection
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrip:
+    def test_node_is_frozen(self) -> None:
+        n = parse_predicate("a == 1")
+        with pytest.raises(Exception):
+            n.value = 2  # type: ignore[misc]
+
+    def test_to_core_predicate_basic(self) -> None:
+        from core.predicates import AttrPredicate
+
+        n = parse_predicate("status == 'pending'")
+        core = to_core_predicate(n)
+        assert isinstance(core, AttrPredicate)
+        assert core.field == "status"
+        assert core.op == "eq"
+        assert core.value == "pending"
+
+    def test_to_core_predicate_compound(self) -> None:
+        from core.predicates import CompoundPredicate
+
+        n = parse_predicate("a == 1 AND b == 2")
+        core = to_core_predicate(n)
+        assert isinstance(core, CompoundPredicate)
+        assert core.logic == "AND"
+        assert len(core.predicates) == 2
+
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+
+class TestSyntaxErrors:
+    def test_unterminated_string(self) -> None:
+        with pytest.raises(PredicateSyntaxError, match="unterminated"):
+            parse_predicate("status == 'oops")
+
+    def test_unknown_operator(self) -> None:
+        with pytest.raises(PredicateSyntaxError):
+            # ``!!`` is not in the operator alphabet — fail at lex.
+            parse_predicate("a !! 1")
+
+    def test_empty_predicate(self) -> None:
+        with pytest.raises(PredicateSyntaxError, match="empty"):
+            parse_predicate("   ")
+
+    def test_dangling_and(self) -> None:
+        with pytest.raises(PredicateSyntaxError):
+            parse_predicate("a == 1 AND")
+
+    def test_bare_keyword(self) -> None:
+        # 'AND' as a bare attribute isn't allowed — it's a keyword.
+        with pytest.raises(PredicateSyntaxError):
+            parse_predicate("AND == 1")
+
+    def test_unbalanced_parens(self) -> None:
+        with pytest.raises(PredicateSyntaxError):
+            parse_predicate("(a == 1")
+
+    def test_function_call_rhs_rejected(self) -> None:
+        # Functions on RHS aren't parsable — there's no tokenisation
+        # path that accepts ``now()``. Should fail at literal parsing.
+        with pytest.raises(PredicateSyntaxError):
+            parse_predicate("ts > now()")
+
+    def test_attr_path_with_function_rejected(self) -> None:
+        with pytest.raises(PredicateSyntaxError):
+            parse_predicate("len(x) > 5")
+
+    def test_in_without_brackets(self) -> None:
+        with pytest.raises(PredicateSyntaxError):
+            parse_predicate("status IN 'pending'")
+
+    def test_extra_token_after_predicate(self) -> None:
+        with pytest.raises(PredicateSyntaxError, match="unexpected token"):
+            parse_predicate("a == 1 b == 2")
+
+    def test_non_string_input(self) -> None:
+        with pytest.raises(PredicateSyntaxError):
+            parse_predicate(123)  # type: ignore[arg-type]
+
+
+class TestSecurityHardening:
+    """Adversarial inputs must be rejected cleanly, never crash the parser."""
+
+    def test_sql_injection_attempt(self) -> None:
+        # Classic attempt — should fail at the very first parse step
+        # (semicolon is not in the alphabet).
+        with pytest.raises(PredicateSyntaxError):
+            parse_predicate("1; DROP TABLE users")
+
+    def test_drop_table_in_string(self) -> None:
+        # OK — it's just a string literal, no SQL is ever executed.
+        n = parse_predicate("note == '1; DROP TABLE users'")
+        assert (
+            evaluate_predicate(n, {"note": "1; DROP TABLE users"}) is True
+        )
+
+    def test_dunder_attr_rejected(self) -> None:
+        with pytest.raises(PredicateSyntaxError, match="dunder"):
+            parse_predicate("x.__class__ == 1")
+
+    def test_dunder_only_in_segment(self) -> None:
+        with pytest.raises(PredicateSyntaxError, match="dunder"):
+            parse_predicate("__class__ == 1")
+
+    def test_class_bases_chain_rejected(self) -> None:
+        with pytest.raises(PredicateSyntaxError):
+            parse_predicate("x.__class__.__bases__[0] == 1")
+
+    def test_deep_nesting_rejected(self) -> None:
+        # MAX_DEPTH is 32 — build something deeper.
+        deep = "(" * 1000 + "a == 1" + ")" * 1000
+        with pytest.raises(PredicateDepthError):
+            parse_predicate(deep)
+
+    def test_oversized_input_rejected(self) -> None:
+        with pytest.raises(PredicateSyntaxError, match="exceeds"):
+            parse_predicate("a == 1 AND " * 1000)
+
+    def test_nul_byte_rejected(self) -> None:
+        with pytest.raises(PredicateSyntaxError, match="NUL"):
+            parse_predicate("a == 1\x00 AND b == 2")
+
+    def test_control_char_rejected(self) -> None:
+        with pytest.raises(PredicateSyntaxError, match="control"):
+            parse_predicate("a == 1\x07 AND b == 2")
+
+    def test_eval_depth_guard_at_runtime(self) -> None:
+        """Hand-craft a node that bypasses the parser depth guard and
+        verify the evaluator's own guard kicks in."""
+        # Build an artificially deep AND tree manually.
+        node: PredicateNode = parse_predicate("a == 1")
+        for _ in range(MAX_DEPTH + 5):
+            node = PredicateNode(
+                kind=node.kind.__class__("and"),
+                children=(node,),
+            )
+        with pytest.raises(PredicateDepthError):
+            evaluate_predicate(node, {"a": 1})
+
+    def test_unicode_identifiers_rejected(self) -> None:
+        # We accept ASCII identifiers only. Non-ASCII attr names must
+        # fail at lex time (no IDENT match).
+        with pytest.raises(PredicateSyntaxError):
+            parse_predicate("café == 1")
+
+    def test_unicode_in_string_literal_ok(self) -> None:
+        # But strings can carry any unicode payload (it's just data).
+        n = parse_predicate("note == 'café — 你好'")
+        assert evaluate_predicate(n, {"note": "café — 你好"}) is True
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_string_with_escape(self) -> None:
+        n = parse_predicate(r"note == 'it\'s ok'")
+        assert evaluate_predicate(n, {"note": "it's ok"}) is True
+
+    def test_string_with_newline_escape(self) -> None:
+        n = parse_predicate(r"note == 'a\nb'")
+        assert evaluate_predicate(n, {"note": "a\nb"}) is True
+
+    def test_signed_integer(self) -> None:
+        n = parse_predicate("delta == -5")
+        assert evaluate_predicate(n, {"delta": -5}) is True
+
+    def test_scientific_notation(self) -> None:
+        n = parse_predicate("threshold > 1e3")
+        assert evaluate_predicate(n, {"threshold": 1500.0}) is True
+        assert evaluate_predicate(n, {"threshold": 500.0}) is False
+
+    def test_comment_is_skipped(self) -> None:
+        n = parse_predicate("a == 1  # this is a comment")
+        assert evaluate_predicate(n, {"a": 1}) is True
+
+    def test_multiline_predicate(self) -> None:
+        src = """
+        a == 1
+        AND b == 2
+        """
+        n = parse_predicate(src)
+        assert evaluate_predicate(n, {"a": 1, "b": 2}) is True
+        assert evaluate_predicate(n, {"a": 1, "b": 3}) is False

--- a/tests/unit/test_change_log_watcher.py
+++ b/tests/unit/test_change_log_watcher.py
@@ -598,3 +598,46 @@ class TestActionDispatchBridge:
         finally:
             watcher.stop()
         assert dispatched == []  # no dispatch because trigger_id unknown
+
+    # ------------------------------------------------------------------
+    # S5: cancellable wait — stop() must return promptly even when the
+    # watcher is asleep on a long ``poll_interval``.
+    # ------------------------------------------------------------------
+
+    def test_stop_returns_promptly_with_long_poll_interval(self) -> None:
+        """Pre-S5 ``time.sleep(poll_interval)`` would force ``stop()`` to
+        wait up to ``poll_interval`` before the thread exited. With the
+        new :class:`Event`-based wait, ``stop()`` should join in well
+        under a second even with ``poll_interval=10s``."""
+        engine = _FakeEngine()
+        hub = _RecordingHub()
+        watcher = ChangeLogWatcher(
+            engine, hub, dataset_id="ds-test", poll_interval=10.0
+        )
+        watcher.start()
+        # Give the thread a chance to enter the wait.
+        assert _wait_until(lambda: watcher.is_running())
+
+        t0 = time.monotonic()
+        watcher.stop()
+        elapsed = time.monotonic() - t0
+
+        assert not watcher.is_running()
+        assert elapsed < 1.5, (
+            f"stop() took {elapsed:.2f}s — Event.wait should interrupt "
+            f"a 10s poll within the 2s join timeout"
+        )
+
+    def test_stop_event_property_is_exposed(self) -> None:
+        """External loops (CLI ``--watch``) consume the same Event when
+        they drive ``_tick`` directly instead of starting the daemon."""
+        engine = _FakeEngine()
+        hub = _RecordingHub()
+        watcher = ChangeLogWatcher(engine, hub, dataset_id="ds-test")
+        ev = watcher.stop_event
+        assert isinstance(ev, threading.Event)
+        assert not ev.is_set()
+        watcher.stop()
+        # After stop(), the event is set so subsequent waiters return
+        # immediately. (The thread was never started here.)
+        assert ev.is_set()


### PR DESCRIPTION
## Summary

Closes #2 — ships the full Mode 1 headless trigger runtime and the `gispulse triggers` CLI subapp.

S1–S5 of the original issue #2 plan, in order:

| Stage | Commit | Surface |
|---|---|---|
| S1 | `bc3eebe` | `gispulse.runtime.headless_runtime` — FastAPI-free wiring of GeoPackageEngine + ChangeLogWatcher + ActionDispatcher |
| S2 | `cfe79dd` | `gispulse.runtime.config_loader` — YAML schema (Pydantic), GPKG validation, identifier guards |
| S3 | `b0783a3` | `gispulse triggers run/validate/list` Typer subapp |
| S3 tests | `4f6cb9f` | unit + integration coverage of S1+S2+S3 |
| S4 | `65a2acb`, `4e9adb8`, `ee962f9` | predicate DSL parser + integration into TriggerEvaluator |
| S5 | `5892d5b` | `RetryingSqlExecutor` — exponential backoff on `SQLITE_BUSY` |
| S5 | `7a580cc` | cancellable error backoff in `ChangeLogWatcher` |
| S5 | `feb3eb6` | `gispulse triggers run --watch` daemon + reload-on-config-change |

## Test plan

- [x] `python -m pytest tests/ --ignore=tests/integration` — 3690 passed, 11 skipped (2 pre-existing pointcloud failures unrelated to this branch — missing optional `laspy` extra)
- [x] Trigger DDL is SQLi-safe (identifier validation in `gpkg_schema._validate_identifier`)
- [x] Webhook actions go through the SSRF-safe `HttpWebhookClient` from #451
- [x] ChangeLogWatcher → ActionDispatcher bridge (#458) wired in `headless_runtime.build_runtime`

## Note on the `--watch` subcommand

The S5 commit `feb3eb6` ships `gispulse triggers run --watch`. Per the v1.3.0 plan in #3, this surface is **superseded** by the new top-level `gispulse watch` command (issue #5), which lands in the **stacked PR-2** that targets this branch as its base. Once both PRs merge, `gispulse triggers run --watch` will be deprecated in favor of `gispulse watch <gpkg> --rules <yaml>`.

The deprecation path itself is part of PR-2, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)