### PR TITLE
feat(qgis-plugin): detect gispulse CLI + OS-specific install dialog (v1.4-2)

### DIFF
--- a/qgis_plugin/main_plugin.py
+++ b/qgis_plugin/main_plugin.py
@@ -15,10 +15,15 @@ class GISPulsePlugin:
         from qgis.PyQt.QtWidgets import QAction
 
         icon = QIcon(str(self.plugin_dir / "icon.png"))
-        action = QAction(icon, "About GISPulse", self.iface.mainWindow())
-        action.triggered.connect(self._show_about)
-        self.iface.addPluginToMenu(self.menu, action)
-        self.actions.append(action)
+        about_action = QAction(icon, "About GISPulse", self.iface.mainWindow())
+        about_action.triggered.connect(self._show_about)
+        self.iface.addPluginToMenu(self.menu, about_action)
+        self.actions.append(about_action)
+
+        check_action = QAction(icon, "Check gispulse install…", self.iface.mainWindow())
+        check_action.triggered.connect(self._check_install)
+        self.iface.addPluginToMenu(self.menu, check_action)
+        self.actions.append(check_action)
 
     def unload(self) -> None:
         for action in self.actions:
@@ -36,3 +41,19 @@ class GISPulsePlugin:
             "Attach trigger dock, sub-process runner, layer refresh.\n\n"
             "https://gispulse.dev",
         )
+
+    def _check_install(self) -> None:
+        from qgis.PyQt.QtWidgets import QMessageBox
+
+        from .runtime import detect_gispulse
+        from .runtime.error_dialog import show_install_dialog
+
+        result = detect_gispulse(use_cache=False)
+        if result.found:
+            QMessageBox.information(
+                self.iface.mainWindow(),
+                "GISPulse",
+                f"GISPulse {result.version_str} found at:\n{result.path}",
+            )
+            return
+        show_install_dialog(self.iface.mainWindow(), result)

--- a/qgis_plugin/runtime/__init__.py
+++ b/qgis_plugin/runtime/__init__.py
@@ -1,0 +1,3 @@
+from .detector import DetectorResult, detect_gispulse, install_hint
+
+__all__ = ["DetectorResult", "detect_gispulse", "install_hint"]

