### PR TITLE
feat(qgis-plugin): Attach-trigger dock widget (v1.4-3)

### DIFF
--- a/qgis_plugin/main_plugin.py
+++ b/qgis_plugin/main_plugin.py
@@ -9,6 +9,7 @@ class GISPulsePlugin:
         self.plugin_dir = Path(__file__).resolve().parent
         self.actions: list = []
         self.menu = "&GISPulse"
+        self._dock = None
 
     def initGui(self) -> None:
         from qgis.PyQt.QtGui import QIcon
@@ -25,7 +26,16 @@ class GISPulsePlugin:
         self.iface.addPluginToMenu(self.menu, check_action)
         self.actions.append(check_action)
 
+        panel_action = QAction(icon, "Show panel", self.iface.mainWindow())
+        panel_action.triggered.connect(self._show_panel)
+        self.iface.addPluginToMenu(self.menu, panel_action)
+        self.actions.append(panel_action)
+
     def unload(self) -> None:
+        if self._dock is not None:
+            self.iface.removeDockWidget(self._dock)
+            self._dock.deleteLater()
+            self._dock = None
         for action in self.actions:
             self.iface.removePluginMenu(self.menu, action)
         self.actions.clear()
@@ -57,3 +67,14 @@ class GISPulsePlugin:
             )
             return
         show_install_dialog(self.iface.mainWindow(), result)
+
+    def _show_panel(self) -> None:
+        from qgis.PyQt.QtCore import Qt
+
+        from .ui.dock_widget import build_dock_widget
+
+        if self._dock is None:
+            self._dock = build_dock_widget(self.iface.mainWindow())
+            self.iface.addDockWidget(Qt.RightDockWidgetArea, self._dock)
+        self._dock.show()
+        self._dock.raise_()

--- a/qgis_plugin/ui/__init__.py
+++ b/qgis_plugin/ui/__init__.py
@@ -1,0 +1,3 @@
+from .state import AttachState, validate_rules_file
+
+__all__ = ["AttachState", "validate_rules_file"]

