### PR TITLE
feat(qgis-plugin): non-blocking gispulse runner + streamed coloured logs (v1.4-4)

### DIFF
--- a/qgis_plugin/runtime/__init__.py
+++ b/qgis_plugin/runtime/__init__.py
@@ -1,3 +1,12 @@
 from .detector import DetectorResult, detect_gispulse, install_hint
+from .log_format import LogLevel, format_log_html, log_file_path, parse_log_level
 
-__all__ = ["DetectorResult", "detect_gispulse", "install_hint"]
+__all__ = [
+    "DetectorResult",
+    "LogLevel",
+    "detect_gispulse",
+    "format_log_html",
+    "install_hint",
+    "log_file_path",
+    "parse_log_level",
+]

--- a/qgis_plugin/runtime/log_format.py
+++ b/qgis_plugin/runtime/log_format.py
@@ -1,0 +1,78 @@
+"""Pure-Python log helpers for the Attach-trigger runner.
+
+Lives in its own module so the parsing/colouring logic can be unit
+tested without pulling Qt. The dock widget consumes these to render
+streamed lines in a `QTextEdit`.
+"""
+
+from __future__ import annotations
+
+import enum
+import re
+from datetime import datetime
+from pathlib import Path
+
+
+class LogLevel(enum.Enum):
+    INFO = "INFO"
+    WARN = "WARN"
+    ERROR = "ERROR"
+
+
+# Hex colours chosen so the same values look reasonable on QGIS' light
+# AND dark themes. Not WCAG AAA but acceptable for ephemeral console
+# output; see PaletteFor follow-up if a11y complaints surface.
+LEVEL_COLOR: dict[LogLevel, str] = {
+    LogLevel.INFO: "#1f8a3a",
+    LogLevel.WARN: "#c97a00",
+    LogLevel.ERROR: "#b00020",
+}
+
+
+# Match the structlog/json formats gispulse emits, plus plain `LEVEL:`
+# prefixes from third-party libraries. The order matters: we check the
+# more specific patterns first.
+_PATTERNS: tuple[tuple[re.Pattern[str], LogLevel], ...] = (
+    (re.compile(r"\[(error|err|critical|fatal)\]", re.IGNORECASE), LogLevel.ERROR),
+    (re.compile(r"\[(warn|warning)\]", re.IGNORECASE), LogLevel.WARN),
+    (re.compile(r"\b(error|critical|fatal|traceback)\b[: ]", re.IGNORECASE), LogLevel.ERROR),
+    (re.compile(r"\b(warn|warning)\b[: ]", re.IGNORECASE), LogLevel.WARN),
+)
+
+
+def parse_log_level(line: str) -> LogLevel:
+    """Best-effort detection of the level for a single stdout/stderr line.
+
+    Defaults to INFO when no marker is present so plain progress lines
+    don't drown the user in red. The runner uses `is_stderr=True` to
+    upgrade unknown-level stderr lines to ERROR — that decision sits in
+    the caller, not here, since stderr is sometimes used by gispulse for
+    non-error structured output.
+    """
+    for pattern, level in _PATTERNS:
+        if pattern.search(line):
+            return level
+    return LogLevel.INFO
+
+
+def format_log_html(line: str, level: LogLevel) -> str:
+    """Render a single line as colour-tagged HTML for `QTextEdit.append()`.
+
+    HTML special chars are escaped because gispulse may surface arbitrary
+    user dataset names (and `<`, `>` in WKT-ish output) which would
+    otherwise be interpreted as tags by Qt's rich-text engine.
+    """
+    safe = line.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").rstrip("\n")
+    color = LEVEL_COLOR[level]
+    return f'<span style="color:{color}; white-space:pre">{safe}</span>'
+
+
+def log_file_path(project_dir: str | Path, *, now: datetime | None = None) -> Path:
+    """Return `<project_dir>/.gispulse/runs/<UTC-timestamp>.log`.
+
+    The directory is *not* created here so the function stays pure and
+    testable. The runner does the `mkdir(parents=True, exist_ok=True)`
+    immediately before opening the handle.
+    """
+    stamp = (now or datetime.utcnow()).strftime("%Y%m%dT%H%M%SZ")
+    return Path(project_dir) / ".gispulse" / "runs" / f"{stamp}.log"

