### PR TITLE
feat(qgis-plugin): post-run change summary + auto-reload + restore (v1.4-5)

### DIFF
--- a/qgis_plugin/runtime/refresh.py
+++ b/qgis_plugin/runtime/refresh.py
@@ -1,0 +1,204 @@
+"""Layer-refresh helpers for the post-run flow (issue v1.4-5).
+
+Splits cleanly into two zones:
+
+* **pure** — `FeatureSignature`, `feature_signature`, `compute_change_summary`,
+  `format_summary`, `backup_path`. No QGIS, no I/O. Unit-tested in CI.
+* **Qt-side** — `signatures_from_qgs_layer`, `signatures_from_gpkg`,
+  `reload_layer_from_gpkg`. Lazily imported by the dock widget.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def _utc_from_timestamp(ts: float) -> datetime:
+    return datetime.fromtimestamp(ts, tz=timezone.utc).replace(tzinfo=None)
+
+
+@dataclass(frozen=True)
+class FeatureSignature:
+    """Stable fingerprint for one feature.
+
+    `attr_hash` and `geom_hash` are SHA-256 hex digests; `geom_hash` is
+    the empty string for null geometries so the diff doesn't mistake a
+    null↔null pair for a change.
+    """
+
+    fid: int
+    attr_hash: str
+    geom_hash: str
+
+
+@dataclass(frozen=True)
+class ChangeSummary:
+    added: int
+    modified: int
+    deleted: int
+    unchanged: int
+
+    @property
+    def total_changes(self) -> int:
+        return self.added + self.modified + self.deleted
+
+    @property
+    def has_changes(self) -> bool:
+        return self.total_changes > 0
+
+
+def feature_signature(
+    fid: int, attributes: Mapping[str, Any], geom_wkb: bytes | None
+) -> FeatureSignature:
+    """Hash the attribute dict + geometry WKB into a `FeatureSignature`.
+
+    Attribute values are normalised through `json.dumps(sort_keys=True,
+    default=str)` so any ordering / Decimal / datetime quirks survive a
+    round-trip without spuriously triggering "modified".
+    """
+    blob = json.dumps(dict(attributes), sort_keys=True, default=str).encode("utf-8")
+    attr_hash = hashlib.sha256(blob).hexdigest()
+    # `b""` must hash differently from `None` — an empty geometry isn't
+    # the same as a null geometry as far as the diff is concerned.
+    geom_hash = hashlib.sha256(geom_wkb).hexdigest() if geom_wkb is not None else ""
+    return FeatureSignature(fid=fid, attr_hash=attr_hash, geom_hash=geom_hash)
+
+
+def compute_change_summary(
+    before: Mapping[int, FeatureSignature],
+    after: Mapping[int, FeatureSignature],
+) -> ChangeSummary:
+    """Diff two `{fid: FeatureSignature}` snapshots.
+
+    `fid` is the join key — gispulse must preserve it across runs (the
+    GPKG provider does this by default).
+    """
+    before_fids = set(before)
+    after_fids = set(after)
+    added = len(after_fids - before_fids)
+    deleted = len(before_fids - after_fids)
+    common = before_fids & after_fids
+    modified = sum(1 for fid in common if before[fid] != after[fid])
+    unchanged = len(common) - modified
+    return ChangeSummary(added=added, modified=modified, deleted=deleted, unchanged=unchanged)
+
+
+def format_summary(summary: ChangeSummary) -> str:
+    """One-line user-facing summary, matching the issue's mock-up.
+
+    Returns a neutral message when nothing changed so the banner stays
+    truthful instead of showing a string of zeros.
+    """
+    if not summary.has_changes:
+        return "No changes detected."
+    parts: list[str] = []
+    if summary.added:
+        parts.append(f"+{summary.added} added")
+    if summary.modified:
+        parts.append(f"~{summary.modified} modified")
+    if summary.deleted:
+        parts.append(f"-{summary.deleted} deleted")
+    return " · ".join(parts)
+
+
+# Backups are kept long enough for the user to undo a run; the dock
+# widget only exposes a "Restore" button while this window is open.
+BACKUP_TTL_SECONDS = 5 * 60
+
+
+def backup_path(project_dir: str | Path, *, now: datetime | None = None) -> Path:
+    """`<project_dir>/.gispulse/backups/<UTC-timestamp>.gpkg`.
+
+    Symmetric with `log_file_path` — directory is *not* created here.
+    """
+    stamp = (now or _utcnow()).strftime("%Y%m%dT%H%M%SZ")
+    return Path(project_dir) / ".gispulse" / "backups" / f"{stamp}.gpkg"
+
+
+def make_backup(src_gpkg: str | Path, project_dir: str | Path) -> Path:
+    """Copy the temp GPKG into `.gispulse/backups/` so the user can
+    Restore. Caller is responsible for displaying the resulting path
+    (e.g. wired to a 5-minute Restore button)."""
+    dst = backup_path(project_dir)
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(src_gpkg, dst)
+    return dst
+
+
+def is_backup_within_ttl(backup: Path, *, now: datetime | None = None) -> bool:
+    """The Restore button is only useful within `BACKUP_TTL_SECONDS`.
+    Returns False if the backup is older or missing."""
+    if not backup.is_file():
+        return False
+    mtime = _utc_from_timestamp(backup.stat().st_mtime)
+    age = (now or _utcnow()) - mtime
+    return age.total_seconds() <= BACKUP_TTL_SECONDS
+
+
+# ─── Qt-side helpers (kept inert until called) ─────────────────────
+
+
+def signatures_from_qgs_layer(layer) -> dict[int, FeatureSignature]:
+    """Walk a `QgsVectorLayer` and produce `{fid: FeatureSignature}`."""
+    sigs: dict[int, FeatureSignature] = {}
+    field_names = [f.name() for f in layer.fields()]
+    for feat in layer.getFeatures():
+        attrs = {name: feat.attribute(name) for name in field_names}
+        geom = feat.geometry()
+        wkb = bytes(geom.asWkb()) if geom and not geom.isEmpty() else None
+        sigs[feat.id()] = feature_signature(feat.id(), attrs, wkb)
+    return sigs
+
+
+def signatures_from_gpkg(gpkg_path: str | Path, layer_name: str) -> dict[int, FeatureSignature]:
+    """Open a GPKG layer with `QgsVectorLayer` and snapshot it.
+
+    Lives behind a function call (not a top-level import) so the whole
+    `refresh` module stays pure-Python importable in unit tests.
+    """
+    from qgis.core import QgsVectorLayer
+
+    uri = f"{gpkg_path}|layername={layer_name}"
+    layer = QgsVectorLayer(uri, layer_name, "ogr")
+    if not layer.isValid():
+        raise RuntimeError(f"could not open GPKG layer {layer_name!r} in {gpkg_path}")
+    return signatures_from_qgs_layer(layer)
+
+
+def reload_layer_from_gpkg(layer, gpkg_path: str | Path, layer_name: str) -> None:
+    """Repoint the live QGIS layer at the (now-updated) temp GPKG and
+    refresh the canvas. Caller is responsible for guarding `layer.isEditable()`
+    before calling this."""
+    uri = f"{gpkg_path}|layername={layer_name}"
+    layer.setDataSource(uri, layer.name(), "ogr")
+    layer.dataProvider().reloadData()
+    layer.triggerRepaint()
+
+
+def restore_from_backup(layer, backup: str | Path, layer_name: str) -> None:
+    """Repoint the layer at the pre-run backup. Symmetric with
+    `reload_layer_from_gpkg` so the dock-widget Restore button is a
+    one-liner."""
+    reload_layer_from_gpkg(layer, backup, layer_name)
+
+
+def signatures_from_features(
+    features: Iterable[tuple[int, Mapping[str, Any], bytes | None]],
+) -> dict[int, FeatureSignature]:
+    """Test-helper convenience: build snapshots without QGIS by feeding
+    `(fid, attrs, geom_wkb)` triples directly.
+
+    Kept in the production module (not the test module) so downstream
+    plugins can reuse it for their own snapshots.
+    """
+    return {fid: feature_signature(fid, attrs, geom) for fid, attrs, geom in features}

--- a/qgis_plugin/ui/dock_widget.py
+++ b/qgis_plugin/ui/dock_widget.py
@@ -1,4 +1,4 @@
-"""Attach-trigger dock widget (issues v1.4-3 + v1.4-4).
+"""Attach-trigger dock widget (issues v1.4-3 + v1.4-4 + v1.4-5).
 
 UI surface and live runner integration:
 
@@ -7,9 +7,13 @@ UI surface and live runner integration:
 * QProcess-backed gispulse runner with streamed coloured logs, Cancel
   with SIGTERM→SIGKILL escalation, success/error status banner, and a
   Pause-autoscroll toggle (v1.4-4)
+* post-run change summary (added / modified / deleted), automatic layer
+  reload, edit-in-progress guard, and a 5-minute Restore button backed
+  by a `.gispulse/backups/` snapshot (v1.4-5)
 
 Pure validation/state logic lives in `state.py`; subprocess wrapping in
-`runtime/runner.py`. This module is the Qt glue between them.
+`runtime/runner.py`; diff + snapshot in `runtime/refresh.py`. This
+module is the Qt glue between them.
 """
 
 from __future__ import annotations
