### PR TITLE
fix(packaging): include core/pricing_catalog.yml + catalog/data/*.json in wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,8 @@ exclude = ["docs*", "tests*"]
 
 [tool.setuptools.package-data]
 viewer = ["dist/**/*", "dist/*"]
+core = ["pricing_catalog.yml"]
+catalog = ["data/*.json"]
 
 [tool.ruff]
 target-version = "py310"


### PR DESCRIPTION
## Summary

The 1.3.1 PyPI wheel ships without 3 runtime data files. Anyone running `pip install gispulse==1.3.1` and exercising tier gating or catalog providers crashes immediately.

## Reproduce on 1.3.1

```bash
pip install gispulse==1.3.1
python -c "from catalog.providers.projections import ProjectionsProvider; ProjectionsProvider()"
# FileNotFoundError: [Errno 2] No such file or directory:
# '.../site-packages/catalog/data/epsg_common.json'
```

## Files affected

| File | Loaded by |
|---|---|
| `core/pricing_catalog.yml` | `core/plugin_hub.py:79` (tier gating) |
| `catalog/data/basemaps.json` | `catalog/providers/basemaps.py:12` |
| `catalog/data/epsg_common.json` | `catalog/providers/projections.py:12` |

## Fix

2 lines in `[tool.setuptools.package-data]`. Verified `python -m build --wheel` now includes the 3 files.

## Recommended follow-up

**v1.3.2 patch release ASAP** — the 1.3.1 wheel on PyPI is partially broken for any consumer touching tier gating or catalog providers.

## Test plan

- [x] `python -m build --wheel` succeeds
- [x] `unzip -l dist/gispulse-1.3.1-py3-none-any.whl | grep -E "pricing_catalog|catalog/data"` shows the 3 files
- [ ] CI green
- [ ] Optional: install built wheel in clean venv + run smoke import