--- a/qgis_plugin/ui/dock_widget.py
+++ b/qgis_plugin/ui/dock_widget.py
@@ -1,0 +1,191 @@
+"""Attach-trigger dock widget (issue v1.4-3).
+
+UI surface only — running the trigger is done in v1.4-4 (#470). The
+"Run trigger" button is wired to a no-op stub that the runner story
+will replace.
+"""
+
+from __future__ import annotations
+
+from .state import CUSTOM_PROPERTY_KEY, AttachState
+
+
+def _qgis_imports():
+    """Lazy import so unit tests on the Qt-free `state` module don't pull
+    in QGIS bindings."""
+    from qgis.core import QgsMapLayer, QgsProject
+    from qgis.PyQt.QtCore import Qt
+    from qgis.PyQt.QtWidgets import (
+        QComboBox,
+        QDockWidget,
+        QFileDialog,
+        QHBoxLayout,
+        QLabel,
+        QPushButton,
+        QTextEdit,
+        QVBoxLayout,
+        QWidget,
+    )
+
+    return {
+        "QgsMapLayer": QgsMapLayer,
+        "QgsProject": QgsProject,
+        "Qt": Qt,
+        "QComboBox": QComboBox,
+        "QDockWidget": QDockWidget,
+        "QFileDialog": QFileDialog,
+        "QHBoxLayout": QHBoxLayout,
+        "QLabel": QLabel,
+        "QPushButton": QPushButton,
+        "QTextEdit": QTextEdit,
+        "QVBoxLayout": QVBoxLayout,
+        "QWidget": QWidget,
+    }
+
+
+def build_dock_widget(parent):
+    q = _qgis_imports()
+    QgsMapLayer = q["QgsMapLayer"]
+    QgsProject = q["QgsProject"]
+    Qt = q["Qt"]
+
+    dock = q["QDockWidget"](_tr("GISPulse"), parent)
+    dock.setObjectName("GISPulseDock")
+    dock.setAllowedAreas(Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea)
+
+    container = q["QWidget"](dock)
+    layout = q["QVBoxLayout"](container)
+    state = AttachState()
+
+    # Layer combo
+    layout.addWidget(q["QLabel"](_tr("Layer:")))
+    layer_combo = q["QComboBox"](container)
+    layout.addWidget(layer_combo)
+    layer_msg = q["QLabel"]("", container)
+    layer_msg.setStyleSheet("color: #b00;")
+    layout.addWidget(layer_msg)
+
+    # Rules YAML picker
+    layout.addWidget(q["QLabel"](_tr("Rules YAML:")))
+    rules_row = q["QHBoxLayout"]()
+    rules_label = q["QLabel"]("(none)", container)
+    rules_btn = q["QPushButton"](_tr("Browse…"), container)
+    rules_row.addWidget(rules_label, stretch=1)
+    rules_row.addWidget(rules_btn)
+    layout.addLayout(rules_row)
+    rules_msg = q["QLabel"]("", container)
+    rules_msg.setStyleSheet("color: #b00;")
+    layout.addWidget(rules_msg)
+
+    # Preview
+    layout.addWidget(q["QLabel"](_tr("Preview:")))
+    preview = q["QTextEdit"](container)
+    preview.setReadOnly(True)
+    preview.setLineWrapMode(q["QTextEdit"].NoWrap)
+    layout.addWidget(preview, stretch=1)
+
+    # Run button
+    run_btn = q["QPushButton"](_tr("Run trigger"), container)
+    run_btn.setEnabled(False)
+    layout.addWidget(run_btn)
+
+    container.setLayout(layout)
+    dock.setWidget(container)
+
+    # ─── helpers ─────────────────────────────────────────────────────
+
+    def _refresh_run_state() -> None:
+        layer_msg.setText(state.layer_message())
+        v = state.rules_validation()
+        rules_msg.setText(v.message)
+        run_btn.setEnabled(state.can_run())
+
+    def _populate_layers() -> None:
+        layer_combo.blockSignals(True)
+        try:
+            current_id = state.layer_id
+            layer_combo.clear()
+            layer_combo.addItem(_tr("(select a layer)"), None)
+            for layer in QgsProject.instance().mapLayers().values():
+                layer_combo.addItem(layer.name(), layer.id())
+            if current_id:
+                idx = layer_combo.findData(current_id)
+                if idx >= 0:
+                    layer_combo.setCurrentIndex(idx)
+        finally:
+            layer_combo.blockSignals(False)
+
+    def _on_layer_changed(idx: int) -> None:
+        layer_id = layer_combo.itemData(idx)
+        if not layer_id:
+            state.set_layer(None, is_vector=False)
+            preview.clear()
+            _refresh_run_state()
+            return
+        layer = QgsProject.instance().mapLayer(layer_id)
+        is_vector = bool(layer) and layer.type() == QgsMapLayer.VectorLayer
+        state.set_layer(layer_id, is_vector=is_vector)
+        if layer is not None:
+            stored = layer.customProperty(CUSTOM_PROPERTY_KEY, "")
+            if stored:
+                _set_rules_path(stored)
+        _refresh_run_state()
+
+    def _set_rules_path(path: str) -> None:
+        state.set_rules_path(path)
+        rules_label.setText(path or "(none)")
+        v = state.rules_validation()
+        if v.valid:
+            try:
+                preview.setPlainText(open(path, encoding="utf-8").read())
+            except OSError as exc:  # pragma: no cover - defensive
+                preview.setPlainText(f"# could not read {path}: {exc}")
+            if state.layer_id:
+                layer = QgsProject.instance().mapLayer(state.layer_id)
+                if layer is not None:
+                    layer.setCustomProperty(CUSTOM_PROPERTY_KEY, path)
+        else:
+            preview.clear()
+        _refresh_run_state()
+
+    def _on_browse_clicked() -> None:
+        path, _filter = q["QFileDialog"].getOpenFileName(
+            container, _tr("Pick a rules YAML"), "", "YAML (*.yml *.yaml)"
+        )
+        if path:
+            _set_rules_path(path)
+
+    def _on_run_clicked() -> None:
+        # Sub-process runner lands in v1.4-4 (#470). For now, emit a
+        # human-readable line into the preview so the wiring is visible.
+        preview.append(f"\n# [v1.4-3 stub] would run gispulse with {state.rules_path}\n")
+
+    # ─── signals ─────────────────────────────────────────────────────
+
+    layer_combo.currentIndexChanged.connect(_on_layer_changed)
+    rules_btn.clicked.connect(_on_browse_clicked)
+    run_btn.clicked.connect(_on_run_clicked)
+
+    project = QgsProject.instance()
+    project.layersAdded.connect(lambda *_: _populate_layers())
+    project.layersRemoved.connect(lambda *_: _populate_layers())
+
+    _populate_layers()
+    _refresh_run_state()
+    return dock
+
+
+def _tr(text: str) -> str:
+    """Translation hook (Qt linguist).
+
+    QGIS plugins use `QCoreApplication.translate(context, text)` which
+    requires `pylupdate5` over the source. For v1.4 the strings live
+    here verbatim; the .ts/.qm files are added in v1.4-7 with the
+    install tutorial work.
+    """
+    try:
+        from qgis.PyQt.QtCore import QCoreApplication
+
+        return QCoreApplication.translate("GISPulseDock", text)
+    except ImportError:
+        return text

