### PR TITLE
feat(api): styling endpoints — breaks, PUT styles, import QML (v1.5)

### DIFF
--- a/gispulse/adapters/http/routers/portal_datasets_router.py
+++ b/gispulse/adapters/http/routers/portal_datasets_router.py
@@ -14,6 +14,8 @@ from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
+from fastapi import File, UploadFile, Form
+
 from gispulse.adapters.http.layer_utils import build_layer_meta, get_layer_styles, load_layers, sanitize_datetime_columns
 from gispulse.adapters.http.rate_limit import limiter
 from core.config import settings as _cfg
@@ -558,4 +560,201 @@ async def get_field_stats(
         "mean": float(numeric.mean()),
         "std": float(numeric.std()),
         "quantiles": {str(q): round(v, 4) for q, v in zip(quantiles, q_values)},
+    })
+
+
+def _load_layer_gdf(request: Request, dataset_id: str, layer_name: str):
+    """Resolve dataset+layer to a GeoDataFrame, populating layer_cache. Raises HTTPException."""
+    layer_cache: dict = request.app.state.layer_cache
+    dataset_repo = request.app.state.dataset_repo
+
+    gdfs = layer_cache.get(dataset_id)
+    if gdfs is None:
+        ds = dataset_repo.get(uuid.UUID(dataset_id))
+        if ds is None:
+            raise HTTPException(404, f"Dataset {dataset_id} not found")
+        if not ds.source_path or not Path(ds.source_path).exists():
+            raise HTTPException(404, "Dataset file not found on disk")
+        _, gdfs = load_layers(ds.source_path, ds.name)
+        layer_cache[dataset_id] = gdfs
+    if layer_name not in gdfs:
+        raise HTTPException(404, f"Layer {layer_name} not found")
+    return gdfs[layer_name]
+
+
+_VALID_BREAKS_METHODS = {"quantile", "equal_interval", "jenks", "pretty", "std_dev"}
+
+
+class BreaksBody(BaseModel):
+    field: str
+    method: str = "jenks"
+    n_classes: int = 5
+
+
+@router.post("/datasets/{dataset_id}/layers/{layer_name}/breaks")
+async def compute_breaks(
+    request: Request,
+    dataset_id: str,
+    layer_name: str,
+    body: BreaksBody,
+) -> JSONResponse:
+    """Compute classification breaks for a numeric field via ClassifyCapability."""
+    if body.method not in _VALID_BREAKS_METHODS:
+        raise HTTPException(
+            400,
+            f"method must be one of {sorted(_VALID_BREAKS_METHODS)}, got '{body.method}'",
+        )
+    if body.n_classes < 2 or body.n_classes > 20:
+        raise HTTPException(400, "n_classes must be between 2 and 20")
+
+    gdf = _load_layer_gdf(request, dataset_id, layer_name)
+    if body.field not in gdf.columns:
+        raise HTTPException(404, f"Field {body.field} not found in layer {layer_name}")
+
+    try:
+        gdf[body.field].dropna().astype(float)
+    except (ValueError, TypeError):
+        raise HTTPException(400, f"Field {body.field} is not numeric")
+
+    from capabilities.classification import ClassifyCapability
+
+    try:
+        result = ClassifyCapability().execute(
+            gdf,
+            field=body.field,
+            method=body.method,
+            bins=body.n_classes,
+            color_col=None,
+        )
+    except ValueError as exc:
+        raise HTTPException(400, str(exc))
+
+    meta = result.attrs.get("gispulse_style", {})
+    breaks = meta.get("breaks") or []
+    labels = [
+        f"{round(breaks[i], 4)} – {round(breaks[i + 1], 4)}"
+        for i in range(len(breaks) - 1)
+    ]
+    return JSONResponse(content={
+        "field": body.field,
+        "method": body.method,
+        "n_classes": len(breaks) - 1 if len(breaks) > 1 else 0,
+        "breaks": [float(b) for b in breaks],
+        "labels": labels,
+    })
+
+
+def _upsert_layer_style(gpkg_path: str, layer_name: str, qml_xml: str) -> None:
+    """DELETE existing styleQML for layer, then INSERT new one. Idempotent."""
+    import sqlite3
+
+    from persistence.gpkg import _CREATE_LAYER_STYLES
+
+    conn = sqlite3.connect(gpkg_path)
+    try:
+        conn.execute(_CREATE_LAYER_STYLES)
+        conn.execute(
+            "DELETE FROM layer_styles WHERE f_table_name = ?",
+            (layer_name,),
+        )
+        conn.execute(
+            "INSERT INTO layer_styles (f_table_name, styleName, styleQML, useAsDefault, description) "
+            "VALUES (?, ?, ?, 1, ?)",
+            (layer_name, f"{layer_name}_style", qml_xml, f"Style for {layer_name}"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+class StyleBody(BaseModel):
+    layer_name: str
+    style_def: dict[str, Any]
+    geom_type: str = "polygon"
+
+
+@router.put("/datasets/{dataset_id}/styles")
+async def put_dataset_style(
+    request: Request,
+    dataset_id: str,
+    body: StyleBody,
+) -> JSONResponse:
+    """Persist a LayerStyleDef into the GPKG layer_styles table (overwrites)."""
+    dataset_repo = request.app.state.dataset_repo
+    layer_cache: dict = request.app.state.layer_cache
+
+    ds = dataset_repo.get(uuid.UUID(dataset_id))
+    if ds is None:
+        raise HTTPException(404, f"Dataset {dataset_id} not found")
+    if not ds.source_path or not Path(ds.source_path).exists():
+        raise HTTPException(404, "Dataset file not found on disk")
+
+    from persistence.style_converter import style_def_to_qml
+
+    try:
+        qml = style_def_to_qml(body.style_def, body.geom_type)
+    except Exception as exc:
+        raise HTTPException(400, f"Invalid style_def: {exc}")
+
+    _upsert_layer_style(ds.source_path, body.layer_name, qml)
+    layer_cache.pop(dataset_id, None)
+
+    return JSONResponse(content={
+        "layer_name": body.layer_name,
+        "qml_size_bytes": len(qml.encode("utf-8")),
+    })
+
+
+_QML_MAX_BYTES = 1_048_576
+
+
+@router.post("/datasets/{dataset_id}/styles/import")
+async def import_qml_style(
+    request: Request,
+    dataset_id: str,
+    layer_name: str = Form(...),
+    geom_type: str = Form("polygon"),
+    file: UploadFile = File(...),
+) -> JSONResponse:
+    """Import a .qml file: parse → LayerStyleDef → persist via upsert."""
+    dataset_repo = request.app.state.dataset_repo
+    layer_cache: dict = request.app.state.layer_cache
+
+    ds = dataset_repo.get(uuid.UUID(dataset_id))
+    if ds is None:
+        raise HTTPException(404, f"Dataset {dataset_id} not found")
+    if not ds.source_path or not Path(ds.source_path).exists():
+        raise HTTPException(404, "Dataset file not found on disk")
+
+    raw = await file.read()
+    if len(raw) > _QML_MAX_BYTES:
+        raise HTTPException(413, "QML file exceeds 1 MB limit")
+
+    try:
+        qml_xml = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        raise HTTPException(400, "QML file must be UTF-8 encoded")
+
+    import xml.etree.ElementTree as _ET
+
+    from persistence.style_converter import qml_to_style_def, style_def_to_qml
+
+    try:
+        _ET.fromstring(qml_xml)
+    except _ET.ParseError as exc:
+        raise HTTPException(400, f"Invalid QML XML: {exc}")
+
+    try:
+        style_def = qml_to_style_def(qml_xml, geom_type)
+    except Exception as exc:
+        raise HTTPException(400, f"Invalid QML: {exc}")
+
+    canonical_qml = style_def_to_qml(style_def, geom_type)
+    _upsert_layer_style(ds.source_path, layer_name, canonical_qml)
+    layer_cache.pop(dataset_id, None)
+
+    return JSONResponse(content={
+        "layer_name": layer_name,
+        "style_def": style_def,
+        "qml_size_bytes": len(raw),
     })

--- a/tests/unit/test_styling_endpoints.py
+++ b/tests/unit/test_styling_endpoints.py
@@ -1,0 +1,246 @@
+"""Tests for v1.5 styling endpoints (breaks / PUT styles / import QML)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import geopandas as gpd
+import pytest
+from fastapi.testclient import TestClient
+from shapely.geometry import Polygon
+
+from core.models import Dataset
+from gispulse.adapters.http.app import create_app
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch):
+    monkeypatch.setenv("GISPULSE_STORAGE", "memory")
+    monkeypatch.delenv("GISPULSE_API_KEYS", raising=False)
+    from gispulse.adapters.http.rate_limit import limiter
+    limiter.enabled = False
+
+
+@pytest.fixture()
+def gpkg_path(tmp_path: Path) -> Path:
+    """Build a tiny polygon GPKG with a numeric attribute for classification."""
+    polys = [Polygon([(i, 0), (i + 1, 0), (i + 1, 1), (i, 1)]) for i in range(20)]
+    gdf = gpd.GeoDataFrame(
+        {"pop": list(range(1, 21)), "category": ["A"] * 7 + ["B"] * 7 + ["C"] * 6},
+        geometry=polys,
+        crs="EPSG:4326",
+    )
+    p = tmp_path / "fixture.gpkg"
+    gdf.to_file(p, layer="parcels", driver="GPKG")
+    return p
+
+
+@pytest.fixture()
+def client(gpkg_path: Path) -> tuple[TestClient, str]:
+    os.environ["GISPULSE_STORAGE"] = "memory"
+    app = create_app()
+    ds = Dataset(name="fixture", source_path=str(gpkg_path), crs="EPSG:4326", format="gpkg")
+    app.state.dataset_repo.save(ds)
+    return TestClient(app, raise_server_exceptions=False), str(ds.id)
+
+
+# ── POST /datasets/{id}/layers/{layer}/breaks ────────────────────────────
+
+
+class TestComputeBreaks:
+    def test_jenks_returns_n_plus_one_breaks(self, client):
+        c, ds_id = client
+        r = c.post(
+            f"/api/portal/datasets/{ds_id}/layers/parcels/breaks",
+            json={"field": "pop", "method": "jenks", "n_classes": 5},
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["field"] == "pop"
+        assert body["method"] == "jenks"
+        assert len(body["breaks"]) == 6
+        assert len(body["labels"]) == 5
+        assert body["breaks"][0] == 1.0
+        assert body["breaks"][-1] == 20.0
+
+    def test_quantile_method(self, client):
+        c, ds_id = client
+        r = c.post(
+            f"/api/portal/datasets/{ds_id}/layers/parcels/breaks",
+            json={"field": "pop", "method": "quantile", "n_classes": 4},
+        )
+        assert r.status_code == 200
+        assert len(r.json()["breaks"]) == 5
+
+    def test_invalid_method_returns_400(self, client):
+        c, ds_id = client
+        r = c.post(
+            f"/api/portal/datasets/{ds_id}/layers/parcels/breaks",
+            json={"field": "pop", "method": "kmeans", "n_classes": 5},
+        )
+        assert r.status_code == 400
+
+    def test_non_numeric_field_returns_400(self, client):
+        c, ds_id = client
+        r = c.post(
+            f"/api/portal/datasets/{ds_id}/layers/parcels/breaks",
+            json={"field": "category", "method": "jenks", "n_classes": 3},
+        )
+        assert r.status_code == 400
+
+    def test_unknown_field_returns_404(self, client):
+        c, ds_id = client
+        r = c.post(
+            f"/api/portal/datasets/{ds_id}/layers/parcels/breaks",
+            json={"field": "missing", "method": "jenks", "n_classes": 5},
+        )
+        assert r.status_code == 404
+
+    def test_unknown_layer_returns_404(self, client):
+        c, ds_id = client
+        r = c.post(
+            f"/api/portal/datasets/{ds_id}/layers/ghost/breaks",
+            json={"field": "pop", "method": "jenks", "n_classes": 5},
+        )
+        assert r.status_code == 404
+
+    def test_n_classes_out_of_range(self, client):
+        c, ds_id = client
+        r = c.post(
+            f"/api/portal/datasets/{ds_id}/layers/parcels/breaks",
+            json={"field": "pop", "method": "jenks", "n_classes": 1},
+        )
+        assert r.status_code == 400
+
+
+# ── PUT /datasets/{id}/styles ────────────────────────────────────────────
+
+
+class TestPutStyle:
+    def test_persists_style_def_as_qml(self, client, gpkg_path):
+        c, ds_id = client
+        style_def = {
+            "renderer": "single",
+            "symbol": {
+                "kind": "fill",
+                "color": "#ff0000",
+                "opacity": 0.5,
+                "strokeColor": "#000000",
+                "strokeWidth": 1.0,
+            },
+        }
+        r = c.put(
+            f"/api/portal/datasets/{ds_id}/styles",
+            json={"layer_name": "parcels", "style_def": style_def, "geom_type": "polygon"},
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["layer_name"] == "parcels"
+        assert r.json()["qml_size_bytes"] > 0
+
+        from persistence.gpkg import read_styles
+        rows = read_styles(str(gpkg_path))
+        parcels_styles = [row for row in rows if row["f_table_name"] == "parcels"]
+        assert len(parcels_styles) == 1
+        assert "<qgis" in parcels_styles[0]["styleQML"]
+
+    def test_replaces_existing_style(self, client, gpkg_path):
+        c, ds_id = client
+        sd1 = {"renderer": "single", "symbol": {"kind": "fill", "color": "#ff0000", "opacity": 0.5, "strokeColor": "#000", "strokeWidth": 1}}
+        sd2 = {"renderer": "single", "symbol": {"kind": "fill", "color": "#00ff00", "opacity": 0.7, "strokeColor": "#000", "strokeWidth": 1}}
+        c.put(f"/api/portal/datasets/{ds_id}/styles", json={"layer_name": "parcels", "style_def": sd1, "geom_type": "polygon"})
+        c.put(f"/api/portal/datasets/{ds_id}/styles", json={"layer_name": "parcels", "style_def": sd2, "geom_type": "polygon"})
+        from persistence.gpkg import read_styles
+        rows = [row for row in read_styles(str(gpkg_path)) if row["f_table_name"] == "parcels"]
+        assert len(rows) == 1
+
+    def test_invalid_style_def_returns_400(self, client):
+        c, ds_id = client
+        r = c.put(
+            f"/api/portal/datasets/{ds_id}/styles",
+            json={"layer_name": "parcels", "style_def": "not a dict", "geom_type": "polygon"},
+        )
+        assert r.status_code in (400, 422)
+
+    def test_unknown_dataset_returns_404(self, client):
+        c, _ = client
+        r = c.put(
+            "/api/portal/datasets/00000000-0000-0000-0000-000000000000/styles",
+            json={"layer_name": "parcels", "style_def": {"renderer": "single"}, "geom_type": "polygon"},
+        )
+        assert r.status_code == 404
+
+
+# ── POST /datasets/{id}/styles/import ────────────────────────────────────
+
+
+_QML_FIXTURE = """<?xml version="1.0" encoding="UTF-8"?>
+<qgis version="3.34">
+  <renderer-v2 type="singleSymbol">
+    <symbols>
+      <symbol name="0" type="fill">
+        <layer class="SimpleFill">
+          <prop k="color" v="31,120,180,180" />
+          <prop k="outline_color" v="0,0,0,255" />
+          <prop k="outline_width" v="0.5" />
+          <prop k="style" v="solid" />
+        </layer>
+      </symbol>
+    </symbols>
+  </renderer-v2>
+</qgis>"""
+
+
+class TestImportQml:
+    def test_imports_qml_and_returns_style_def(self, client):
+        c, ds_id = client
+        r = c.post(
+            f"/api/portal/datasets/{ds_id}/styles/import",
+            data={"layer_name": "parcels", "geom_type": "polygon"},
+            files={"file": ("fixture.qml", _QML_FIXTURE, "application/xml")},
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["layer_name"] == "parcels"
+        assert body["style_def"]["renderer"] == "single"
+        assert body["style_def"]["symbol"]["kind"] == "fill"
+
+    def test_persists_imported_qml_to_gpkg(self, client, gpkg_path):
+        c, ds_id = client
+        c.post(
+            f"/api/portal/datasets/{ds_id}/styles/import",
+            data={"layer_name": "parcels", "geom_type": "polygon"},
+            files={"file": ("fixture.qml", _QML_FIXTURE, "application/xml")},
+        )
+        from persistence.gpkg import read_styles
+        rows = [row for row in read_styles(str(gpkg_path)) if row["f_table_name"] == "parcels"]
+        assert len(rows) == 1
+        assert "<qgis" in rows[0]["styleQML"]
+
+    def test_invalid_xml_returns_400(self, client):
+        c, ds_id = client
+        r = c.post(
+            f"/api/portal/datasets/{ds_id}/styles/import",
+            data={"layer_name": "parcels", "geom_type": "polygon"},
+            files={"file": ("bad.qml", "<not xml at all", "application/xml")},
+        )
+        assert r.status_code == 400
+
+    def test_oversized_file_returns_413(self, client):
+        c, ds_id = client
+        big = "<qgis>" + ("x" * 1_100_000) + "</qgis>"
+        r = c.post(
+            f"/api/portal/datasets/{ds_id}/styles/import",
+            data={"layer_name": "parcels", "geom_type": "polygon"},
+            files={"file": ("big.qml", big, "application/xml")},
+        )
+        assert r.status_code == 413
+
+    def test_unknown_dataset_returns_404(self, client):
+        c, _ = client
+        r = c.post(
+            "/api/portal/datasets/00000000-0000-0000-0000-000000000000/styles/import",
+            data={"layer_name": "parcels", "geom_type": "polygon"},
+            files={"file": ("fixture.qml", _QML_FIXTURE, "application/xml")},
+        )
+        assert r.status_code == 404


### PR DESCRIPTION
## Summary
- Closes #41 — `POST /datasets/{id}/layers/{layer}/breaks` (jenks/quantile/equal_interval/std_dev/pretty via `ClassifyCapability`)
- Closes #42 — `PUT /datasets/{id}/styles` (persist `LayerStyleDef` → GPKG `layer_styles` via `style_def_to_qml`)
- Closes #43 — `POST /datasets/{id}/styles/import` (multipart .qml → `qml_to_style_def` → upsert)
- Part of EPIC #40

## Why
Backend audit 2026-04-29 found that `persistence/style_converter.py` (608 LOC, 4 renderers + labels, 20 roundtrip tests already green) and `capabilities/classification.py` were already production-ready, but the portal had no HTTP surface to use them. This PR closes that gap — **no new dependency, GeoStyler not needed**.

## Implementation notes
- `_load_layer_gdf` helper extracts the dataset → layer-cache → gdf flow shared with `/distinct` and `/stats`.
- `_upsert_layer_style` does `DELETE WHERE f_table_name=? then INSERT` (no UPSERT on the GPKG OGC schema), invalidates `layer_cache`.
- Strict `ET.fromstring()` pre-parse on QML import so malformed XML returns 400 (the converter is permissive by design).
- `n_classes` capped 2..20, file upload capped 1 MB.

## Test plan
- [x] `pytest tests/unit/test_styling_endpoints.py` — 16 cases, all green
- [x] Regression: `test_portal_datasets_router.py` + `test_style_converter.py` + `test_classify_capability.py` — 63 cases, all green
- [x] `ruff check` — pass

## Follow-ups
- imagodata/gispulse#44 — extended QML roundtrip integration tests on 5 representative QGIS exports
- imagodata/gispulse-portal#22 — wrap these 3 endpoints in `api/styles.ts`