### PR TITLE
Expand plugin author API imports

### DIFF
--- a/core/plugin_contracts.py
+++ b/core/plugin_contracts.py
@@ -37,6 +37,21 @@ PROTOCOL_VERSION = "1.0"
 # ---------------------------------------------------------------------------
 
 
+@dataclass(frozen=True)
+class PluginHostContext:
+    """Stable host context passed to context-aware plugin factories.
+
+    This first #68 slice is intentionally small. It exposes only the
+    runtime objects plugins already need at mount time without requiring
+    them to inspect ``app.state`` directly.
+    """
+
+    app: "FastAPI"
+    settings: Any
+    logger: Any
+    plugin_hub: Any
+
+
 @runtime_checkable
 class RouterFactory(Protocol):
     """Plugin that mounts an :class:`fastapi.APIRouter` on the host app.
@@ -49,6 +64,16 @@ class RouterFactory(Protocol):
     name: str
 
     def create(self, app: "FastAPI") -> "APIRouter | None":
+        ...
+
+
+@runtime_checkable
+class ContextAwareRouterFactory(Protocol):
+    """Additive router factory contract receiving :class:`PluginHostContext`."""
+
+    name: str
+
+    def create(self, context: PluginHostContext) -> "APIRouter | None":
         ...
 
 

--- a/docs/PLUGIN_CONTRACT.md
+++ b/docs/PLUGIN_CONTRACT.md
@@ -1,0 +1,160 @@
+# GISPulse Plugin Contract
+
+This document describes the current external plugin surface used by
+`PluginHub`. It is intentionally factual: the contract below is usable today,
+but the typed SDK host context is not yet stable.
+
+This work is tracked by
+[imagodata/gispulse#68](https://github.com/imagodata/gispulse/issues/68).
+Commits and PRs that advance this surface should use `Refs #68` until the full
+acceptance criteria are covered.
+
+## SDK Scope
+
+`sdk/gispulse_sdk` is the existing REST client SDK. It is for external clients
+that call a running GISPulse HTTP API.
+
+Issue #68 is about a different surface: the future in-process plugin-author API
+used by packages installed into the host process. Do not put this authoring
+surface under `gispulse_sdk`; keep it separate from the REST client SDK.
+
+## Entry Point Groups
+
+GISPulse discovers plugins through Python package entry points.
+
+| Group | Contract | Current status |
+| --- | --- | --- |
+| `gispulse.capabilities` | Callable `register()` that imports capability classes using `@register` | Legacy supported / transitional surface |
+| `gispulse.routers` | `RouterFactory.create(app)` returning a FastAPI `APIRouter` or `None` | Current host surface |
+| `gispulse.middleware` | `MiddlewareFactory.install(app)` | Current host surface |
+| `gispulse.auth_provider` | `AuthProvider` protocol | Current host surface |
+| `gispulse.billing_provider` | `BillingProvider` protocol | Current host surface |
+| `gispulse.licence_provider` | `LicenceProvider` protocol | Current host surface |
+| `gispulse.connectors` | `Connector` protocol | Current host surface |
+
+Capability plugins are discovered by the capability registry. Host plugins for
+routers, middleware, auth, billing, licence and connectors are discovered by
+`core.plugin_hub.PluginHub` and mounted by the HTTP app in full mode.
+
+`gispulse.mcp_tools` has been observed in the Permis Check integration, but
+this first host-runtime slice does not prove or stabilize it. Do not treat it as
+equally wired as `gispulse.routers` unless core host discovery is added and
+tested.
+
+## Router Contract
+
+An external router plugin declares:
+
+```toml
+[project.entry-points."gispulse.routers"]
+example = "gispulse_cap_example.routers:ExampleRouterFactory"
+```
+
+The factory object may be an instance or a class. If it is a class, `PluginHub`
+instantiates it with no arguments.
+
+```python
+from fastapi import APIRouter
+
+
+class ExampleRouterFactory:
+    name = "example"
+
+    def create(self, app):
+        router = APIRouter(prefix="/plugins/example")
+
+        @router.get("/health")
+        def health():
+            return {"plugin": "example", "status": "ok"}
+
+        return router
+```
+
+`RouterFactory.create(app)` receives the FastAPI application object. Returning
+`None` skips mounting without failing host startup. Raising an exception is
+caught by the host and logged as a plugin mount failure.
+
+`app` is the current contract. New plugins should not treat `app.state` as a
+stable SDK. Use `app.state` only as a temporary escape hatch when no documented
+host surface exists, and keep that access narrow so it can be replaced by the
+typed context planned in #68.
+
+## Capability Contract
+
+Capability plugins declare:
+
+```toml
+[project.entry-points."gispulse.capabilities"]
+example = "gispulse_cap_example:register"
+```
+
+The `register()` function imports modules that use the capability registry
+decorator:
+
+```python
+from gispulse.plugins.api import Capability, register_capability
+
+
+@register_capability
+class ExampleCapability(Capability):
+    name = "example"
+    description = "Example capability."
+
+    def execute(self, gdf, **params):
+        return gdf
+```
+
+Use explicit keyword parameters when a capability accepts configuration. Avoid
+the old `execute(gdf, config: dict)` shape; orchestration dispatch now validates
+keyword parameters through the current `Capability.execute(gdf, **params)`
+contract.
+
+`gispulse.capabilities` is supported for existing plugins, but direct imports
+from `capabilities.*` are transitional rather than the final new SDK shape. New
+plugins should import capability primitives from `gispulse.plugins.api`.
+
+## Additive Host Context
+
+`RouterFactory.create(app)` remains the legacy-compatible contract. This slice
+also introduces a small `PluginHostContext` for new router factories. A factory
+can opt into it by naming the first `create()` parameter `ctx`, `context`,
+`host_context` or `plugin_context`, or by annotating it as `PluginHostContext`.
+
+```python
+from fastapi import APIRouter
+from gispulse.plugins.api import PluginHostContext
+
+
+class ExampleRouterFactory:
+    name = "example"
+
+    def create(self, ctx: PluginHostContext):
+        router = APIRouter(prefix="/plugins/example")
+        ctx.logger.info("example_plugin_mounting")
+        return router
+```
+
+The first context is deliberately small: `app`, `settings`, `logger` and
+`plugin_hub`. Catalog/source access, spatial helpers, auth/tenant context,
+cache/storage and pipeline execution should be added only as tested follow-up
+slices for `#68`.
+
+## Known Limits
+
+The current host plugin API passes the raw FastAPI `app` to router and
+middleware factories. This keeps existing plugins simple, but it also exposes
+internal application details through `app.state`.
+
+The current `PluginHostContext` is additive, small and not yet the full stable SDK.
+It intentionally exposes only mount-time host objects that are already needed by
+real plugins.
+
+Issue #68 should reduce the need for product plugins to import directly from
+internal modules such as `core.*`, `catalog.*`, `orchestration.*`,
+`capabilities.*`, or `gispulse.adapters.*`. Those imports work today, but they
+create an accidental public API and make host refactors harder.
+
+## Template
+
+See `examples/plugin-template` for a minimal package that declares both a
+capability entry point and a host router entry point.

--- a/docs/PLUGIN_CONTRACT.md
+++ b/docs/PLUGIN_CONTRACT.md
@@ -113,6 +113,41 @@ contract.
 from `capabilities.*` are transitional rather than the final new SDK shape. New
 plugins should import capability primitives from `gispulse.plugins.api`.
 
+## Plugin Author Imports
+
+New plugins should prefer the curated authoring namespace over internal module
+paths:
+
+```python
+from gispulse.plugins.api import (
+    CatalogEntry,
+    Capability,
+    OGCSourceConfig,
+    PipelineExecutor,
+    PipelineSpec,
+    StepSpec,
+    fetch_wfs,
+    get_catalog_entry,
+    get_flux_entry,
+    is_angular,
+    register_capability,
+    suggest_metric_crs,
+)
+```
+
+The namespace is intentionally thin for now. It re-exports the runtime
+primitives already exercised by real plugins while keeping the supported import
+path stable for plugin authors. Direct imports from `core.*`, `catalog.*`,
+`orchestration.*`, `capabilities.*`, or `gispulse.adapters.*` should be treated
+as legacy/transitional in new plugin code.
+
+Focused submodules are also available when plugins need narrower imports:
+
+- `gispulse.plugins.pipeline`: `PipelineSpec`, `StepSpec`, `PipelineExecutor`
+- `gispulse.plugins.sources`: catalog lookup, flux entry lookup, OGC source
+  config and WFS helpers
+- `gispulse.plugins.spatial`: CRS helpers used by spatial capabilities
+
 ## Additive Host Context
 
 `RouterFactory.create(app)` remains the legacy-compatible contract. This slice
@@ -135,9 +170,9 @@ class ExampleRouterFactory:
 ```
 
 The first context is deliberately small: `app`, `settings`, `logger` and
-`plugin_hub`. Catalog/source access, spatial helpers, auth/tenant context,
-cache/storage and pipeline execution should be added only as tested follow-up
-slices for `#68`.
+`plugin_hub`. Catalog/source, spatial and pipeline primitives are exposed
+through `gispulse.plugins.api`; auth/tenant context and cache/storage remain
+future tested slices for `#68`.
 
 ## Known Limits
 
@@ -158,3 +193,18 @@ create an accidental public API and make host refactors harder.
 
 See `examples/plugin-template` for a minimal package that declares both a
 capability entry point and a host router entry point.
+
+## PR Plan
+
+The issue is the durable target. The intended PR series is:
+
+1. `#72`: add the additive `PluginHostContext`, preserve `create(app)`, and
+   document the current host contract.
+2. Add the curated plugin-author imports in `gispulse.plugins.api` and focused
+   submodules for capabilities, pipeline, sources and spatial helpers.
+3. Migrate `gispulse-permis` to the new imports for capabilities and spatial
+   pipelines first, proving that product plugins can avoid `capabilities.*`,
+   `core.pipeline` and `orchestration.*` imports.
+4. Follow with source/client and MCP-compatible plugin integration once the
+   underlying host pieces exist on the upstream base, including any API Carto or
+   `gispulse.mcp_tools` discovery work needed to make the contract real.

--- a/examples/plugin-template/README.md
+++ b/examples/plugin-template/README.md
@@ -33,7 +33,7 @@ gispulse-cap-example/
    registry.
 
 4. In full HTTP mode, GISPulse scans `gispulse.routers`, instantiates the
-   factory, calls `RouterFactory.create(app)`, and mounts the returned
+   factory, calls `RouterFactory.create(ctx)`, and mounts the returned
    `APIRouter`.
 
 The example capability uses the current `execute(gdf, **params)` shape. Do not
@@ -50,8 +50,8 @@ use the old `execute(gdf, config: dict)` signature for new capabilities.
 6. Verify: `gispulse capabilities` should list your new capability
 7. Start the HTTP host and call `/plugins/example/health`
 
-The legacy router API still accepts `RouterFactory.create(app)`. New router
-factories can opt into the additive `PluginHostContext`; see
+The legacy router API still accepts `RouterFactory.create(app)` for existing
+plugins. New router factories should use `PluginHostContext`; see
 `docs/PLUGIN_CONTRACT.md`. Keep any direct `app.state` access narrow and
 temporary.
 

--- a/examples/plugin-template/README.md
+++ b/examples/plugin-template/README.md
@@ -1,6 +1,7 @@
 # GISPulse Plugin Template
 
-This is a minimal template for creating a GISPulse capability plugin.
+This is a minimal template for creating a GISPulse external plugin on the
+current host contract.
 
 ## Structure
 
@@ -9,7 +10,8 @@ gispulse-cap-example/
   pyproject.toml                        # Package metadata + entry-point
   gispulse_cap_example/
     __init__.py                         # register() function (entry-point target)
-    capabilities.py                     # Capability classes with @register decorator
+    capabilities.py                     # Capability classes with register_capability decorator
+    routers.py                          # RouterFactory for host API extension
 ```
 
 ## How it works
@@ -18,22 +20,40 @@ gispulse-cap-example/
    ```toml
    [project.entry-points."gispulse.capabilities"]
    example = "gispulse_cap_example:register"
+
+   [project.entry-points."gispulse.routers"]
+   example = "gispulse_cap_example.routers:ExampleRouterFactory"
    ```
 
 2. When GISPulse starts, it scans the `gispulse.capabilities` entry-point group
    and calls each `register()` function.
 
 3. The `register()` function imports the capabilities module, which triggers
-   the `@register` decorator to add capabilities to the global registry.
+   the `register_capability` decorator to add capabilities to the global
+   registry.
+
+4. In full HTTP mode, GISPulse scans `gispulse.routers`, instantiates the
+   factory, calls `RouterFactory.create(app)`, and mounts the returned
+   `APIRouter`.
+
+The example capability uses the current `execute(gdf, **params)` shape. Do not
+use the old `execute(gdf, config: dict)` signature for new capabilities.
 
 ## Creating your own plugin
 
 1. Copy this template
 2. Rename `gispulse_cap_example` to `gispulse_cap_<yourname>`
 3. Update `pyproject.toml` (name, entry-point key, module path)
-4. Implement your capabilities by subclassing `Capability` and using `@register`
+4. Implement your capabilities by importing `Capability` and `register_capability`
+   from `gispulse.plugins.api`
 5. Install in development mode: `pip install -e .`
 6. Verify: `gispulse capabilities` should list your new capability
+7. Start the HTTP host and call `/plugins/example/health`
+
+The legacy router API still accepts `RouterFactory.create(app)`. New router
+factories can opt into the additive `PluginHostContext`; see
+`docs/PLUGIN_CONTRACT.md`. Keep any direct `app.state` access narrow and
+temporary.
 
 ## Naming convention
 

--- a/examples/plugin-template/gispulse_cap_example/capabilities.py
+++ b/examples/plugin-template/gispulse_cap_example/capabilities.py
@@ -7,11 +7,10 @@ from __future__ import annotations
 
 import geopandas as gpd
 
-from capabilities.base import Capability
-from capabilities.registry import register
+from gispulse.plugins.api import Capability, register_capability
 
 
-@register
+@register_capability
 class CentroidCapability(Capability):
     """Compute the centroid of each geometry."""
 
@@ -25,7 +24,7 @@ class CentroidCapability(Capability):
             "additionalProperties": False,
         }
 
-    def execute(self, gdf: gpd.GeoDataFrame, config: dict) -> gpd.GeoDataFrame:
+    def execute(self, gdf: gpd.GeoDataFrame, **_params: object) -> gpd.GeoDataFrame:
         result = gdf.copy()
         result["geometry"] = result.geometry.centroid
         return result

--- a/examples/plugin-template/gispulse_cap_example/routers.py
+++ b/examples/plugin-template/gispulse_cap_example/routers.py
@@ -1,10 +1,10 @@
-"""Example host router factory for the current PluginHub contract."""
+"""Example host router factory for the typed PluginHostContext contract."""
 
 from __future__ import annotations
 
-from typing import Any
-
 from fastapi import APIRouter
+
+from gispulse.plugins.api import PluginHostContext
 
 
 class ExampleRouterFactory:
@@ -12,7 +12,8 @@ class ExampleRouterFactory:
 
     name = "example"
 
-    def create(self, app: Any) -> APIRouter:
+    def create(self, ctx: PluginHostContext) -> APIRouter:
+        ctx.logger.debug("example_plugin_router_mounting")
         router = APIRouter(prefix="/plugins/example", tags=["plugins"])
 
         @router.get("/health")

--- a/examples/plugin-template/gispulse_cap_example/routers.py
+++ b/examples/plugin-template/gispulse_cap_example/routers.py
@@ -1,0 +1,22 @@
+"""Example host router factory for the current PluginHub contract."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter
+
+
+class ExampleRouterFactory:
+    """Factory loaded from the ``gispulse.routers`` entry-point group."""
+
+    name = "example"
+
+    def create(self, app: Any) -> APIRouter:
+        router = APIRouter(prefix="/plugins/example", tags=["plugins"])
+
+        @router.get("/health")
+        def health() -> dict[str, str]:
+            return {"plugin": "example", "status": "ok"}
+
+        return router

