### PR TITLE
docs(qgis-plugin): plugins.qgis.org submission package (v1.4-8)

### DIFF
--- a/qgis_plugin/PUBLISHING.md
+++ b/qgis_plugin/PUBLISHING.md
@@ -1,0 +1,94 @@
+# Publishing the GISPulse QGIS plugin
+
+Maintainer workflow for shipping the plugin to the official
+[QGIS Plugin Repository](https://plugins.qgis.org/).
+
+## Prerequisites
+
+1. An OSGeo / QGIS account with maintainer rights on the `GISPulse`
+   plugin once it exists (the first upload creates the entry under
+   the uploader's account; transfer to `imagodata` org is a follow-up
+   request to the QGIS plugin admins).
+2. A tagged release on this repo (`v*.*.*`) — the
+   [release workflow](../.github/workflows/release.yml) builds the
+   ZIP and attaches it to the GitHub Release.
+
+## First-time submission
+
+Done **once** for the lifetime of the plugin entry on plugins.qgis.org.
+
+1. Confirm `qgis_plugin/metadata.txt` is up to date — see the field
+   inventory below.
+2. Run `make plugin-zip-check` to enforce the
+   `metadata.txt` ↔ `pyproject.toml` lockstep.
+3. Run `make plugin-zip` and verify the resulting ZIP installs cleanly
+   in a fresh QGIS profile via Extensions → Install from ZIP.
+4. Sign in to <https://plugins.qgis.org/> and open
+   <https://plugins.qgis.org/plugins/add/>.
+5. Upload `dist/gispulse-qgis-plugin-<version>.zip` from a tagged
+   release (do **not** upload a dirty local build). The form parses
+   `metadata.txt` to populate the listing.
+6. The plugin lands as `experimental` (because `experimental=True` in
+   metadata) — it's installable immediately for users who tick "Show
+   experimental plugins" in QGIS, but won't appear in the default
+   plugin list until a reviewer approves the entry.
+7. Reviewer turnaround is typically 1–4 weeks. While waiting, the
+   GitHub Release ZIP remains the canonical install path; both routes
+   point at the same artefact.
+
+## Subsequent releases
+
+Once the plugin entry exists, every new tagged release should bump it.
+
+1. Bump `qgis_plugin/metadata.txt` `version=` and prepend a new
+   `changelog=` entry. Keep the version in lockstep with
+   `pyproject.toml` — `make plugin-zip-check` enforces this.
+2. Push a tag `v*.*.*` — CI builds + attaches the ZIP to the GitHub
+   Release ([`build-plugin-zip` job](../.github/workflows/release.yml)).
+3. From <https://plugins.qgis.org/plugins/GISPulse/>, click **Manage
+   versions → Upload new version** and pick the freshly tagged ZIP.
+4. Publishing a new version retains the `experimental` flag from
+   metadata; flip it to `False` only after a beta cycle (target:
+   v1.6.x).
+
+## metadata.txt field inventory
+
+| Field | Status | Notes |
+|---|---|---|
+| `name` | required | Free-form, must be unique in the QGIS repo |
+| `qgisMinimumVersion` | required | We pin `3.28` (LTR) |
+| `qgisMaximumVersion` | recommended | We pin `3.99` to allow 3.x bumps |
+| `description` | required | ≤ 512 chars, single line |
+| `about` | required | Multiline, used as the listing body |
+| `version` | required | semver, **must** match the wheel version |
+| `author` | required | Display name |
+| `email` | required | Public — visible on the listing |
+| `homepage` | recommended | <https://gispulse.dev> |
+| `tracker` | recommended | GitHub issues URL |
+| `repository` | recommended | GitHub repo URL |
+| `icon` | recommended | 24×24 PNG, path relative to `metadata.txt` |
+| `category` | recommended | `Vector` for us |
+| `tags` | recommended | CSV, used for search ranking |
+| `experimental` | recommended | `True` until v1.6.x |
+| `deprecated` | recommended | `False` |
+| `hasProcessingProvider` | recommended | `no` (no processing algorithms exposed) |
+| `server` | recommended | `False` (no server-side plugin) |
+| `plugin_dependencies` | optional | none |
+| `changelog` | recommended | Multiline; QGIS renders it on the version page |
+
+## Reviewer feedback
+
+If the OSGeo reviewer asks for changes, edit `metadata.txt` (and any
+referenced files), bump `version` to the next patch (e.g. 1.5.1 →
+1.5.2), and re-upload via the standard release workflow above.
+**Do not** edit a published version in place — the QGIS plugin manager
+caches by version number and won't re-fetch.
+
+## Post-approval comms
+
+Out of scope for this repo, but the planned channels are:
+
+- A short `Mastodon @foss4g.org` toot
+- A LinkedIn post on the company page
+- A note in the next release announcement on
+  [`docs.gispulse.dev/changelog`](https://docs.gispulse.dev/changelog)

--- a/qgis_plugin/README.md
+++ b/qgis_plugin/README.md
@@ -1,18 +1,30 @@
 # GISPulse — QGIS plugin
 
-Companion plugin for the [`gispulse`](https://pypi.org/project/gispulse/) CLI.
-Lets you attach trigger rules to QGIS layers and run them on save.
+Companion plugin for the [`gispulse`](https://pypi.org/project/gispulse/)
+Python CLI. Pick a vector layer, point it at a `rules.yml`, click Run —
+the plugin shells out to your local gispulse install and streams its
+logs into a dock widget, then reloads the layer with a per-feature
+change summary.
 
 ## Status
 
-`v1.4.0` is the first scaffold release. Full UI lands across child issues
-[v1.4-2](https://github.com/imagodata/gispulse-enterprise/issues/468) →
-[v1.4-8](https://github.com/imagodata/gispulse-enterprise/issues/474).
+First public release. **Pending approval** on the official
+[QGIS Plugin Repository](https://plugins.qgis.org/) — install from the
+ZIP attached to each [GitHub Release](https://github.com/imagodata/gispulse/releases)
+in the meantime.
+
+## User documentation
+
+- [Install guide (FR)](https://gispulse.dev/plugins/qgis-install) ·
+  [(EN)](https://gispulse.dev/en/plugins/qgis-install)
+- [Troubleshooting (FR)](https://gispulse.dev/plugins/qgis-troubleshooting) ·
+  [(EN)](https://gispulse.dev/en/plugins/qgis-troubleshooting)
 
 ## Requirements
 
 - QGIS ≥ 3.28
-- `gispulse` CLI on `PATH` — `pipx install gispulse` (recommended) or `pip install gispulse`
+- `gispulse` CLI on a `PATH` visible to QGIS — `pipx install gispulse`
+  (recommended) or `pip install gispulse`
 
 ## Build a ZIP locally
 
@@ -21,6 +33,10 @@ make plugin-zip            # → dist/gispulse-qgis-plugin-<version>.zip
 ```
 
 Install the ZIP from QGIS → Extensions → Install from ZIP.
+
+## Submitting to plugins.qgis.org
+
+See [PUBLISHING.md](PUBLISHING.md) for the maintainer workflow.
 
 ## License
 

--- a/qgis_plugin/metadata.txt
+++ b/qgis_plugin/metadata.txt
@@ -3,7 +3,7 @@ name=GISPulse
 qgisMinimumVersion=3.28
 qgisMaximumVersion=3.99
 description=Trigger-driven spatial CDC for QGIS — attach gispulse rules to any layer.
-about=GISPulse turns QGIS layers into reactive datasets. Save a tracked GeoPackage and gispulse fires the rules attached to it: webhooks, downstream layer refresh, validation. Requires the gispulse Python CLI (pip install gispulse).
+about=GISPulse turns QGIS layers into reactive datasets. Save a tracked GeoPackage and gispulse fires the rules attached to it: webhooks, downstream layer refresh, validation. The plugin is a thin bridge — it shells out to the gispulse Python CLI (pip install gispulse) and streams its logs into a dock widget. Requires gispulse >= 1.3.0 on the PATH visible to QGIS.
 version=1.5.1
 author=Imagodata
 email=hello@gispulse.dev
@@ -12,9 +12,22 @@ tracker=https://github.com/imagodata/gispulse/issues
 repository=https://github.com/imagodata/gispulse
 icon=icon.png
 category=Vector
-tags=cdc,triggers,rules,geopackage,automation,webhooks
+tags=cdc,triggers,rules,geopackage,automation,etl,webhooks,gispulse,processing
 experimental=True
 deprecated=False
 hasProcessingProvider=no
 server=False
 plugin_dependencies=
+changelog=
+    1.5.1 — First public plugin release
+      * Detect the gispulse CLI on PATH / ~/.local/bin / sys.executable -m
+      * OS-specific install dialog (OSGeo4W, Standalone, Homebrew, pipx)
+      * Attach-trigger dock widget — combo layers, YAML picker, vector-only gate
+      * Per-layer rules path persists in QgsMapLayer customProperty
+      * Non-blocking QProcess runner, streamed coloured logs (INFO/WARN/ERROR)
+      * Cancel with SIGTERM → SIGKILL escalation (5s grace)
+      * Post-run change summary (+added · ~modified · -deleted)
+      * Automatic layer reload + 5-minute Restore button
+      * Per-run log files under <project>/.gispulse/runs/
+      * Edit-in-progress modal (Save / Discard / Cancel)
+      * Install + troubleshooting docs at https://gispulse.dev/plugins/qgis-install

--- a/scripts/build_qgis_plugin_zip.py
+++ b/scripts/build_qgis_plugin_zip.py
@@ -34,6 +34,9 @@ PLUGIN_FOLDER_NAME = "gispulse"
 
 INCLUDED_SUFFIXES = {".py", ".png", ".txt", ".md", ".svg", ".qml", ".ui"}
 EXCLUDED_DIRS = {"__pycache__", ".pytest_cache", ".mypy_cache"}
+# Files that live in qgis_plugin/ but are maintainer-only and should NOT
+# ship to end users via the QGIS Plugin Manager ZIP.
+EXCLUDED_FILES = {"PUBLISHING.md"}
 
 
 def _read_plugin_version() -> str:
@@ -66,6 +69,8 @@ def _iter_plugin_files() -> list[Path]:
         if path.is_dir():
             continue
         if any(part in EXCLUDED_DIRS for part in path.parts):
+            continue
+        if path.name in EXCLUDED_FILES:
             continue
         if path.suffix and path.suffix not in INCLUDED_SUFFIXES:
             continue

--- a/tests/unit/test_qgis_plugin_scaffold.py
+++ b/tests/unit/test_qgis_plugin_scaffold.py
@@ -93,3 +93,22 @@ def test_build_zip_produces_installable_archive(tmp_path: Path) -> None:
     )
     for required in ("gispulse/metadata.txt", "gispulse/__init__.py", "gispulse/icon.png"):
         assert required in names, f"missing {required} in ZIP"
+    # PUBLISHING.md is a maintainer-only guide; shipping it would clutter
+    # the QGIS Plugin Manager listing and confuse users.
+    assert "gispulse/PUBLISHING.md" not in names, (
+        "PUBLISHING.md must stay out of the user-facing ZIP — see EXCLUDED_FILES"
+    )
+
+
+def test_metadata_has_required_qgis_fields() -> None:
+    """plugins.qgis.org rejects uploads missing any of these fields,
+    so we enforce them here rather than discovering on submission."""
+    parser = configparser.ConfigParser()
+    parser.read(PLUGIN_DIR / "metadata.txt", encoding="utf-8")
+    g = parser["general"]
+    assert g["category"] == "Vector"
+    assert g["experimental"] in ("True", "true")
+    assert "changelog" in g
+    # Description must be a single line under the QGIS 512-char cap.
+    assert len(g["description"]) <= 512
+    assert "\n" not in g["description"].strip()


### PR DESCRIPTION
## Summary

Stacked on top of #80 (`feat/qgis-plugin-docs`). Retarget to `main`
once the v1.4 stack is merged.

Final story of the v1.4 plugin sprint. Brings `metadata.txt` up to the
[plugins.qgis.org](https://plugins.qgis.org/) upload contract, ships
the maintainer publishing playbook, and adds CI gates so future
versions can't silently drift away from the upload requirements.

## What's new

**`qgis_plugin/metadata.txt`**
- `changelog=` block summarising the v1.5.1 first-public-release
  surface (detector, dock widget, runner, refresh, restore)
- broader `tags=` (`etl,gispulse,processing` added) for search ranking
- expanded `about=` calling out the "thin bridge" architecture + the
  `gispulse >= 1.3.0` PATH requirement so the listing is self-describing

**`qgis_plugin/PUBLISHING.md`** (new) — maintainer playbook:
- first-time submission flow on plugins.qgis.org
- per-release upload procedure
- reviewer-feedback loop ("bump version, re-upload — never edit in
  place")
- field-by-field `metadata.txt` inventory mapped to plugins.qgis.org
  requirements
- post-approval comms staging (Mastodon/LinkedIn/changelog)

**`qgis_plugin/README.md`**
- promotes "first public release · pending approval"
- links the FR/EN install + troubleshooting docs from #80
- points the maintainer section at PUBLISHING.md

**Hardening**
- `scripts/build_qgis_plugin_zip.py` gains `EXCLUDED_FILES` so
  `PUBLISHING.md` (maintainer-only) doesn't ship to end users
- new test `test_metadata_has_required_qgis_fields` enforces
  `category=Vector`, `experimental=True`, `changelog` present, and the
  **512-char single-line description cap** so submissions fail fast
  locally instead of in the qgis.org form
- existing ZIP test now also asserts `PUBLISHING.md` is **absent**
  from the installable archive

## Test plan

- [x] `python -m pytest tests/unit/test_qgis_plugin_*.py` → **99 passed, 1 skipped**
- [x] `ruff check qgis_plugin/ scripts/build_qgis_plugin_zip.py` → clean
- [x] `python scripts/build_qgis_plugin_zip.py --check` → "versions in lockstep: 1.5.1"
- [x] ZIP audit (`unzip -l`): 13 user files, no `PUBLISHING.md`, README + metadata + runtime/* + ui/* + icon all present

## Out of scope (explicit, blocked by external gates)

- Creating the plugins.qgis.org account & uploading the ZIP — manual
  per the playbook (action: maintainer with QGIS account, after the
  v1.4 stack lands and the next tagged release ships)
- Root `README.md` badge "Available on QGIS Plugin Repo (pending
  approval)" — to be added in a follow-up once the listing actually
  exists (premature otherwise)
- Post-approval announcements — staged in PUBLISHING.md but not yet
  scheduled
- `experimental=False` flip → v1.6.x after a beta cycle

Closes imagodata/gispulse-enterprise#474