### PR TITLE
fix(tests): structural Click introspection for test_watch_help_registers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Tests — `test_watch_help_registers` Rich rendering** — replace the substring assertion (`"--rules" in res.output`) with structural Click introspection via `typer.main.get_command()`. The `monkeypatch.setenv("COLUMNS", "200")` fix in 1218dfa was a no-op: `typer.testing.CliRunner` redirects stdout/stderr to `StringIO`, which Rich detects as non-TTY and falls back to a default 80-col width *regardless of the env*. Required option names like `--rules` then wrap mid-line and fail the substring match. The new assertion walks `click_app.commands["watch"].params` and checks each required `--rules` / `--webhook` / `--once` / `--bulk-threshold` is declared — this bypasses Rich entirely and is stable across Click 8.2 / 8.3, Typer 0.20 / 0.25, and any future GHA runner default.
+
 ## [1.3.1] - 2026-04-29
 
 Hotfix release that unblocks the v1.3.0 distribution: `pipx install gispulse` now ships a working `triggers run` / `watch` (httpx was missing from base deps), the local Docker stack boots on community tier, the portal serves favicon/robots/manifest correctly, and CI is green again.

--- a/tests/unit/test_cli_watch.py
+++ b/tests/unit/test_cli_watch.py
@@ -76,11 +76,33 @@ def valid_yaml(tmp_path: Path, tracked_gpkg: Path) -> Path:
 
 
 def test_watch_help_registers(runner: CliRunner) -> None:
+    # Smoke-test that ``--help`` exits 0 and prints the command summary. We
+    # do NOT assert on the rendered option list — Rich's panel rendering
+    # truncates long Typer apps under the GitHub Actions runner because
+    # CliRunner redirects stdout to a StringIO that Rich detects as
+    # non-TTY (defaulting to 80 cols regardless of the COLUMNS env, see
+    # commit 1218dfa chasing this gate). The structural test below is the
+    # source of truth.
     res = runner.invoke(app, ["watch", "--help"])
     assert res.exit_code == 0
     assert "Watch a GeoPackage" in res.output
-    assert "--rules" in res.output
-    assert "--webhook" in res.output
+
+    # Structural assertion: the underlying Click command must declare the
+    # options the rest of the CLI contract relies on. This bypasses Rich
+    # rendering and is stable across Click/Typer/terminal-width quirks.
+    from typer.main import get_command
+
+    click_app = get_command(app)
+    watch_cmd = click_app.commands["watch"]
+    opt_names: set[str] = set()
+    for param in watch_cmd.params:
+        if hasattr(param, "opts"):
+            opt_names.update(param.opts)
+    for required_opt in ("--rules", "--webhook", "--once", "--bulk-threshold"):
+        assert required_opt in opt_names, (
+            f"watch command is missing the {required_opt!r} option — "
+            f"declared options: {sorted(opt_names)}"
+        )
 
 
 def test_watch_missing_rules_exits_2(runner: CliRunner, tracked_gpkg: Path) -> None:


### PR DESCRIPTION
Follow-up to **1218dfa** (\`fix(v1.3.1): unblock CI test suite\`) — the watch-help fixture is still red on Python 3.10 in the latest CI run on main (25123889635 against cda0c90).

## Why 1218dfa's fix is a no-op

\`monkeypatch.setenv(\"COLUMNS\", \"200\")\` doesn't reach Rich. The mechanism :

1. \`typer.testing.CliRunner\` redirects \`stdout\`/\`stderr\` to a fresh \`StringIO\` for output capture.
2. Rich's \`Console.\_detect\_terminal\_size()\` calls \`shutil.get\_terminal\_size()\` on that \`StringIO\`, which is **not a TTY**.
3. \`get\_terminal\_size\` reads the underlying \`os.terminal\_size\`, fails the \`isatty()\` check, and returns the **fallback** — \`shutil.get\_terminal\_size((80, 24))\` ignores \`os.environ['COLUMNS']\` when stdout is a pipe / StringIO.

Result : the panel still wraps at 80 cols. \`--rules\` is rendered mid-line and the substring assertion fails. The trace from the latest CI run :

\`\`\`
FAILED tests/unit/test_cli_watch.py::test_watch_help_registers
  - AssertionError: assert '--rules' in '\\x1b[1m...\\x1b[0m'
\`\`\`

## Fix : bypass Rich entirely

Walk the underlying Click command's \`.params\` and assert structurally that each required option is declared :

\`\`\`python
from typer.main import get_command

click_app = get_command(app)
watch_cmd = click_app.commands[\"watch\"]
opt_names: set[str] = set()
for param in watch_cmd.params:
    if hasattr(param, \"opts\"):
        opt_names.update(param.opts)
for required_opt in (\"--rules\", \"--webhook\", \"--once\", \"--bulk-threshold\"):
    assert required_opt in opt_names, ...
\`\`\`

This is what the test was actually trying to verify — that the watch subcommand declares the options the rest of the CLI contract relies on. The previous substring approach was a brittle proxy for that.

Stable across :
- Click 8.2 / 8.3 (param attribute renames in 8.3)
- Typer 0.20 / 0.25 (rich rendering changes)
- GHA runner default \`COLUMNS\`
- Future Rich versions that may change wrap heuristics

## What's preserved

- \`assert res.exit_code == 0\` — Typer/Click still has to wire the command without errors.
- \`assert \"Watch a GeoPackage\" in res.output\` — the docstring summary is in the leading paragraph that Rich never wraps. This stays as a smoke test that help-rendering works at all.

## Test plan

\`\`\`bash
ruff check tests/unit/test_cli_watch.py     # All checks passed!
pytest tests/unit/test_cli_watch.py::test_watch_help_registers
# 1 passed in 0.20s
\`\`\`

The 8 other tests in this file are unaffected (they assert on \`exit_code\` only, never on the help-panel rendering).

## Out of scope

- The \`monkeypatch.setenv(\"COLUMNS\")\` line in the \`runner\` fixture is left in place. It's harmless — it doesn't fix anything but doesn't break anything either, and removing it would be a 1218dfa rebase. Drop in a follow-up cleanup PR if desired.