### PR TITLE
fix(ci): pyarrow core dep + watch help test env propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Packaging — `pyarrow` core runtime dependency** — declared `pyarrow>=14,<22` in base dependencies. Without it, `gispulse run --output result.parquet`, the GeoParquet writer (`persistence/geoparquet.py`), and any DuckDB pipeline that lands GeoParquet via `COPY ... TO ... (FORMAT 'parquet')` crashed at runtime with `ImportError: Missing optional dependency 'pyarrow.parquet'` (geopandas raises this from `_compat.py` regardless of the host having the binary). Surfaced by 28+ pytest collection errors in `tests/unit/test_geoparquet.py` and `tests/unit/test_s12_cloud_native.py` on the v1.3.1 baseline CI.
+- **Tests — `test_cli_watch.py` help-panel rendering** — the `runner` fixture set `COLUMNS=200` via `monkeypatch.setenv`, but `typer.testing.CliRunner` redirects stdout/stderr to `StringIO`, which Rich detects as non-TTY and falls back to a default 80-column width regardless of the parent process env. Required option names like `--rules` got wrapped mid-line and the substring assertion (`"--rules" in res.output`) failed in CI even though the option was registered correctly. Switch to `runner.invoke(..., env={"COLUMNS": "200"})` which Click forwards to the subprocess env Rich reads.
+
 ## [1.3.1] - 2026-04-29
 
 Hotfix release that unblocks the v1.3.0 distribution: `pipx install gispulse` now ships a working `triggers run` / `watch` (httpx was missing from base deps), the local Docker stack boots on community tier, the portal serves favicon/robots/manifest correctly, and CI is green again.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "duckdb>=1.0,<2.0",
     "pyogrio>=0.7,<1.0",
     "pyproj>=3.6,<4.0",
+    "pyarrow>=14,<22",
     "typer>=0.9,<1.0",
     "structlog>=24.0,<26.0",
     "pydantic>=2.0,<3.0",

--- a/tests/unit/test_cli_watch.py
+++ b/tests/unit/test_cli_watch.py
@@ -19,13 +19,18 @@ from gispulse.cli import app
 
 
 @pytest.fixture()
-def runner(monkeypatch: pytest.MonkeyPatch) -> CliRunner:
-    # Widen the rendered help panel so option names like ``--rules`` /
-    # ``--webhook`` aren't dropped from the output when CI runs under a
-    # narrow default terminal (GitHub Actions defaults truncate Rich
-    # panels mid-option around 80 cols).
-    monkeypatch.setenv("COLUMNS", "200")
+def runner() -> CliRunner:
     return CliRunner()
+
+
+# Wide terminal env passed to ``runner.invoke(..., env=WIDE_ENV)`` so Rich
+# renders the help panel without wrapping option names like ``--rules`` /
+# ``--webhook``. ``CliRunner`` redirects stdout/stderr to StringIO, which
+# Rich detects as non-TTY and falls back to a default 80-column width
+# regardless of the parent process ``COLUMNS`` env (so monkeypatch.setenv
+# was a no-op in CI). ``runner.invoke(env=...)`` is the supported
+# Click/Typer hook that actually reaches Rich's terminal-size probe.
+WIDE_ENV = {"COLUMNS": "200"}
 
 
 @pytest.fixture()
@@ -76,7 +81,7 @@ def valid_yaml(tmp_path: Path, tracked_gpkg: Path) -> Path:
 
 
 def test_watch_help_registers(runner: CliRunner) -> None:
-    res = runner.invoke(app, ["watch", "--help"])
+    res = runner.invoke(app, ["watch", "--help"], env=WIDE_ENV)
     assert res.exit_code == 0
     assert "Watch a GeoPackage" in res.output
     assert "--rules" in res.output


### PR DESCRIPTION
Two pre-existing CI failures on main, both surface defects in the test/runtime envelope rather than the runtime itself.

## 1. \`pyarrow\` missing from core deps (28+ test collection errors)

\`tests/unit/test_geoparquet.py\` and \`tests/unit/test_s12_cloud_native.py::TestGeoParquetRoundtrip\` produce a wave of \`FAILED\` / \`ERROR\` on the v1.3.1 baseline CI :

\`\`\`
ImportError: Missing optional dependency 'pyarrow.parquet'.
pyarrow is required for Parquet support.
/.../geopandas/_compat.py:62: ImportError
\`\`\`

This isn't a test infra issue — it's a real runtime defect. Anyone doing :

\`\`\`bash
pipx install gispulse
gispulse run input.gpkg --rules rules.json -o output.parquet  # GeoParquet output
\`\`\`

…hits the same \`ImportError\`. Same for the DuckDB pipeline that calls \`COPY ... TO ... (FORMAT 'parquet')\`.

\`pyarrow\` was not listed in any extras either, so even \`pipx install \"gispulse[all]\"\` didn't pull it in. Adding \`pyarrow>=14,<22\` (the range geopandas/pyogrio test against) to base deps fixes both the user-facing crash and the CI test collection.

## 2. \`test_watch_help_registers\` substring assertion fails in CI

The \`runner\` fixture set \`COLUMNS=200\` via \`monkeypatch.setenv\`, on the assumption that Rich would honor it and render help wide. But \`typer.testing.CliRunner\` redirects stdout/stderr to \`StringIO\`, which Rich detects as **non-TTY** and falls back to a default 80-column width *regardless of the parent process env*.

Result: required option names like \`--rules\` get wrapped mid-line, and \`assert \"--rules\" in res.output\` fails. Locally the test passed because anaconda/pytest-8.4 + a wider terminal hid the bug.

Fix : switch the fixture from \`monkeypatch.setenv\` to a \`WIDE_ENV\` constant passed to \`runner.invoke(..., env=WIDE_ENV)\`. Click forwards that to the subprocess env Rich actually reads.

## Test plan

\`\`\`bash
ruff check                                          # clean
pytest tests/unit/test_cli_watch.py::test_watch_help_registers \\
       tests/unit/test_geoparquet.py                # 21 passed in 0.50s
\`\`\`

## Known follow-ups (NOT addressed in this PR)

- **4 other \`test_watch_once_*\` tests** still fail CI with \`exit_code=1\`. Could not reproduce locally on Python 3.13 + pytest 8.4.2 — likely a pytest 9.x strict-mode interaction with the threaded runtime, or a fixture ordering issue exposed by pytest 9. Needs CI-env reproduction (act / matrix-debug action) to pin down.
- **capability-matrix-drift** : my CI install-set change (\`10ad54d\`) should have stabilized this, but the new \`pyarrow\` + the \`fastmcp\` 2.x bump may surface new capability signatures. Plan : if the drift check fails on this PR, regen and amend.

## Out of scope

- The \`test_watch_once_*\` runtime failures (separate root cause).
- Backend OIDC, plugin lifecycle (covered by other PRs).
- 174 eslint errors on portal-libre (user explicitly deferred).