### PR TITLE
fix(ci): unblock test (3.10/3.12) — Click introspection for watch help test

### DIFF
--- a/scripts/build_capability_matrix.py
+++ b/scripts/build_capability_matrix.py
@@ -98,7 +98,7 @@ def _build_test_index() -> dict[str, list[Path]]:
 
 
 def _build_doc_set() -> set[str]:
-    """capability names that appear in `docs-site/guide/capabilities.md`.
+    r"""capability names that appear in `docs-site/guide/capabilities.md`.
 
     Only counts a capability when it shows up as a Markdown table-cell
     leader (``| \`name\` |``) — this is the convention used by every row

--- a/tests/unit/test_cli_watch.py
+++ b/tests/unit/test_cli_watch.py
@@ -76,11 +76,32 @@ def valid_yaml(tmp_path: Path, tracked_gpkg: Path) -> Path:
 
 
 def test_watch_help_registers(runner: CliRunner) -> None:
+    # Smoke-test that ``--help`` exits 0 and prints the command summary. We
+    # do NOT assert on the rendered option list — Rich's panel rendering
+    # truncates long Typer apps under the GitHub Actions runner, and the
+    # exact set of visible options drifts between Click 8.2 / 8.3 and
+    # Typer 0.20 / 0.25 (see commits 1218dfa, cda0c90 chasing this gate).
+    # The structural test below is the source of truth.
     res = runner.invoke(app, ["watch", "--help"])
     assert res.exit_code == 0
     assert "Watch a GeoPackage" in res.output
-    assert "--rules" in res.output
-    assert "--webhook" in res.output
+
+    # Structural assertion: the underlying Click command must declare the
+    # options the rest of the CLI contract relies on. This bypasses Rich
+    # rendering and is stable across Click/Typer/terminal-width quirks.
+    from typer.main import get_command
+
+    click_app = get_command(app)
+    watch_cmd = click_app.commands["watch"]
+    opt_names: set[str] = set()
+    for param in watch_cmd.params:
+        if hasattr(param, "opts"):
+            opt_names.update(param.opts)
+    for required_opt in ("--rules", "--webhook", "--once", "--bulk-threshold"):
+        assert required_opt in opt_names, (
+            f"watch command is missing the {required_opt!r} option — "
+            f"declared options: {sorted(opt_names)}"
+        )
 
 
 def test_watch_missing_rules_exits_2(runner: CliRunner, tracked_gpkg: Path) -> None:


### PR DESCRIPTION
## Summary
- Replaces the rendered-help assertion in ``test_watch_help_registers`` with a structural check on the Click command's ``params`` list (via ``typer.main.get_command``). Rich panel rendering truncates options under GitHub Actions' non-TTY stdout regardless of ``COLUMNS`` env, so the previous text-search approach was fundamentally fragile.
- Silences ``SyntaxWarning: invalid escape sequence '\``'`` on line 100 of ``scripts/build_capability_matrix.py`` by switching the docstring to a raw string.

## Context
After commits 1218dfa + cda0c90, only one CI failure remained on ``main``: ``test (3.10)`` and ``test (3.12)`` red on ``test_watch_help_registers``. Capability-matrix-drift and pyarrow extras are already fixed. v1.3.1 release is blocked on this last test.

## Test plan
- [x] ``python -m pytest tests/unit/test_cli_watch.py`` — 9/9 pass locally
- [x] ``python scripts/build_capability_matrix.py --check`` — no SyntaxWarning, matrix in sync (118 capabilities)
- [ ] CI ``test (3.10)`` + ``test (3.12)`` green on this PR