@@ -19,15 +23,24 @@ from pathlib import Path
 
 from ..runtime import LogLevel, detect_gispulse, format_log_html
 from ..runtime.error_dialog import show_install_dialog
+from ..runtime.refresh import (
+    compute_change_summary,
+    format_summary,
+    make_backup,
+    reload_layer_from_gpkg,
+    restore_from_backup,
+    signatures_from_gpkg,
+    signatures_from_qgs_layer,
+)
 from ..runtime.runner import make_runner_class
 from .state import CUSTOM_PROPERTY_KEY, AttachState
 
 
 def _qgis_imports():
-    """Lazy import so unit tests on the Qt-free `state` / `log_format`
-    modules don't pull in QGIS bindings."""
+    """Lazy import so unit tests on the Qt-free `state` / `log_format` /
+    `refresh` modules don't pull in QGIS bindings."""
     from qgis.core import QgsMapLayer, QgsProject, QgsVectorFileWriter
-    from qgis.PyQt.QtCore import Qt
+    from qgis.PyQt.QtCore import Qt, QTimer
     from qgis.PyQt.QtWidgets import (
         QCheckBox,
         QComboBox,
@@ -35,6 +48,7 @@ def _qgis_imports():
         QFileDialog,
         QHBoxLayout,
         QLabel,
+        QMessageBox,
         QPushButton,
         QTextEdit,
         QVBoxLayout,
@@ -46,12 +60,14 @@ def _qgis_imports():
         "QgsProject": QgsProject,
         "QgsVectorFileWriter": QgsVectorFileWriter,
         "Qt": Qt,
+        "QTimer": QTimer,
         "QCheckBox": QCheckBox,
         "QComboBox": QComboBox,
         "QDockWidget": QDockWidget,
         "QFileDialog": QFileDialog,
         "QHBoxLayout": QHBoxLayout,
         "QLabel": QLabel,
+        "QMessageBox": QMessageBox,
         "QPushButton": QPushButton,
         "QTextEdit": QTextEdit,
         "QVBoxLayout": QVBoxLayout,
@@ -120,6 +136,12 @@ def build_dock_widget(parent):
     status.setVisible(False)
     layout.addWidget(status)
 
+    # Restore (post-run, 5 min TTL)
+    restore_btn = q["QPushButton"](_tr("Restore previous version"), container)
+    restore_btn.setEnabled(False)
+    restore_btn.setVisible(False)
+    layout.addWidget(restore_btn)
+
     # Live logs area
     layout.addWidget(q["QLabel"](_tr("Logs:")))
     logs = q["QTextEdit"](container)
@@ -132,6 +154,7 @@ def build_dock_widget(parent):
     dock.setWidget(container)
 
     runner = GispulseRunner(container)
+    pending: dict = {}  # carries before_sigs / dataset_path / backup_path / layer_name across run
 
     # ─── helpers ─────────────────────────────────────────────────────
 
@@ -218,6 +241,28 @@ def build_dock_widget(parent):
         )
         return str(out)
 
