### PR TITLE
Formalize initial plugin SDK contract surface

### DIFF
--- a/core/plugin_contracts.py
+++ b/core/plugin_contracts.py
@@ -37,6 +37,21 @@ PROTOCOL_VERSION = "1.0"
 # ---------------------------------------------------------------------------
 
 
+@dataclass(frozen=True)
+class PluginHostContext:
+    """Stable host context passed to context-aware plugin factories.
+
+    This first #68 slice is intentionally small. It exposes only the
+    runtime objects plugins already need at mount time without requiring
+    them to inspect ``app.state`` directly.
+    """
+
+    app: "FastAPI"
+    settings: Any
+    logger: Any
+    plugin_hub: Any
+
+
 @runtime_checkable
 class RouterFactory(Protocol):
     """Plugin that mounts an :class:`fastapi.APIRouter` on the host app.
@@ -49,6 +64,16 @@ class RouterFactory(Protocol):
     name: str
 
     def create(self, app: "FastAPI") -> "APIRouter | None":
+        ...
+
+
+@runtime_checkable
+class ContextAwareRouterFactory(Protocol):
+    """Additive router factory contract receiving :class:`PluginHostContext`."""
+
+    name: str
+
+    def create(self, context: PluginHostContext) -> "APIRouter | None":
         ...
 
 

--- a/docs/PLUGIN_CONTRACT.md
+++ b/docs/PLUGIN_CONTRACT.md
@@ -1,0 +1,160 @@
+# GISPulse Plugin Contract
+
+This document describes the current external plugin surface used by
+`PluginHub`. It is intentionally factual: the contract below is usable today,
+but the typed SDK host context is not yet stable.
+
+This work is tracked by
+[imagodata/gispulse#68](https://github.com/imagodata/gispulse/issues/68).
+Commits and PRs that advance this surface should use `Refs #68` until the full
+acceptance criteria are covered.
+
+## SDK Scope
+
+`sdk/gispulse_sdk` is the existing REST client SDK. It is for external clients
+that call a running GISPulse HTTP API.
+
+Issue #68 is about a different surface: the future in-process plugin-author API
+used by packages installed into the host process. Do not put this authoring
+surface under `gispulse_sdk`; keep it separate from the REST client SDK.
+
+## Entry Point Groups
+
+GISPulse discovers plugins through Python package entry points.
+
+| Group | Contract | Current status |
+| --- | --- | --- |
+| `gispulse.capabilities` | Callable `register()` that imports capability classes using `@register` | Legacy supported / transitional surface |
+| `gispulse.routers` | `RouterFactory.create(app)` returning a FastAPI `APIRouter` or `None` | Current host surface |
+| `gispulse.middleware` | `MiddlewareFactory.install(app)` | Current host surface |
+| `gispulse.auth_provider` | `AuthProvider` protocol | Current host surface |
+| `gispulse.billing_provider` | `BillingProvider` protocol | Current host surface |
+| `gispulse.licence_provider` | `LicenceProvider` protocol | Current host surface |
+| `gispulse.connectors` | `Connector` protocol | Current host surface |
+
+Capability plugins are discovered by the capability registry. Host plugins for
+routers, middleware, auth, billing, licence and connectors are discovered by
+`core.plugin_hub.PluginHub` and mounted by the HTTP app in full mode.
+
+`gispulse.mcp_tools` has been observed in the Permis Check integration, but
+this first host-runtime slice does not prove or stabilize it. Do not treat it as
+equally wired as `gispulse.routers` unless core host discovery is added and
+tested.
+
+## Router Contract
+
+An external router plugin declares:
+
+```toml
+[project.entry-points."gispulse.routers"]
+example = "gispulse_cap_example.routers:ExampleRouterFactory"
+```
+
+The factory object may be an instance or a class. If it is a class, `PluginHub`
+instantiates it with no arguments.
+
+```python
+from fastapi import APIRouter
+
+
+class ExampleRouterFactory:
+    name = "example"
+
+    def create(self, app):
+        router = APIRouter(prefix="/plugins/example")
+
+        @router.get("/health")
+        def health():
+            return {"plugin": "example", "status": "ok"}
+
+        return router
+```
+
+`RouterFactory.create(app)` receives the FastAPI application object. Returning
+`None` skips mounting without failing host startup. Raising an exception is
+caught by the host and logged as a plugin mount failure.
+
+`app` is the current contract. New plugins should not treat `app.state` as a
+stable SDK. Use `app.state` only as a temporary escape hatch when no documented
+host surface exists, and keep that access narrow so it can be replaced by the
+typed context planned in #68.
+
+## Capability Contract
+
+Capability plugins declare:
+
+```toml
+[project.entry-points."gispulse.capabilities"]
+example = "gispulse_cap_example:register"
+```
+
+The `register()` function imports modules that use the capability registry
+decorator:
+
+```python
+from gispulse.plugins.api import Capability, register_capability
+
+
+@register_capability
+class ExampleCapability(Capability):
+    name = "example"
+    description = "Example capability."
+
+    def execute(self, gdf, **params):
+        return gdf
+```
+
+Use explicit keyword parameters when a capability accepts configuration. Avoid
+the old `execute(gdf, config: dict)` shape; orchestration dispatch now validates
+keyword parameters through the current `Capability.execute(gdf, **params)`
+contract.
+
+`gispulse.capabilities` is supported for existing plugins, but direct imports
+from `capabilities.*` are transitional rather than the final new SDK shape. New
+plugins should import capability primitives from `gispulse.plugins.api`.
+
+## Additive Host Context
+
+`RouterFactory.create(app)` remains the legacy-compatible contract. This slice
+also introduces a small `PluginHostContext` for new router factories. A factory
+can opt into it by naming the first `create()` parameter `ctx`, `context`,
+`host_context` or `plugin_context`, or by annotating it as `PluginHostContext`.
+
+```python
+from fastapi import APIRouter
+from gispulse.plugins.api import PluginHostContext
+
+
+class ExampleRouterFactory:
+    name = "example"
+
+    def create(self, ctx: PluginHostContext):
+        router = APIRouter(prefix="/plugins/example")
+        ctx.logger.info("example_plugin_mounting")
+        return router
+```
+
+The first context is deliberately small: `app`, `settings`, `logger` and
+`plugin_hub`. Catalog/source access, spatial helpers, auth/tenant context,
+cache/storage and pipeline execution should be added only as tested follow-up
+slices for `#68`.
+
+## Known Limits
+
+The current host plugin API passes the raw FastAPI `app` to router and
+middleware factories. This keeps existing plugins simple, but it also exposes
+internal application details through `app.state`.
+
+The current `PluginHostContext` is additive, small and not yet the full stable SDK.
+It intentionally exposes only mount-time host objects that are already needed by
+real plugins.
+
+Issue #68 should reduce the need for product plugins to import directly from
+internal modules such as `core.*`, `catalog.*`, `orchestration.*`,
+`capabilities.*`, or `gispulse.adapters.*`. Those imports work today, but they
+create an accidental public API and make host refactors harder.
+
+## Template
+
+See `examples/plugin-template` for a minimal package that declares both a
+capability entry point and a host router entry point.

--- a/examples/plugin-template/README.md
+++ b/examples/plugin-template/README.md
@@ -1,6 +1,7 @@
 # GISPulse Plugin Template
 
-This is a minimal template for creating a GISPulse capability plugin.
+This is a minimal template for creating a GISPulse external plugin on the
+current host contract.
 
 ## Structure
 
@@ -9,7 +10,8 @@ gispulse-cap-example/
   pyproject.toml                        # Package metadata + entry-point
   gispulse_cap_example/
     __init__.py                         # register() function (entry-point target)
-    capabilities.py                     # Capability classes with @register decorator
+    capabilities.py                     # Capability classes with register_capability decorator
+    routers.py                          # RouterFactory for host API extension
 ```
 
 ## How it works
@@ -18,22 +20,40 @@ gispulse-cap-example/
    ```toml
    [project.entry-points."gispulse.capabilities"]
    example = "gispulse_cap_example:register"
+
+   [project.entry-points."gispulse.routers"]
+   example = "gispulse_cap_example.routers:ExampleRouterFactory"
    ```
 
 2. When GISPulse starts, it scans the `gispulse.capabilities` entry-point group
    and calls each `register()` function.
 
 3. The `register()` function imports the capabilities module, which triggers
-   the `@register` decorator to add capabilities to the global registry.
+   the `register_capability` decorator to add capabilities to the global
+   registry.
+
+4. In full HTTP mode, GISPulse scans `gispulse.routers`, instantiates the
+   factory, calls `RouterFactory.create(app)`, and mounts the returned
+   `APIRouter`.
+
+The example capability uses the current `execute(gdf, **params)` shape. Do not
+use the old `execute(gdf, config: dict)` signature for new capabilities.
 
 ## Creating your own plugin
 
 1. Copy this template
 2. Rename `gispulse_cap_example` to `gispulse_cap_<yourname>`
 3. Update `pyproject.toml` (name, entry-point key, module path)
-4. Implement your capabilities by subclassing `Capability` and using `@register`
+4. Implement your capabilities by importing `Capability` and `register_capability`
+   from `gispulse.plugins.api`
 5. Install in development mode: `pip install -e .`
 6. Verify: `gispulse capabilities` should list your new capability
+7. Start the HTTP host and call `/plugins/example/health`
+
+The legacy router API still accepts `RouterFactory.create(app)`. New router
+factories can opt into the additive `PluginHostContext`; see
+`docs/PLUGIN_CONTRACT.md`. Keep any direct `app.state` access narrow and
+temporary.
 
 ## Naming convention
 

--- a/examples/plugin-template/gispulse_cap_example/capabilities.py
+++ b/examples/plugin-template/gispulse_cap_example/capabilities.py
@@ -7,11 +7,10 @@ from __future__ import annotations
 
 import geopandas as gpd
 
-from capabilities.base import Capability
-from capabilities.registry import register
+from gispulse.plugins.api import Capability, register_capability
 
 
-@register
+@register_capability
 class CentroidCapability(Capability):
     """Compute the centroid of each geometry."""
 
@@ -25,7 +24,7 @@ class CentroidCapability(Capability):
             "additionalProperties": False,
         }
 
-    def execute(self, gdf: gpd.GeoDataFrame, config: dict) -> gpd.GeoDataFrame:
+    def execute(self, gdf: gpd.GeoDataFrame, **_params: object) -> gpd.GeoDataFrame:
         result = gdf.copy()
         result["geometry"] = result.geometry.centroid
         return result

--- a/examples/plugin-template/gispulse_cap_example/routers.py
+++ b/examples/plugin-template/gispulse_cap_example/routers.py
@@ -1,0 +1,22 @@
+"""Example host router factory for the current PluginHub contract."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter
+
+
+class ExampleRouterFactory:
+    """Factory loaded from the ``gispulse.routers`` entry-point group."""
+
+    name = "example"
+
+    def create(self, app: Any) -> APIRouter:
+        router = APIRouter(prefix="/plugins/example", tags=["plugins"])
+
+        @router.get("/health")
+        def health() -> dict[str, str]:
+            return {"plugin": "example", "status": "ok"}
+
+        return router