--- a/examples/plugin-template/pyproject.toml
+++ b/examples/plugin-template/pyproject.toml
@@ -8,9 +8,13 @@ version = "0.1.0"
 description = "Example GISPulse capability plugin"
 requires-python = ">=3.10"
 dependencies = [
+    "fastapi>=0.100,<1.0",
     "geopandas>=0.14",
 ]
 
-# This is the key: register the entry-point so GISPulse discovers the plugin
+# Register entry-points so GISPulse discovers the plugin.
 [project.entry-points."gispulse.capabilities"]
 example = "gispulse_cap_example:register"
+
+[project.entry-points."gispulse.routers"]
+example = "gispulse_cap_example.routers:ExampleRouterFactory"

--- a/gispulse/adapters/http/app.py
+++ b/gispulse/adapters/http/app.py
@@ -17,6 +17,7 @@ import os
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, Literal
+from typing import get_type_hints
 
 from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request
 
@@ -154,16 +155,28 @@ def _create_plugin_router(
     """Create a plugin router with context support and legacy fallback."""
     parameters = list(inspect.signature(factory.create).parameters.values())
     first_param = parameters[0] if parameters else None
-    wants_context = (
-        first_param is not None
-        and (
-            first_param.annotation is PluginHostContext
-            or first_param.name in {"context", "ctx", "host_context", "plugin_context"}
-        )
+    wants_context = first_param is not None and _plugin_factory_wants_context(
+        factory.create,
+        first_param,
     )
     if wants_context:
         return factory.create(context)  # type: ignore[arg-type]
     return factory.create(app)
+
+
+def _plugin_factory_wants_context(method: Any, first_param: inspect.Parameter) -> bool:
+    if first_param.name in {"context", "ctx", "host_context", "plugin_context"}:
+        return True
+    if first_param.annotation is PluginHostContext:
+        return True
+    if isinstance(first_param.annotation, str):
+        normalized = first_param.annotation.strip("'\"").rsplit(".", 1)[-1]
+        if normalized == "PluginHostContext":
+            return True
+    try:
+        return get_type_hints(method).get(first_param.name) is PluginHostContext
+    except Exception:
+        return False
 
 
 def create_app(

--- a/gispulse/adapters/http/app.py
+++ b/gispulse/adapters/http/app.py
@@ -12,14 +12,16 @@ variable (comma-separated list of valid keys). Absent or empty = auth disabled
 
 from __future__ import annotations
 
+import inspect
 import os
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, Literal
 
-from fastapi import Depends, FastAPI, HTTPException, Request
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request
 
 from core.config import settings as cfg
+from core.plugin_contracts import PluginHostContext, RouterFactory
 from fastapi.responses import HTMLResponse, PlainTextResponse
 from fastapi.staticfiles import StaticFiles
 
@@ -142,6 +144,26 @@ def _setup_cors(app: FastAPI, origins: list[str]) -> None:
         allow_headers=["*"],
         allow_credentials=allow_creds,
     )
+
+
+def _create_plugin_router(
+    factory: RouterFactory,
+    app: FastAPI,
+    context: PluginHostContext,
+) -> APIRouter | None:
+    """Create a plugin router with context support and legacy fallback."""
+    parameters = list(inspect.signature(factory.create).parameters.values())
+    first_param = parameters[0] if parameters else None
+    wants_context = (
+        first_param is not None
+        and (
+            first_param.annotation is PluginHostContext
+            or first_param.name in {"context", "ctx", "host_context", "plugin_context"}
+        )
+    )
+    if wants_context:
+        return factory.create(context)  # type: ignore[arg-type]
+    return factory.create(app)
 
 
 def create_app(
@@ -801,9 +823,16 @@ def create_app(
         from core.plugin_hub import PluginHub
 
         hub = PluginHub.get()
+        plugin_context = PluginHostContext(
+            app=app,
+            settings=cfg,
+            logger=log,
+            plugin_hub=hub,
+        )
+        app.state.plugin_host_context = plugin_context
         for plugin_name, factory in hub.routers.items():
             try:
-                router = factory.create(app)
+                router = _create_plugin_router(factory, app, plugin_context)
             except Exception as exc:
                 log.warning("plugin_router_create_failed", plugin=plugin_name, error=str(exc))
                 continue

--- a/gispulse/plugins/__init__.py
+++ b/gispulse/plugins/__init__.py
@@ -1,5 +1,35 @@
 """Curated plugin-author API for GISPulse extensions."""
 
-from gispulse.plugins.api import Capability, PluginHostContext, register_capability
+from gispulse.plugins.api import (
+    CatalogEntry,
+    Capability,
+    FluxEntry,
+    OGCSourceConfig,
+    PipelineExecutor,
+    PipelineSpec,
+    PluginHostContext,
+    StepSpec,
+    fetch_wfs,
+    get_catalog_entry,
+    get_flux_entry,
+    is_angular,
+    register_capability,
+    suggest_metric_crs,
+)
 
-__all__ = ["Capability", "PluginHostContext", "register_capability"]
+__all__ = [
+    "CatalogEntry",
+    "Capability",
+    "FluxEntry",
+    "OGCSourceConfig",
+    "PipelineExecutor",
+    "PipelineSpec",
+    "PluginHostContext",
+    "StepSpec",
+    "fetch_wfs",
+    "get_catalog_entry",
+    "get_flux_entry",
+    "is_angular",
+    "register_capability",
+    "suggest_metric_crs",
+]

--- a/gispulse/plugins/__init__.py
+++ b/gispulse/plugins/__init__.py
@@ -1,0 +1,5 @@
+"""Curated plugin-author API for GISPulse extensions."""
+
+from gispulse.plugins.api import Capability, PluginHostContext, register_capability
+
+__all__ = ["Capability", "PluginHostContext", "register_capability"]

--- a/gispulse/plugins/__init__.py
+++ b/gispulse/plugins/__init__.py
@@ -1,35 +1,19 @@
 """Curated plugin-author API for GISPulse extensions."""
 
 from gispulse.plugins.api import (
-    CatalogEntry,
-    Capability,
-    FluxEntry,
-    OGCSourceConfig,
-    PipelineExecutor,
-    PipelineSpec,
-    PluginHostContext,
-    StepSpec,
-    fetch_wfs,
-    get_catalog_entry,
-    get_flux_entry,
-    is_angular,
-    register_capability,
-    suggest_metric_crs,
+    __all__ as _API_ALL,
+    Capability as Capability,
+    PluginHostContext as PluginHostContext,
+    register_capability as register_capability,
 )
 
-__all__ = [
-    "CatalogEntry",
-    "Capability",
-    "FluxEntry",
-    "OGCSourceConfig",
-    "PipelineExecutor",
-    "PipelineSpec",
-    "PluginHostContext",
-    "StepSpec",
-    "fetch_wfs",
-    "get_catalog_entry",
-    "get_flux_entry",
-    "is_angular",
-    "register_capability",
-    "suggest_metric_crs",
-]
+
+def __getattr__(name: str) -> object:
+    from gispulse.plugins import api
+
+    value = getattr(api, name)
+    globals()[name] = value
+    return value
+
+
+__all__ = list(_API_ALL)

--- a/gispulse/plugins/api.py
+++ b/gispulse/plugins/api.py
@@ -7,5 +7,30 @@ keeps its existing internal module layout.
 from capabilities.base import Capability
 from capabilities.registry import register as register_capability
 from core.plugin_contracts import PluginHostContext
+from gispulse.plugins.pipeline import PipelineExecutor, PipelineSpec, StepSpec
+from gispulse.plugins.sources import (
+    CatalogEntry,
+    FluxEntry,
+    OGCSourceConfig,
+    fetch_wfs,
+    get_catalog_entry,
+    get_flux_entry,
+)
+from gispulse.plugins.spatial import is_angular, suggest_metric_crs
 
-__all__ = ["Capability", "PluginHostContext", "register_capability"]
+__all__ = [
+    "CatalogEntry",
+    "Capability",
+    "FluxEntry",
+    "OGCSourceConfig",
+    "PipelineExecutor",
+    "PipelineSpec",
+    "PluginHostContext",
+    "StepSpec",
+    "fetch_wfs",
+    "get_catalog_entry",
+    "get_flux_entry",
+    "is_angular",
+    "register_capability",
+    "suggest_metric_crs",
+]

--- a/gispulse/plugins/api.py
+++ b/gispulse/plugins/api.py
@@ -7,30 +7,35 @@ keeps its existing internal module layout.
 from capabilities.base import Capability
 from capabilities.registry import register as register_capability
 from core.plugin_contracts import PluginHostContext
-from gispulse.plugins.pipeline import PipelineExecutor, PipelineSpec, StepSpec
-from gispulse.plugins.sources import (
-    CatalogEntry,
-    FluxEntry,
-    OGCSourceConfig,
-    fetch_wfs,
-    get_catalog_entry,
-    get_flux_entry,
-)
-from gispulse.plugins.spatial import is_angular, suggest_metric_crs
+
+_LAZY_EXPORTS = {
+    "CatalogEntry": "gispulse.plugins.sources",
+    "FluxEntry": "gispulse.plugins.sources",
+    "OGCSourceConfig": "gispulse.plugins.sources",
+    "fetch_wfs": "gispulse.plugins.sources",
+    "get_catalog_entry": "gispulse.plugins.sources",
+    "get_flux_entry": "gispulse.plugins.sources",
+    "PipelineExecutor": "gispulse.plugins.pipeline",
+    "PipelineSpec": "gispulse.plugins.pipeline",
+    "StepSpec": "gispulse.plugins.pipeline",
+    "is_angular": "gispulse.plugins.spatial",
+    "suggest_metric_crs": "gispulse.plugins.spatial",
+}
+
+
+def __getattr__(name: str) -> object:
+    module_name = _LAZY_EXPORTS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    from importlib import import_module
+
+    value = getattr(import_module(module_name), name)
+    globals()[name] = value
+    return value
 
 __all__ = [
-    "CatalogEntry",
     "Capability",
-    "FluxEntry",
-    "OGCSourceConfig",
-    "PipelineExecutor",
-    "PipelineSpec",
     "PluginHostContext",
-    "StepSpec",
-    "fetch_wfs",
-    "get_catalog_entry",
-    "get_flux_entry",
-    "is_angular",
     "register_capability",
-    "suggest_metric_crs",
+    *_LAZY_EXPORTS,
 ]

--- a/gispulse/plugins/api.py
+++ b/gispulse/plugins/api.py
@@ -1,0 +1,11 @@
+"""Transitional public API for external GISPulse plugin authors.
+
+The goal is to give plugins one documented import path while the runtime
+keeps its existing internal module layout.
+"""
+
+from capabilities.base import Capability
+from capabilities.registry import register as register_capability
+from core.plugin_contracts import PluginHostContext
+
+__all__ = ["Capability", "PluginHostContext", "register_capability"]

--- a/gispulse/plugins/pipeline.py
+++ b/gispulse/plugins/pipeline.py
@@ -1,0 +1,8 @@
+"""Pipeline primitives supported for external plugin authors."""
+
+from __future__ import annotations
+
+from core.pipeline import PipelineSpec, StepSpec
+from orchestration.pipeline_executor import PipelineExecutor
+
+__all__ = ["PipelineExecutor", "PipelineSpec", "StepSpec"]

--- a/gispulse/plugins/sources.py
+++ b/gispulse/plugins/sources.py
@@ -1,0 +1,31 @@
+"""Catalog and source-client primitives supported for plugin authors."""
+
+from __future__ import annotations
+
+from catalog import registry
+from catalog.models import CatalogEntry, FluxEntry
+from core.models import OGCSourceConfig
+from gispulse.adapters.ogc.wfs_client import fetch_wfs
+
+
+def get_catalog_entry(entry_id: str) -> CatalogEntry | None:
+    """Return a catalog entry by id through the host catalog registry."""
+    return registry.get_entry(entry_id)
+
+
+def get_flux_entry(entry_id: str) -> FluxEntry | None:
+    """Return a flux catalog entry by id, or None when the entry is absent or another type."""
+    entry = get_catalog_entry(entry_id)
+    if isinstance(entry, FluxEntry):
+        return entry
+    return None
+
+
+__all__ = [
+    "CatalogEntry",
+    "FluxEntry",
+    "OGCSourceConfig",
+    "fetch_wfs",
+    "get_catalog_entry",
+    "get_flux_entry",
+]

--- a/gispulse/plugins/spatial.py
+++ b/gispulse/plugins/spatial.py
@@ -1,0 +1,7 @@
+"""Spatial helper primitives supported for external plugin authors."""
+
+from __future__ import annotations
+
+from core.crs import is_angular, suggest_metric_crs
+
+__all__ = ["is_angular", "suggest_metric_crs"]

--- a/tests/unit/test_plugin_api.py
+++ b/tests/unit/test_plugin_api.py
@@ -3,6 +3,20 @@
 from __future__ import annotations
 
 
+def test_plugin_api_core_imports_do_not_eagerly_import_source_clients() -> None:
+    import sys
+
+    sys.modules.pop("gispulse.plugins.api", None)
+    sys.modules.pop("gispulse.plugins.sources", None)
+
+    from gispulse.plugins.api import Capability, PluginHostContext, register_capability
+
+    assert Capability is not None
+    assert PluginHostContext is not None
+    assert register_capability is not None
+    assert "gispulse.plugins.sources" not in sys.modules
+
+
 def test_plugin_api_reexports_curated_runtime_primitives() -> None:
     from capabilities.base import Capability
     from capabilities.registry import register

--- a/tests/unit/test_plugin_api.py
+++ b/tests/unit/test_plugin_api.py
@@ -1,0 +1,100 @@
+"""Tests for the curated plugin-author import surface."""
+
+from __future__ import annotations
+
+
+def test_plugin_api_reexports_curated_runtime_primitives() -> None:
+    from capabilities.base import Capability
+    from capabilities.registry import register
+    from catalog.models import CatalogEntry, FluxEntry
+    from core.crs import is_angular, suggest_metric_crs
+    from core.models import OGCSourceConfig
+    from core.pipeline import PipelineSpec, StepSpec
+    from core.plugin_contracts import PluginHostContext
+    from gispulse.adapters.ogc.wfs_client import fetch_wfs
+    from gispulse.plugins import api
+    from orchestration.pipeline_executor import PipelineExecutor
+
+    assert api.Capability is Capability
+    assert api.register_capability is register
+    assert api.PluginHostContext is PluginHostContext
+    assert api.CatalogEntry is CatalogEntry
+    assert api.PipelineSpec is PipelineSpec
+    assert api.StepSpec is StepSpec
+    assert api.PipelineExecutor is PipelineExecutor
+    assert api.FluxEntry is FluxEntry
+    assert api.OGCSourceConfig is OGCSourceConfig
+    assert api.fetch_wfs is fetch_wfs
+    assert api.is_angular is is_angular
+    assert api.suggest_metric_crs is suggest_metric_crs
+
+
+def test_plugin_submodules_reexport_curated_runtime_primitives() -> None:
+    from catalog.models import CatalogEntry, FluxEntry
+    from core.crs import is_angular, suggest_metric_crs
+    from core.models import OGCSourceConfig
+    from core.pipeline import PipelineSpec, StepSpec
+    from gispulse.adapters.ogc.wfs_client import fetch_wfs
+    from gispulse.plugins import pipeline, sources, spatial
+    from orchestration.pipeline_executor import PipelineExecutor
+
+    assert pipeline.PipelineSpec is PipelineSpec
+    assert pipeline.StepSpec is StepSpec
+    assert pipeline.PipelineExecutor is PipelineExecutor
+    assert sources.FluxEntry is FluxEntry
+    assert sources.CatalogEntry is CatalogEntry
+    assert sources.OGCSourceConfig is OGCSourceConfig
+    assert sources.fetch_wfs is fetch_wfs
+    assert spatial.is_angular is is_angular
+    assert spatial.suggest_metric_crs is suggest_metric_crs
+
+
+def test_get_catalog_entry_delegates_to_catalog_registry(monkeypatch) -> None:
+    from catalog.models import CatalogDomain, CatalogEntry
+    from gispulse.plugins import sources
+
+    expected = CatalogEntry(
+        id="flux:example:roads",
+        domain=CatalogDomain.FLUX,
+        provider="example",
+        name="Roads",
+    )
+    calls: list[str] = []
+
+    def fake_get_entry(entry_id: str) -> CatalogEntry:
+        calls.append(entry_id)
+        return expected
+
+    monkeypatch.setattr(sources.registry, "get_entry", fake_get_entry)
+
+    assert sources.get_catalog_entry("flux:example:roads") is expected
+    assert calls == ["flux:example:roads"]
+
+
+def test_get_flux_entry_returns_only_flux_entries(monkeypatch) -> None:
+    from catalog.models import CatalogDomain, CatalogEntry, FluxEntry, FluxProtocol
+    from gispulse.plugins import sources
+
+    flux = FluxEntry(
+        id="flux:example:roads",
+        domain=CatalogDomain.FLUX,
+        provider="example",
+        name="Roads",
+        protocol=FluxProtocol.WFS,
+    )
+    projection = CatalogEntry(
+        id="projection:example:lambert",
+        domain=CatalogDomain.PROJECTION,
+        provider="example",
+        name="Lambert",
+    )
+    entries = {
+        flux.id: flux,
+        projection.id: projection,
+    }
+
+    monkeypatch.setattr(sources.registry, "get_entry", entries.get)
+
+    assert sources.get_flux_entry("flux:example:roads") is flux
+    assert sources.get_flux_entry("projection:example:lambert") is None
+    assert sources.get_flux_entry("missing") is None

--- a/tests/unit/test_plugin_hub.py
+++ b/tests/unit/test_plugin_hub.py
@@ -189,6 +189,24 @@ class TestPluginRouterCreation:
         assert isinstance(router, APIRouter)
         assert seen == [context]
 
+    def test_context_factory_can_be_detected_by_annotation_only(self) -> None:
+        app = FastAPI()
+        hub = plugin_hub.PluginHub()
+        context = PluginHostContext(app=app, settings=object(), logger=object(), plugin_hub=hub)
+        seen: list[PluginHostContext] = []
+
+        class AnnotatedFactory:
+            name = "annotated-context"
+
+            def create(self, host: PluginHostContext):
+                seen.append(host)
+                return APIRouter()
+
+        router = _create_plugin_router(AnnotatedFactory(), app, context)
+
+        assert isinstance(router, APIRouter)
+        assert seen == [context]
+
     def test_legacy_factory_receives_app_when_signature_is_legacy(self) -> None:
         app = FastAPI()
         hub = plugin_hub.PluginHub()

--- a/tests/unit/test_plugin_hub.py
+++ b/tests/unit/test_plugin_hub.py
@@ -10,9 +10,11 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+from fastapi import APIRouter, FastAPI
 
 from core import plugin_hub
-from core.plugin_contracts import LicenceState, PROTOCOL_VERSION
+from core.plugin_contracts import LicenceState, PluginHostContext, PROTOCOL_VERSION
+from gispulse.adapters.http.app import _create_plugin_router
 
 
 # ---------------------------------------------------------------------------
@@ -161,6 +163,70 @@ class TestPluginHubDiscovery:
         )
         hub = plugin_hub.PluginHub.get()
         assert hub.routers["needs-stripe"].create(app=None) is None
+
+
+# ---------------------------------------------------------------------------
+# Host router creation contract
+# ---------------------------------------------------------------------------
+
+
+class TestPluginRouterCreation:
+    def test_context_aware_factory_receives_plugin_host_context(self) -> None:
+        app = FastAPI()
+        hub = plugin_hub.PluginHub()
+        context = PluginHostContext(app=app, settings=object(), logger=object(), plugin_hub=hub)
+        seen: list[PluginHostContext] = []
+
+        class ContextAwareFactory:
+            name = "context-aware"
+
+            def create(self, ctx):
+                seen.append(ctx)
+                return APIRouter()
+
+        router = _create_plugin_router(ContextAwareFactory(), app, context)
+
+        assert isinstance(router, APIRouter)
+        assert seen == [context]
+
+    def test_legacy_factory_receives_app_when_signature_is_legacy(self) -> None:
+        app = FastAPI()
+        hub = plugin_hub.PluginHub()
+        context = PluginHostContext(app=app, settings=object(), logger=object(), plugin_hub=hub)
+        seen: list[FastAPI] = []
+
+        class LegacyFactory:
+            name = "legacy"
+
+            def create(self, app_arg):
+                if not isinstance(app_arg, FastAPI):
+                    raise TypeError("legacy factory expects FastAPI")
+                seen.append(app_arg)
+                return APIRouter()
+
+        router = _create_plugin_router(LegacyFactory(), app, context)
+
+        assert isinstance(router, APIRouter)
+        assert seen == [app]
+
+    def test_context_factory_type_error_is_not_treated_as_legacy_signature(self) -> None:
+        app = FastAPI()
+        hub = plugin_hub.PluginHub()
+        context = PluginHostContext(app=app, settings=object(), logger=object(), plugin_hub=hub)
+
+        class BrokenContextAwareFactory:
+            name = "broken-context-aware"
+
+            def create(self, ctx):
+                raise TypeError("plugin bug")
+
+        with pytest.raises(TypeError, match="plugin bug"):
+            _create_plugin_router(BrokenContextAwareFactory(), app, context)
+
+    def test_plugin_host_context_is_exported_from_plugin_author_api(self) -> None:
+        from gispulse.plugins.api import PluginHostContext as PublicPluginHostContext
+
+        assert PublicPluginHostContext is PluginHostContext
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_plugin_template_contract.py
+++ b/tests/unit/test_plugin_template_contract.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import inspect
 import importlib
+import logging
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -13,6 +14,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 import pytest
 
+from core.plugin_contracts import PluginHostContext
 from core import plugin_hub
 
 
@@ -70,7 +72,13 @@ def test_plugin_template_declares_mountable_router_entry_point() -> None:
         sys.path.remove(str(TEMPLATE))
 
     app = FastAPI()
-    app.include_router(ExampleRouterFactory().create(app))
+    ctx = PluginHostContext(
+        app=app,
+        settings=None,
+        logger=logging.getLogger("test.plugin_template"),
+        plugin_hub=None,
+    )
+    app.include_router(ExampleRouterFactory().create(ctx))
 
     response = TestClient(app).get("/plugins/example/health")
 
@@ -97,7 +105,13 @@ def test_plugin_template_router_is_discoverable_through_plugin_hub(
     try:
         hub = plugin_hub.PluginHub.get()
         app = FastAPI()
-        app.include_router(hub.routers["example"].create(app))
+        ctx = PluginHostContext(
+            app=app,
+            settings=None,
+            logger=logging.getLogger("test.plugin_template"),
+            plugin_hub=hub,
+        )
+        app.include_router(hub.routers["example"].create(ctx))
     finally:
         sys.path.remove(str(TEMPLATE))
         plugin_hub.PluginHub.reset()
@@ -122,6 +136,7 @@ def test_plugin_contract_document_exists_for_current_host_surface() -> None:
     assert "RouterFactory.create(app)" in content
     assert "gispulse.plugins.api" in content
     assert "PluginHostContext" in content
+    assert "PR Plan" in content
     assert "not yet the full stable SDK" in content
     assert "transitional" in content
     assert "New plugins should not treat `app.state` as a\nstable SDK" in content

--- a/tests/unit/test_plugin_template_contract.py
+++ b/tests/unit/test_plugin_template_contract.py
@@ -1,0 +1,129 @@
+"""Contract checks for the external plugin template."""
+
+from __future__ import annotations
+
+import inspect
+import importlib
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import pytest
+
+from core import plugin_hub
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TEMPLATE = ROOT / "examples" / "plugin-template"
+
+
+@dataclass
+class _TemplateEntryPoint:
+    name: str
+    value: str
+
+    def load(self) -> Any:
+        module_name, object_name = self.value.split(":", 1)
+        module = importlib.import_module(module_name)
+        return getattr(module, object_name)
+
+
+def test_plugin_template_capability_uses_current_execute_signature() -> None:
+    from capabilities.registry import REGISTRY
+
+    source = (TEMPLATE / "gispulse_cap_example" / "capabilities.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "from gispulse.plugins.api import Capability, register_capability" in source
+    assert "from capabilities." not in source
+
+    REGISTRY._items.pop("centroid", None)
+    sys.path.insert(0, str(TEMPLATE))
+    try:
+        from gispulse_cap_example.capabilities import CentroidCapability
+    finally:
+        sys.path.remove(str(TEMPLATE))
+
+    signature = inspect.signature(CentroidCapability.execute)
+
+    assert "config" not in signature.parameters
+    assert any(
+        parameter.kind == inspect.Parameter.VAR_KEYWORD
+        for parameter in signature.parameters.values()
+    )
+
+
+def test_plugin_template_declares_mountable_router_entry_point() -> None:
+    pyproject = (TEMPLATE / "pyproject.toml").read_text(encoding="utf-8")
+
+    assert '[project.entry-points."gispulse.routers"]' in pyproject
+    assert 'example = "gispulse_cap_example.routers:ExampleRouterFactory"' in pyproject
+
+    sys.path.insert(0, str(TEMPLATE))
+    try:
+        from gispulse_cap_example.routers import ExampleRouterFactory
+    finally:
+        sys.path.remove(str(TEMPLATE))
+
+    app = FastAPI()
+    app.include_router(ExampleRouterFactory().create(app))
+
+    response = TestClient(app).get("/plugins/example/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"plugin": "example", "status": "ok"}
+
+
+def test_plugin_template_router_is_discoverable_through_plugin_hub(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_entry_points(group: str | None = None, **_kwargs: object) -> list[_TemplateEntryPoint]:
+        if group == "gispulse.routers":
+            return [
+                _TemplateEntryPoint(
+                    "example",
+                    "gispulse_cap_example.routers:ExampleRouterFactory",
+                )
+            ]
+        return []
+
+    monkeypatch.setattr(plugin_hub, "entry_points", fake_entry_points)
+    plugin_hub.PluginHub.reset()
+    sys.path.insert(0, str(TEMPLATE))
+    try:
+        hub = plugin_hub.PluginHub.get()
+        app = FastAPI()
+        app.include_router(hub.routers["example"].create(app))
+    finally:
+        sys.path.remove(str(TEMPLATE))
+        plugin_hub.PluginHub.reset()
+
+    response = TestClient(app).get("/plugins/example/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"plugin": "example", "status": "ok"}
+
+
+def test_plugin_contract_document_exists_for_current_host_surface() -> None:
+    doc = ROOT / "docs" / "PLUGIN_CONTRACT.md"
+
+    content = doc.read_text(encoding="utf-8")
+
+    assert "https://github.com/imagodata/gispulse/issues/68" in content
+    assert "Refs #68" in content
+    assert "gispulse.routers" in content
+    assert "gispulse.mcp_tools" in content
+    assert "observed in the Permis Check integration" in content
+    assert "does not prove or stabilize it" in content
+    assert "RouterFactory.create(app)" in content
+    assert "gispulse.plugins.api" in content
+    assert "PluginHostContext" in content
+    assert "not yet the full stable SDK" in content
+    assert "transitional" in content
+    assert "New plugins should not treat `app.state` as a\nstable SDK" in content
+    assert "temporary escape hatch" in content
+    assert "`core.*`, `catalog.*`, `orchestration.*`" in content


### PR DESCRIPTION
## Summary

Refs #68.

This is PR 2 in the plugin SDK contract series and is stacked on #72. Until #72 is merged, this PR includes the host-context commits in its diff when viewed against main.

Changes:
- adds the curated plugin-author submodules `gispulse.plugins.pipeline`, `gispulse.plugins.sources`, and `gispulse.plugins.spatial`;
- expands `gispulse.plugins.api` / `gispulse.plugins` re-exports for capability, pipeline, catalog/WFS, and CRS primitives that real plugins already use;
- updates the plugin template to use `PluginHostContext` as the new router-factory shape;
- documents the 4-PR plan for #68.

This intentionally does not export API Carto yet, because that adapter is introduced by the catalog-source PR and is not present on the upstream main base.

## Validation

- `uv run pytest tests/unit/test_plugin_api.py tests/unit/test_plugin_discovery.py tests/unit/test_plugin_hub.py tests/unit/test_plugin_template_contract.py -q`
- `uv run ruff check examples/plugin-template/gispulse_cap_example/routers.py gispulse/plugins/__init__.py gispulse/plugins/api.py gispulse/plugins/pipeline.py gispulse/plugins/sources.py gispulse/plugins/spatial.py tests/unit/test_plugin_api.py tests/unit/test_plugin_template_contract.py`