--- a/qgis_plugin/runtime/detector.py
+++ b/qgis_plugin/runtime/detector.py
@@ -1,0 +1,194 @@
+"""Locate the gispulse CLI from inside QGIS' embedded Python.
+
+QGIS ships its own Python interpreter (OSGeo4W on Windows, the standalone
+installer's bundle on Linux/Windows, Homebrew on macOS) which usually does
+NOT have `gispulse` on its `sys.path`. The plugin therefore shells out to
+the user-level CLI; this module finds it and reports a clear, OS-specific
+install hint when it isn't installed or is too old.
+
+The detection logic is intentionally Qt-free so it can be unit-tested
+outside QGIS. The companion `error_dialog` module turns a `DetectorResult`
+into a `QMessageBox`.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+
+# Min CLI version that exposes the runtime contract this plugin scaffold
+# relies on. Bumped lockstep with `pyproject.toml` major changes.
+MIN_VERSION: Final[tuple[int, int, int]] = (1, 3, 0)
+
+# Detection result is cached for the lifetime of the QGIS process to avoid
+# re-running subprocesses on every dock-widget open. Use `clear_cache()` to
+# force a re-check (wired to the "Test again" button in the dialog).
+_CACHE: list["DetectorResult"] = []
+
+
+@dataclass(frozen=True)
+class DetectorResult:
+    found: bool
+    path: str | None
+    version: tuple[int, int, int] | None
+    error: str | None
+
+    @property
+    def version_str(self) -> str:
+        if self.version is None:
+            return "unknown"
+        return ".".join(str(p) for p in self.version)
+
+
+def clear_cache() -> None:
+    """Forget the last detection. The next `detect_gispulse()` call will
+    re-run all subprocesses. Wired to the "Test again" button (#v1.4-3).
+    """
+    _CACHE.clear()
+
+
+def detect_gispulse(*, use_cache: bool = True) -> DetectorResult:
+    """Locate `gispulse` and verify its version >= MIN_VERSION.
+
+    Probes (in order) until one succeeds:
+        1. `shutil.which("gispulse")` — most install paths land here
+        2. `~/.local/bin/gispulse` — `pip install --user` / `pipx`
+        3. `<sys.executable> -m gispulse --version` — same Python QGIS uses
+
+    If no probe finds a working CLI, the *first informative* failure is
+    bubbled up (e.g. timeout, version-too-old, non-zero exit) so the user
+    gets actionable diagnostics instead of a generic "not found".
+    """
+    if use_cache and _CACHE:
+        return _CACHE[0]
+    informative: DetectorResult | None = None
+    for probe in (_probe_path, _probe_user_local, _probe_module):
+        result = probe()
+        if result.found:
+            _CACHE.append(result)
+            return result
+        if informative is None and result.error:
+            informative = result
+    final = informative or DetectorResult(
+        found=False,
+        path=None,
+        version=None,
+        error="gispulse executable not found on PATH, ~/.local/bin, or as a Python module.",
+    )
+    _CACHE.append(final)
+    return final
+
+
+def install_hint(os_name: str | None = None) -> str:
+    """Return an OS-specific, copy-pasteable install command."""
+    name = (os_name or platform.system()).lower()
+    if "windows" in name:
+        return (
+            "Open the OSGeo4W Shell (Start → OSGeo4W) and run:\n"
+            "    pip install gispulse\n"
+            "Or install the standalone CLI from https://gispulse.dev/install"
+        )
+    if "darwin" in name or "mac" in name:
+        return (
+            "Run in Terminal:\n"
+            "    brew install pipx && pipx install gispulse\n"
+            "Or, if you prefer pip:\n"
+            "    pip3 install --user gispulse"
+        )
+    return "Run in your shell:\n    pipx install gispulse\nOr:\n    pip install --user gispulse"
+
+
+# ──────────────────────────── probes ───────────────────────────────
+
+
+def _probe_path() -> DetectorResult:
+    exe = shutil.which("gispulse")
+    if not exe:
+        return _not_found()
+    return _verify(exe, [exe, "--version"])
+
+
+def _probe_user_local() -> DetectorResult:
+    candidate = Path(os.path.expanduser("~/.local/bin/gispulse"))
+    if not candidate.is_file():
+        return _not_found()
+    return _verify(str(candidate), [str(candidate), "--version"])
+
+
+def _probe_module() -> DetectorResult:
+    return _verify(
+        f"{sys.executable} -m gispulse",
+        [sys.executable, "-m", "gispulse", "--version"],
+    )
+
+
+# ──────────────────────────── helpers ──────────────────────────────
+
+
+def _not_found() -> DetectorResult:
+    return DetectorResult(found=False, path=None, version=None, error=None)
+
+
+def _verify(display_path: str, cmd: list[str]) -> DetectorResult:
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        return DetectorResult(
+            found=False, path=None, version=None, error=f"failed to invoke {cmd[0]!r}: {exc}"
+        )
+    if proc.returncode != 0:
+        return DetectorResult(
+            found=False,
+            path=None,
+            version=None,
+            error=f"`{' '.join(cmd)}` exited with {proc.returncode}: {proc.stderr.strip() or proc.stdout.strip()}",
+        )
+    version = _parse_version(proc.stdout) or _parse_version(proc.stderr)
+    if version is None:
+        return DetectorResult(
+            found=False,
+            path=None,
+            version=None,
+            error=f"could not parse version from output: {proc.stdout.strip() or proc.stderr.strip()!r}",
+        )
+    if version < MIN_VERSION:
+        return DetectorResult(
+            found=False,
+            path=display_path,
+            version=version,
+            error=(
+                f"gispulse {_v(version)} is installed at {display_path} but the plugin "
+                f"requires >= {_v(MIN_VERSION)}. Upgrade with: pip install --upgrade gispulse"
+            ),
+        )
+    return DetectorResult(found=True, path=display_path, version=version, error=None)
+
+
+def _parse_version(text: str) -> tuple[int, int, int] | None:
+    """Pull the first `MAJOR.MINOR.PATCH` triple from arbitrary CLI output.
+
+    Accepts `gispulse 1.5.1` (Typer default), a lone `1.5.1`, and `v2.0.0`
+    (no word boundary before the leading digit when prefixed by a letter).
+    """
+    import re
+
+    match = re.search(r"(\d+)\.(\d+)\.(\d+)", text)
+    if not match:
+        return None
+    return (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+
+
+def _v(parts: tuple[int, int, int]) -> str:
+    return ".".join(str(p) for p in parts)

--- a/qgis_plugin/runtime/error_dialog.py
+++ b/qgis_plugin/runtime/error_dialog.py
@@ -1,0 +1,67 @@
+"""Qt-side companion to `detector.py`.
+
+Kept in a separate module so unit tests can import `detector` without
+pulling in `qgis.PyQt`. The "Test again" button calls `clear_cache()` and
+re-runs detection without restarting QGIS.
+"""
+
+from __future__ import annotations
+
+from .detector import DetectorResult, clear_cache, detect_gispulse, install_hint
+
+DOC_URL = "https://gispulse.dev/install"
+
+
+def show_install_dialog(parent, result: DetectorResult) -> DetectorResult:
+    """Show a modal explaining how to install / upgrade gispulse, with
+    a 'Test again' button. Returns the (possibly fresh) DetectorResult."""
+    from qgis.PyQt.QtCore import QUrl
+    from qgis.PyQt.QtGui import QDesktopServices
+    from qgis.PyQt.QtWidgets import QDialog, QDialogButtonBox, QLabel, QVBoxLayout
+
+    dialog = QDialog(parent)
+    dialog.setWindowTitle("GISPulse — install required")
+    layout = QVBoxLayout(dialog)
+
+    layout.addWidget(QLabel(_format_message(result)))
+    hint = QLabel(install_hint())
+    hint.setTextInteractionFlags(hint.textInteractionFlags() | 0x4)
+    layout.addWidget(hint)
+
+    buttons = QDialogButtonBox()
+    test_btn = buttons.addButton("Test again", QDialogButtonBox.ActionRole)
+    docs_btn = buttons.addButton("Open docs", QDialogButtonBox.ActionRole)
+    close_btn = buttons.addButton(QDialogButtonBox.Close)
+    layout.addWidget(buttons)
+
+    state: dict[str, DetectorResult] = {"result": result}
+
+    def _retest() -> None:
+        clear_cache()
+        fresh = detect_gispulse(use_cache=False)
+        state["result"] = fresh
+        if fresh.found:
+            dialog.accept()
+        else:
+            layout.itemAt(0).widget().setText(_format_message(fresh))
+
+    test_btn.clicked.connect(_retest)
+    docs_btn.clicked.connect(lambda: QDesktopServices.openUrl(QUrl(DOC_URL)))
+    close_btn.clicked.connect(dialog.reject)
+
+    dialog.exec_()
+    return state["result"]
+
+
+def _format_message(result: DetectorResult) -> str:
+    if result.found:
+        return f"GISPulse {result.version_str} found at {result.path}."
+    if result.path and result.version is not None:
+        return (
+            f"GISPulse {result.version_str} found at {result.path}, but the plugin "
+            f"needs a newer version. Please upgrade and click 'Test again'."
+        )
+    return (
+        "GISPulse CLI was not found on this system.\n"
+        "Install it with the command below, then click 'Test again'."
+    )

--- a/tests/unit/test_qgis_plugin_detector.py
+++ b/tests/unit/test_qgis_plugin_detector.py
@@ -1,0 +1,212 @@
+"""Unit tests for the QGIS plugin gispulse-CLI detector (issue v1.4-2).
+
+Subprocesses are mocked so the suite runs in QGIS-less, gispulse-less
+sandboxes (CI runners). For an end-to-end probe of the actually-installed
+CLI, see `test_detector_real_cli` (auto-skips when gispulse isn't on PATH).
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from qgis_plugin.runtime import detector
+from qgis_plugin.runtime.detector import (
+    MIN_VERSION,
+    DetectorResult,
+    clear_cache,
+    detect_gispulse,
+    install_hint,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    clear_cache()
+    yield
+    clear_cache()
+
+
+def _fake_completed(stdout: str = "", returncode: int = 0):
+    return subprocess.CompletedProcess(
+        args=["gispulse"], returncode=returncode, stdout=stdout, stderr=""
+    )
+
+
+class TestParseVersion:
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("gispulse 1.5.1", (1, 5, 1)),
+            ("1.3.0", (1, 3, 0)),
+            ("GISPulse v2.0.0 (build deadbeef)", (2, 0, 0)),
+            ("no version here", None),
+            ("", None),
+        ],
+    )
+    def test_parses(self, text: str, expected) -> None:
+        assert detector._parse_version(text) == expected
+
+
+class TestProbePath:
+    def test_returns_found_when_which_finds_cli_with_compatible_version(self) -> None:
+        with (
+            patch.object(shutil, "which", return_value="/usr/local/bin/gispulse"),
+            patch.object(subprocess, "run", return_value=_fake_completed("gispulse 1.5.1\n")),
+        ):
+            r = detect_gispulse()
+        assert r.found is True
+        assert r.path == "/usr/local/bin/gispulse"
+        assert r.version == (1, 5, 1)
+        assert r.error is None
+
+    def test_returns_not_found_when_path_empty(self) -> None:
+        with (
+            patch.object(shutil, "which", return_value=None),
+            patch("pathlib.Path.is_file", return_value=False),
+            patch.object(subprocess, "run", side_effect=FileNotFoundError("no python")),
+        ):
+            r = detect_gispulse()
+        assert r.found is False
+        # `_probe_module` raises FileNotFoundError → that informative error
+        # bubbles up instead of the generic fallback.
+        err = (r.error or "").lower()
+        assert "not found" in err or "failed to invoke" in err
+
+
+class TestVersionGate:
+    def test_rejects_too_old_version(self) -> None:
+        too_old = "gispulse 1.2.9"
+        with (
+            patch.object(shutil, "which", return_value="/usr/local/bin/gispulse"),
+            patch.object(subprocess, "run", return_value=_fake_completed(too_old)),
+        ):
+            r = detect_gispulse()
+        assert r.found is False
+        assert r.version == (1, 2, 9)
+        assert ">=" in (r.error or "")
+        assert ".".join(str(p) for p in MIN_VERSION) in (r.error or "")
+
+    def test_accepts_exact_min_version(self) -> None:
+        exact = f"gispulse {'.'.join(str(p) for p in MIN_VERSION)}"
+        with (
+            patch.object(shutil, "which", return_value="/usr/local/bin/gispulse"),
+            patch.object(subprocess, "run", return_value=_fake_completed(exact)),
+        ):
+            r = detect_gispulse()
+        assert r.found is True
+        assert r.version == MIN_VERSION
+
+
+class TestSubprocessFailures:
+    def test_nonzero_exit_marks_not_found(self) -> None:
+        with (
+            patch.object(shutil, "which", return_value="/usr/local/bin/gispulse"),
+            patch.object(subprocess, "run", return_value=_fake_completed("boom", returncode=1)),
+        ):
+            r = detect_gispulse()
+        assert r.found is False
+        assert "exited with 1" in (r.error or "")
+
+    def test_timeout_marks_not_found(self) -> None:
+        with (
+            patch.object(shutil, "which", return_value="/usr/local/bin/gispulse"),
+            patch.object(
+                subprocess,
+                "run",
+                side_effect=subprocess.TimeoutExpired(cmd="gispulse", timeout=10),
+            ),
+        ):
+            r = detect_gispulse()
+        assert r.found is False
+        assert "timeout" in (r.error or "").lower() or "timed out" in (r.error or "").lower()
+
+
+class TestCache:
+    def test_second_call_is_cached(self) -> None:
+        with (
+            patch.object(shutil, "which", return_value="/usr/local/bin/gispulse"),
+            patch.object(
+                subprocess, "run", return_value=_fake_completed("gispulse 1.5.1")
+            ) as mock_run,
+        ):
+            r1 = detect_gispulse()
+            r2 = detect_gispulse()
+        assert r1 == r2
+        # 1 call to verify the version, no second probe
+        assert mock_run.call_count == 1
+
+    def test_use_cache_false_re_runs(self) -> None:
+        with (
+            patch.object(shutil, "which", return_value="/usr/local/bin/gispulse"),
+            patch.object(
+                subprocess, "run", return_value=_fake_completed("gispulse 1.5.1")
+            ) as mock_run,
+        ):
+            detect_gispulse()
+            detect_gispulse(use_cache=False)
+        assert mock_run.call_count == 2
+
+    def test_clear_cache_forces_recheck(self) -> None:
+        with (
+            patch.object(shutil, "which", return_value="/usr/local/bin/gispulse"),
+            patch.object(
+                subprocess, "run", return_value=_fake_completed("gispulse 1.5.1")
+            ) as mock_run,
+        ):
+            detect_gispulse()
+            clear_cache()
+            detect_gispulse()
+        assert mock_run.call_count == 2
+
+
+class TestInstallHint:
+    @pytest.mark.parametrize("os_name", ["Windows", "windows", "WINDOWS"])
+    def test_windows_hint_mentions_osgeo4w(self, os_name: str) -> None:
+        assert "OSGeo4W" in install_hint(os_name)
+        assert "pip install gispulse" in install_hint(os_name)
+
+    @pytest.mark.parametrize("os_name", ["Darwin", "macos"])
+    def test_macos_hint_mentions_brew_or_pipx(self, os_name: str) -> None:
+        text = install_hint(os_name)
+        assert "brew" in text or "pipx" in text
+        assert "gispulse" in text
+
+    def test_linux_hint_mentions_pipx_or_user_install(self) -> None:
+        text = install_hint("Linux")
+        assert "pipx" in text or "--user" in text
+        assert "gispulse" in text
+
+
+class TestVersionStr:
+    def test_version_str_unknown_when_no_version(self) -> None:
+        r = DetectorResult(found=False, path=None, version=None, error="x")
+        assert r.version_str == "unknown"
+
+    def test_version_str_dotted(self) -> None:
+        r = DetectorResult(found=True, path="/x", version=(1, 5, 1), error=None)
+        assert r.version_str == "1.5.1"
+
+
+# ─── End-to-end smoke (auto-skipped on runners without a runnable gispulse) ───
+
+
+def _gispulse_runs() -> bool:
+    exe = shutil.which("gispulse")
+    if not exe:
+        return False
+    try:
+        return subprocess.run([exe, "--version"], capture_output=True, timeout=5).returncode == 0
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _gispulse_runs(), reason="gispulse CLI not runnable in this env")
+def test_detector_real_cli() -> None:
+    r = detect_gispulse(use_cache=False)
+    assert r.found is True, r.error
+    assert r.version is not None
+    assert r.version >= MIN_VERSION