+    def _confirm_editable_save_or_cancel(layer) -> bool:
+        """Block the run if the layer is being edited and let the user
+        choose: commit the buffer, discard it, or cancel the run.
+        Returns True if the run can proceed, False if the user cancelled.
+        """
+        if not layer.isEditable():
+            return True
+        ans = q["QMessageBox"].question(
+            container,
+            _tr("Layer is being edited"),
+            _tr(
+                "The selected layer has unsaved edits. Save them before running, "
+                "or cancel and resolve manually?"
+            ),
+            q["QMessageBox"].Save | q["QMessageBox"].Discard | q["QMessageBox"].Cancel,
+        )
+        if ans == q["QMessageBox"].Save:
+            return bool(layer.commitChanges())
+        if ans == q["QMessageBox"].Discard:
+            return bool(layer.rollBack())
+        return False
+
     def _on_run_clicked() -> None:
         det = detect_gispulse(use_cache=False)
         if not det.found:
@@ -225,12 +270,36 @@ def build_dock_widget(parent):
             return
         if not state.layer_id or not state.rules_path:
             return
+        layer = QgsProject.instance().mapLayer(state.layer_id)
+        if layer is None:
+            return
+        if not _confirm_editable_save_or_cancel(layer):
+            return
+        try:
+            before_sigs = signatures_from_qgs_layer(layer)
+        except Exception as exc:  # pragma: no cover - defensive
+            _show_status(_tr("Could not snapshot layer: {err}").format(err=exc), "#b00020")
+            return
         dataset_path = _export_layer_to_gpkg(state.layer_id)
         if not dataset_path:
             _show_status(_tr("Failed to export layer to GeoPackage."), "#b00020")
             return