--- a/qgis_plugin/runtime/runner.py
+++ b/qgis_plugin/runtime/runner.py
@@ -1,0 +1,160 @@
+"""Non-blocking gispulse trigger runner backed by `QProcess`.
+
+`subprocess.Popen` blocks the QGIS event loop while polling stdout, so
+we use `QProcess` and connect to `readyReadStandardOutput` /
+`readyReadStandardError` to push lines into the dock widget as they
+arrive. Streaming latency is the MVP's load-bearing UX promise:
+"`[Running…]` frozen for 30 seconds" is the failure mode we're avoiding.
+"""
+
+from __future__ import annotations
+
+import shlex
+from datetime import datetime
+from pathlib import Path
+
+from .log_format import LogLevel, log_file_path, parse_log_level
+
+# Time we give the child to react to SIGTERM before escalating to SIGKILL.
+# Longer than gispulse's own shutdown grace so well-behaved runs flush
+# their state, short enough that hitting Cancel still feels responsive.
+KILL_GRACE_MS = 5_000
+
+
+def build_command(*, exe: str, rules_path: str, dataset_path: str) -> list[str]:
+    """Compose the argv for `gispulse triggers run`. Kept Qt-free so the
+    test suite can assert the contract without spinning up QProcess.
+    """
+    return [exe, "triggers", "run", "--rules", rules_path, "--dataset", dataset_path]
+
+
+def shell_repr(argv: list[str]) -> str:
+    """Render argv as a single, copy-pasteable shell line for the log
+    file header. Uses `shlex.join` so paths with spaces stay quoted.
+    """
+    return shlex.join(argv)
+
+
+def _qprocess_imports():
+    from qgis.PyQt.QtCore import QObject, QProcess, QTimer, pyqtSignal
+
+    return QObject, QProcess, QTimer, pyqtSignal
+
+
+def make_runner_class():
+    """Build `GispulseRunner` lazily so importing this module doesn't
+    require Qt — keeps the rest of `runtime/` unit-testable in CI.
+    """
+    QObject, QProcess, QTimer, pyqtSignal = _qprocess_imports()
+
+    class GispulseRunner(QObject):
+        log_line = pyqtSignal(str, str)  # (line, level_name)
+        finished = pyqtSignal(int)  # exit code
+        started = pyqtSignal()
+
+        def __init__(self, parent=None) -> None:
+            super().__init__(parent)
+            self._proc: QProcess | None = None
+            self._kill_timer: QTimer | None = None
+            self._log_handle = None
+            self._cancelled = False
+
+        def is_running(self) -> bool:
+            return self._proc is not None and self._proc.state() != QProcess.NotRunning
+
+        def start(
+            self,
+            *,
+            exe: str,
+            rules_path: str,
+            dataset_path: str,
+            project_dir: str | Path,
+        ) -> None:
+            if self.is_running():
+                raise RuntimeError("a runner is already in progress")
+            self._cancelled = False
+            argv = build_command(exe=exe, rules_path=rules_path, dataset_path=dataset_path)
+            log_path = log_file_path(project_dir, now=datetime.utcnow())
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            self._log_handle = log_path.open("w", encoding="utf-8")
+            self._log_handle.write(f"# {shell_repr(argv)}\n")
+            self._log_handle.flush()
+
+            self._proc = QProcess(self)
+            self._proc.setProcessChannelMode(QProcess.SeparateChannels)
+            self._proc.readyReadStandardOutput.connect(self._on_stdout)
+            self._proc.readyReadStandardError.connect(self._on_stderr)
+            self._proc.finished.connect(self._on_finished)
+            self._proc.errorOccurred.connect(self._on_error)
+            self._proc.start(argv[0], argv[1:])
+            self.started.emit()
+
+        def cancel(self) -> None:
+            if not self.is_running():
+                return
+            self._cancelled = True
+            assert self._proc is not None
+            self._proc.terminate()
+            timer = QTimer(self)
+            timer.setSingleShot(True)
+            timer.timeout.connect(self._kill_if_running)
+            timer.start(KILL_GRACE_MS)
+            self._kill_timer = timer
+
+        # ─── slots ────────────────────────────────────────────────
+
+        def _on_stdout(self) -> None:
+            assert self._proc is not None
+            data = bytes(self._proc.readAllStandardOutput()).decode("utf-8", "replace")
+            self._emit_lines(data, is_stderr=False)
+
+        def _on_stderr(self) -> None:
+            assert self._proc is not None
+            data = bytes(self._proc.readAllStandardError()).decode("utf-8", "replace")
+            self._emit_lines(data, is_stderr=True)
+
+        def _emit_lines(self, data: str, *, is_stderr: bool) -> None:
+            for raw in data.splitlines():
+                if not raw:
+                    continue
+                level = parse_log_level(raw)
+                # gispulse uses stderr for structured progress AND errors;
+                # only escalate when the line itself doesn't already
+                # carry an explicit level marker.
+                if is_stderr and level is LogLevel.INFO:
+                    level = LogLevel.WARN
+                if self._log_handle is not None:
+                    self._log_handle.write(raw + "\n")
+                    self._log_handle.flush()
+                self.log_line.emit(raw, level.value)
+
+        def _on_finished(self, exit_code: int, _exit_status: int) -> None:
+            self._teardown()
+            code = exit_code if not self._cancelled else 130  # convention: "user cancelled"
+            self.finished.emit(code)
+
+        def _on_error(self, _err: int) -> None:
+            # `errorOccurred` fires for FailedToStart, Crashed, etc. We
+            # let `finished` handle the cleanup; this slot just records
+            # a diagnostic line.
+            assert self._proc is not None
+            msg = self._proc.errorString()
+            self.log_line.emit(f"[error] {msg}", LogLevel.ERROR.value)
+
+        def _kill_if_running(self) -> None:
+            if self.is_running():
+                assert self._proc is not None
+                self._proc.kill()
+
+        def _teardown(self) -> None:
+            if self._log_handle is not None:
+                try:
+                    self._log_handle.close()
+                except OSError:
+                    pass
+                self._log_handle = None
+            if self._kill_timer is not None:
+                self._kill_timer.stop()
+                self._kill_timer = None
+
+    return GispulseRunner

