### PR TITLE
docs(cli): gispulse portal/engine guides + cli reference sync (#52)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,20 @@ gispulse serve parcels.gpkg
 gispulse doctor
 ```
 
+### Run the portal locally
+
+```bash
+# Install the CLI plus the bundled SPA workbench
+pipx install gispulse-portal
+
+# Start the local engine and open the browser at localhost:8001/portal
+gispulse portal
+```
+
+For headless runs (no SPA), use `gispulse engine` instead. See:
+[Running the Portal locally](https://imagodata.github.io/gispulse/en/guide/portal-local) ·
+[Running the engine](https://imagodata.github.io/gispulse/en/guide/engine).
+
 ### Docker (development)
 
 ```bash

--- a/docs-site/.vitepress/config.ts
+++ b/docs-site/.vitepress/config.ts
@@ -107,6 +107,8 @@ const frSidebar = {
       text: 'Guide',
       items: [
         { text: 'CLI — Référence', link: '/guide/cli' },
+        { text: 'Lancer le portail localement', link: '/guide/portal-local' },
+        { text: 'Lancer le moteur', link: '/guide/engine' },
         { text: 'Écrire des règles', link: '/guide/rules' },
         { text: 'Capabilities', link: '/guide/capabilities' },
         { text: 'Matrice de couverture', link: '/guide/coverage' },
@@ -224,6 +226,8 @@ const enSidebar = {
       text: 'Guide',
       items: [
         { text: 'CLI Reference', link: '/en/guide/cli' },
+        { text: 'Running the Portal locally', link: '/en/guide/portal-local' },
+        { text: 'Running the engine', link: '/en/guide/engine' },
         { text: 'Writing Rules', link: '/en/guide/rules' },
         { text: 'Capabilities', link: '/en/guide/capabilities' },
         { text: 'Coverage matrix', link: '/en/guide/coverage' },

--- a/docs-site/en/guide/cli.md
+++ b/docs-site/en/guide/cli.md
@@ -306,7 +306,7 @@ gispulse serve output/result.gpkg --port 9000
 
 ## `gispulse portal`
 
-Launches the GISPulse Portal — visual pipeline editor and dataset manager.
+Launches the GISPulse Portal — a visual workbench (node canvas, capability registry, dataset manager) served by the local engine. Requires the optional `gispulse-portal` package. Full reference: [Running the Portal locally](/en/guide/portal-local).
 
 ```bash
 gispulse portal [OPTIONS]
@@ -316,16 +316,20 @@ gispulse portal [OPTIONS]
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--port`, `-p` | `8001` | Listening port |
-| `--host` | `0.0.0.0` | Host (0.0.0.0 = LAN accessible) |
-| `--data-dir`, `-d` | `~/.gispulse/data` | Directory for uploaded datasets |
-| `--dev` | `false` | Dev mode: API only |
+| `--port`, `-p` | `8001` | Listening port (local mode). |
+| `--host` | `127.0.0.1` | Bind host (local mode). |
+| `--data-dir`, `-d` | `~/.gispulse/data` | Directory for uploaded datasets. |
+| `--backend URL` | — | Remote mode: open the GH-Pages portal pointed at a remote engine. |
+| `--no-browser` | `false` | Don't open the browser. |
+| `--dev` | `false` | Allow falling back to the local checkout's `portal/dist/` (contributor workflow). |
 
 ```bash
-# Standard startup
+# Local (default)
 gispulse portal
+# GISPulse Portal at http://127.0.0.1:8001/portal/
 
-# GISPulse Portal at http://127.0.0.1:8001
+# Remote (no local engine)
+gispulse portal --backend=https://api.example.com
 ```
 
 ---
@@ -368,18 +372,27 @@ gispulse update --force
 
 ## `gispulse engine`
 
-Launches the full GISPulse stack (API + Portal + Viewer) as a single process — convenient for local or single-server deployments.
+Launches the GISPulse engine in headless mode (REST API + WebSocket, **no SPA**). Used by the Tauri sidecar, server deployments and third-party integrations. For a local visual workbench, see [`gispulse portal`](#gispulse-portal) and [Running the Portal locally](/en/guide/portal-local).
 
 ```bash
-gispulse engine --host 0.0.0.0 --port 8000
+gispulse engine [OPTIONS]
 ```
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--host` | `127.0.0.1` | Bind address |
-| `--port` | `8000` | HTTP port |
-| `--mode` | `portal` | `portal` (visual editor) or `api` (headless) |
-| `--reload` | off | Enable uvicorn auto-reload (dev) |
+| `--port`, `-p` | `0` (auto) | Listening port (`0` = auto-detect free port for Tauri). |
+| `--host` | `127.0.0.1` | Bind host. |
+| `--engine`, `-e` | `duckdb` | Spatial backend (`duckdb`, `postgis`, `hybrid`). |
+| `--data-dir`, `-d` | `~/.gispulse/data` | Datasets directory. |
+| `--no-browser` | `false` | Don't open the browser. |
+
+Emits a startup JSON line on stdout for the Tauri sidecar:
+
+```
+GISPULSE_READY:{"port": 8001, "host": "127.0.0.1", "engine": "duckdb", "pid": 12345}
+```
+
+Full reference: [Running the engine](/en/guide/engine).
 
 ---
 

--- a/docs-site/en/guide/engine.md
+++ b/docs-site/en/guide/engine.md
@@ -1,0 +1,165 @@
+---
+title: Running the engine
+description: Run the GISPulse engine headlessly (REST API + WebSocket, no SPA) via `gispulse engine`. Server, Tauri sidecar, third-party integration use cases.
+---
+
+# Running the engine (`gispulse engine`)
+
+The GISPulse engine is a FastAPI server that exposes rule pipelines, ESB triggers, datasets, and an event-bus WebSocket. The `gispulse engine` command runs it **headlessly** — no SPA mounted, just the API.
+
+> **When should I use `gispulse engine` instead of `gispulse portal`?** When you don't need the visual workbench: automated pipelines, the Tauri desktop sidecar, a backend for a separately-hosted portal, third-party integrations consuming the REST API. For local visual editing on a workstation, use [`gispulse portal`](/en/guide/portal-local).
+
+## Command
+
+```bash
+gispulse engine [OPTIONS]
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--port`, `-p` | `0` (auto) | Listening port. `0` = auto-detect a free port (handy for the Tauri sidecar). |
+| `--host` | `127.0.0.1` | Bind host. Use `0.0.0.0` to expose on the LAN or behind a reverse proxy. |
+| `--engine`, `-e` | `duckdb` | Spatial backend: `duckdb` (local), `postgis` (server), `hybrid` (Pro, mix of both). |
+| `--data-dir`, `-d` | `~/.gispulse/data` | Datasets upload directory. |
+| `--no-browser` | `false` | Don't open the browser on the API root. |
+
+### Boot and "ready" mode
+
+On boot, `gispulse engine` emits a JSON line on stdout so a parent process (Tauri, supervisor, script) can read the port and PID:
+
+```
+GISPULSE_READY:{"port": 8001, "host": "127.0.0.1", "engine": "duckdb", "pid": 12345}
+GISPulse at http://127.0.0.1:8001
+```
+
+The `GISPULSE_READY:` prefix is stable — you can parse this line in a sidecar.
+
+## API surface
+
+In `full` mode (the default), the engine mounts the following FastAPI routers. Full reference: [REST API](/en/api/rest) and the live `/docs` Swagger UI.
+
+| Endpoint | Method | Description |
+|---|---|---|
+| `/health` | GET | Healthcheck — returns `{"status": "ok"}`. Used by the `gispulse portal` healthcheck. |
+| `/metrics` | GET | Prometheus metrics (text format). Enabled in `full` mode. |
+| `/datasets` | GET / POST / DELETE | Dataset management (upload, list, delete). |
+| `/projects` | GET / POST | Multi-rule workspaces. |
+| `/scenarios` | GET / POST | Scenario = project + versioned ruleset. |
+| `/rules` | CRUD | Rules (capabilities + parameters). |
+| `/triggers` | CRUD | ESB triggers (DML watchers, webhooks). |
+| `/relations` | CRUD | Spatial / attribute relations between layers. |
+| `/jobs` | GET | Async jobs (status, result). |
+| `/capabilities` | GET | List available capabilities + parameter schemas. |
+| `/marketplace` | GET | Third-party capabilities catalog (Pro). |
+| `/examples` | GET | Mode 2 portal Try-it — embedded demo datasets. |
+| `/styles` | GET / PUT | QML / SLD / classification breaks. |
+| `/schedules` | CRUD | Cron pipelines (Pro). |
+| `/pipelines` | POST | Pipeline execution. |
+| `/sessions` | POST | Ephemeral DuckDB sessions. |
+| `/ws/events` | WebSocket | Live ESB event stream. |
+
+::: tip Live OpenAPI documentation
+Once the engine is running, open `http://localhost:8001/docs` (Swagger UI) or `http://localhost:8001/redoc` (ReDoc) to explore the exact API surface of your installed version.
+:::
+
+## Authentication
+
+| Tier | Authentication | Notes |
+|---|---|---|
+| **Community** | None (localhost only by default) | Fine for personal use and CI. |
+| **Pro / Enterprise** | API key (`X-API-Key` header) or OIDC | Enabled in `full` mode when `GISPULSE_REQUIRE_AUTH=1`. |
+
+For a server deployment (host `0.0.0.0`), **always** enable auth:
+
+```bash
+GISPULSE_TIER=pro \
+GISPULSE_REQUIRE_AUTH=1 \
+GISPULSE_API_KEYS="key1,key2" \
+gispulse engine --host 0.0.0.0 --port 8001
+```
+
+## Backend `duckdb` vs `postgis`
+
+| Flag | Backend | Use case |
+|---|---|---|
+| `--engine duckdb` | DuckDB local + GPKG/GeoParquet | Portable mode, no external DB, < ~10M features. |
+| `--engine postgis` | PostgreSQL/PostGIS server | Persistence, `pg_notify` triggers, multi-user. Requires `GISPULSE_DSN`. |
+| `--engine hybrid` | DuckDB compute + PostGIS storage (Pro) | Heterogeneous volumes, max throughput. |
+
+Details in [Engines — DuckDB / PostGIS / Hybrid](/en/guide/engines).
+
+```bash
+# PostGIS mode against a Postgres in Docker
+GISPULSE_DSN=postgresql://gispulse:secret@localhost:5432/gispulse \
+gispulse engine --engine postgis --port 8001
+```
+
+## Reverse proxy (Caddy / nginx)
+
+To expose the engine over HTTPS on a VPS, bind it to `127.0.0.1:8001` and let the reverse proxy terminate TLS.
+
+### Caddy (auto-TLS via Let's Encrypt)
+
+```caddy
+api.example.com {
+    reverse_proxy 127.0.0.1:8001
+    encode gzip zstd
+
+    # WebSocket (event bus) — Caddy handles this natively
+    @ws {
+        path /ws/*
+    }
+    reverse_proxy @ws 127.0.0.1:8001
+}
+```
+
+### nginx (manual TLS)
+
+```nginx
+server {
+    listen 443 ssl http2;
+    server_name api.example.com;
+
+    ssl_certificate     /etc/letsencrypt/live/api.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/api.example.com/privkey.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:8001;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Proto https;
+
+        # WebSocket upgrade
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 3600s;
+    }
+}
+```
+
+See [Deployment](/en/guide/deployment) for the full stack (PostGIS + Caddy + Prometheus + backups).
+
+## Cohabitation with `gispulse portal`
+
+Both commands launch the same `create_app()` FastAPI app. The only difference:
+
+| Command | Mounts SPA | Default auth | Use case |
+|---|---|---|---|
+| `gispulse engine` | no | env-controlled | server, Tauri sidecar, third-party integration |
+| `gispulse portal` | yes (`/portal`) | disabled (localhost) | workstation, visual onboarding |
+
+You can absolutely:
+
+1. Run `gispulse engine --host 0.0.0.0` on a VPS.
+2. Run `gispulse portal --backend=https://your.engine.example.com` on your laptop.
+
+The GH-Pages portal then connects to the remote engine — see [Running the Portal locally](/en/guide/portal-local#remote-mode-backend-url).
+
+## See also
+
+- [`gispulse portal`](/en/guide/portal-local) — same engine plus the bundled SPA.
+- [CLI Reference](/en/guide/cli) — all commands.
+- [Engines — DuckDB / PostGIS / Hybrid](/en/guide/engines) — pick the right backend.
+- [Deployment](/en/guide/deployment) — production VPS, Docker Compose, Prometheus.
+- [REST API](/en/api/rest) — full endpoint reference.

--- a/docs-site/en/guide/portal-local.md
+++ b/docs-site/en/guide/portal-local.md
@@ -1,0 +1,166 @@
+---
+title: Running the Portal locally
+description: Step-by-step guide for running the GISPulse Portal workbench on your machine via `gispulse portal` — no HTTPS, no CORS, no GIS plugin required.
+---
+
+# Running the Portal locally
+
+The **GISPulse Portal** is a visual workbench (node canvas, capability registry, dataset manager) served by the GISPulse engine. This page documents the `gispulse portal` command, which mounts the bundled SPA on your local engine and opens the browser.
+
+> **Product axiom.** The CLI and the Portal are two equivalent UIs over the same source of truth (`triggers.yaml` + change-log). Anything you configure in the Portal can be edited via the CLI, and vice versa.
+
+## Quick start (30 seconds)
+
+```bash
+# 1. Install the CLI plus the bundled SPA
+pipx install gispulse-portal
+
+# 2. Start the engine and open the browser at localhost:8001/portal
+gispulse portal
+```
+
+That's it. The browser opens at `http://127.0.0.1:8001/portal/`, you edit your triggers, and `Ctrl+C` stops the server.
+
+::: tip Why two packages?
+`gispulse-portal` is a separate PyPI wheel that ships the built SPA (`dist/`). It depends on `gispulse`, so `pipx install gispulse-portal` installs both in one go. This split keeps `gispulse` lean (~3 MB) for CLI-only / CI users. See the [architecture note](/en/guide/architecture) for details.
+:::
+
+## The `gispulse portal` command
+
+```bash
+gispulse portal [OPTIONS]
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--port`, `-p` | `8001` | Local engine listening port. |
+| `--host` | `127.0.0.1` | Bind host. Keep `127.0.0.1` unless you need LAN access. |
+| `--data-dir`, `-d` | `~/.gispulse/data` | Directory for datasets uploaded via the portal. |
+| `--no-browser` | `false` | Don't open the browser (useful over SSH / headless). |
+| `--backend URL` | — | Remote mode: open the GH-Pages portal pointed at a remote engine, **does not start** a local engine. |
+| `--dev` | `false` | Allow falling back to `portal/dist/` from a local checkout (contributor workflow). |
+
+### Behavior
+
+1. **SPA bundle resolution.** The command looks up `gispulse_portal.PORTAL_DIST_PATH`. If absent and `--dev` is set, falls back to `<repo>/portal/dist/`.
+2. **Same-origin mount.** The SPA is served by FastAPI under `/portal` via `StaticFiles`. The engine (REST API + WebSocket) lives on the root. No mixed-content, no CORS — everything goes through `localhost:8001`.
+3. **Healthcheck plus browser open.** A daemon thread polls `GET /health` every 100 ms for 3 s, then calls `webbrowser.open()` on the portal URL. If the healthcheck times out, we open anyway — worst case you see the loader.
+4. **Uvicorn run.** The engine runs in the foreground. `Ctrl+C` shuts down cleanly.
+
+### Examples
+
+```bash
+# Custom port (port 8001 conflict)
+gispulse portal --port 9000
+
+# No browser (SSH deployment, container, CI)
+gispulse portal --no-browser
+
+# Project-local datasets directory
+gispulse portal --data-dir ./my-project/data
+
+# Contributor workflow (from a repo checkout)
+gispulse portal --dev
+```
+
+## Without the `gispulse-portal` package
+
+If you only installed `gispulse` (no SPA bundle), the command fails cleanly with an install hint:
+
+```
+$ gispulse portal
+Error: gispulse-portal package is not installed.
+Install it with:
+  pip install gispulse-portal
+Or, for a remote workbench without a local install:
+  gispulse portal --backend=https://your-engine.example.com
+```
+
+This is intentional: CLI-only users (CI/CD, headless servers, terminal-first power users) don't pay the SPA cost. If you only need REST API + WebSocket without UI, use [`gispulse engine`](/en/guide/engine) instead.
+
+## Remote mode: `--backend URL`
+
+Instead of a local engine, you can point the GH-Pages portal (served over HTTPS) at **an engine deployed elsewhere**:
+
+```bash
+gispulse portal --backend=https://your.engine.example.com
+```
+
+The command URL-encodes the parameter and opens:
+
+```
+https://gispulse.dev/?backend=https%3A%2F%2Fyour.engine.example.com
+```
+
+**Use cases:**
+
+- You have an engine running on a VPS (see [Deployment](/en/guide/deployment)) and want to drive it from your laptop.
+- You're evaluating the hosted SaaS edition (v1.6+, `pro.gispulse.dev`).
+- You're demoing the portal to a client without installing Python on their machine.
+
+::: warning Mixed-content
+The GH-Pages portal is served over HTTPS. The `backend` URL must also be HTTPS — `http://localhost:8001` won't work (the browser blocks it). For a local engine, use the default mode (no `--backend`), which serves the SPA same-origin and side-steps the issue.
+:::
+
+## Troubleshooting
+
+### Port conflict (`EADDRINUSE`)
+
+Port `8001` is already in use (for example, a previous engine that wasn't killed). Diagnose:
+
+```bash
+# Linux / macOS
+lsof -i :8001
+
+# Windows
+netstat -ano | findstr :8001
+```
+
+Fix: `gispulse portal --port 9000`.
+
+### Firewall (Windows / corporate)
+
+On first launch, Windows Defender may prompt for permission for `python.exe` or `uvicorn`. Approve **Private networks** only — no need to expose the port publicly.
+
+### Healthcheck timeout (~3 s)
+
+If the engine takes more than 3 s to start (large datasets, slow GDAL, cold container), the browser opens anyway on a not-yet-ready endpoint. Refresh once. For consistently slow starts, open manually after a few seconds:
+
+```bash
+gispulse portal --no-browser
+# wait until the engine logs "Application startup complete"
+# then open http://127.0.0.1:8001/portal/ manually
+```
+
+### Browser doesn't open at all
+
+`webbrowser.open()` fails silently in some environments (WSL without `wslview`, Docker containers, broken SSH X-forward). The URL is printed on stdout:
+
+```
+GISPulse Portal at http://127.0.0.1:8001/portal/
+```
+
+Copy-paste the URL into your browser.
+
+### Managing the engine process
+
+`gispulse portal` runs in the foreground. To run it in the background:
+
+```bash
+# Linux / macOS
+gispulse portal --no-browser &
+echo $!  # PID
+
+# tmux / screen
+tmux new -d -s gispulse 'gispulse portal --no-browser'
+
+# systemd user unit (persistent local production)
+# see /en/guide/deployment
+```
+
+## See also
+
+- [`gispulse engine`](/en/guide/engine) — engine without the SPA (REST API + WebSocket only).
+- [CLI Reference](/en/guide/cli) — all commands.
+- [Architecture](/en/guide/architecture) — why two PyPI packages.
+- [Deployment](/en/guide/deployment) — multi-user production (PostGIS, Caddy, Docker).

--- a/docs-site/guide/cli.md
+++ b/docs-site/guide/cli.md
@@ -254,7 +254,7 @@ gispulse serve output/result.gpkg --port 9000
 
 ## `gispulse portal`
 
-Lance le Portal GISPulse — éditeur visuel de pipelines, gestionnaire de datasets.
+Lance le Portal GISPulse — workbench visuel (canvas de noeuds, registre de capabilities, gestionnaire de datasets) servi par le moteur local. Nécessite le package optionnel `gispulse-portal`. Référence détaillée : [Lancer le portail localement](/guide/portal-local).
 
 ```bash
 gispulse portal [OPTIONS]
@@ -262,21 +262,27 @@ gispulse portal [OPTIONS]
 
 | Option | Défaut | Description |
 |--------|--------|-------------|
-| `--port`, `-p` | `8001` | Port d'écoute |
-| `--host` | `0.0.0.0` | Hôte (0.0.0.0 = accessible LAN) |
-| `--data-dir`, `-d` | `~/.gispulse/data` | Répertoire pour les datasets uploadés |
-| `--dev` | `false` | Mode dev : API seulement |
+| `--port`, `-p` | `8001` | Port d'écoute (mode local). |
+| `--host` | `127.0.0.1` | Hôte (mode local). |
+| `--data-dir`, `-d` | `~/.gispulse/data` | Répertoire pour les datasets uploadés. |
+| `--backend URL` | — | Mode remote : ouvre le portail GH Pages pointé sur un moteur distant. |
+| `--no-browser` | `false` | Ne pas ouvrir le navigateur. |
+| `--dev` | `false` | Autorise le fallback sur `portal/dist/` du checkout (workflow contributeur). |
 
 ```bash
+# Local (par défaut)
 gispulse portal
-# GISPulse Portal at http://127.0.0.1:8001
+# GISPulse Portal at http://127.0.0.1:8001/portal/
+
+# Remote (pas de moteur local)
+gispulse portal --backend=https://api.example.com
 ```
 
 ---
 
 ## `gispulse engine`
 
-Lance le moteur complet : API REST + Portal + Viewer dans un seul processus. Utilisé par le desktop app (Tauri sidecar).
+Lance le moteur GISPulse en headless (API REST + WebSocket, **sans SPA**). Utilisé par le sidecar Tauri, les déploiements serveur et les intégrations tierces. Pour un workbench visuel local, voir [`gispulse portal`](#gispulse-portal) et le guide [Lancer le portail localement](/guide/portal-local).
 
 ```bash
 gispulse engine [OPTIONS]
@@ -284,17 +290,19 @@ gispulse engine [OPTIONS]
 
 | Option | Défaut | Description |
 |--------|--------|-------------|
-| `--port`, `-p` | `8001` | Port d'écoute (0 = port libre auto-détecté) |
+| `--port`, `-p` | `0` (auto) | Port d'écoute (`0` = port libre auto-détecté pour Tauri) |
 | `--host` | `127.0.0.1` | Hôte |
-| `--engine-backend` | `duckdb` | Backend moteur (`duckdb`, `postgis`, `hybrid`) |
-| `--data-dir` | `~/.gispulse/data` | Répertoire données |
+| `--engine`, `-e` | `duckdb` | Backend spatial (`duckdb`, `postgis`, `hybrid`) |
+| `--data-dir`, `-d` | `~/.gispulse/data` | Répertoire des datasets |
 | `--no-browser` | `false` | Ne pas ouvrir le navigateur |
 
 Émet un JSON de démarrage sur stdout pour le sidecar Tauri :
 
-```json
-{"port": 8001, "pid": 12345, "url": "http://127.0.0.1:8001"}
 ```
+GISPULSE_READY:{"port": 8001, "host": "127.0.0.1", "engine": "duckdb", "pid": 12345}
+```
+
+Référence détaillée : [Lancer le moteur](/guide/engine).
 
 ---
 

--- a/docs-site/guide/engine.md
+++ b/docs-site/guide/engine.md
@@ -1,0 +1,165 @@
+---
+title: Lancer le moteur
+description: Faire tourner le moteur GISPulse en headless (API REST + WebSocket, sans SPA) avec `gispulse engine`. Cas d'usage serveur, sidecar Tauri, intégration tierce.
+---
+
+# Lancer le moteur (`gispulse engine`)
+
+Le moteur GISPulse est un serveur FastAPI qui expose les pipelines de règles, les triggers ESB, les datasets et les WebSockets d'évènements. La commande `gispulse engine` le lance **en mode headless** — pas de SPA monté, juste l'API.
+
+> **Quand utiliser `gispulse engine` plutôt que `gispulse portal` ?** Quand vous n'avez pas besoin du workbench visuel : pipelines automatisés, sidecar de l'app desktop Tauri, backend pour un portail hébergé séparément, intégration tierce qui consomme l'API REST. Pour un workflow d'édition visuelle sur poste, utilisez plutôt [`gispulse portal`](/guide/portal-local).
+
+## Commande
+
+```bash
+gispulse engine [OPTIONS]
+```
+
+| Option | Défaut | Description |
+|--------|--------|-------------|
+| `--port`, `-p` | `0` (auto) | Port d'écoute. `0` = port libre auto-détecté (utile pour sidecar Tauri). |
+| `--host` | `127.0.0.1` | Hôte d'écoute. Mettre `0.0.0.0` pour exposer en LAN ou derrière un reverse proxy. |
+| `--engine`, `-e` | `duckdb` | Backend spatial : `duckdb` (local), `postgis` (serveur), `hybrid` (Pro, mix des deux). |
+| `--data-dir`, `-d` | `~/.gispulse/data` | Répertoire des datasets uploadés. |
+| `--no-browser` | `false` | Ne pas ouvrir le navigateur sur la racine de l'API. |
+
+### Démarrage et mode "ready"
+
+Au boot, `gispulse engine` émet une ligne JSON sur stdout pour permettre à un parent process (Tauri, supervisor, script) de récupérer port et PID :
+
+```
+GISPULSE_READY:{"port": 8001, "host": "127.0.0.1", "engine": "duckdb", "pid": 12345}
+GISPulse at http://127.0.0.1:8001
+```
+
+Le format `GISPULSE_READY:` est stable — vous pouvez parser cette ligne dans un sidecar.
+
+## Surface API
+
+Le moteur monte les routeurs FastAPI suivants en mode `full` (par défaut). Référence complète : [REST API](/api/rest) et `/docs` Swagger UI sur l'instance live.
+
+| Endpoint | Méthode | Description |
+|---|---|---|
+| `/health` | GET | Healthcheck — renvoie `{"status": "ok"}`. Utilisé par le healthcheck de `gispulse portal`. |
+| `/metrics` | GET | Métriques Prometheus (text format). Activé en mode `full`. |
+| `/datasets` | GET / POST / DELETE | Gestion des datasets (upload, list, delete). |
+| `/projects` | GET / POST | Workspaces multi-rules. |
+| `/scenarios` | GET / POST | Scénarios = projet + ruleset versionné. |
+| `/rules` | CRUD | Règles (capabilities + paramètres). |
+| `/triggers` | CRUD | Triggers ESB (DML watchers, webhooks). |
+| `/relations` | CRUD | Relations spatiales / attributaires entre layers. |
+| `/jobs` | GET | Jobs asynchrones (statut, résultat). |
+| `/capabilities` | GET | Liste les capabilities disponibles + schémas de paramètres. |
+| `/marketplace` | GET | Catalogue de capabilities tierces (Pro). |
+| `/examples` | GET | Mode 2 portail Try-it — datasets de démo embarqués. |
+| `/styles` | GET / PUT | QML / SLD / breaks de classification. |
+| `/schedules` | CRUD | Pipelines cron (Pro). |
+| `/pipelines` | POST | Exécution d'un pipeline. |
+| `/sessions` | POST | Sessions DuckDB éphémères. |
+| `/ws/events` | WebSocket | Stream live des évènements ESB. |
+
+::: tip Documentation OpenAPI live
+Une fois le moteur démarré, ouvrez `http://localhost:8001/docs` (Swagger UI) ou `http://localhost:8001/redoc` (ReDoc) pour explorer la surface API exacte de la version installée.
+:::
+
+## Authentification
+
+| Tier | Authentification | Notes |
+|---|---|---|
+| **Community** | Aucune (localhost only par défaut) | OK pour usage personnel et CI. |
+| **Pro / Enterprise** | API key (header `X-API-Key`) ou OIDC | Activée en mode `full` quand `GISPULSE_REQUIRE_AUTH=1`. |
+
+Pour un déploiement serveur (host `0.0.0.0`), **toujours** activer l'auth :
+
+```bash
+GISPULSE_TIER=pro \
+GISPULSE_REQUIRE_AUTH=1 \
+GISPULSE_API_KEYS="key1,key2" \
+gispulse engine --host 0.0.0.0 --port 8001
+```
+
+## Backend `duckdb` vs `postgis`
+
+| Flag | Backend | Cas d'usage |
+|---|---|---|
+| `--engine duckdb` | DuckDB local + GPKG/GeoParquet | Mode portable, pas de DB externe, < ~10M features. |
+| `--engine postgis` | PostgreSQL/PostGIS distant | Persistance, triggers `pg_notify`, multi-user. Nécessite `GISPULSE_DSN`. |
+| `--engine hybrid` | DuckDB calcul + PostGIS stockage (Pro) | Volumes hétérogènes, perf maximale. |
+
+Détails dans [Moteurs DuckDB / PostGIS / Hybrid](/guide/engines).
+
+```bash
+# Mode PostGIS sur un Postgres en Docker
+GISPULSE_DSN=postgresql://gispulse:secret@localhost:5432/gispulse \
+gispulse engine --engine postgis --port 8001
+```
+
+## Reverse proxy (Caddy / nginx)
+
+Pour exposer le moteur en HTTPS sur un VPS, on le bind sur `127.0.0.1:8001` et on délègue le TLS au reverse proxy.
+
+### Caddy (auto-TLS Let's Encrypt)
+
+```caddy
+api.example.com {
+    reverse_proxy 127.0.0.1:8001
+    encode gzip zstd
+
+    # WebSocket (events bus) — Caddy gère ça nativement
+    @ws {
+        path /ws/*
+    }
+    reverse_proxy @ws 127.0.0.1:8001
+}
+```
+
+### nginx (TLS manuel)
+
+```nginx
+server {
+    listen 443 ssl http2;
+    server_name api.example.com;
+
+    ssl_certificate     /etc/letsencrypt/live/api.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/api.example.com/privkey.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:8001;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Proto https;
+
+        # WebSocket upgrade
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 3600s;
+    }
+}
+```
+
+Voir [Déploiement](/guide/deployment) pour la stack complète (PostGIS + Caddy + Prometheus + backups).
+
+## Cohabitation avec `gispulse portal`
+
+Les deux commandes lancent le même `create_app()` FastAPI. La seule différence :
+
+| Commande | Mount SPA | Auth par défaut | Cas d'usage |
+|---|---|---|---|
+| `gispulse engine` | non | activable via env | serveur, sidecar Tauri, intégration tierce |
+| `gispulse portal` | oui (`/portal`) | désactivée (localhost) | poste de travail, onboarding visuel |
+
+Vous pouvez tout à fait :
+
+1. Lancer `gispulse engine --host 0.0.0.0` sur un VPS.
+2. Lancer `gispulse portal --backend=https://your.engine.example.com` sur votre poste.
+
+Le portail GH Pages se connecte alors au moteur distant — voir [Lancer le portail localement](/guide/portal-local#mode-remote-backend-url).
+
+## Voir aussi
+
+- [`gispulse portal`](/guide/portal-local) — version avec SPA bundlé.
+- [CLI Référence](/guide/cli) — toutes les commandes.
+- [Moteurs DuckDB / PostGIS / Hybrid](/guide/engines) — choisir le bon backend.
+- [Déploiement](/guide/deployment) — production VPS, Docker Compose, Prometheus.
+- [REST API](/api/rest) — référence complète des endpoints.

--- a/docs-site/guide/portal-local.md
+++ b/docs-site/guide/portal-local.md
@@ -1,0 +1,166 @@
+---
+title: Lancer le portail localement
+description: Guide pas-à-pas pour faire tourner le workbench GISPulse Portal sur votre machine via `gispulse portal`, sans HTTPS, sans CORS, sans plugin GIS.
+---
+
+# Lancer le portail localement
+
+Le **GISPulse Portal** est un éditeur visuel (canvas de noeuds, registre de capabilities, gestionnaire de datasets) servi par le moteur GISPulse. Cette page documente la commande `gispulse portal`, qui mounte le SPA sur votre moteur local et ouvre le navigateur.
+
+> **Axiome produit.** CLI et portail sont deux UIs équivalentes sur la même source de vérité (`triggers.yaml` + change-log). Tout ce que vous configurez via le portail est éditable via le CLI, et inversement.
+
+## Quick start (30 secondes)
+
+```bash
+# 1. Installer le CLI + le bundle SPA
+pipx install gispulse-portal
+
+# 2. Lancer le moteur + ouvrir le navigateur sur localhost:8001/portal
+gispulse portal
+```
+
+C'est tout. Le navigateur s'ouvre sur `http://127.0.0.1:8001/portal/`, vous éditez vos triggers, et `Ctrl+C` arrête le serveur.
+
+::: tip Pourquoi deux packages ?
+`gispulse-portal` est un wheel PyPI distinct qui ship le SPA build (`dist/`). Il dépend de `gispulse`, donc `pipx install gispulse-portal` installe les deux d'un coup. Ce découpage évite de gonfler `gispulse` (resté lean ~3 MB) pour les utilisateurs CLI-only / CI-only. Voir le [billet d'architecture](/guide/architecture) pour le détail.
+:::
+
+## La commande `gispulse portal`
+
+```bash
+gispulse portal [OPTIONS]
+```
+
+| Option | Défaut | Description |
+|--------|--------|-------------|
+| `--port`, `-p` | `8001` | Port d'écoute du moteur local. |
+| `--host` | `127.0.0.1` | Hôte d'écoute. Garder `127.0.0.1` sauf besoin LAN. |
+| `--data-dir`, `-d` | `~/.gispulse/data` | Répertoire pour les datasets uploadés via le portail. |
+| `--no-browser` | `false` | Ne pas ouvrir le navigateur (utile pour SSH / headless). |
+| `--backend URL` | — | Mode "remote" : ouvre le portail GH Pages pointé sur un moteur distant, **n'instancie pas** de moteur local. |
+| `--dev` | `false` | Autorise le fallback sur `portal/dist/` du checkout local (workflow contributeur). |
+
+### Comportement
+
+1. **Resolve du SPA bundlé.** La commande cherche `gispulse_portal.PORTAL_DIST_PATH`. Si introuvable et `--dev` actif, fallback sur `<repo>/portal/dist/`.
+2. **Mount same-origin.** Le SPA est servi par FastAPI sous `/portal` via `StaticFiles`. Le moteur (API REST + WebSocket) est servi sur la racine. Pas de mixed-content, pas de CORS — tout passe par `localhost:8001`.
+3. **Healthcheck + ouverture du navigateur.** Un thread daemon poll `GET /health` toutes les 100 ms pendant 3 s, puis appelle `webbrowser.open()` sur l'URL du portail. Si le healthcheck timeout, on ouvre quand même — au pire vous voyez le loader.
+4. **Uvicorn run.** Le moteur tourne en foreground. `Ctrl+C` arrête proprement.
+
+### Exemples
+
+```bash
+# Port custom (conflit sur 8001)
+gispulse portal --port 9000
+
+# Pas de navigateur (déploiement SSH, container, CI)
+gispulse portal --no-browser
+
+# Datasets dans un répertoire projet
+gispulse portal --data-dir ./my-project/data
+
+# Workflow contributeur (depuis un checkout du repo)
+gispulse portal --dev
+```
+
+## Sans le package `gispulse-portal`
+
+Si vous avez installé uniquement `gispulse` (sans le bundle SPA), la commande échoue proprement avec un message d'install :
+
+```
+$ gispulse portal
+Error: gispulse-portal package is not installed.
+Install it with:
+  pip install gispulse-portal
+Or, for a remote workbench without a local install:
+  gispulse portal --backend=https://your-engine.example.com
+```
+
+C'est intentionnel : les utilisateurs CLI-only (CI/CD, serveurs headless, power users terminal) ne payent pas le coût du SPA. Si vous voulez juste l'API REST + WebSocket sans UI, utilisez plutôt [`gispulse engine`](/guide/engine).
+
+## Mode remote : `--backend URL`
+
+Plutôt qu'un moteur local, vous pouvez pointer le portail GH Pages (servi en HTTPS) sur **un moteur déjà déployé** quelque part :
+
+```bash
+gispulse portal --backend=https://your.engine.example.com
+```
+
+La commande encode le paramètre dans la querystring et ouvre :
+
+```
+https://gispulse.dev/?backend=https%3A%2F%2Fyour.engine.example.com
+```
+
+**Cas d'usage :**
+
+- Vous avez un moteur sur un VPS (cf. [Déploiement](/guide/deployment)) et voulez juste le piloter depuis votre poste.
+- Vous évaluez la version SaaS hébergée (v1.6+, `pro.gispulse.dev`).
+- Vous démontrez le portail à un client sans installer Python sur leur poste.
+
+::: warning Mixed-content
+Le portail GH Pages est servi en HTTPS. Le `backend` doit lui aussi être HTTPS — un `http://localhost:8001` ne fonctionnera pas (le navigateur bloque). Pour un moteur local, utilisez le mode par défaut (sans `--backend`), qui sert le SPA same-origin et règle le problème.
+:::
+
+## Troubleshooting
+
+### Conflit de port (`EADDRINUSE`)
+
+Le port `8001` est déjà pris (par exemple un moteur précédent qui n'a pas été tué). Diagnostique :
+
+```bash
+# Linux / macOS
+lsof -i :8001
+
+# Windows
+netstat -ano | findstr :8001
+```
+
+Solution : `gispulse portal --port 9000`.
+
+### Pare-feu (Windows / Corporate)
+
+Au premier lancement, Windows Defender peut demander l'autorisation pour `python.exe` ou `uvicorn`. Acceptez sur **Réseaux privés** uniquement — pas besoin d'exposer le port en public.
+
+### Healthcheck timeout (~3 s)
+
+Si le moteur met plus de 3 s à démarrer (datasets volumineux, GDAL lent, container froid), le navigateur s'ouvre quand même mais sur un endpoint pas encore prêt. Rafraîchir une fois suffit. Pour des démarrages systématiquement lents, ouvrir manuellement après quelques secondes :
+
+```bash
+gispulse portal --no-browser
+# attendre que le moteur log "Application startup complete"
+# puis ouvrir http://127.0.0.1:8001/portal/ à la main
+```
+
+### Le navigateur ne s'ouvre pas du tout
+
+`webbrowser.open()` échoue silencieusement sur certains environnements (WSL sans `wslview`, conteneur Docker, SSH X-forward cassé). L'URL est imprimée sur stdout :
+
+```
+GISPulse Portal at http://127.0.0.1:8001/portal/
+```
+
+Copier-coller l'URL dans votre navigateur.
+
+### Gérer le processus moteur
+
+`gispulse portal` reste en foreground. Pour le faire tourner en arrière-plan :
+
+```bash
+# Linux / macOS
+gispulse portal --no-browser &
+echo $!  # PID
+
+# tmux / screen
+tmux new -d -s gispulse 'gispulse portal --no-browser'
+
+# systemd user unit (production locale persistante)
+# voir /guide/deployment
+```
+
+## Voir aussi
+
+- [`gispulse engine`](/guide/engine) — moteur sans SPA (API REST + WebSocket only).
+- [CLI Référence](/guide/cli) — toutes les commandes.
+- [Architecture](/guide/architecture) — pourquoi deux packages PyPI.
+- [Déploiement](/guide/deployment) — production multi-user (PostGIS, Caddy, Docker).

--- a/gispulse/cli.py
+++ b/gispulse/cli.py
@@ -633,7 +633,7 @@ def _doctor_render(results: list[tuple[str, str, str]]) -> None:
 def engine(
     port: int = typer.Option(0, "--port", "-p", help="Port to listen on (0 = auto-detect free port)."),
     host: str = typer.Option("127.0.0.1", "--host", help="Host to bind to."),
-    engine_backend: str = typer.Option("duckdb", "--engine", "-e", help="Spatial engine: 'duckdb' (local) or 'postgis'."),
+    engine_backend: str = typer.Option("duckdb", "--engine", "-e", help="Spatial engine: 'duckdb' (local), 'postgis' (server, requires GISPULSE_DSN), or 'hybrid' (Pro)."),
     data_dir: str = typer.Option("~/.gispulse/data", "--data-dir", "-d", help="Data directory."),
     no_browser: bool = typer.Option(False, "--no-browser", help="Don't open browser on start."),
 ) -> None:


### PR DESCRIPTION
Closes #52. Milestone v1.5.1.

## Summary

- New self-serve docs for the two CLI surfaces a v1.5.1 user is most likely to discover: `gispulse portal` (bundled SPA workbench) and `gispulse engine` (headless API). Each guide is FR + EN, ≤2 pages, links into the existing CLI reference, deployment, and engines pages.
- Also sync the existing `cli.md` `engine`/`portal` blocks: realign with the actual flag set (`--engine` not `--engine-backend`, default port `0`, drop the imaginary `--mode`/`--reload`, document `--backend` remote mode).
- README gets a "Run the portal locally" subsection right under Quick start.
- Single small code touch: extend `engine`'s `--engine` help string to list `hybrid` alongside `duckdb`/`postgis` so `gispulse engine --help` matches the docs.

## Why

PR #58 just merged `gispulse portal`. Without docs, a new user has no path from `pipx install gispulse-portal` to "the portal is running on my machine". This burns down that gap before the PyPI release.

Reinforces the CLI ↔ Portal symmetry axiom: same-origin, no plugin required, works offline. Aligns with the two-package architecture decision (gispulse vs gispulse-portal).

## Pages added

- `docs-site/guide/portal-local.md` (FR)
- `docs-site/guide/engine.md` (FR)
- `docs-site/en/guide/portal-local.md` (EN)
- `docs-site/en/guide/engine.md` (EN)

Each covers: quick start, full flag table, behaviour walk-through, remote `--backend=URL` mode (portal only), graceful degrade when `gispulse-portal` is absent, troubleshooting (port conflict, firewall, healthcheck timeout, headless management). The engine guide adds API-surface map, auth posture per tier, Caddy + nginx reverse proxy snippets.

## Test plan

- [x] VitePress build runs locally without dead-link errors (`npx vitepress build`).
- [x] Capability matrix regenerated, no drift (`scripts/build_capability_matrix.py`).
- [x] `gispulse engine --help` and `gispulse portal --help` render cleanly.
- [x] `tests/unit/test_cli_portal.py` + `tests/integration/test_cli_portal.py` pass (10/10).
- [ ] CI green (notably `capability-matrix-drift`, lint, docs build, dco).
- [ ] Reviewer spot-checks both languages and confirms terminology parity.

## Out of scope

- No new CLI features. Help-text edit on `cli.py` is the only code touch.
- Screencasts / GIFs deferred.
- `symmetry.md` cross-link deferred — the page from PR #59 isn't on `main` yet; will be a one-line follow-up once it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)