+        try:
+            backup = make_backup(dataset_path, _project_dir())
+        except OSError as exc:
+            _show_status(_tr("Could not create backup: {err}").format(err=exc), "#b00020")
+            return
+        pending.clear()
+        pending.update(
+            before=before_sigs,
+            dataset_path=dataset_path,
+            layer_name=layer.name(),
+            backup=str(backup),
+        )
         logs.clear()
         status.setVisible(False)
+        restore_btn.setVisible(False)
+        restore_btn.setEnabled(False)
         run_btn.setEnabled(False)
         cancel_btn.setEnabled(True)
         runner.start(
@@ -254,18 +323,75 @@ def build_dock_widget(parent):
             scroll = logs.verticalScrollBar()
             scroll.setValue(scroll.maximum())
 
+    def _enable_restore_with_ttl() -> None:
+        """Show + enable the Restore button for `BACKUP_TTL_SECONDS` after a
+        successful run, then auto-disable so the user doesn't restore a
+        stale backup by surprise."""
+        from ..runtime.refresh import BACKUP_TTL_SECONDS
+
+        restore_btn.setVisible(True)
+        restore_btn.setEnabled(True)
+        timer = q["QTimer"](container)
+        timer.setSingleShot(True)
+        timer.timeout.connect(lambda: restore_btn.setEnabled(False))
+        timer.start(BACKUP_TTL_SECONDS * 1000)
+
     def _on_finished(exit_code: int) -> None:
         cancel_btn.setEnabled(False)
-        if exit_code == 0:
-            _show_status(_tr("Trigger completed successfully."), "#1f8a3a")
-        elif exit_code == 130:
+        if exit_code == 130:
             _show_status(_tr("Trigger cancelled."), "#c97a00")
-        else:
+            _refresh_run_state()
+            return
+        if exit_code != 0:
             _show_status(
                 _tr("Trigger failed (exit {code}). See logs above.").format(code=exit_code),
                 "#b00020",
             )
+            _refresh_run_state()
+            return
+        # Success — diff snapshot, reload layer, expose Restore.
+        layer = QgsProject.instance().mapLayer(state.layer_id) if state.layer_id else None
+        if layer is None or not pending:
+            _show_status(_tr("Trigger completed successfully."), "#1f8a3a")
+            _refresh_run_state()
+            return
+        try:
+            after_sigs = signatures_from_gpkg(pending["dataset_path"], pending["layer_name"])
+        except Exception as exc:
+            _show_status(
+                _tr("Trigger ran but the result could not be read: {err}").format(err=exc),
+                "#c97a00",
+            )
+            _refresh_run_state()
+            return
+        summary = compute_change_summary(pending["before"], after_sigs)
+        text = format_summary(summary)
+        _show_status(_tr("{summary}").format(summary=text), "#1f8a3a")
+        if summary.has_changes:
+            try:
+                reload_layer_from_gpkg(layer, pending["dataset_path"], pending["layer_name"])
+            except Exception as exc:
+                _show_status(
+                    _tr("Trigger succeeded but reload failed: {err}").format(err=exc),
+                    "#c97a00",
+                )
+            else:
+                _enable_restore_with_ttl()
         _refresh_run_state()
+
+    def _on_restore_clicked() -> None:
+        if not pending or not state.layer_id:
+            return
+        layer = QgsProject.instance().mapLayer(state.layer_id)
+        if layer is None:
+            return
+        try:
+            restore_from_backup(layer, pending["backup"], pending["layer_name"])
+        except Exception as exc:
+            _show_status(_tr("Restore failed: {err}").format(err=exc), "#b00020")
+            return
+        restore_btn.setEnabled(False)
+        _show_status(_tr("Previous version restored."), "#c97a00")
 
     # ─── signals ─────────────────────────────────────────────────────
 
@@ -273,6 +399,7 @@ def build_dock_widget(parent):
     rules_btn.clicked.connect(_on_browse_clicked)
     run_btn.clicked.connect(_on_run_clicked)
     cancel_btn.clicked.connect(_on_cancel_clicked)
+    restore_btn.clicked.connect(_on_restore_clicked)
     runner.log_line.connect(_on_log_line)
     runner.finished.connect(_on_finished)
 

--- a/tests/unit/test_qgis_plugin_refresh.py
+++ b/tests/unit/test_qgis_plugin_refresh.py
@@ -1,0 +1,223 @@
+"""Unit tests for the post-run refresh helpers (issue v1.4-5).
+
+Exercises the pure-Python surface only; the Qt-side
+`signatures_from_qgs_layer` / `reload_layer_from_gpkg` need a live QGIS
+process and are part of the manual review matrix on each install env
+(OSGeo4W, Standalone, Homebrew).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from qgis_plugin.runtime.refresh import (
+    BACKUP_TTL_SECONDS,
+    ChangeSummary,
+    FeatureSignature,
+    backup_path,
+    compute_change_summary,
+    feature_signature,
+    format_summary,
+    is_backup_within_ttl,
+    make_backup,
+    signatures_from_features,
+)
+
+
+class TestFeatureSignature:
+    def test_same_inputs_produce_same_hash(self) -> None:
+        a = feature_signature(1, {"name": "a", "v": 1}, b"\x01\x02")
+        b = feature_signature(1, {"name": "a", "v": 1}, b"\x01\x02")
+        assert a == b
+
+    def test_attribute_change_changes_signature(self) -> None:
+        a = feature_signature(1, {"name": "a"}, b"")
+        b = feature_signature(1, {"name": "b"}, b"")
+        assert a.attr_hash != b.attr_hash
+
+    def test_geometry_change_changes_signature(self) -> None:
+        a = feature_signature(1, {}, b"\x01")
+        b = feature_signature(1, {}, b"\x02")
+        assert a.geom_hash != b.geom_hash
+
+    def test_attr_order_does_not_matter(self) -> None:
+        a = feature_signature(1, {"a": 1, "b": 2}, None)
+        b = feature_signature(1, {"b": 2, "a": 1}, None)
+        assert a == b
+
+    def test_null_geometry_uses_empty_hash(self) -> None:
+        a = feature_signature(1, {}, None)
+        assert a.geom_hash == ""
+
+    def test_null_geom_does_not_collide_with_empty_bytes(self) -> None:
+        # `b""` and `None` should not produce the same geom_hash
+        a = feature_signature(1, {}, None)
+        b = feature_signature(1, {}, b"")
+        assert a.geom_hash != b.geom_hash
+
+
+class TestComputeChangeSummary:
+    def test_empty_inputs(self) -> None:
+        s = compute_change_summary({}, {})
+        assert s == ChangeSummary(0, 0, 0, 0)
+
+    def test_pure_addition(self) -> None:
+        before = {}
+        after = signatures_from_features([(1, {"x": 1}, None), (2, {"x": 2}, None)])
+        s = compute_change_summary(before, after)
+        assert s.added == 2
+        assert s.modified == 0
+        assert s.deleted == 0
+        assert s.unchanged == 0
+
+    def test_pure_deletion(self) -> None:
+        before = signatures_from_features([(1, {"x": 1}, None)])
+        after = {}
+        s = compute_change_summary(before, after)
+        assert s.deleted == 1
+        assert s.added == 0
+        assert s.modified == 0
+
+    def test_modified_only(self) -> None:
+        before = signatures_from_features([(1, {"x": 1}, None)])
+        after = signatures_from_features([(1, {"x": 2}, None)])
+        s = compute_change_summary(before, after)
+        assert s.modified == 1
+        assert s.unchanged == 0
+
+    def test_unchanged_only(self) -> None:
+        before = signatures_from_features([(1, {"x": 1}, None), (2, {"x": 2}, None)])
+        after = before
+        s = compute_change_summary(before, after)
+        assert s.unchanged == 2
+        assert s.modified == 0
+        assert s.has_changes is False
+
+    def test_mixed(self) -> None:
+        before = signatures_from_features(
+            [
+                (1, {"x": 1}, None),  # unchanged
+                (2, {"x": 2}, None),  # will be modified
+                (3, {"x": 3}, None),  # will be deleted
+            ]
+        )
+        after = signatures_from_features(
+            [
+                (1, {"x": 1}, None),
+                (2, {"x": 99}, None),  # modified
+                (4, {"x": 4}, None),  # added
+            ]
+        )
+        s = compute_change_summary(before, after)
+        assert s.added == 1
+        assert s.modified == 1
+        assert s.deleted == 1
+        assert s.unchanged == 1
+        assert s.total_changes == 3
+        assert s.has_changes
+
+
+class TestFormatSummary:
+    def test_zero_changes_message(self) -> None:
+        text = format_summary(ChangeSummary(0, 0, 0, 100))
+        assert "no changes" in text.lower()
+
+    def test_added_only(self) -> None:
+        text = format_summary(ChangeSummary(added=12, modified=0, deleted=0, unchanged=5))
+        assert "+12 added" in text
+        assert "modified" not in text
+        assert "deleted" not in text
+
+    def test_full_mix_uses_separator(self) -> None:
+        text = format_summary(ChangeSummary(added=12, modified=5, deleted=2, unchanged=10))
+        assert "+12 added" in text
+        assert "~5 modified" in text
+        assert "-2 deleted" in text
+        assert " · " in text
+
+
+class TestBackupPath:
+    def test_layout(self, tmp_path: Path) -> None:
+        when = datetime(2026, 5, 2, 14, 30, 0)
+        p = backup_path(tmp_path, now=when)
+        assert p.parent == tmp_path / ".gispulse" / "backups"
+        assert p.name == "20260502T143000Z.gpkg"
+
+    def test_does_not_create_dir(self, tmp_path: Path) -> None:
+        backup_path(tmp_path, now=datetime(2026, 1, 1))
+        assert not (tmp_path / ".gispulse").exists()
+
+
+class TestMakeBackup:
+    def test_copies_source(self, tmp_path: Path) -> None:
+        src = tmp_path / "input.gpkg"
+        src.write_bytes(b"GPKG-FAKE\x00")
+        out = make_backup(src, tmp_path)
+        assert out.is_file()
+        assert out.read_bytes() == b"GPKG-FAKE\x00"
+        assert out.parent == tmp_path / ".gispulse" / "backups"
+
+    def test_creates_parent_dir(self, tmp_path: Path) -> None:
+        src = tmp_path / "input.gpkg"
+        src.write_bytes(b"x")
+        out = make_backup(src, tmp_path)
+        assert out.parent.is_dir()
+
+
+class TestBackupTtl:
+    def test_fresh_backup_is_valid(self, tmp_path: Path) -> None:
+        b = tmp_path / "fresh.gpkg"
+        b.write_bytes(b"x")
+        assert is_backup_within_ttl(b) is True
+
+    def test_old_backup_is_invalid(self, tmp_path: Path) -> None:
+        b = tmp_path / "old.gpkg"
+        b.write_bytes(b"x")
+        # Forge an mtime older than TTL
+        old = time.time() - BACKUP_TTL_SECONDS - 60
+        os.utime(b, (old, old))
+        assert is_backup_within_ttl(b) is False
+
+    def test_missing_backup_is_invalid(self, tmp_path: Path) -> None:
+        assert is_backup_within_ttl(tmp_path / "absent.gpkg") is False
+
+    def test_now_override(self, tmp_path: Path) -> None:
+        b = tmp_path / "fresh.gpkg"
+        b.write_bytes(b"x")
+        # Pretend "now" is 1h after the file was written
+        mtime = datetime.fromtimestamp(b.stat().st_mtime, tz=timezone.utc).replace(tzinfo=None)
+        future = mtime + timedelta(hours=1)
+        assert is_backup_within_ttl(b, now=future) is False
+
+
+class TestSignaturesFromFeatures:
+    def test_dict_assembly(self) -> None:
+        out = signatures_from_features([(1, {"x": 1}, None), (2, {"x": 2}, b"g")])
+        assert set(out.keys()) == {1, 2}
+        assert all(isinstance(v, FeatureSignature) for v in out.values())
+
+    def test_dedup_on_fid(self) -> None:
+        # Test fixture: if the same fid appears twice, last one wins.
+        # Real GPKGs guarantee unique fids — this just documents the
+        # helper's behaviour in case downstream code relies on it.
+        out = signatures_from_features([(1, {"x": 1}, None), (1, {"x": 2}, None)])
+        assert len(out) == 1
+        assert out[1] == feature_signature(1, {"x": 2}, None)
+
+
+@pytest.mark.parametrize(
+    "summary,expected",
+    [
+        (ChangeSummary(0, 0, 0, 0), False),
+        (ChangeSummary(1, 0, 0, 0), True),
+        (ChangeSummary(0, 1, 0, 0), True),
+        (ChangeSummary(0, 0, 1, 0), True),
+    ],
+)
+def test_has_changes(summary: ChangeSummary, expected: bool) -> None:
+    assert summary.has_changes is expected


### PR DESCRIPTION
## Summary

Stacked on top of #76 (`feat/qgis-plugin-runner`). Retarget to `main`
once #71 → #73 → #74 → #76 are merged.

Closes the loop on the runner: once `gispulse triggers run` exits 0,
snapshot the temp GPKG, diff against the pre-run snapshot, surface
`+12 added · ~5 modified · -2 deleted`, reload the live QGIS layer, and
offer a 5-minute Restore button backed by `.gispulse/backups/<UTC>.gpkg`.

## What's new

**`runtime/refresh.py`** — split into two zones for testability:
- *pure*: `FeatureSignature`, `feature_signature`, `compute_change_summary`, `format_summary`, `backup_path`, `make_backup`, `is_backup_within_ttl`
- *Qt-side* (lazy-import `qgis.core`): `signatures_from_qgs_layer`, `signatures_from_gpkg`, `reload_layer_from_gpkg`, `restore_from_backup`

**`ui/dock_widget.py`**
- pre-run: snapshot live layer via `signatures_from_qgs_layer`, copy the exported GPKG into `.gispulse/backups/`, **editable-layer guard** with Save / Discard / Cancel modal
- post-run (exit 0):
  - read after-snapshot from temp GPKG
  - compute `ChangeSummary` and paint the success banner with the formatted summary (or neutral "No changes detected." when nothing moved)
  - when `has_changes`, `layer.setDataSource(temp.gpkg) → reloadData() → triggerRepaint()`
  - **Restore previous version** button shown for 5 min (`QTimer` auto-disables it)
- post-run (exit ≠ 0 / 130): unchanged from v1.4-4 (failure / cancelled banner)

## Test plan

- [x] `python -m pytest tests/unit/test_qgis_plugin_refresh.py` → **29 passed**
- [x] Full plugin suite (scaffold + detector + dock_state + log_format + refresh) → **98 passed, 1 skipped**
- [x] `ruff check qgis_plugin/` → clean
- [x] `ruff format --check` → clean
- [ ] Manual on QGIS 3.28+: run with no changes (neutral message), with adds + edits + deletes (banner shows the right counts), Restore within 5 min, edit-in-progress modal (deferred to reviewer per acceptance matrix)

## Out of scope

- Cartographic before/after diff view → v1.4.1+
- GeoJSON changeset export → v1.4.1+
- "View changes" — open attribute table filtered on modified fids → can ship as a follow-up; the current banner already gives the user the per-class counts
- OS notification → v1.5+

Closes imagodata/gispulse-enterprise#471