--- a/qgis_plugin/ui/dock_widget.py
+++ b/qgis_plugin/ui/dock_widget.py
@@ -1,21 +1,35 @@
-"""Attach-trigger dock widget (issue v1.4-3).
+"""Attach-trigger dock widget (issues v1.4-3 + v1.4-4).
 
-UI surface only — running the trigger is done in v1.4-4 (#470). The
-"Run trigger" button is wired to a no-op stub that the runner story
-will replace.
+UI surface and live runner integration:
+
+* layer + rules picker, vector-only gate, persisted custom properties
+  (v1.4-3)
+* QProcess-backed gispulse runner with streamed coloured logs, Cancel
+  with SIGTERM→SIGKILL escalation, success/error status banner, and a
+  Pause-autoscroll toggle (v1.4-4)
+
+Pure validation/state logic lives in `state.py`; subprocess wrapping in
+`runtime/runner.py`. This module is the Qt glue between them.
 """
 
 from __future__ import annotations
 
+import tempfile
+from pathlib import Path
+
+from ..runtime import LogLevel, detect_gispulse, format_log_html
+from ..runtime.error_dialog import show_install_dialog
+from ..runtime.runner import make_runner_class
 from .state import CUSTOM_PROPERTY_KEY, AttachState
 
 
 def _qgis_imports():
-    """Lazy import so unit tests on the Qt-free `state` module don't pull
-    in QGIS bindings."""
-    from qgis.core import QgsMapLayer, QgsProject
+    """Lazy import so unit tests on the Qt-free `state` / `log_format`
+    modules don't pull in QGIS bindings."""
+    from qgis.core import QgsMapLayer, QgsProject, QgsVectorFileWriter
     from qgis.PyQt.QtCore import Qt
     from qgis.PyQt.QtWidgets import (
+        QCheckBox,
         QComboBox,
         QDockWidget,
         QFileDialog,
@@ -30,7 +44,9 @@ def _qgis_imports():
     return {
         "QgsMapLayer": QgsMapLayer,
         "QgsProject": QgsProject,
+        "QgsVectorFileWriter": QgsVectorFileWriter,
         "Qt": Qt,
+        "QCheckBox": QCheckBox,
         "QComboBox": QComboBox,
         "QDockWidget": QDockWidget,
         "QFileDialog": QFileDialog,
@@ -47,7 +63,9 @@ def build_dock_widget(parent):
     q = _qgis_imports()
     QgsMapLayer = q["QgsMapLayer"]
     QgsProject = q["QgsProject"]
+    QgsVectorFileWriter = q["QgsVectorFileWriter"]
     Qt = q["Qt"]
+    GispulseRunner = make_runner_class()
 
     dock = q["QDockWidget"](_tr("GISPulse"), parent)
     dock.setObjectName("GISPulseDock")
@@ -77,20 +95,43 @@ def build_dock_widget(parent):
     rules_msg.setStyleSheet("color: #b00;")
     layout.addWidget(rules_msg)
 
-    # Preview
+    # Preview (rules YAML)
     layout.addWidget(q["QLabel"](_tr("Preview:")))
     preview = q["QTextEdit"](container)
     preview.setReadOnly(True)
     preview.setLineWrapMode(q["QTextEdit"].NoWrap)
     layout.addWidget(preview, stretch=1)
 
-    # Run button
+    # Run / Cancel + autoscroll
+    button_row = q["QHBoxLayout"]()
     run_btn = q["QPushButton"](_tr("Run trigger"), container)
     run_btn.setEnabled(False)
-    layout.addWidget(run_btn)
+    cancel_btn = q["QPushButton"](_tr("Cancel"), container)
+    cancel_btn.setEnabled(False)
+    autoscroll = q["QCheckBox"](_tr("Autoscroll"), container)
+    autoscroll.setChecked(True)
+    button_row.addWidget(run_btn, stretch=1)
+    button_row.addWidget(cancel_btn)
+    button_row.addWidget(autoscroll)
+    layout.addLayout(button_row)
+
+    # Status banner
+    status = q["QLabel"]("", container)
+    status.setVisible(False)
+    layout.addWidget(status)
+
+    # Live logs area
+    layout.addWidget(q["QLabel"](_tr("Logs:")))
+    logs = q["QTextEdit"](container)
+    logs.setReadOnly(True)
+    logs.setLineWrapMode(q["QTextEdit"].NoWrap)
+    logs.setStyleSheet("font-family: monospace;")
+    layout.addWidget(logs, stretch=2)
 
     container.setLayout(layout)
     dock.setWidget(container)
+
+    runner = GispulseRunner(container)
 
     # ─── helpers ─────────────────────────────────────────────────────
 
@@ -98,7 +139,7 @@ def build_dock_widget(parent):
         layer_msg.setText(state.layer_message())
         v = state.rules_validation()
         rules_msg.setText(v.message)
-        run_btn.setEnabled(state.can_run())
+        run_btn.setEnabled(state.can_run() and not runner.is_running())
 
     def _populate_layers() -> None:
         layer_combo.blockSignals(True)
@@ -155,16 +196,85 @@ def build_dock_widget(parent):
         if path:
             _set_rules_path(path)
 
+    def _show_status(text: str, color: str) -> None:
+        status.setText(text)
+        status.setStyleSheet(f"padding: 4px; color: white; background-color: {color};")
+        status.setVisible(True)
+
+    def _project_dir() -> str:
+        path = QgsProject.instance().homePath()
+        return path or tempfile.gettempdir()
+
+    def _export_layer_to_gpkg(layer_id: str) -> str | None:
+        layer = QgsProject.instance().mapLayer(layer_id)
+        if layer is None:
+            return None
+        out = Path(tempfile.gettempdir()) / f"gispulse_{layer_id}.gpkg"
+        opts = QgsVectorFileWriter.SaveVectorOptions()
+        opts.driverName = "GPKG"
+        opts.layerName = layer.name()
+        QgsVectorFileWriter.writeAsVectorFormatV3(
+            layer, str(out), QgsProject.instance().transformContext(), opts
+        )
+        return str(out)
+
     def _on_run_clicked() -> None:
-        # Sub-process runner lands in v1.4-4 (#470). For now, emit a
-        # human-readable line into the preview so the wiring is visible.
-        preview.append(f"\n# [v1.4-3 stub] would run gispulse with {state.rules_path}\n")
+        det = detect_gispulse(use_cache=False)
+        if not det.found:
+            show_install_dialog(parent, det)
+            return
+        if not state.layer_id or not state.rules_path:
+            return
+        dataset_path = _export_layer_to_gpkg(state.layer_id)
+        if not dataset_path:
+            _show_status(_tr("Failed to export layer to GeoPackage."), "#b00020")
+            return
+        logs.clear()
+        status.setVisible(False)
+        run_btn.setEnabled(False)
+        cancel_btn.setEnabled(True)
+        runner.start(
+            exe=det.path or "gispulse",
+            rules_path=state.rules_path,
+            dataset_path=dataset_path,
+            project_dir=_project_dir(),
+        )
+
+    def _on_cancel_clicked() -> None:
+        runner.cancel()
+        cancel_btn.setEnabled(False)
+
+    def _on_log_line(line: str, level_name: str) -> None:
+        try:
+            level = LogLevel[level_name]
+        except KeyError:
+            level = LogLevel.INFO
+        logs.append(format_log_html(line, level))
+        if autoscroll.isChecked():
+            scroll = logs.verticalScrollBar()
+            scroll.setValue(scroll.maximum())
+
+    def _on_finished(exit_code: int) -> None:
+        cancel_btn.setEnabled(False)
+        if exit_code == 0:
+            _show_status(_tr("Trigger completed successfully."), "#1f8a3a")
+        elif exit_code == 130:
+            _show_status(_tr("Trigger cancelled."), "#c97a00")
+        else:
+            _show_status(
+                _tr("Trigger failed (exit {code}). See logs above.").format(code=exit_code),
+                "#b00020",
+            )
+        _refresh_run_state()
 
     # ─── signals ─────────────────────────────────────────────────────
 
     layer_combo.currentIndexChanged.connect(_on_layer_changed)
     rules_btn.clicked.connect(_on_browse_clicked)
     run_btn.clicked.connect(_on_run_clicked)
+    cancel_btn.clicked.connect(_on_cancel_clicked)
+    runner.log_line.connect(_on_log_line)
+    runner.finished.connect(_on_finished)
 
     project = QgsProject.instance()
     project.layersAdded.connect(lambda *_: _populate_layers())

--- a/tests/unit/test_qgis_plugin_log_format.py
+++ b/tests/unit/test_qgis_plugin_log_format.py
@@ -1,0 +1,114 @@
+"""Unit tests for the runner's log helpers (issue v1.4-4).
+
+The QProcess wrapper itself can't be exercised without Qt; what's
+testable in pure Python — level detection, HTML escaping, log path
+generation, argv composition — lives here.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from qgis_plugin.runtime.log_format import (
+    LEVEL_COLOR,
+    LogLevel,
+    format_log_html,
+    log_file_path,
+    parse_log_level,
+)
+from qgis_plugin.runtime.runner import build_command, shell_repr
+
+
+class TestParseLogLevel:
+    @pytest.mark.parametrize(
+        "line,expected",
+        [
+            ("[info] starting trigger", LogLevel.INFO),
+            ("[INFO] starting trigger", LogLevel.INFO),
+            ("plain progress", LogLevel.INFO),
+            ("[warn] cache miss", LogLevel.WARN),
+            ("[WARNING] config defaulted", LogLevel.WARN),
+            ("warning: deprecated flag", LogLevel.WARN),
+            ("[error] connection refused", LogLevel.ERROR),
+            ("[ERR] failed to load", LogLevel.ERROR),
+            ("[critical] db down", LogLevel.ERROR),
+            ("[fatal] cannot continue", LogLevel.ERROR),
+            ("Error: cannot open dataset", LogLevel.ERROR),
+            ("Traceback (most recent call last):", LogLevel.ERROR),
+        ],
+    )
+    def test_dispatches(self, line: str, expected: LogLevel) -> None:
+        assert parse_log_level(line) is expected
+
+    def test_error_outranks_warn_when_both_present(self) -> None:
+        assert parse_log_level("[error] also a warn condition") is LogLevel.ERROR
+
+    def test_unknown_line_defaults_to_info(self) -> None:
+        assert parse_log_level("just some output") is LogLevel.INFO
+
+
+class TestFormatLogHtml:
+    def test_uses_level_color(self) -> None:
+        html = format_log_html("hello", LogLevel.INFO)
+        assert LEVEL_COLOR[LogLevel.INFO] in html
+        assert "hello" in html
+
+    def test_escapes_html_special_chars(self) -> None:
+        html = format_log_html("<script>alert(1)</script>", LogLevel.WARN)
+        # No raw `<script>` survives in the output Qt would render.
+        assert "<script>" not in html
+        assert "&lt;script&gt;" in html
+        assert "&lt;/script&gt;" in html
+
+    def test_escapes_ampersand(self) -> None:
+        html = format_log_html("a & b", LogLevel.INFO)
+        assert "a &amp; b" in html
+
+    def test_strips_trailing_newline(self) -> None:
+        html = format_log_html("trailing\n", LogLevel.INFO)
+        assert html.endswith("</span>")
+        assert "trailing\n" not in html
+        assert ">trailing<" in html
+
+
+class TestLogFilePath:
+    def test_path_layout(self, tmp_path: Path) -> None:
+        when = datetime(2026, 5, 2, 14, 30, 0)
+        p = log_file_path(tmp_path, now=when)
+        assert p.parent == tmp_path / ".gispulse" / "runs"
+        assert p.name == "20260502T143000Z.log"
+
+    def test_does_not_create_dir(self, tmp_path: Path) -> None:
+        # Function is pure; runner is responsible for mkdir.
+        p = log_file_path(tmp_path, now=datetime(2026, 1, 1))
+        assert not p.parent.exists()
+
+
+class TestBuildCommand:
+    def test_argv_shape(self) -> None:
+        argv = build_command(
+            exe="/usr/local/bin/gispulse",
+            rules_path="/tmp/rules.yml",
+            dataset_path="/tmp/data.gpkg",
+        )
+        assert argv == [
+            "/usr/local/bin/gispulse",
+            "triggers",
+            "run",
+            "--rules",
+            "/tmp/rules.yml",
+            "--dataset",
+            "/tmp/data.gpkg",
+        ]
+
+    def test_shell_repr_quotes_paths_with_spaces(self) -> None:
+        argv = build_command(
+            exe="gispulse",
+            rules_path="/tmp/with space/rules.yml",
+            dataset_path="/tmp/data.gpkg",
+        )
+        rendered = shell_repr(argv)
+        assert "'/tmp/with space/rules.yml'" in rendered


### PR DESCRIPTION
## Summary

Stacked on top of #74 (`feat/qgis-plugin-dock-widget`). Retarget to
`main` once #71 → #73 → #74 are merged.

Replaces the v1.4-3 stub Run button with a **non-blocking QProcess
runner** that streams every gispulse stdout / stderr line into the dock
as it arrives. The MVP UX promise — no frozen `[Running…]` banner — is
the load-bearing requirement of this story.

## What's new

**Runtime**
- `runtime/runner.py` lazy-builds `GispulseRunner(QObject)` (Qt only
  loaded when the dock actually opens, so the rest of `runtime/` stays
  unit-testable in CI)
- argv via `build_command()` → `gispulse triggers run --rules <yml> --dataset <gpkg>`
- per-run log file at `<project_dir>/.gispulse/runs/<UTC>.log` with the
  shell-quoted command as the first comment line
- Cancel: `terminate()` → 5s grace timer → `kill()`. Cancelled runs
  report exit code **130** (POSIX "user cancelled") so the UI can
  distinguish cancellation from real failure.
- stderr without explicit level → upgraded to WARN; explicit `[error]`
  / `Traceback` always wins

**UI** (`dock_widget`)
- exports the selected vector layer to a temp GPKG via
  `QgsVectorFileWriter.writeAsVectorFormatV3` before spawning gispulse
- coloured log area (INFO / WARN / ERROR) with HTML-escaped lines
- Autoscroll toggle (default on)
- Cancel button gated on running state
- coloured status banner: success / cancelled / failure with exit code
- gates the run on `detect_gispulse(use_cache=False)` — missing CLI
  opens the install dialog instead of spawning a doomed process

## Test plan

- [x] `python -m pytest tests/unit/test_qgis_plugin_log_format.py` → **22 passed**
- [x] Full plugin suite (`scaffold + detector + dock_state + log_format`) → **69 passed, 1 skipped**
- [x] `ruff check qgis_plugin/` → clean
- [x] `ruff format --check qgis_plugin/ tests/unit/test_qgis_plugin_log_format.py` → clean
- [ ] Manual on QGIS 3.28+: nominal run (~10s), long run (~2min), Cancel mid-run, gispulse exit 1 (deferred to reviewer per acceptance matrix in the issue)

## Out of scope

- v1.4-5 (#471) layer refresh post-run + change summary
- v1.4-6 (#472) GH Actions wheel + ZIP on tag
- multi-layer / parallel runs → v1.4.1+
- run history browser → v1.4.1+

Closes imagodata/gispulse-enterprise#470