--- a/qgis_plugin/ui/state.py
+++ b/qgis_plugin/ui/state.py
@@ -1,0 +1,80 @@
+"""Qt-free state for the Attach-trigger dock widget.
+
+Extracted from `dock_widget.py` so the validation rules (vector-only
+layers, .yml/.yaml extension, "Run" button enable gate) can be unit
+tested without a running QGIS instance.
+
+The persistent layer↔rules mapping uses `QgsMapLayer.customProperty()`
+under the key `CUSTOM_PROPERTY_KEY` so the assignment survives project
+save/reload.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+CUSTOM_PROPERTY_KEY = "gispulse/rules_yaml"
+ALLOWED_RULES_SUFFIXES = (".yml", ".yaml")
+
+
+@dataclass(frozen=True)
+class ValidationOutcome:
+    valid: bool
+    message: str
+
+
+def validate_rules_file(path: str | Path | None) -> ValidationOutcome:
+    """The rules file must exist and be `.yml` / `.yaml`.
+
+    Empty / None returns invalid with an empty message — the widget uses
+    that to keep the inline label empty until the user actually picks
+    something.
+    """
+    if not path:
+        return ValidationOutcome(valid=False, message="")
+    p = Path(path)
+    if not p.is_file():
+        return ValidationOutcome(valid=False, message=f"File not found: {p}")
+    if p.suffix.lower() not in ALLOWED_RULES_SUFFIXES:
+        return ValidationOutcome(
+            valid=False,
+            message=f"Rules file must end in .yml or .yaml (got {p.suffix!r}).",
+        )
+    return ValidationOutcome(valid=True, message="")
+
+
+@dataclass
+class AttachState:
+    """Tracks dock-widget inputs and tells the widget when to enable Run.
+
+    Layer types follow QGIS' `QgsMapLayer.LayerType` numeric values, but
+    we only care about *vector* (=0). Anything else surfaces an inline
+    "vector-only" message; the Run button stays disabled.
+    """
+
+    layer_id: str | None = None
+    layer_is_vector: bool = False
+    rules_path: str | None = None
+
+    def set_layer(self, layer_id: str | None, *, is_vector: bool) -> None:
+        self.layer_id = layer_id
+        self.layer_is_vector = is_vector
+
+    def set_rules_path(self, path: str | None) -> None:
+        self.rules_path = path
+
+    def rules_validation(self) -> ValidationOutcome:
+        return validate_rules_file(self.rules_path)
+
+    def layer_message(self) -> str:
+        if self.layer_id is None:
+            return ""
+        if not self.layer_is_vector:
+            return "GISPulse v1.4 supports vector layers only."
+        return ""
+
+    def can_run(self) -> bool:
+        if self.layer_id is None or not self.layer_is_vector:
+            return False
+        return self.rules_validation().valid

--- a/tests/unit/test_qgis_plugin_dock_state.py
+++ b/tests/unit/test_qgis_plugin_dock_state.py
@@ -1,0 +1,137 @@
+"""Unit tests for the Attach-trigger dock-widget state machine (v1.4-3).
+
+Only the Qt-free `state` module is exercised here. The actual `QDockWidget`
+needs a running QGIS / Qt loop and is covered by manual review on each
+QGIS env (OSGeo4W, Standalone, Homebrew) per the issue acceptance.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from qgis_plugin.ui.state import (
+    ALLOWED_RULES_SUFFIXES,
+    CUSTOM_PROPERTY_KEY,
+    AttachState,
+    validate_rules_file,
+)
+
+
+@pytest.fixture
+def yaml_file(tmp_path: Path) -> Path:
+    p = tmp_path / "rules.yaml"
+    p.write_text("rules:\n  - name: demo\n", encoding="utf-8")
+    return p
+
+
+@pytest.fixture
+def yml_file(tmp_path: Path) -> Path:
+    p = tmp_path / "rules.yml"
+    p.write_text("rules: []\n", encoding="utf-8")
+    return p
+
+
+class TestValidateRulesFile:
+    def test_none_is_invalid_with_empty_message(self) -> None:
+        v = validate_rules_file(None)
+        assert v.valid is False
+        assert v.message == ""
+
+    def test_empty_string_is_invalid_with_empty_message(self) -> None:
+        v = validate_rules_file("")
+        assert v.valid is False
+        assert v.message == ""
+
+    def test_missing_file(self, tmp_path: Path) -> None:
+        v = validate_rules_file(tmp_path / "nope.yml")
+        assert v.valid is False
+        assert "not found" in v.message.lower()
+
+    @pytest.mark.parametrize("suffix", [".txt", ".json", ".yamlx", ""])
+    def test_wrong_suffix(self, tmp_path: Path, suffix: str) -> None:
+        p = tmp_path / f"rules{suffix}"
+        p.write_text("anything", encoding="utf-8")
+        v = validate_rules_file(p)
+        assert v.valid is False
+        assert ".yml" in v.message or ".yaml" in v.message
+
+    def test_yaml_file_is_valid(self, yaml_file: Path) -> None:
+        assert validate_rules_file(yaml_file).valid is True
+
+    def test_yml_file_is_valid(self, yml_file: Path) -> None:
+        assert validate_rules_file(yml_file).valid is True
+
+    def test_uppercase_extension_is_valid(self, tmp_path: Path) -> None:
+        p = tmp_path / "rules.YML"
+        p.write_text("x", encoding="utf-8")
+        assert validate_rules_file(p).valid is True
+
+
+class TestAttachState:
+    def test_initial_state_cant_run(self) -> None:
+        s = AttachState()
+        assert s.can_run() is False
+        assert s.layer_message() == ""
+        assert s.rules_validation().valid is False
+
+    def test_layer_only_cant_run(self) -> None:
+        s = AttachState()
+        s.set_layer("layer-1", is_vector=True)
+        assert s.can_run() is False
+
+    def test_rules_only_cant_run(self, yaml_file: Path) -> None:
+        s = AttachState()
+        s.set_rules_path(str(yaml_file))
+        assert s.can_run() is False
+
+    def test_vector_layer_plus_yaml_can_run(self, yaml_file: Path) -> None:
+        s = AttachState()
+        s.set_layer("layer-1", is_vector=True)
+        s.set_rules_path(str(yaml_file))
+        assert s.can_run() is True
+
+    def test_non_vector_layer_blocks_run(self, yaml_file: Path) -> None:
+        s = AttachState()
+        s.set_layer("layer-raster", is_vector=False)
+        s.set_rules_path(str(yaml_file))
+        assert s.can_run() is False
+        assert "vector" in s.layer_message().lower()
+
+    def test_clearing_layer_blocks_run(self, yaml_file: Path) -> None:
+        s = AttachState()
+        s.set_layer("layer-1", is_vector=True)
+        s.set_rules_path(str(yaml_file))
+        assert s.can_run() is True
+        s.set_layer(None, is_vector=False)
+        assert s.can_run() is False
+        assert s.layer_message() == ""
+
+    def test_clearing_rules_blocks_run(self, yaml_file: Path) -> None:
+        s = AttachState()
+        s.set_layer("layer-1", is_vector=True)
+        s.set_rules_path(str(yaml_file))
+        assert s.can_run() is True
+        s.set_rules_path(None)
+        assert s.can_run() is False
+
+    def test_invalid_rules_extension_blocks_run(self, tmp_path: Path) -> None:
+        bad = tmp_path / "rules.txt"
+        bad.write_text("x", encoding="utf-8")
+        s = AttachState()
+        s.set_layer("layer-1", is_vector=True)
+        s.set_rules_path(str(bad))
+        assert s.can_run() is False
+        assert ".yml" in s.rules_validation().message
+
+
+class TestModuleConstants:
+    def test_custom_property_key_is_namespaced(self) -> None:
+        # Anything stored on a QgsMapLayer survives project save/reload;
+        # the key must stay stable across versions or restored properties
+        # silently disappear.
+        assert CUSTOM_PROPERTY_KEY == "gispulse/rules_yaml"
+
+    def test_allowed_suffixes_lower_only(self) -> None:
+        assert ALLOWED_RULES_SUFFIXES == (".yml", ".yaml")