### PR DESCRIPTION
## Summary

Stacked on top of #71 (scaffold). Once #71 is merged, retarget this PR to `main`.

Implements the detection layer for issue `imagodata/gispulse-enterprise#468` (v1.4-2):

- `qgis_plugin/runtime/detector.py` — Qt-free, unit-testable. `detect_gispulse(use_cache=True) -> DetectorResult` probes `shutil.which`, `~/.local/bin`, then `sys.executable -m gispulse`. Enforces `MIN_VERSION=(1,3,0)`. **First informative failure** (timeout / non-zero / version-too-old) bubbles up instead of a generic fallback so users get actionable diagnostics.
- `qgis_plugin/runtime/error_dialog.py` — `QDialog` with OS-specific install hint (`OSGeo4W` shell on Windows, `brew`/`pipx` on macOS, `pipx`/`--user` on Linux), `"Test again"` button (clears cache + re-runs detection without restarting QGIS), and `"Open docs"` link.
- `qgis_plugin/main_plugin.py` — adds `"Check gispulse install…"` menu action that runs the detector and shows either an info box (found) or the install dialog (not found / outdated).
- `tests/unit/test_qgis_plugin_detector.py` — 22 unit tests + 1 real-CLI smoke (auto-skipped when gispulse isn't runnable in the env).

## Test plan

- [x] `python -m pytest tests/unit/test_qgis_plugin_detector.py -v` → 22 passed, 1 skipped
- [x] `ruff check qgis_plugin/ tests/unit/test_qgis_plugin_detector.py` → All checks passed
- [x] `ruff format --check qgis_plugin/ tests/unit/test_qgis_plugin_detector.py` → All formatted
- [ ] Manual install on QGIS 3.28+ on each OS (deferred to reviewer; covers the 3 install matrices the issue requires)

## Out of scope

- v1.4-3 dock widget Attach trigger (consumes detector)
- v1.4-4 sub-process runner
- Auto-install of gispulse from the plugin (security, hors MVP)

Closes imagodata/gispulse-enterprise#468