### PR TITLE
fix(auth): resolve session via PluginHub.auth_providers — closes OIDC 401 in #505

### DIFF
--- a/gispulse/adapters/http/auth.py
+++ b/gispulse/adapters/http/auth.py
@@ -69,29 +69,32 @@ def _get_auth_repo(request: Request) -> AuthRepository | None:
 
 
 async def _resolve_user_from_session(request: Request) -> User | None:
-    """Attempt to resolve a user from the OIDC session cookie.
+    """Attempt to resolve a user from a session cookie via plugin AuthProviders.
 
-    Returns None if no session cookie is present or OIDC is not configured.
-    Raises HTTPException on invalid/expired session tokens.
+    Iterates ``PluginHub.auth_providers`` (e.g. the ``oidc`` provider shipped
+    by ``gispulse-enterprise``); the first provider that returns claims wins.
+    Returns ``None`` when no provider is registered, none accept the request,
+    no auth repository is configured, or the resolved user is inactive.
+
+    A provider raising during ``authenticate`` is treated as a soft failure
+    so API key auth can still take over.
     """
-    try:
-        from gispulse.adapters.http.oidc import OIDCError, OIDCProvider, decode_session_token
-    except ImportError:
-        # gispulse-enterprise not installed — OIDC sessions unavailable
+    from core.plugin_hub import PluginHub
+
+    providers = PluginHub.get().auth_providers
+    if not providers:
         return None
 
-    cookie = request.cookies.get("gispulse_session")
-    if not cookie:
-        return None
+    claims: dict | None = None
+    for provider in providers.values():
+        try:
+            claims = await provider.authenticate(request)
+        except Exception:
+            claims = None
+        if claims is not None:
+            break
 
-    oidc: OIDCProvider | None = getattr(request.app.state, "oidc_provider", None)
-    if oidc is None:
-        return None
-
-    try:
-        claims = decode_session_token(cookie, oidc.config.session_secret)
-    except OIDCError:
-        # Invalid/expired session — don't block, fall through to API key auth
+    if claims is None:
         return None
 
     auth_repo = _get_auth_repo(request)

--- a/tests/unit/test_auth_session_resolution.py
+++ b/tests/unit/test_auth_session_resolution.py
@@ -1,0 +1,134 @@
+"""Contract tests for ``_resolve_user_from_session`` (issue #505 OIDC 401 part).
+
+The legacy implementation hard-coded ``from gispulse.adapters.http.oidc import …``
+which no longer exists post OSS split, so OIDC session resolution silently
+always returned ``None`` (→ 401 in tests). The refactor delegates to
+``PluginHub.auth_providers``.
+
+This test guards the new contract:
+
+* No AuthProvider registered → ``None``.
+* A provider returns claims → user resolved via auth_repo.
+* A provider raises → fall through (does not break API key auth path).
+* Provider claims valid but auth_repo missing or user inactive → ``None``.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from core import plugin_hub
+from gispulse.adapters.http.auth import _resolve_user_from_session
+from persistence.auth_models import User
+
+
+@pytest.fixture(autouse=True)
+def _reset_hub():
+    plugin_hub.PluginHub.reset()
+    yield
+    plugin_hub.PluginHub.reset()
+
+
+def _make_request(*, app_state=None, cookie: str | None = None) -> MagicMock:
+    request = MagicMock()
+    request.app.state = app_state or MagicMock()
+    request.state = MagicMock()
+    request.cookies = {"gispulse_session": cookie} if cookie else {}
+    return request
+
+
+def _install_providers(monkeypatch: pytest.MonkeyPatch, providers: dict) -> None:
+    hub = plugin_hub.PluginHub.get()
+    monkeypatch.setattr(hub, "auth_providers", providers)
+
+
+@pytest.mark.asyncio
+async def test_no_providers_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_providers(monkeypatch, {})
+    result = await _resolve_user_from_session(_make_request())
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_provider_returns_claims_resolves_user(monkeypatch: pytest.MonkeyPatch) -> None:
+    user = User(id="u-123", email="alice@example.com", role="editor", is_active=True)
+    auth_repo = MagicMock()
+    auth_repo.get_user.return_value = user
+
+    provider = MagicMock()
+    provider.authenticate = AsyncMock(return_value={"sub": "u-123"})
+    _install_providers(monkeypatch, {"oidc": provider})
+
+    state = MagicMock(auth_repo=auth_repo)
+    request = _make_request(app_state=state)
+
+    result = await _resolve_user_from_session(request)
+    assert result is user
+    auth_repo.get_user.assert_called_once_with("u-123")
+    assert request.state.user is user
+    assert request.state.api_key_scopes == ["read", "write"]
+
+
+@pytest.mark.asyncio
+async def test_provider_raises_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = MagicMock()
+    provider.authenticate = AsyncMock(side_effect=RuntimeError("boom"))
+    _install_providers(monkeypatch, {"oidc": provider})
+
+    result = await _resolve_user_from_session(_make_request())
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_provider_returns_none_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = MagicMock()
+    provider.authenticate = AsyncMock(return_value=None)
+    _install_providers(monkeypatch, {"oidc": provider})
+
+    result = await _resolve_user_from_session(_make_request())
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_first_provider_with_claims_short_circuits(monkeypatch: pytest.MonkeyPatch) -> None:
+    user = User(id="u-1", role="viewer", is_active=True)
+    auth_repo = MagicMock()
+    auth_repo.get_user.return_value = user
+
+    first = MagicMock()
+    first.authenticate = AsyncMock(return_value={"sub": "u-1"})
+    second = MagicMock()
+    second.authenticate = AsyncMock(return_value={"sub": "should-not-call"})
+    _install_providers(monkeypatch, {"oidc": first, "saml": second})
+
+    state = MagicMock(auth_repo=auth_repo)
+    result = await _resolve_user_from_session(_make_request(app_state=state))
+    assert result is user
+    second.authenticate.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_no_auth_repo_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = MagicMock()
+    provider.authenticate = AsyncMock(return_value={"sub": "u-1"})
+    _install_providers(monkeypatch, {"oidc": provider})
+
+    state = MagicMock(spec=[])  # no auth_repo attribute
+    result = await _resolve_user_from_session(_make_request(app_state=state))
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_inactive_user_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    user = User(id="u-1", is_active=False)
+    auth_repo = MagicMock()
+    auth_repo.get_user.return_value = user
+
+    provider = MagicMock()
+    provider.authenticate = AsyncMock(return_value={"sub": "u-1"})
+    _install_providers(monkeypatch, {"oidc": provider})
+
+    state = MagicMock(auth_repo=auth_repo)
+    result = await _resolve_user_from_session(_make_request(app_state=state))
+    assert result is None


### PR DESCRIPTION
## Summary

OSS ``_resolve_user_from_session`` in [gispulse/adapters/http/auth.py](gispulse/adapters/http/auth.py) still hard-coded ``from gispulse.adapters.http.oidc import …`` — a module that **no longer exists in OSS post-split**. The ``except ImportError`` swallowed the failure silently, so OIDC session resolution always returned ``None`` and ``get_current_user`` rejected the request with **401** even when ``gispulse_session`` cookie was valid.

This is the **OIDC-401 half** of [imagodata/gispulse-enterprise#505](https://github.com/imagodata/gispulse-enterprise/issues/505). Companion to imagodata/gispulse#85 (admin/billing legacy imports) — together they close the post-split silent-bugs pattern (3rd recurrence).

## What changed

- ``gispulse/adapters/http/auth.py`` — iterate ``PluginHub.auth_providers`` (e.g. ``oidc`` shipped by ``gispulse-enterprise`` as ``OidcAuthProvider``). The first provider whose ``authenticate(request)`` returns claims wins. A provider raising is treated as a soft failure so API-key auth can still take over.
- ``tests/unit/test_auth_session_resolution.py`` (new, 7 tests) — contract tests covering: no providers, claims accepted, provider raises, provider returns None, two-provider short-circuit, missing auth_repo, inactive user.

## Test plan

- [x] ``pytest tests/unit/test_auth_session_resolution.py`` → 7 passed
- [x] ``pytest tests/unit/test_filter_router.py tests/unit/test_triggers_router.py tests/unit/test_rules_router.py tests/unit/test_datasets_router.py tests/unit/test_sql_preview_auth.py`` → 86 passed (no regression)

## How this works end-to-end with gispulse-enterprise installed

1. ``gispulse-enterprise`` exposes ``oidc = gispulse_enterprise.auth:oidc_provider`` via ``[project.entry-points.\"gispulse.auth_provider\"]``.
2. ``PluginHub`` discovers it on first ``.get()`` call.
3. ``OidcAuthProvider.authenticate(request)`` reads ``gispulse_session`` cookie + ``app.state.oidc_provider``, decodes the locally-signed JWT, returns claims.
4. ``_resolve_user_from_session`` consumes the claims, fetches the User via ``auth_repo``, sets ``request.state``.
5. With no enterprise installed: ``providers`` dict is empty → ``None`` → falls through to API-key auth (legacy behaviour preserved).

## Closes (when sibling PRs merge)

- imagodata/gispulse#85 (admin/billing legacy imports — companion)
- imagodata/gispulse-enterprise#505 OIDC 401 part (this PR)

The third part of #505 — wiring ``app.state.auth_repo`` / ``app.state.oidc_provider`` in ``test_admin_router.py`` and ``test_oidc.py`` fixtures — lives in the enterprise repo and is a sibling PR (PR B in the v1.5.2 critical-path plan).

## Refs

- Memory ``post_split_silent_bugs_2026_05_02`` — third recurrence of this pattern
- Memory ``brainstorm_saas_pro_v16_2026_05_02`` — Phase 0 dette
- Plugin contract: [docs/PLUGIN_CONTRACT.md](docs/PLUGIN_CONTRACT.md)