--- a/examples/plugin-template/pyproject.toml
+++ b/examples/plugin-template/pyproject.toml
@@ -8,9 +8,13 @@ version = "0.1.0"
 description = "Example GISPulse capability plugin"
 requires-python = ">=3.10"
 dependencies = [
+    "fastapi>=0.100,<1.0",
     "geopandas>=0.14",
 ]
 
-# This is the key: register the entry-point so GISPulse discovers the plugin
+# Register entry-points so GISPulse discovers the plugin.
 [project.entry-points."gispulse.capabilities"]
 example = "gispulse_cap_example:register"
+
+[project.entry-points."gispulse.routers"]
+example = "gispulse_cap_example.routers:ExampleRouterFactory"

--- a/gispulse/adapters/http/app.py
+++ b/gispulse/adapters/http/app.py
@@ -17,6 +17,7 @@ import os
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, Literal
+from typing import get_type_hints
 
 from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request
 
@@ -154,16 +155,28 @@ def _create_plugin_router(
     """Create a plugin router with context support and legacy fallback."""
     parameters = list(inspect.signature(factory.create).parameters.values())
     first_param = parameters[0] if parameters else None
-    wants_context = (
-        first_param is not None
-        and (
-            first_param.annotation is PluginHostContext
-            or first_param.name in {"context", "ctx", "host_context", "plugin_context"}
-        )
+    wants_context = first_param is not None and _plugin_factory_wants_context(
+        factory.create,
+        first_param,
     )
     if wants_context:
         return factory.create(context)  # type: ignore[arg-type]
     return factory.create(app)
+
+
+def _plugin_factory_wants_context(method: Any, first_param: inspect.Parameter) -> bool:
+    if first_param.name in {"context", "ctx", "host_context", "plugin_context"}:
+        return True
+    if first_param.annotation is PluginHostContext:
+        return True
+    if isinstance(first_param.annotation, str):
+        normalized = first_param.annotation.strip("'\"").rsplit(".", 1)[-1]
+        if normalized == "PluginHostContext":
+            return True
+    try:
+        return get_type_hints(method).get(first_param.name) is PluginHostContext
+    except Exception:
+        return False
 
 
 def create_app(

--- a/gispulse/adapters/http/app.py
+++ b/gispulse/adapters/http/app.py
@@ -12,14 +12,16 @@ variable (comma-separated list of valid keys). Absent or empty = auth disabled
 
 from __future__ import annotations
 
+import inspect
 import os
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, Literal
 
-from fastapi import Depends, FastAPI, HTTPException, Request
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request
 
 from core.config import settings as cfg
+from core.plugin_contracts import PluginHostContext, RouterFactory
 from fastapi.responses import HTMLResponse, PlainTextResponse
 from fastapi.staticfiles import StaticFiles
 
@@ -142,6 +144,26 @@ def _setup_cors(app: FastAPI, origins: list[str]) -> None:
         allow_headers=["*"],
         allow_credentials=allow_creds,
     )
+
+
+def _create_plugin_router(
+    factory: RouterFactory,
+    app: FastAPI,
+    context: PluginHostContext,
+) -> APIRouter | None:
+    """Create a plugin router with context support and legacy fallback."""
+    parameters = list(inspect.signature(factory.create).parameters.values())
+    first_param = parameters[0] if parameters else None
+    wants_context = (
+        first_param is not None
+        and (
+            first_param.annotation is PluginHostContext
+            or first_param.name in {"context", "ctx", "host_context", "plugin_context"}
+        )
+    )
+    if wants_context:
+        return factory.create(context)  # type: ignore[arg-type]
+    return factory.create(app)
 
 
 def create_app(
@@ -801,9 +823,16 @@ def create_app(
         from core.plugin_hub import PluginHub
 
         hub = PluginHub.get()
+        plugin_context = PluginHostContext(
+            app=app,
+            settings=cfg,
+            logger=log,
+            plugin_hub=hub,
+        )
+        app.state.plugin_host_context = plugin_context
         for plugin_name, factory in hub.routers.items():
             try:
-                router = factory.create(app)
+                router = _create_plugin_router(factory, app, plugin_context)
             except Exception as exc:
                 log.warning("plugin_router_create_failed", plugin=plugin_name, error=str(exc))
                 continue

--- a/gispulse/plugins/__init__.py
+++ b/gispulse/plugins/__init__.py
@@ -1,0 +1,5 @@
+"""Curated plugin-author API for GISPulse extensions."""
+
+from gispulse.plugins.api import Capability, PluginHostContext, register_capability
+
+__all__ = ["Capability", "PluginHostContext", "register_capability"]

--- a/gispulse/plugins/api.py
+++ b/gispulse/plugins/api.py
@@ -1,0 +1,11 @@
+"""Transitional public API for external GISPulse plugin authors.
+
+The goal is to give plugins one documented import path while the runtime
+keeps its existing internal module layout.
+"""
+
+from capabilities.base import Capability
+from capabilities.registry import register as register_capability
+from core.plugin_contracts import PluginHostContext
+
+__all__ = ["Capability", "PluginHostContext", "register_capability"]

--- a/tests/unit/test_plugin_hub.py
+++ b/tests/unit/test_plugin_hub.py
@@ -189,6 +189,24 @@ class TestPluginRouterCreation:
         assert isinstance(router, APIRouter)
         assert seen == [context]
 
+    def test_context_factory_can_be_detected_by_annotation_only(self) -> None:
+        app = FastAPI()
+        hub = plugin_hub.PluginHub()
+        context = PluginHostContext(app=app, settings=object(), logger=object(), plugin_hub=hub)
+        seen: list[PluginHostContext] = []
+
+        class AnnotatedFactory:
+            name = "annotated-context"
+
+            def create(self, host: PluginHostContext):
+                seen.append(host)
+                return APIRouter()
+
+        router = _create_plugin_router(AnnotatedFactory(), app, context)
+
+        assert isinstance(router, APIRouter)
+        assert seen == [context]
+
     def test_legacy_factory_receives_app_when_signature_is_legacy(self) -> None:
         app = FastAPI()
         hub = plugin_hub.PluginHub()

--- a/tests/unit/test_plugin_hub.py
+++ b/tests/unit/test_plugin_hub.py
@@ -10,9 +10,11 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+from fastapi import APIRouter, FastAPI
 
 from core import plugin_hub
-from core.plugin_contracts import LicenceState, PROTOCOL_VERSION
+from core.plugin_contracts import LicenceState, PluginHostContext, PROTOCOL_VERSION
+from gispulse.adapters.http.app import _create_plugin_router
 
 
 # ---------------------------------------------------------------------------
@@ -161,6 +163,70 @@ class TestPluginHubDiscovery:
         )
         hub = plugin_hub.PluginHub.get()
         assert hub.routers["needs-stripe"].create(app=None) is None
+
+
+# ---------------------------------------------------------------------------
+# Host router creation contract
+# ---------------------------------------------------------------------------
+
+
+class TestPluginRouterCreation:
+    def test_context_aware_factory_receives_plugin_host_context(self) -> None:
+        app = FastAPI()
+        hub = plugin_hub.PluginHub()
+        context = PluginHostContext(app=app, settings=object(), logger=object(), plugin_hub=hub)
+        seen: list[PluginHostContext] = []
+
+        class ContextAwareFactory:
+            name = "context-aware"
+
+            def create(self, ctx):
+                seen.append(ctx)
+                return APIRouter()
+
+        router = _create_plugin_router(ContextAwareFactory(), app, context)
+
+        assert isinstance(router, APIRouter)
+        assert seen == [context]
+
+    def test_legacy_factory_receives_app_when_signature_is_legacy(self) -> None:
+        app = FastAPI()
+        hub = plugin_hub.PluginHub()
+        context = PluginHostContext(app=app, settings=object(), logger=object(), plugin_hub=hub)
+        seen: list[FastAPI] = []
+
+        class LegacyFactory:
+            name = "legacy"
+
+            def create(self, app_arg):
+                if not isinstance(app_arg, FastAPI):
+                    raise TypeError("legacy factory expects FastAPI")
+                seen.append(app_arg)
+                return APIRouter()
+
+        router = _create_plugin_router(LegacyFactory(), app, context)
+
+        assert isinstance(router, APIRouter)
+        assert seen == [app]
+
+    def test_context_factory_type_error_is_not_treated_as_legacy_signature(self) -> None:
+        app = FastAPI()
+        hub = plugin_hub.PluginHub()
+        context = PluginHostContext(app=app, settings=object(), logger=object(), plugin_hub=hub)
+
+        class BrokenContextAwareFactory:
+            name = "broken-context-aware"
+
+            def create(self, ctx):
+                raise TypeError("plugin bug")
+
+        with pytest.raises(TypeError, match="plugin bug"):
+            _create_plugin_router(BrokenContextAwareFactory(), app, context)
+
+    def test_plugin_host_context_is_exported_from_plugin_author_api(self) -> None:
+        from gispulse.plugins.api import PluginHostContext as PublicPluginHostContext
+
+        assert PublicPluginHostContext is PluginHostContext
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_plugin_template_contract.py
+++ b/tests/unit/test_plugin_template_contract.py
@@ -1,0 +1,129 @@
+"""Contract checks for the external plugin template."""
+
+from __future__ import annotations
+
+import inspect
+import importlib
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import pytest
+
+from core import plugin_hub
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TEMPLATE = ROOT / "examples" / "plugin-template"
+
+
+@dataclass
+class _TemplateEntryPoint:
+    name: str
+    value: str
+
+    def load(self) -> Any:
+        module_name, object_name = self.value.split(":", 1)
+        module = importlib.import_module(module_name)
+        return getattr(module, object_name)
+
+
+def test_plugin_template_capability_uses_current_execute_signature() -> None:
+    from capabilities.registry import REGISTRY
+
+    source = (TEMPLATE / "gispulse_cap_example" / "capabilities.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "from gispulse.plugins.api import Capability, register_capability" in source
+    assert "from capabilities." not in source
+
+    REGISTRY._items.pop("centroid", None)
+    sys.path.insert(0, str(TEMPLATE))
+    try:
+        from gispulse_cap_example.capabilities import CentroidCapability
+    finally:
+        sys.path.remove(str(TEMPLATE))
+
+    signature = inspect.signature(CentroidCapability.execute)
+
+    assert "config" not in signature.parameters
+    assert any(
+        parameter.kind == inspect.Parameter.VAR_KEYWORD
+        for parameter in signature.parameters.values()
+    )
+
+
+def test_plugin_template_declares_mountable_router_entry_point() -> None:
+    pyproject = (TEMPLATE / "pyproject.toml").read_text(encoding="utf-8")
+
+    assert '[project.entry-points."gispulse.routers"]' in pyproject
+    assert 'example = "gispulse_cap_example.routers:ExampleRouterFactory"' in pyproject
+
+    sys.path.insert(0, str(TEMPLATE))
+    try:
+        from gispulse_cap_example.routers import ExampleRouterFactory
+    finally:
+        sys.path.remove(str(TEMPLATE))
+
+    app = FastAPI()
+    app.include_router(ExampleRouterFactory().create(app))
+
+    response = TestClient(app).get("/plugins/example/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"plugin": "example", "status": "ok"}
+
+
+def test_plugin_template_router_is_discoverable_through_plugin_hub(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_entry_points(group: str | None = None, **_kwargs: object) -> list[_TemplateEntryPoint]:
+        if group == "gispulse.routers":
+            return [
+                _TemplateEntryPoint(
+                    "example",
+                    "gispulse_cap_example.routers:ExampleRouterFactory",
+                )
+            ]
+        return []
+
+    monkeypatch.setattr(plugin_hub, "entry_points", fake_entry_points)
+    plugin_hub.PluginHub.reset()
+    sys.path.insert(0, str(TEMPLATE))
+    try:
+        hub = plugin_hub.PluginHub.get()
+        app = FastAPI()
+        app.include_router(hub.routers["example"].create(app))
+    finally:
+        sys.path.remove(str(TEMPLATE))
+        plugin_hub.PluginHub.reset()
+
+    response = TestClient(app).get("/plugins/example/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"plugin": "example", "status": "ok"}
+
+
+def test_plugin_contract_document_exists_for_current_host_surface() -> None:
+    doc = ROOT / "docs" / "PLUGIN_CONTRACT.md"
+
+    content = doc.read_text(encoding="utf-8")
+
+    assert "https://github.com/imagodata/gispulse/issues/68" in content
+    assert "Refs #68" in content
+    assert "gispulse.routers" in content
+    assert "gispulse.mcp_tools" in content
+    assert "observed in the Permis Check integration" in content
+    assert "does not prove or stabilize it" in content
+    assert "RouterFactory.create(app)" in content
+    assert "gispulse.plugins.api" in content
+    assert "PluginHostContext" in content
+    assert "not yet the full stable SDK" in content
+    assert "transitional" in content
+    assert "New plugins should not treat `app.state` as a\nstable SDK" in content
+    assert "temporary escape hatch" in content
+    assert "`core.*`, `catalog.*`, `orchestration.*`" in content


### PR DESCRIPTION
## Summary

- Documents the current plugin contract and SDK naming boundary.
- Adds a transitional `gispulse.plugins.api` namespace for plugin authors.
- Adds additive `PluginHostContext` support while preserving legacy `create(app)`.
- Updates the plugin template and adds PluginHub discovery tests.

## Issue

Refs #68

## Tests

- `uv run pytest tests/unit/test_plugin_discovery.py tests/unit/test_plugin_hub.py tests/unit/test_plugin_template_contract.py -q`
- `uv run ruff check core/plugin_contracts.py gispulse/adapters/http/app.py gispulse/plugins/__init__.py gispulse/plugins/api.py examples/plugin-template/gispulse_cap_example/capabilities.py examples/plugin-template/gispulse_cap_example/routers.py tests/unit/test_plugin_hub.py tests/unit/test_plugin_template_contract.py`
