### PR TITLE
fix(packaging): httpx core dep — unblocks gispulse triggers run on 1.3.0+ pipx installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Packaging** — declare `httpx>=0.24,<1.0` as a core runtime dependency. Previously listed only under `[api]` / `[sso]` / `[dev]` extras, so `pipx install gispulse` produced a working CLI for `track` / `info` / `run` but `gispulse triggers run` and `gispulse watch` crashed on `ModuleNotFoundError: No module named 'httpx'` (the webhook client at `gispulse/adapters/webhooks/http_client.py` imports it unconditionally). Affects 1.3.0 release; users on 1.3.0 can work around with `pipx install "gispulse[api]"`.
+
 ## [1.3.0] - 2026-04-27
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "pydantic>=2.0,<3.0",
     "pydantic-settings>=2.0,<3.0",
     "PyYAML>=6.0,<7.0",
+    "httpx>=0.24,<1.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary

`gispulse triggers run --once` and `gispulse watch` crash on a plain `pipx install gispulse` (1.3.0) with `ModuleNotFoundError: No module named 'httpx'`. Root cause: the webhook client at `gispulse/adapters/webhooks/http_client.py:35` imports `httpx` unconditionally, but `httpx` was only declared under the `[api]` / `[sso]` / `[dev]` extras in `pyproject.toml`.

This PR moves `httpx>=0.24,<1.0` to the core `dependencies` block so the runtime is usable out-of-the-box.

## Reproduction (before)

```bash
pipx install gispulse==1.3.0
cp examples/datasets/muret_parcels.gpkg /tmp/smoke.gpkg
gispulse track install /tmp/smoke.gpkg --layer parcels
gispulse triggers validate --config examples/cli/triggers.yaml
gispulse triggers run --config examples/cli/triggers.yaml --once
# -> {"event":"runtime_build_failed","error":"No module named 'httpx'"}
# -> Runtime build failed: No module named 'httpx'
```

## After this PR

```bash
gispulse triggers run --config /tmp/smoke-triggers.yaml --once
# -> {"event":"runtime_starting", "triggers":1, "mode":"once"}
# -> {"event":"tick_done","processed":0}
# -> OK one tick processed 0 change-log row(s) on smoke.gpkg.
```

## Impact

- Affects every user who installed 1.3.0 via `pipx install gispulse` or `pip install gispulse` (without the `[api]` extra) and tried to use the headline v1.3 features (`gispulse triggers run`, `gispulse watch`).
- Workaround for users on 1.3.0 until 1.3.1 ships: `pipx install "gispulse[api]"`.
- Recommend tagging `v1.3.1` as a hotfix release immediately after merge — the public announce of v1.3.0 should wait on this.

## Test plan

- [x] `ruff check pyproject.toml` — clean.
- [x] Local smoke test on `pipx install gispulse==1.3.0` + `pip install httpx` in venv reproduces the fix path (`tick_done processed 0`).
- [ ] CI green on this PR.
- [ ] After merge: bump version to `1.3.1`, tag, release workflow publishes to PyPI.

## Notes

- Single-line dep move + CHANGELOG entry under `[Unreleased]`. No code changes.
- `[api]` / `[sso]` / `[dev]` extras still list httpx for now; harmless duplicate that can be cleaned up in a follow-up.