### PR TITLE
fix(engine): preserve CRS through DuckDB SQL round-trip

### DIFF
--- a/tests/unit/test_duckdb_engine.py
+++ b/tests/unit/test_duckdb_engine.py
@@ -108,10 +108,6 @@ class TestDuckDBSession:
     def test_sql_does_not_invent_crs_when_no_tables_registered(self, sample_gdf):
         """If sql() runs against an empty CRS map, the result has no CRS."""
         with DuckDBSession() as session:
-            # Register then query a different (non-existent in map) name via
-            # a literal subquery; result has geometry but no resolvable CRS.
             session.register_gdf("known", sample_gdf)
-            result = session.sql(
-                "SELECT * FROM known WHERE 1=0"  # references known => keeps CRS
-            )
+            result = session.sql("SELECT * FROM known WHERE 1=0")
             assert str(result.crs) == str(sample_gdf.crs)


### PR DESCRIPTION
## Bug

`DuckDBSession.sql()` returns CRS-less GeoDataFrames. Every DuckDB-backed capability (`filter`, `buffer`, `clip`, `intersects`) silently produces output GeoPackages with `crs=None`.

**Repro on BD TOPO D031** (`troncon_de_route`, ~383k features):
```bash
gispulse run BDT_3-5_GPKG_LAMB93_D031.gpkg \
  -r rules/batiments_pres_routes.json \
  -o output/result.gpkg \
  -l troncon_de_route \
  --ref-source batiment:BDT_3-5_GPKG_LAMB93_D031.gpkg \
  --engine duckdb

python -c "import pyogrio; print(pyogrio.read_info('output/result.gpkg')['crs'])"
# Before:  None
# After:   EPSG:2154
```

## Root cause

`register_gdf()` serialises geometry to WKB with `include_srid=False`, then `sql()` rebuilds `gpd.GeoDataFrame(df, geometry=geometries)` without `crs=`. The CRS is dropped on input and never re-attached.

`spatial_join` was unaffected because its only execution strategy is the Python in-memory path — no DuckDB SQL round-trip.

## Fix

- `__init__`: `self._table_crs: dict[str, Any] = {}`
- `register_gdf`: persist `gdf.crs` keyed by table name
- `sql()`: new `_infer_result_crs(query)` regex-matches registered table names referenced in the SQL and returns their shared CRS, or `None` if they diverge

Diverging CRS across joined tables fall back to `None` rather than guessing — caller is responsible for reprojecting if a single CRS is required.

## Test plan

- [x] 3 new regression tests in `test_duckdb_engine.py` (preservation, divergence → None, single-table happy path)
- [x] 11/11 `tests/unit/test_duckdb_engine.py` pass
- [x] 511/511 tests on `filter`/`buffer`/`clip`/`intersects`/`duckdb` keyword pass — no regression
- [x] End-to-end re-run on BD TOPO D031: 260 714 features, output GPKG now reads `EPSG:2154`