### PR DESCRIPTION
## Summary

Stacked on top of #73 (`feat/qgis-plugin-detector`). Retarget to `main`
once #71 + #73 are merged (or fast-forward via PR retargeting after each
merge in the chain).

Adds the **GISPulse panel** (Extensions → GISPulse → Show panel): a
dock widget for selecting a vector layer + a rules YAML and previewing
the file before firing a trigger.

- combo box live-bound to `QgsProject.layersAdded` / `layersRemoved`
- vector-only gate with inline error label
- file picker validating `.yml` / `.yaml` (case-insensitive)
- preview in a read-only `QTextEdit`
- Run button disabled until both inputs are valid
- per-layer rules path persists in `QgsMapLayer.customProperty("gispulse/rules_yaml")` (survives project save/reload)
- i18n via `QCoreApplication.translate("GISPulseDock", …)`

The actual sub-process runner is **out of scope** — that lands in
v1.4-4 (`#470`). The Run button currently appends a stub line so the
wiring is visible end-to-end.

## Test plan

- [x] `python -m pytest tests/unit/test_qgis_plugin_dock_state.py` → **20 passed**
- [x] `ruff check qgis_plugin/ tests/unit/test_qgis_plugin_dock_state.py` → clean
- [x] Full plugin suite (`scaffold + detector + dock_state`) → **47 passed, 1 skipped**
- [ ] Manual: open plugin in QGIS 3.28+, switch a vector ↔ raster layer, pick a YAML, click Run; reopen project to confirm the rules path persisted (deferred to reviewer per acceptance matrix)

## Out of scope

- v1.4-4 (#470) sub-process runner + log streaming
- v1.4-5 (#471) layer refresh after run
- in-app YAML editor / templates library → v1.4.1+
- multi-layer / batch run → v1.4.1+

Closes imagodata/gispulse-enterprise#469