### PR TITLE
docs(qgis-plugin): install + troubleshooting guides FR/EN (v1.4-7)

### DIFF
--- a/docs-site/.vitepress/config.ts
+++ b/docs-site/.vitepress/config.ts
@@ -131,9 +131,16 @@ const frSidebar = {
   ],
   '/plugins/': [
     {
-      text: 'Plugins & intégrations',
+      text: 'Plugin QGIS',
       items: [
-        { text: 'Plugin QGIS', link: '/plugins/qgis' },
+        { text: 'Vue d\'ensemble', link: '/plugins/qgis' },
+        { text: 'Installer le plugin', link: '/plugins/qgis-install' },
+        { text: 'Dépannage', link: '/plugins/qgis-troubleshooting' },
+      ],
+    },
+    {
+      text: 'Autres plugins',
+      items: [
         { text: 'Add-in ArcGIS', link: '/plugins/arcgis' },
         { text: 'Développer un plugin', link: '/plugins/developing' },
       ],
@@ -251,9 +258,16 @@ const enSidebar = {
   ],
   '/en/plugins/': [
     {
-      text: 'Plugins & Integrations',
+      text: 'QGIS plugin',
       items: [
-        { text: 'QGIS Plugin', link: '/en/plugins/qgis' },
+        { text: 'Overview', link: '/en/plugins/qgis' },
+        { text: 'Install the plugin', link: '/en/plugins/qgis-install' },
+        { text: 'Troubleshooting', link: '/en/plugins/qgis-troubleshooting' },
+      ],
+    },
+    {
+      text: 'Other plugins',
+      items: [
         { text: 'ArcGIS Add-in', link: '/en/plugins/arcgis' },
         { text: 'Develop a Plugin', link: '/en/plugins/developing' },
       ],

--- a/docs-site/en/plugins/qgis-install.md
+++ b/docs-site/en/plugins/qgis-install.md
@@ -1,0 +1,107 @@
+---
+title: Install the QGIS plugin
+description: Step-by-step install for the GISPulse QGIS plugin (CLI bridge) on Windows OSGeo4W, Windows Standalone, macOS, and Linux.
+---
+
+# Install the QGIS plugin
+
+The GISPulse QGIS plugin is a *bridge* between QGIS and the `gispulse`
+CLI shipped on PyPI. It **does not contain the engine** — it shells
+out to your local `gispulse` install to run triggers against your
+GeoPackages.
+
+## Prerequisites
+
+| Component | Minimum version | Why |
+|---|---|---|
+| QGIS | 3.28 (LTR) | plugin manager API + `QgsVectorFileWriter` v3 |
+| Python | 3.10+ | required by the gispulse CLI |
+| `gispulse` (CLI) | ≥ 1.3.0 | the `gispulse triggers run` sub-command |
+
+## Step 1 — install the `gispulse` CLI
+
+::: tabs
+
+== Windows · OSGeo4W
+
+QGIS installed via **OSGeo4W** ships its own embedded Python. Open
+the *OSGeo4W Shell* from the Start menu, then:
+
+```bat
+pip install gispulse
+gispulse --version
+```
+
+> Use **OSGeo4W Shell**, not a regular PowerShell. Otherwise `pip`
+> targets a different Python than the one QGIS uses.
+
+== Windows · Standalone
+
+The Standalone installer doesn't expose a dedicated shell. Install the
+CLI at user level from any Python 3.10+ terminal:
+
+```bat
+py -m pip install --user gispulse
+py -m pip show gispulse
+```
+
+Make sure `gispulse` is on the `PATH` (`%APPDATA%\Python\Python3xx\Scripts`).
+
+== macOS · Homebrew
+
+```bash
+brew install pipx
+pipx install gispulse
+gispulse --version
+```
+
+`pipx` isolates the CLI in its own venv — preferable to `pip3 install`
+which would pollute the system Python.
+
+== Linux
+
+```bash
+pipx install gispulse
+# or, without pipx:
+pip install --user gispulse
+gispulse --version
+```
+
+:::
+
+## Step 2 — install the plugin
+
+Until the [plugins.qgis.org](https://plugins.qgis.org) submission is
+finalised ([#v1.4-8](https://github.com/imagodata/gispulse-enterprise/issues/474)),
+install the ZIP **from the GitHub Release**:
+
+1. Download `gispulse-qgis-plugin-<version>.zip` from the
+   [Releases page](https://github.com/imagodata/gispulse/releases)
+2. In QGIS: **Plugins → Manage and Install Plugins → Install from ZIP**
+3. Pick the ZIP → **Install plugin**
+
+## Step 3 — verify the install
+
+1. In QGIS: **Plugins → GISPulse → Check gispulse install…**
+2. You should see: *"GISPulse `<version>` found at
+   `/path/to/gispulse`"*
+
+If you instead see *"GISPulse CLI was not found on this system"*: the
+plugin loaded correctly but the CLI is missing or off-PATH. Head to
+the [**Troubleshooting** guide](/en/plugins/qgis-troubleshooting).
+
+## Step 4 — open the panel
+
+1. **Plugins → GISPulse → Show panel**
+2. The GISPulse dock opens on the right
+3. Pick a vector layer, a `rules.yml` file, click **Run trigger** —
+   logs stream live and the layer reloads with a change summary on
+   completion
+
+## Next
+
+- [YAML triggers guide](/en/guide/triggers) — write your own rules
+- [Plugin troubleshooting](/en/plugins/qgis-troubleshooting) — fixes
+  for the most common errors
+- [Open a bug](https://github.com/imagodata/gispulse/issues) — attach
+  the log produced under `<project>/.gispulse/runs/`

--- a/docs-site/en/plugins/qgis-troubleshooting.md
+++ b/docs-site/en/plugins/qgis-troubleshooting.md
@@ -1,0 +1,142 @@
+---
+title: Troubleshooting — QGIS plugin
+description: Diagnose "gispulse not found", permission errors, missing modules, plugin crashing on QGIS startup.
+---
+
+# Troubleshooting — QGIS plugin
+
+This page lists the most common errors when starting the GISPulse
+plugin, in decreasing order of frequency in the tracker.
+
+## "gispulse not found" — 3-question triage
+
+The number-one error. The plugin loaded, but it can't find the CLI to
+call. Walk through the questions below **in order**:
+
+### 1. Is the CLI installed at all?
+
+Open the **same terminal** where you ran `pip install gispulse` in
+step 1 of the install guide:
+
+```bash
+gispulse --version
+```
+
+- ✅ "`gispulse, version 1.x.x`" → go to question 2
+- ❌ "*command not found*" → revisit
+  [Step 1 of the install guide](/en/plugins/qgis-install#step-1-install-the-gispulse-cli)
+
+### 2. Is it on the `PATH` QGIS sees?
+
+QGIS on OSGeo4W and Standalone runs an embedded Python which **doesn't
+share your shell `PATH`**. In QGIS, open the Python Console
+(Plugins → Python Console) and type:
+
+```python
+import shutil; shutil.which("gispulse")
+```
+
+- ✅ Returns a path → CLI found. Click "Test again" in the plugin
+  error dialog.
+- ❌ Returns `None` → the CLI is installed somewhere QGIS doesn't
+  look. See question 3.
+
+### 3. Which Python is the plugin using?
+
+```python
+import sys; sys.executable
+```
+
+Compare with where `pip install gispulse` actually wrote the CLI:
+
+```bash
+pip show -f gispulse | grep -E "(Location|gispulse$)"
+```
+
+If the two paths differ (e.g. `pip` targeted system Python but QGIS
+ships OSGeo4W Python), **reinstall with the right Python**:
+
+::: tabs
+
+== Windows · OSGeo4W
+
+Make sure to open **OSGeo4W Shell** (not PowerShell) before `pip install`.
+
+== Windows · Standalone
+
+```bat
+"C:\Program Files\QGIS 3.28\bin\python-qgis.bat" -m pip install --user gispulse
+```
+
+== macOS · Homebrew
+
+`pipx install gispulse` is enough — the plugin probes `~/.local/bin`
+through the `HOME` env var.
+
+== Linux
+
+Add `~/.local/bin` to the `PATH` your desktop manager launches (not
+just `.bashrc`, which doesn't load for GUI apps).
+
+:::
+
+## "Permission denied" (Windows)
+
+Happens when `pip install gispulse` tries to write to a system folder
+(e.g. `C:\Program Files\…`).
+
+**Fix**: use `pip install --user gispulse` or run the *OSGeo4W Shell*
+as Administrator (right-click → *Run as administrator*).
+
+## "ModuleNotFoundError: No module named 'gdal'"
+
+The gispulse CLI needs GDAL bindings for some operations. On
+Linux/macOS:
+
+```bash
+pip install --upgrade "gispulse[gdal]"
+```
+
+On Windows OSGeo4W, GDAL is already shipped by QGIS and reused by the
+CLI — if the error persists, check you opened the right shell (see
+"gispulse not found · question 3").
+
+## Plugin crashes at QGIS startup
+
+1. Open **View → Panels → Log Messages** in QGIS
+2. **Plugins** tab — the Python traceback is there
+3. Copy it into a [GitHub issue](https://github.com/imagodata/gispulse/issues/new)
+   along with: QGIS version, OS, `gispulse --version`
+
+## "Layer is being edited" — Save / Discard / Cancel
+
+The plugin refuses to fire a trigger on a layer with unsaved edits.
+The modal offers three choices:
+
+- **Save** — commit the in-progress edits, then run
+- **Discard** — roll back the edits, then run
+- **Cancel** — don't run (resolve manually)
+
+## "Trigger succeeded but reload failed"
+
+The trigger ran fine but QGIS couldn't refresh the layer (e.g. the
+temp GeoPackage got removed). The *Restore previous version* button
+stays active for 5 minutes to recover the pre-run snapshot from
+`<project>/.gispulse/backups/`.
+
+## Where are the logs?
+
+Each run writes a full log to:
+
+```
+<project-folder>/.gispulse/runs/<UTC-timestamp>.log
+```
+
+The first line contains the exact shell command — copy it if you want
+to reproduce the run outside the plugin.
+
+## Still stuck?
+
+- Check the [open issues](https://github.com/imagodata/gispulse/issues)
+- If yours isn't there, open one with: QGIS version, OS, `gispulse
+  --version` output, and the contents of `.gispulse/runs/<timestamp>.log`

--- a/docs-site/plugins/qgis-install.md
+++ b/docs-site/plugins/qgis-install.md
@@ -1,0 +1,109 @@
+---
+title: Installer le plugin QGIS
+description: Installation pas-à-pas du plugin GISPulse (CLI bridge) sur Windows OSGeo4W, Windows Standalone, macOS et Linux.
+---
+
+# Installer le plugin QGIS
+
+Le plugin QGIS GISPulse est un *bridge* entre QGIS et la CLI `gispulse`
+publiée sur PyPI. Il **ne contient pas le moteur** — il appelle votre
+installation locale de `gispulse` pour exécuter les triggers sur vos
+GeoPackages.
+
+## Prérequis
+
+| Composant | Version minimale | Pourquoi |
+|---|---|---|
+| QGIS | 3.28 (LTR) | API du plugin manager + `QgsVectorFileWriter` v3 |
+| Python | 3.10+ | Exigé par la CLI gispulse |
+| `gispulse` (CLI) | ≥ 1.3.0 | Sous-commande `gispulse triggers run` |
+
+## Étape 1 : installer la CLI `gispulse`
+
+::: tabs
+
+== Windows · OSGeo4W
+
+QGIS installé via **OSGeo4W** embarque son propre Python. Ouvrez le
+*OSGeo4W Shell* depuis le menu Démarrer puis :
+
+```bat
+pip install gispulse
+gispulse --version
+```
+
+> Attention : utilisez bien **OSGeo4W Shell**, pas un PowerShell
+> classique. Sinon `pip` cible un autre Python que celui de QGIS.
+
+== Windows · Standalone
+
+L'installeur Standalone n'expose pas de shell dédié. Installez la CLI
+au niveau utilisateur dans n'importe quel terminal Python 3.10+ :
+
+```bat
+py -m pip install --user gispulse
+py -m pip show gispulse
+```
+
+Vérifiez que `gispulse` est sur le `PATH` (`%APPDATA%\Python\Python3xx\Scripts`).
+
+== macOS · Homebrew
+
+```bash
+brew install pipx
+pipx install gispulse
+gispulse --version
+```
+
+`pipx` isole la CLI dans son propre venv — préférable à `pip3 install`
+car ça évite de polluer le Python système.
+
+== Linux
+
+```bash
+pipx install gispulse
+# ou, sans pipx :
+pip install --user gispulse
+gispulse --version
+```
+
+:::
+
+## Étape 2 : installer le plugin
+
+Tant que la soumission sur [plugins.qgis.org](https://plugins.qgis.org)
+n'est pas finalisée ([#v1.4-8](https://github.com/imagodata/gispulse-enterprise/issues/474)),
+installez le ZIP **depuis la GitHub Release** :
+
+1. Téléchargez `gispulse-qgis-plugin-<version>.zip` depuis la
+   [page Releases](https://github.com/imagodata/gispulse/releases)
+2. Dans QGIS : **Extensions → Installer/Gérer les extensions… →
+   Installer depuis un ZIP**
+3. Sélectionnez le ZIP téléchargé → **Installer le plugin**
+
+## Étape 3 : vérifier l'installation
+
+1. Dans QGIS : **Extensions → GISPulse → Check gispulse install…**
+2. Vous devriez voir : *« GISPulse `<version>` found at
+   `/path/to/gispulse` »*
+
+Si à la place vous obtenez « *GISPulse CLI was not found on this
+system* » : le plugin a parfaitement chargé mais la CLI manque ou n'est
+pas sur le `PATH`. Direction le guide
+[**Dépannage**](/plugins/qgis-troubleshooting).
+
+## Étape 4 : ouvrir le panneau
+
+1. **Extensions → GISPulse → Show panel**
+2. Le dock GISPulse s'ouvre à droite
+3. Choisissez une layer vecteur, un fichier `rules.yml`, cliquez
+   **Run trigger** — les logs s'affichent en temps réel et la layer
+   est rechargée à la fin avec un résumé des changements
+
+## Et après ?
+
+- [Guide des triggers YAML](/guide/triggers) — apprendre à écrire des règles
+- [Dépannage du plugin](/plugins/qgis-troubleshooting) — solutions
+  aux erreurs les plus fréquentes
+- [Soumettre un bug](https://github.com/imagodata/gispulse/issues) —
+  référez-vous au log produit dans `<projet>/.gispulse/runs/`

--- a/docs-site/plugins/qgis-troubleshooting.md
+++ b/docs-site/plugins/qgis-troubleshooting.md
@@ -1,0 +1,143 @@
+---
+title: Dépannage — plugin QGIS
+description: Diagnostiquer "gispulse not found", erreurs de permission, modules manquants, plugin qui crashe au démarrage de QGIS.
+---
+
+# Dépannage — plugin QGIS
+
+Cette page liste les erreurs les plus fréquentes au démarrage du plugin
+GISPulse, par ordre décroissant de fréquence dans le tracker.
+
+## "gispulse not found" — diagnostic en 3 questions
+
+C'est l'erreur n°1. Le plugin a chargé, mais ne trouve pas la CLI à
+appeler. Posez-vous les questions ci-dessous **dans l'ordre** :
+
+### 1. La CLI est-elle installée ?
+
+Ouvrez le **même terminal** que celui où vous avez lancé `pip install
+gispulse` à l'étape 1 du guide d'install :
+
+```bash
+gispulse --version
+```
+
+- ✅ « `gispulse, version 1.x.x` » → passez à la question 2
+- ❌ « *command not found* » → revenez à
+  [Étape 1 du guide d'install](/plugins/qgis-install#étape-1-installer-la-cli-gispulse)
+
+### 2. Est-elle sur le `PATH` que QGIS voit ?
+
+QGIS sous OSGeo4W et Standalone utilise un Python embarqué qui n'a
+**pas le même `PATH` que votre shell**. Dans QGIS, ouvrez la console
+Python (Plugins → Python Console) et tapez :
+
+```python
+import shutil; shutil.which("gispulse")
+```
+
+- ✅ Affiche un chemin → la CLI est trouvée. Cliquez « Test again »
+  dans le dialog d'erreur du plugin.
+- ❌ Renvoie `None` → la CLI est installée ailleurs que sur le `PATH`
+  de QGIS. Voir question 3.
+
+### 3. Quel Python le plugin utilise-t-il ?
+
+```python
+import sys; sys.executable
+```
+
+Comparez avec là où `pip install gispulse` a effectivement écrit la CLI :
+
+```bash
+pip show -f gispulse | grep -E "(Location|gispulse$)"
+```
+
+Si les deux paths divergent (ex. : `pip` vise le Python système, mais
+QGIS embarque OSGeo4W Python), **réinstallez avec le bon Python** :
+
+::: tabs
+
+== Windows · OSGeo4W
+
+Ouvrez bien le **OSGeo4W Shell** (pas PowerShell) avant `pip install`.
+
+== Windows · Standalone
+
+```bat
+"C:\Program Files\QGIS 3.28\bin\python-qgis.bat" -m pip install --user gispulse
+```
+
+== macOS · Homebrew
+
+`pipx install gispulse` doit suffire — le plugin probe `~/.local/bin`
+via la variable `HOME`.
+
+== Linux
+
+Ajoutez `~/.local/bin` au `PATH` lancé par votre desktop manager (pas
+juste votre `.bashrc`, qui n'est pas chargé pour les apps GUI).
+
+:::
+
+## "Permission denied" (Windows)
+
+Survient quand `pip install gispulse` essaie d'écrire dans un
+répertoire système (ex. : `C:\Program Files\…`).
+
+**Solution** : utilisez `pip install --user gispulse` ou lancez le
+*OSGeo4W Shell* en mode administrateur (clic droit → *Exécuter en tant
+qu'administrateur*).
+
+## "ModuleNotFoundError: No module named 'gdal'"
+
+La CLI gispulse a besoin de bindings GDAL pour certaines opérations.
+Sur Linux/macOS :
+
+```bash
+pip install --upgrade "gispulse[gdal]"
+```
+
+Sur Windows OSGeo4W, GDAL est déjà fourni par QGIS et ré-utilisé par la
+CLI — si l'erreur persiste, vérifiez que vous avez ouvert le bon shell
+(voir « gispulse not found · question 3 »).
+
+## Le plugin crashe au démarrage de QGIS
+
+1. Ouvrez **Vue → Panneaux → Journal des messages** dans QGIS
+2. Onglet **Plugins** — la trace Python est visible
+3. Copiez-la dans une [issue GitHub](https://github.com/imagodata/gispulse/issues/new)
+   en y joignant : version QGIS, OS, version `gispulse --version`
+
+## "Layer is being edited" — Save / Discard / Cancel
+
+Le plugin refuse de lancer un trigger sur une layer encore en édition.
+La modale propose trois options :
+
+- **Save** — commite les modifications dans la layer puis lance le run
+- **Discard** — annule les modifications puis lance le run
+- **Cancel** — n'exécute rien (à vous de gérer manuellement)
+
+## "Trigger succeeded but reload failed"
+
+Le trigger a bien tourné mais QGIS n'a pas pu rafraîchir la layer (par
+exemple : le GeoPackage temporaire a été supprimé). Le bouton
+*Restore previous version* reste actif 5 minutes pour récupérer l'état
+pré-run depuis `<projet>/.gispulse/backups/`.
+
+## Où sont les logs ?
+
+Pour chaque run, le plugin écrit un fichier complet dans :
+
+```
+<dossier-du-projet>/.gispulse/runs/<UTC-timestamp>.log
+```
+
+La première ligne contient la commande shell exacte exécutée — copiez-la
+si vous voulez reproduire le run hors du plugin.
+
+## Toujours bloqué ?
+
+- Cherchez dans les [issues ouvertes](https://github.com/imagodata/gispulse/issues)
+- Si l'issue n'existe pas, ouvrez-en une avec : version QGIS, OS,
+  version `gispulse --version`, contenu du `.gispulse/runs/<timestamp>.log`

--- a/qgis_plugin/runtime/error_dialog.py
+++ b/qgis_plugin/runtime/error_dialog.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from .detector import DetectorResult, clear_cache, detect_gispulse, install_hint
 
-DOC_URL = "https://gispulse.dev/install"
+DOC_URL = "https://gispulse.dev/plugins/qgis-troubleshooting"
 
 
 def show_install_dialog(parent, result: DetectorResult) -> DetectorResult:


### PR DESCRIPTION
## Summary

Stacked on top of #79 (`feat/qgis-plugin-release-ci`). Retarget to
`main` once the v1.4 stack is merged.

User-facing docs for the v1.4 QGIS plugin (CLI bridge), in both
languages, plus a sidebar restructure that promotes the QGIS plugin
out of the generic "Plugins & Integrations" group.

## What's new

**New pages**
- `docs-site/plugins/qgis-install.md` (FR)
- `docs-site/plugins/qgis-troubleshooting.md` (FR)
- `docs-site/en/plugins/qgis-install.md` (EN)
- `docs-site/en/plugins/qgis-troubleshooting.md` (EN)

Each install guide covers the **4 supported environments** — Windows
OSGeo4W, Windows Standalone, macOS Homebrew, Linux — with copy-paste
commands and the gotcha about OSGeo4W's embedded Python.

The troubleshooting page leads with the **#1 expected error** (`gispulse
not found`) and walks through a **3-question triage**:
1. is the CLI installed at all?
2. is it on the `PATH` QGIS sees? (with QGIS Python Console snippet)
3. which Python is the plugin using? (resolve OSGeo4W ↔ system Python mismatch)

Plus the rest of the issue acceptance: `Permission denied`,
`ModuleNotFoundError: gdal`, plugin crashes on startup, the
edit-in-progress modal, the post-run "reload failed" guard, and where
to find the per-run logs.

**Wiring**
- `qgis_plugin/runtime/error_dialog.DOC_URL` repointed at the
  troubleshooting page so the install dialog's "Open docs" button lands
  users at the right page on first miss
- VitePress sidebars (FR + EN): QGIS plugin gets its own group with
  Overview / Install / Troubleshooting; ArcGIS + Develop a plugin move
  to a secondary group

## Test plan

- [x] `python -m pytest tests/unit/test_qgis_plugin_*.py` → **98 passed, 1 skipped** (no regression)
- [x] Pages render structure verified (h1 + h2 + h3 headers, no broken in-page anchors)
- [x] All `[link]` targets are existing repo paths or external URLs
- [ ] `npx vitepress build docs-site` clean — deferred to reviewer / CI (the docs CI exercises the build on every push)

## Out of scope (left as flagged follow-ups in the body)

- Screenshots per OS — to be captured by a reviewer with QGIS access
- 90s demo video — recommended but optional per acceptance criteria
- Migration ArcGIS → GISPulse → v1.5+

Closes imagodata/gispulse-enterprise#473