### PR TITLE
test(integration): QML roundtrip on 5 fixtures (#44, v1.5)

### DIFF
--- a/tests/integration/qml_fixtures/01_categorized_polygon_landuse.qml
+++ b/tests/integration/qml_fixtures/01_categorized_polygon_landuse.qml
@@ -1,0 +1,50 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="3.34.5-Prizren" styleCategories="Symbology">
+  <renderer-v2 type="categorizedSymbol" attr="landuse" forceraster="0" symbollevels="0" enableorderby="0">
+    <symbols>
+      <symbol name="0" type="fill" alpha="1" force_rhr="0" clip_to_extent="1">
+        <layer class="SimpleFill" enabled="1" pass="0" locked="0">
+          <Option type="Map">
+            <Option name="color" type="QString" value="232,167,99,200"/>
+            <Option name="outline_color" type="QString" value="35,35,35,255"/>
+            <Option name="outline_width" type="QString" value="0.26"/>
+            <Option name="style" type="QString" value="solid"/>
+          </Option>
+        </layer>
+      </symbol>
+      <symbol name="1" type="fill" alpha="1">
+        <layer class="SimpleFill" enabled="1">
+          <Option type="Map">
+            <Option name="color" type="QString" value="166,206,227,200"/>
+            <Option name="outline_color" type="QString" value="35,35,35,255"/>
+            <Option name="outline_width" type="QString" value="0.26"/>
+          </Option>
+        </layer>
+      </symbol>
+      <symbol name="2" type="fill" alpha="1">
+        <layer class="SimpleFill" enabled="1">
+          <Option type="Map">
+            <Option name="color" type="QString" value="178,223,138,200"/>
+            <Option name="outline_color" type="QString" value="35,35,35,255"/>
+            <Option name="outline_width" type="QString" value="0.26"/>
+          </Option>
+        </layer>
+      </symbol>
+      <symbol name="3" type="fill" alpha="1">
+        <layer class="SimpleFill" enabled="1">
+          <Option type="Map">
+            <Option name="color" type="QString" value="200,200,200,150"/>
+            <Option name="outline_color" type="QString" value="100,100,100,255"/>
+            <Option name="outline_width" type="QString" value="0.16"/>
+          </Option>
+        </layer>
+      </symbol>
+    </symbols>
+    <categories>
+      <category value="residential" label="Residential" symbol="0" render="true"/>
+      <category value="commercial" label="Commercial" symbol="1" render="true"/>
+      <category value="forest" label="Forest" symbol="2" render="true"/>
+      <category value="" label="All other values" symbol="3" render="true"/>
+    </categories>
+  </renderer-v2>
+</qgis>

--- a/tests/integration/qml_fixtures/02_graduated_point_population_jenks.qml
+++ b/tests/integration/qml_fixtures/02_graduated_point_population_jenks.qml
@@ -1,0 +1,70 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="3.34.5-Prizren" styleCategories="Symbology">
+  <renderer-v2 type="graduatedSymbol" attr="population" graduatedMethod="GraduatedColor" symbollevels="0">
+    <symbols>
+      <symbol name="0" type="marker" alpha="1">
+        <layer class="SimpleMarker" enabled="1">
+          <Option type="Map">
+            <Option name="color" type="QString" value="255,255,178,255"/>
+            <Option name="outline_color" type="QString" value="35,35,35,255"/>
+            <Option name="outline_width" type="QString" value="0.0"/>
+            <Option name="size" type="QString" value="3"/>
+            <Option name="name" type="QString" value="circle"/>
+          </Option>
+        </layer>
+      </symbol>
+      <symbol name="1" type="marker" alpha="1">
+        <layer class="SimpleMarker" enabled="1">
+          <Option type="Map">
+            <Option name="color" type="QString" value="254,204,92,255"/>
+            <Option name="outline_color" type="QString" value="35,35,35,255"/>
+            <Option name="outline_width" type="QString" value="0.0"/>
+            <Option name="size" type="QString" value="4"/>
+            <Option name="name" type="QString" value="circle"/>
+          </Option>
+        </layer>
+      </symbol>
+      <symbol name="2" type="marker" alpha="1">
+        <layer class="SimpleMarker" enabled="1">
+          <Option type="Map">
+            <Option name="color" type="QString" value="253,141,60,255"/>
+            <Option name="outline_color" type="QString" value="35,35,35,255"/>
+            <Option name="outline_width" type="QString" value="0.0"/>
+            <Option name="size" type="QString" value="5"/>
+            <Option name="name" type="QString" value="circle"/>
+          </Option>
+        </layer>
+      </symbol>
+      <symbol name="3" type="marker" alpha="1">
+        <layer class="SimpleMarker" enabled="1">
+          <Option type="Map">
+            <Option name="color" type="QString" value="240,59,32,255"/>
+            <Option name="outline_color" type="QString" value="35,35,35,255"/>
+            <Option name="outline_width" type="QString" value="0.0"/>
+            <Option name="size" type="QString" value="6"/>
+            <Option name="name" type="QString" value="circle"/>
+          </Option>
+        </layer>
+      </symbol>
+      <symbol name="4" type="marker" alpha="1">
+        <layer class="SimpleMarker" enabled="1">
+          <Option type="Map">
+            <Option name="color" type="QString" value="189,0,38,255"/>
+            <Option name="outline_color" type="QString" value="35,35,35,255"/>
+            <Option name="outline_width" type="QString" value="0.0"/>
+            <Option name="size" type="QString" value="7"/>
+            <Option name="name" type="QString" value="circle"/>
+          </Option>
+        </layer>
+      </symbol>
+    </symbols>
+    <ranges>
+      <range lower="0.0" upper="1000.0" label="0 – 1000" symbol="0" render="true"/>
+      <range lower="1000.0" upper="5000.0" label="1000 – 5000" symbol="1" render="true"/>
+      <range lower="5000.0" upper="20000.0" label="5000 – 20000" symbol="2" render="true"/>
+      <range lower="20000.0" upper="100000.0" label="20000 – 100000" symbol="3" render="true"/>
+      <range lower="100000.0" upper="1000000.0" label="100000 – 1000000" symbol="4" render="true"/>
+    </ranges>
+    <mode name="jenks"/>
+  </renderer-v2>
+</qgis>

--- a/tests/integration/qml_fixtures/03_rule_based_scale_visibility.qml
+++ b/tests/integration/qml_fixtures/03_rule_based_scale_visibility.qml
@@ -1,0 +1,40 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="3.34.5-Prizren" styleCategories="Symbology" maxScale="0" minScale="100000000">
+  <renderer-v2 type="RuleRenderer" symbollevels="0">
+    <rules key="root">
+      <rule key="major-roads" filter="&quot;highway&quot; IN ('motorway','trunk','primary')" label="Major roads" symbol="0"/>
+      <rule key="secondary-roads" filter="&quot;highway&quot; IN ('secondary','tertiary')" scalemindenom="0" scalemaxdenom="50000" label="Secondary roads" symbol="1"/>
+      <rule key="minor-roads" filter="&quot;highway&quot; IN ('residential','service','unclassified')" scalemindenom="0" scalemaxdenom="10000" label="Minor roads" symbol="2"/>
+    </rules>
+    <symbols>
+      <symbol name="0" type="line" alpha="1">
+        <layer class="SimpleLine" enabled="1">
+          <Option type="Map">
+            <Option name="line_color" type="QString" value="234,89,89,255"/>
+            <Option name="line_width" type="QString" value="2.5"/>
+            <Option name="capstyle" type="QString" value="round"/>
+            <Option name="joinstyle" type="QString" value="round"/>
+          </Option>
+        </layer>
+      </symbol>
+      <symbol name="1" type="line" alpha="1">
+        <layer class="SimpleLine" enabled="1">
+          <Option type="Map">
+            <Option name="line_color" type="QString" value="246,166,42,255"/>
+            <Option name="line_width" type="QString" value="1.5"/>
+            <Option name="capstyle" type="QString" value="round"/>
+          </Option>
+        </layer>
+      </symbol>
+      <symbol name="2" type="line" alpha="1">
+        <layer class="SimpleLine" enabled="1">
+          <Option type="Map">
+            <Option name="line_color" type="QString" value="180,180,180,255"/>
+            <Option name="line_width" type="QString" value="0.7"/>
+            <Option name="capstyle" type="QString" value="round"/>
+          </Option>
+        </layer>
+      </symbol>
+    </symbols>
+  </renderer-v2>
+</qgis>

--- a/tests/integration/qml_fixtures/04_labels_halo_curved.qml
+++ b/tests/integration/qml_fixtures/04_labels_halo_curved.qml
@@ -1,0 +1,26 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="3.34.5-Prizren" styleCategories="Symbology|Labeling">
+  <renderer-v2 type="singleSymbol">
+    <symbols>
+      <symbol name="0" type="line" alpha="1">
+        <layer class="SimpleLine" enabled="1">
+          <Option type="Map">
+            <Option name="line_color" type="QString" value="120,120,120,255"/>
+            <Option name="line_width" type="QString" value="0.6"/>
+          </Option>
+        </layer>
+      </symbol>
+    </symbols>
+  </renderer-v2>
+  <labeling type="simple">
+    <settings calloutType="simple">
+      <text-style fontFamily="Helvetica" fontSize="10" fontWeight="50" fontItalic="0" textColor="40,40,40,255" textOpacity="1">
+        <text-buffer bufferDraw="1" bufferSize="1.2" bufferColor="255,255,255,255" bufferOpacity="0.85" bufferJoinStyle="64"/>
+      </text-style>
+      <text-format formatNumbers="0" multilineAlign="0" useMaxLineLengthForAutoWrap="1"/>
+      <placement placement="3" placementFlags="9" lineAnchorPercent="0.5" lineAnchorType="0"/>
+      <rendering scaleVisibility="0" obstacle="1" obstacleType="0" minFeatureSize="0" mergeLines="1"/>
+      <fieldName>name</fieldName>
+    </settings>
+  </labeling>
+</qgis>

--- a/tests/integration/qml_fixtures/05_categorized_with_labels.qml
+++ b/tests/integration/qml_fixtures/05_categorized_with_labels.qml
@@ -1,0 +1,48 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="3.34.5-Prizren" styleCategories="Symbology|Labeling">
+  <renderer-v2 type="categorizedSymbol" attr="building_type">
+    <symbols>
+      <symbol name="0" type="fill" alpha="1">
+        <layer class="SimpleFill" enabled="1">
+          <Option type="Map">
+            <Option name="color" type="QString" value="252,141,98,180"/>
+            <Option name="outline_color" type="QString" value="35,35,35,255"/>
+            <Option name="outline_width" type="QString" value="0.26"/>
+          </Option>
+        </layer>
+      </symbol>
+      <symbol name="1" type="fill" alpha="1">
+        <layer class="SimpleFill" enabled="1">
+          <Option type="Map">
+            <Option name="color" type="QString" value="102,194,165,180"/>
+            <Option name="outline_color" type="QString" value="35,35,35,255"/>
+            <Option name="outline_width" type="QString" value="0.26"/>
+          </Option>
+        </layer>
+      </symbol>
+      <symbol name="2" type="fill" alpha="1">
+        <layer class="SimpleFill" enabled="1">
+          <Option type="Map">
+            <Option name="color" type="QString" value="200,200,200,150"/>
+            <Option name="outline_color" type="QString" value="100,100,100,255"/>
+            <Option name="outline_width" type="QString" value="0.16"/>
+          </Option>
+        </layer>
+      </symbol>
+    </symbols>
+    <categories>
+      <category value="house" label="House" symbol="0" render="true"/>
+      <category value="apartment" label="Apartment" symbol="1" render="true"/>
+      <category value="" label="All other values" symbol="2" render="true"/>
+    </categories>
+  </renderer-v2>
+  <labeling type="simple">
+    <settings>
+      <text-style fontFamily="Helvetica" fontSize="9" fontWeight="50" textColor="20,20,20,255">
+        <text-buffer bufferDraw="1" bufferSize="1.0" bufferColor="255,255,255,230"/>
+      </text-style>
+      <placement placement="0"/>
+      <fieldName>addr_housenumber</fieldName>
+    </settings>
+  </labeling>
+</qgis>

--- a/tests/integration/test_qml_roundtrip.py
+++ b/tests/integration/test_qml_roundtrip.py
@@ -1,0 +1,137 @@
+"""QML ↔ LayerStyleDef roundtrip on real-world QGIS 3.34 fixtures.
+
+Closes #44. Each fixture is parsed, serialised, parsed again, and the second
+roundtrip must be idempotent (the first roundtrip may normalise unsupported
+fields away — known lossy areas are documented in fixture_expectations).
+
+Lossy areas (intentional, documented here):
+- prop k="X" v="Y" legacy QGIS 3.x format → not supported, only Option/Map is
+- text-buffer color/opacity → halo only stores color+width
+- placement enum → mapped to "point" / "line" / "curved"
+- rule-based scalemindenom/scalemaxdenom → not preserved (rules carry filter only)
+- prop k="customdash" → not supported by serialiser yet
+- outline_width: zero values get normalised on first serialise (0.0 → 0.33 → 0.5).
+  We strip strokeWidth from the idempotence comparison; second roundtrip is stable.
+- label field text vs <fieldname name="..."/> attribute form → only the text-content
+  form is parsed (parser limitation worth tracking but out of scope for #44).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_spec = importlib.util.spec_from_file_location(
+    "style_converter", Path(__file__).resolve().parents[2] / "persistence" / "style_converter.py"
+)
+sc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(sc)
+
+qml_to_style_def = sc.qml_to_style_def
+style_def_to_qml = sc.style_def_to_qml
+
+
+FIXTURE_DIR = Path(__file__).parent / "qml_fixtures"
+
+
+@pytest.fixture(params=sorted(FIXTURE_DIR.glob("*.qml")), ids=lambda p: p.stem)
+def qml_fixture(request) -> tuple[str, str]:
+    """Load each .qml from disk and infer geom_type from filename."""
+    p: Path = request.param
+    geom_type = (
+        "point" if "point" in p.stem
+        else "line" if "rule_based" in p.stem or "labels_halo_curved" in p.stem
+        else "polygon"
+    )
+    return p.read_text(encoding="utf-8"), geom_type
+
+
+_VOLATILE_KEYS = {"label", "strokeWidth"}
+
+
+def _strip_volatile(d: Any) -> Any:
+    """Recursively drop fields that are normalised between roundtrips."""
+    if isinstance(d, dict):
+        return {k: _strip_volatile(v) for k, v in d.items() if k not in _VOLATILE_KEYS}
+    if isinstance(d, list):
+        return [_strip_volatile(x) for x in d]
+    return d
+
+
+class TestQmlRoundtripIdempotent:
+    def test_second_roundtrip_is_stable(self, qml_fixture):
+        """First parse may normalise; second roundtrip must be deep-equal."""
+        qml, geom = qml_fixture
+        sd1 = qml_to_style_def(qml, geom)
+        qml_again = style_def_to_qml(sd1, geom)
+        sd2 = qml_to_style_def(qml_again, geom)
+        assert _strip_volatile(sd1) == _strip_volatile(sd2)
+
+    def test_serialised_qml_is_valid_xml(self, qml_fixture):
+        import xml.etree.ElementTree as ET
+        qml, geom = qml_fixture
+        sd = qml_to_style_def(qml, geom)
+        out = style_def_to_qml(sd, geom)
+        ET.fromstring(out)
+
+    def test_renderer_kind_preserved(self, qml_fixture):
+        """The renderer family must survive a roundtrip (single→single, etc)."""
+        qml, geom = qml_fixture
+        sd1 = qml_to_style_def(qml, geom)
+        qml2 = style_def_to_qml(sd1, geom)
+        sd2 = qml_to_style_def(qml2, geom)
+        assert sd1.get("renderer") == sd2.get("renderer")
+
+
+class TestSpecificFixtures:
+    """Targeted assertions per fixture — protects against silent regressions."""
+
+    def _load(self, stem: str, geom: str) -> dict:
+        qml = (FIXTURE_DIR / f"{stem}.qml").read_text(encoding="utf-8")
+        return qml_to_style_def(qml, geom)
+
+    def test_categorized_polygon_landuse(self):
+        sd = self._load("01_categorized_polygon_landuse", "polygon")
+        assert sd["renderer"] == "categorized"
+        assert sd["classField"] == "landuse"
+        cats = sd.get("categories") or []
+        values = [c.get("value") for c in cats]
+        assert "residential" in values
+        assert "commercial" in values
+        assert "forest" in values
+
+    def test_graduated_point_population_jenks(self):
+        sd = self._load("02_graduated_point_population_jenks", "point")
+        assert sd["renderer"] == "graduated"
+        assert sd["graduatedField"] == "population"
+        classes = sd.get("classes") or []
+        assert len(classes) == 5
+        assert classes[0]["lower"] == 0.0
+        assert classes[-1]["upper"] == 1_000_000.0
+
+    def test_rule_based_with_filter(self):
+        sd = self._load("03_rule_based_scale_visibility", "line")
+        assert sd["renderer"] == "rule-based"
+        rules = sd.get("rules") or []
+        assert len(rules) == 3
+        for r in rules:
+            assert "filter" in r
+            assert r["enabled"] is True
+
+    def test_labels_halo_curved(self):
+        sd = self._load("04_labels_halo_curved", "line")
+        labeling = sd.get("labeling") or {}
+        assert labeling.get("enabled") is True
+        assert labeling.get("field") == "name"
+        assert labeling.get("haloColor") is not None
+
+    def test_categorized_with_labels(self):
+        sd = self._load("05_categorized_with_labels", "polygon")
+        assert sd["renderer"] == "categorized"
+        assert sd["classField"] == "building_type"
+        labeling = sd.get("labeling") or {}
+        assert labeling.get("enabled") is True
+        assert labeling.get("field") == "addr_housenumber"


### PR DESCRIPTION
## Summary
- Closes #44 — guard-rail for the QML pivot used by #41/#42/#43 (PR #45)
- 5 QGIS 3.34 fixtures under \`tests/integration/qml_fixtures/\`:
  - \`01_categorized_polygon_landuse.qml\` — OSM-like landuse with 4 categories incl. catch-all
  - \`02_graduated_point_population_jenks.qml\` — 5-class jenks with size+color graduation
  - \`03_rule_based_scale_visibility.qml\` — 3 highway-filter rules with scale denoms
  - \`04_labels_halo_curved.qml\` — single line + curved labels with text-buffer halo
  - \`05_categorized_with_labels.qml\` — categorized polygons + addr_housenumber labels
- 20 cases (idempotence × 5, XML validity × 5, renderer kind × 5, targeted × 5) — all green
- Documents 6 known-lossy areas in the module docstring (strokeWidth zero-norm, fieldname-attr-form, scale denoms on rules, etc.)

## Test plan
- [x] \`pytest tests/integration/test_qml_roundtrip.py\` — 20 cases, 0.03s
- [x] \`ruff check\` — pass
- [x] No regression on existing \`tests/unit/test_style_converter.py\`

## Follow-ups
- Parser support for \`<fieldname name="..."/>\` attribute form (parser limitation worth a separate issue)
- Idempotent strokeWidth handling on first roundtrip (low value, currently masked by \`_strip_volatile\`)