### PR TITLE
docs(plugins): fix dead git clone URLs in qgis.md

### DIFF
--- a/docs-site/en/plugins/qgis.md
+++ b/docs-site/en/plugins/qgis.md
@@ -21,7 +21,7 @@ The GISPulse QGIS plugin connects QGIS to a GISPulse backend (local or remote) t
 
 ```bash
 # Clone the repository
-git clone https://github.com/gispulse/gispulse
+git clone https://github.com/imagodata/gispulse
 cd gispulse/clients/qgis
 
 # Build the plugin (creates gispulse_qgis.zip)

--- a/docs-site/plugins/qgis.md
+++ b/docs-site/plugins/qgis.md
@@ -21,7 +21,7 @@ Le plugin QGIS GISPulse connecte QGIS à un backend GISPulse (local ou distant) 
 
 ```bash
 # Cloner le dépôt
-git clone https://github.com/gispulse/gispulse
+git clone https://github.com/imagodata/gispulse
 cd gispulse/clients/qgis
 
 # Construire le plugin (crée gispulse_qgis.zip)

--- a/docs/CLI_PORTAL_PARITY_AUDIT.md
+++ b/docs/CLI_PORTAL_PARITY_AUDIT.md
@@ -1,0 +1,166 @@
+# Audit de parité CLI ↔ Portal
+
+**Date** : 2026-05-03 · **Version auditée** : v1.5.1 · **Doctrine de référence** : axiome de symétrie (CLI et Portal sont deux UIs équivalentes sur la même source de vérité `triggers.yaml` + change-log).
+
+> **Errata 2026-05-03 (post-vérification)** — l'audit initial avait deux faux négatifs majeurs sur les endpoints existants. Cette version corrige le verdict : le portail seul couvre **plus que ~60 %** ; le bloquant "impossible d'activer le tracking depuis le portail" n'existe pas (l'endpoint `POST /datasets/{id}/enable_tracking` est shippé depuis v1.5.x avec auto-register `WatcherRegistry`). Trois P0 réels demeurent : changelog inspection, watcher dashboard UI, triggers.yaml import. Système doctor (P0-4) livré 2026-05-03.
+
+> **Leçon** : les audits Explore agent peuvent hallucinate l'absence d'endpoints quand ils ne grep pas tous les routers. Toujours croiser avec [`docs-site/guide/symmetry.md`](../docs-site/guide/symmetry.md) qui est la matrice manuellement maintenue.
+
+Réf. complémentaires : [`USAGE_MATRIX.md`](USAGE_MATRIX.md), [`INTEGRATION_MATRIX.md`](INTEGRATION_MATRIX.md), [`TRIGGERS_GUIDE.md`](TRIGGERS_GUIDE.md).
+
+---
+
+## 1. Surface auditée
+
+**CLI (Python — Click/Typer)** :
+- [`gispulse/cli.py`](../gispulse/cli.py) — verbes principaux (`init`, `run`, `layers`, `formats`, `serve`, `validate`, `capabilities`, `info`, `doctor`, `engine`, `update`, `jobs *`, `template *`, `marketplace *`, `telemetry`)
+- [`gispulse/cli_triggers.py`](../gispulse/cli_triggers.py) — `triggers run --once|--watch`, `triggers validate`, `triggers list`
+- [`gispulse/cli_track.py`](../gispulse/cli_track.py) — `track install|uninstall|list|tail|doctor`
+- [`gispulse/cli_watch.py`](../gispulse/cli_watch.py) — `watch` (legacy daemon)
+- [`gispulse/cli_portal.py`](../gispulse/cli_portal.py) — `portal` (lance la SPA bundlée + StaticFiles same-origin)
+
+**Portal (React/TS — `gispulse-portal/`)** :
+- Routes : `/explorer`, `/map`, `/workflows`, `/datasets`, `/catalog`, `/schema`, `/marketplace`, `/login`
+- Pages : `ExplorerView`, `WorkflowsView`, `DatasetsView`, `MapView`, `CatalogWorkspace`, `SchemaView`, `MarketplacePage`
+- API clients : `datasets.ts`, `pipelines.ts`, `catalog.ts`, `marketplace.ts`, `projects.ts`, `scenarios.ts`, `schedules.ts`, `styles.ts`
+
+**Backend HTTP (consommé par les deux)** :
+- [`gispulse/adapters/http/`](../gispulse/adapters/http/) — routers FastAPI (datasets, pipelines, triggers, jobs, runs, ws, capabilities)
+
+---
+
+## 2. Matrice de parité détaillée
+
+Légende : ✅ disponible · ⚠️ partiel · ❌ absent
+
+### Datasets
+
+| Fonctionnalité | CLI | Portal | Notes |
+|---|---|---|---|
+| Browser / lister datasets serveur | ❌ | ✅ | CLI n'a que `layers FILE` (fichier local) |
+| Uploader / importer dataset | ❌ | ✅ | upload, import-url |
+| Supprimer dataset | ❌ | ✅ | |
+| Inspecter schéma + CRS + métadata | ✅ `info` | ⚠️ | CLI plus riche (styles, drivers, formats) |
+| Exporter (GPKG, GeoJSON, Parquet, CSV) | ⚠️ via `run` | ✅ | Portal : export multi-format direct |
+| Éditer features (SQL execute / row CRUD) | ❌ | ✅ | Portal seul |
+| Styling (QML / SLD / colors) | ❌ | ✅ StyleEditor | Portal seul |
+
+### Pipelines / Rules
+
+| Fonctionnalité | CLI | Portal | Notes |
+|---|---|---|---|
+| Édition pipeline v2 | ✅ fichier JSON | ✅ NodeEditor visuel | parité (vecteurs différents) |
+| Édition règle v1 (legacy) | ❌ | ❌ | déprécation v1.5 acceptable |
+| Validation pipeline | ✅ `validate` | ✅ `/pipelines/validate` SSE | parité ✅ |
+| Exécution one-shot | ✅ `run` | ✅ `/pipelines/execute` | parité ✅ |
+| Visualisation résultat | ⚠️ `serve` viewer simple | ✅ MapView complet | Portal mieux |
+| Templates / presets browse | ✅ `template list/use` | ⚠️ via marketplace browse | parité partielle |
+| Capabilities introspection | ✅ `capabilities` | ✅ fetch `/capabilities` | parité ✅ |
+
+### Triggers DML
+
+| Fonctionnalité | CLI | Portal | Notes |
+|---|---|---|---|
+| Créer / éditer un trigger | ⚠️ YAML manuel | ✅ TriggerBuilderModal | Portal mieux |
+| Configurer une action / webhook | ⚠️ YAML manuel | ✅ ActionEditor | Portal mieux |
+| Tester un trigger sur payload | ❌ | ✅ `/triggers/{id}/evaluate` SSE | Portal seul |
+| Activer / désactiver un trigger | ⚠️ via éditer YAML | ✅ toggle UI | Portal mieux |
+| Importer un `triggers.yaml` externe | ✅ `triggers validate --config` | ❌ | **Gap P0** |
+| Lister triggers SQL natifs (`sqlite_master`) | ✅ `triggers list` | ❌ | gap moyen |
+
+### Change-tracking (cœur du runtime DML)
+
+| Fonctionnalité | CLI | Portal | Notes |
+|---|---|---|---|
+| Activer le change-log sur un GPKG | ✅ `track install` | ✅ `POST /datasets/{id}/enable_tracking` | **CORRIGÉ** — déjà shippé v1.5.x, audit initial faux négatif. Auto-register `WatcherRegistry`. |
+| Désactiver le change-log | ✅ `track uninstall` | ✅ `POST /datasets/{id}/disable_tracking` | **CORRIGÉ** — déjà shippé. |
+| Lister couches tracées | ✅ `track list` | ✅ `GET /datasets/{id}/tracking_status` | **CORRIGÉ** — déjà shippé. |
+| Inspecter le change-log (tail rows) | ✅ `track tail` | **❌** | gap réel — debug aveugle depuis le portail |
+| Stats change-log (pending par couche) | ✅ `track list` | ⚠️ partiel (`tracking_status` ne donne pas pending counts détaillés) | gap moyen |
+| Diagnostic santé tracking | ✅ `track doctor [--auto-fix]` | **❌** | gap réel — debug |
+
+### Watcher / runtime daemon
+
+| Fonctionnalité | CLI | Portal | Notes |
+|---|---|---|---|
+| Lancer le watcher long-running | ✅ `triggers run --watch` | ✅ **AUTO** sur `enable_tracking` (WatcherRegistry) | **CORRIGÉ** — pas besoin d'endpoint dédié, le watcher démarre automatiquement à l'activation du tracking |
+| Lister les watchers actifs | ✅ via logs CLI | ❌ pas d'endpoint `/watchers` ni dashboard UI | gap observabilité |
+| Arrêter un watcher | ✅ Ctrl+C | ✅ via `disable_tracking` (registry.unregister) | parité fonctionnelle |
+| Mode one-shot tick | ✅ `triggers run --once` | ⚠️ via `/triggers/eval-stream` | parité partielle |
+| Voir les fires en stream | ✅ logs stderr structurés | ⚠️ SSE event stream | parité fonctionnelle |
+| Voir le journal des runs (jobs) | ✅ `jobs list/status/cancel` | ✅ jobs view + SSE | parité ✅ |
+
+### Système / opérations
+
+| Fonctionnalité | CLI | Portal | Notes |
+|---|---|---|---|
+| Doctor (GDAL/DuckDB/PostGIS/OIDC) | ✅ `doctor` | ⚠️ portal assets seulement | gap |
+| `gispulse update [--check]` | ✅ | ❌ | acceptable (touche pip/wheel) |
+| Marketplace install / uninstall plugin | ✅ | ❌ (browse seul) | acceptable (touche pip) |
+| Scaffold projet (`init`) | ✅ | ❌ | acceptable |
+| Auth / login | ❌ (Bearer env) | ✅ OIDC | acceptable (cohérent) |
+| Telemetry opt-in | ✅ | ❌ | acceptable (machine-side) |
+
+---
+
+## 3. Gaps prioritaires (corrigé après vérification 2026-05-03)
+
+| # | État | Endpoint | Remplace | Sans ça, un user portal-only ne peut pas… |
+|---|---|---|---|---|
+| ~~P0-1~~ | ✅ déjà shippé v1.5.x | `POST /datasets/{id}/enable_tracking` + `disable_tracking` + `GET /tracking_status` | `gispulse track install/uninstall/list` | (déjà couvert — issue #92 à fermer) |
+| **P0-2** | ❌ à livrer | `GET /datasets/{id}/changelog` (paginated tail) + `POST /changelog/doctor` | `gispulse track tail/doctor` | …débugger "pourquoi mon trigger n'a pas fire" |
+| **P0-3** | ⚠️ partiel | `GET /watchers` (list) + UI "Background Tasks" + stats temps réel | `gispulse triggers run --watch` (visualisation seule, le daemon démarre auto sur `enable_tracking`) | …voir / superviser les watchers actifs depuis le navigateur |
+| **P0-4** | ✅ livré 2026-05-03 | `POST /system/doctor` | `gispulse doctor` | (livré — issue #91, EPIC #90) |
+| **P0-5** | ❌ à livrer | `POST /triggers/import` (validation + hydratation) | `gispulse triggers validate --config` | …reprendre dans le portail un projet édité en CLI |
+
+**Sprint réduit** : 3 P0 réels demeurent (P0-2 + P0-3 dashboard + P0-5) ≈ **5-7 jours** dev (au lieu de 10-13 estimés initialement).
+
+**Note d'architecture** : aucun des P0 restants ne casse l'axiome de symétrie. Ils HTTP-isent une opération déjà implémentée en Python (réutiliser les fonctions de `cli_track.py` et `cli_triggers.py` côté backend, ne pas réimplémenter en JS).
+
+---
+
+## 4. Doctrine front — vérifications
+
+Recherche systématique de logique runtime qui devrait rester backend-only :
+
+| Suspect inspecté | Verdict | Justification |
+|---|---|---|
+| `PredicateBuilder.tsx` (ATTR_OPS, GEOM_OPS, AGG_COMPARE_OPS) | ✅ acceptable | enums UI labels seulement, pas d'évaluation |
+| `NodeEditor.tsx` (build PipelineSpec → executePipeline) | ✅ acceptable | sérialisation client puis POST `/pipelines/execute`, runtime côté backend |
+| `TriggerBuilderModal` + `ActionEditor` | ✅ acceptable | forme JSON envoyée à `/triggers/{id}/evaluate` SSE — aucune éval locale |
+| Capabilities catalog côté front | ✅ acceptable | fetch backend, pas de registry hardcodée |
+| MarketplacePage filters | ✅ acceptable | UX state seul (catégories, search) |
+
+**Conclusion** : le portail respecte la doctrine "sucre syntaxique". Toute la logique reste dans le runtime Python.
+
+---
+
+## 5. Asymétries acceptables (à NE PAS combler)
+
+- **Auth/login portal-only** : la CLI est stateless avec Bearer token via env. Cohérent.
+- **`marketplace install/uninstall` CLI-only** : touche `pip`, doit rester côté machine.
+- **`gispulse update` CLI-only** : idem, met à jour le wheel.
+- **`init` (scaffold projet) CLI-only** : crée fichiers locaux, sans intérêt portail.
+- **Édition règle v1 absente partout** : déprécation v1.5 documentée.
+- **Telemetry opt-in CLI-only** : configuration machine-side.
+
+---
+
+## 6. Plan de remédiation
+
+Avec les 5 endpoints P0 + l'UI `Background Tasks` :
+
+- Le portail passe de "design tool + viewer" à **complete headless workbench**
+- La promesse big-launch v1.5.2 ("tout depuis le navigateur, optionnellement depuis le terminal") tient mécaniquement
+- L'axiome de symétrie est respecté sans dette résiduelle bloquante
+
+Estimation grossière : **1 sprint de 2 semaines** pour les 5 endpoints + UI (ils HTTP-isent du code existant, pas de nouveau runtime).
+
+---
+
+## Voir aussi
+
+- [`PARITY_P0_SPEC.md`](PARITY_P0_SPEC.md) — spec technique des 5 endpoints P0 (contrats, réutilisation code existant, ordre de livraison)
+- [`USAGE_MATRIX.md`](USAGE_MATRIX.md) — matrice persona × scénario × canal (replace "Portal" par "Portal + CLI" tant que les 5 P0 ne sont pas livrés)
+- [`INTEGRATION_MATRIX.md`](INTEGRATION_MATRIX.md) — matrice clients GIS × modes d'échange
+- [`TRIGGERS_GUIDE.md`](TRIGGERS_GUIDE.md) — sémantique des triggers DML / contrat webhook

--- a/docs/PARITY_P0_SPEC.md
+++ b/docs/PARITY_P0_SPEC.md
@@ -1,0 +1,340 @@
+# Spec — 5 endpoints P0 pour fermer la dette CLI ↔ Portal
+
+> **Errata 2026-05-03** — vérification post-audit : P0-1 (enable/disable tracking) **est déjà shippé** depuis v1.5.x via `POST /datasets/{id}/enable_tracking,disable_tracking` + auto-register `WatcherRegistry`. Sa section ci-dessous (#P0-1) est **caduque**. P0-3 watcher endpoint a aussi été redimensionné : le watcher démarre automatiquement à l'activation du tracking, donc seul un dashboard d'observabilité (`GET /watchers`) reste à livrer. Sprint réduit à 3 P0 réels (P0-2, P0-3 dashboard, P0-5) ≈ 5-7 jours.
+
+**Contexte** : voir [`CLI_PORTAL_PARITY_AUDIT.md`](CLI_PORTAL_PARITY_AUDIT.md). Cinq endpoints HTTP qui HTTP-isent du code Python déjà existant (réutilisation, pas réimplémentation).
+
+**Principe directeur** : chaque endpoint réutilise les fonctions de `cli_track.py` / `cli_triggers.py` / `gispulse.persistence.gpkg_schema`. Le portail ne réimplémente rien — il appelle. Doctrine de symétrie respectée.
+
+**Auth** : tous les endpoints écrivent dans le filesystem ou pilotent des process → exigent un user authentifié avec rôle `editor` au minimum (cf. middleware existant). En portal-mode self-hosted local (`gispulse portal`), auth désactivée par défaut comme aujourd'hui.
+
+---
+
+## P0-1 — Activer / désactiver le change-tracking sur un dataset
+
+**Remplace** : `gispulse track install/uninstall`.
+**Sans ça** : un user portal-only ne peut pas du tout activer un trigger DML — rien ne fire jamais sur GPKG.
+
+### Endpoints
+
+```
+POST   /datasets/{id}/tracking          → enable
+DELETE /datasets/{id}/tracking          → disable (toutes couches)
+```
+
+### Body POST
+
+```json
+{
+  "layers": ["parcelles", "permis"],   // ou null = --all-layers
+  "primary_key": "fid"                  // optional, default = "fid"
+}
+```
+
+### Réponse 200
+
+```json
+{
+  "dataset_id": "…",
+  "tracked_layers": [
+    {"layer": "parcelles", "operations": ["insert", "update", "delete"], "pk": "fid"},
+    {"layer": "permis",    "operations": ["insert", "update", "delete"], "pk": "fid"}
+  ],
+  "changelog_table": "_gispulse_changelog",
+  "installed_at": "2026-05-03T14:32:11Z"
+}
+```
+
+### Erreurs
+
+| Code | Cas |
+|---|---|
+| 404 | dataset_id inconnu |
+| 409 | tracking déjà installé sur la couche (idempotent : retourner 200 avec `already_installed: true` si flag `--force` absent) |
+| 422 | couche n'existe pas dans le GPKG, PK invalide, GPKG non writable |
+
+### Réutilisation
+
+- `gispulse.persistence.gpkg_schema.install_change_tracking()` (déjà ligne 406)
+- `gispulse.persistence.gpkg_schema.uninstall_change_tracking()` (déjà ligne 469)
+- Validation identifier : `_validate_identifier()` (déjà ligne 41) — protège contre l'injection SQL
+
+### Tests
+
+- 200 happy path mono-couche
+- 200 `--all-layers` équivalent (`layers: null`)
+- 409 idempotence
+- 422 PK manquante
+- 422 GPKG read-only filesystem
+- intégration : POST tracking → INSERT row via API portal → GET /changelog vérifie qu'une ligne arrive
+
+### UI Portal
+
+- Bouton `Enable change-tracking` dans `DatasetsView` → `/datasets/{id}` page détails
+- État affiché : "tracked since YYYY-MM-DD on layers [...]"
+- Bouton rouge `Disable tracking` avec confirmation modale
+
+---
+
+## P0-2 — Inspecter le change-log d'un dataset
+
+**Remplace** : `gispulse track tail`, `track list`, `track doctor`.
+**Sans ça** : impossible de débugger "pourquoi mon trigger n'a pas fire" depuis le portail.
+
+### Endpoints
+
+```
+GET  /datasets/{id}/changelog                       → liste paginée
+GET  /datasets/{id}/changelog/stats                 → résumé par couche
+POST /datasets/{id}/changelog/doctor                → diagnostic santé (auto-fix optionnel)
+```
+
+### Query params (`/changelog`)
+
+| Param | Type | Default | Notes |
+|---|---|---|---|
+| `layer` | string | (toutes) | filtre par couche tracée |
+| `op` | enum | (toutes) | `insert` / `update` / `delete` |
+| `since_id` | int | 0 | curseur (id du dernier event vu) |
+| `limit` | int | 50 | max 500 |
+
+### Réponse `/changelog`
+
+```json
+{
+  "items": [
+    {
+      "id": 142,
+      "layer": "parcelles",
+      "op": "INSERT",
+      "row_id": "f00…",
+      "ts": "2026-05-03T14:33:01Z",
+      "user": "alice@…"   // si configuré
+    }
+  ],
+  "next_since_id": 142,
+  "has_more": false
+}
+```
+
+### Réponse `/changelog/stats`
+
+```json
+{
+  "layers": [
+    {"layer": "parcelles", "pending": 12, "last_event_at": "2026-05-03T14:33:01Z", "ops": {"insert": 5, "update": 6, "delete": 1}}
+  ],
+  "total_pending": 12
+}
+```
+
+### Réponse `/changelog/doctor`
+
+Schéma identique à la sortie JSON de `gispulse track doctor --json` (cf. `cli_track.py:464`). Champs `health_score`, `issues[]`, `fixed[]` (si `auto_fix=true`).
+
+### Réutilisation
+
+- Helpers `_installed_triggers()`, `_list_spatial_layers()` de `cli_track.py:61-100`
+- Doctor : extraire la fonction sous-jacente de `cli_track.py:cmd_doctor` dans un module shared `gispulse.persistence.changelog_doctor` puis l'appeler depuis CLI ET endpoint (parité forte)
+
+### UI Portal
+
+- Onglet `Change-log` dans `DatasetsView` → table paginée live (curseur SSE optionnel)
+- Bouton `Run doctor` → modal avec `health_score` + checklist `issues[]`
+
+---
+
+## P0-3 — Watcher / daemon long-running depuis le portail
+
+**Remplace** : `gispulse triggers run --watch`.
+**Sans ça** : impossible de démarrer un polling daemon depuis le navigateur.
+
+### Endpoints
+
+```
+POST   /watchers                       → démarrer un watcher
+GET    /watchers                       → lister watchers actifs
+GET    /watchers/{id}                  → détail d'un watcher (état, stats, logs récents)
+GET    /watchers/{id}/events           → SSE stream des fires
+DELETE /watchers/{id}                  → arrêter un watcher
+```
+
+### Body POST
+
+```json
+{
+  "config_source": "stored",           // "stored" (triggers de la base) | "yaml"
+  "yaml_content": null,                // requis si config_source=yaml
+  "dataset_id": "…",                   // dataset cible (GPKG path résolu côté backend)
+  "poll_interval_ms": 100,
+  "name": "preset-ppri-prod"
+}
+```
+
+### Réponse 201
+
+```json
+{
+  "id": "wtch_…",
+  "status": "running",
+  "started_at": "…",
+  "config": { /* ... */ },
+  "stats": {"ticks": 0, "fires": 0, "errors": 0}
+}
+```
+
+### Modèle d'exécution
+
+Watchers tournent dans le **process backend** (ASGI worker), pas en sous-process. Une `asyncio.Task` par watcher, supervisée par un `WatcherRegistry` singleton. Si le process redémarre, les watchers actifs sont restaurés depuis la table `watchers_state` (persistance).
+
+**Limite Community OSS** : max 1 watcher concurrent par instance backend (raison : single-writer GPKG). Pro lift cette limite.
+
+### Réutilisation
+
+- `gispulse.runtime.build_runtime()` + `ChangeLogWatcher` existants (cf. `cli_triggers.py:107-292`)
+- Wrapper `WatcherRegistry` à créer sous `gispulse/runtime/watcher_registry.py` — partagé CLI futur (`gispulse triggers run --watch` peut à terme écrire dans la table aussi pour visualisation portal)
+
+### UI Portal
+
+- Page `/runtime` (nouvelle) — section "Background Tasks" : liste des watchers, start/stop, vue détaillée avec SSE des fires
+- Indicateur de statut watcher dans le header (badge "1 watcher running")
+
+---
+
+## P0-4 — Diagnostic système depuis le portail
+
+**Remplace** : `gispulse doctor`.
+**Sans ça** : impossible de troubleshoot une install cassée sans terminal.
+
+### Endpoint
+
+```
+POST /system/doctor
+```
+
+### Body (optionnel)
+
+```json
+{
+  "checks": ["python", "gdal", "duckdb", "spatialite", "postgis", "oidc", "assets"]
+}
+```
+
+Si absent : tous les checks.
+
+### Réponse 200
+
+```json
+{
+  "summary": {"ok": 5, "warning": 1, "error": 0},
+  "checks": [
+    {"name": "python",     "status": "ok",      "detail": "3.12.4"},
+    {"name": "gdal",       "status": "ok",      "detail": "3.9.0"},
+    {"name": "duckdb",     "status": "ok",      "detail": "1.0.0 + spatial"},
+    {"name": "spatialite", "status": "warning", "detail": "mod_spatialite not on LD_LIBRARY_PATH; fallback ok"},
+    {"name": "postgis",    "status": "skipped", "detail": "no PG_DSN configured"},
+    {"name": "oidc",       "status": "ok",      "detail": "issuer reachable"}
+  ],
+  "ran_at": "…"
+}
+```
+
+### Réutilisation
+
+- Refactor `cli.py:cmd_doctor` (lignes 491-648) → extraire dans `gispulse/diagnostics/system.py` avec une fonction pure `run_checks(names: list[str]) -> DoctorResult` callable depuis CLI ET endpoint
+- CLI devient un consommateur de cette fonction → `gispulse doctor --json` peut sérialiser exactement le même schéma
+
+### UI Portal
+
+- Page `/system/health` (nouvelle, footer link) — bouton `Run diagnostic`, table des checks colorée, copy-to-clipboard du JSON pour issues GitHub
+
+### Sécurité
+
+- Endpoint **admin only** (rôle `admin`), même en portal-mode local désactiver pour `auth_disabled` impose un confirm prompt → exposition de versions = recon léger
+
+---
+
+## P0-5 — Importer / valider un `triggers.yaml` externe
+
+**Remplace** : `gispulse triggers validate --config`.
+**Sans ça** : un user qui édite en CLI ne peut pas reprendre dans le portail.
+
+### Endpoints
+
+```
+POST /triggers/import              → valider et hydrater l'éditeur (dry-run)
+POST /triggers/import?commit=true  → valider et persister (créer les triggers)
+```
+
+### Body
+
+```yaml
+# multipart upload OU body raw application/x-yaml
+```
+
+### Réponse 200 (dry-run)
+
+```json
+{
+  "valid": true,
+  "summary": {"triggers": 4, "actions": 6},
+  "preview": [
+    {
+      "name": "alerte_ppri",
+      "table": "permis",
+      "operation": "INSERT",
+      "predicate": "intersects(ppri_zone)",
+      "actions": ["webhook:teams"]
+    }
+  ],
+  "warnings": []
+}
+```
+
+### Réponse 422 (invalide)
+
+```json
+{
+  "valid": false,
+  "errors": [
+    {"path": "$.triggers[0].predicate", "message": "unknown function 'intersects_with'", "line": 12}
+  ]
+}
+```
+
+### Réutilisation
+
+- Parser et validateur de `cli_triggers.py:cmd_validate` (lignes 294-346)
+- Extraction recommandée : `gispulse/runtime/yaml_loader.py` partagé, callable depuis CLI ET endpoint
+
+### UI Portal
+
+- Bouton `Import YAML` dans `WorkflowsView` → file picker / textarea
+- Modal preview avec diff (existing triggers vs imported)
+- Bouton `Commit` après validation OK
+
+---
+
+## Synthèse par priorité
+
+| # | Endpoint | Effort dev (j) | Débloque |
+|---|---|---|---|
+| **P0-1** | `POST/DELETE /datasets/{id}/tracking` | 2 | tout le mode DML portal-only |
+| **P0-2** | `GET /datasets/{id}/changelog{,/stats,/doctor}` | 2-3 | debug change-log |
+| **P0-3** | `POST/GET/DELETE /watchers` + UI | 4-5 | daemon depuis navigateur |
+| **P0-4** | `POST /system/doctor` | 1 | diagnostic install |
+| **P0-5** | `POST /triggers/import` | 1-2 | reprise CLI → portal |
+
+**Total estimé** : 10-13 jours dev backend + UI = sprint v1.5.2 (2 semaines avec QA + docs).
+
+**Ordre de livraison recommandé** : P0-4 (le moins risqué, refactor doctor vers shared module = template pour les autres extractions) → P0-1 (débloque mode DML) → P0-2 (suit immédiatement) → P0-5 (rapide) → P0-3 (le plus complexe, watcher registry).
+
+---
+
+## Voir aussi
+
+- [`CLI_PORTAL_PARITY_AUDIT.md`](CLI_PORTAL_PARITY_AUDIT.md) — audit complet, contexte
+- [`USAGE_MATRIX.md`](USAGE_MATRIX.md) — caveat de parité aligné
+- `gispulse/cli_track.py` — code à HTTP-iser pour P0-1 / P0-2
+- `gispulse/cli_triggers.py` — code à HTTP-iser pour P0-3 / P0-5
+- `gispulse/cli.py:491-648` — `cmd_doctor` à refactorer pour P0-4

--- a/docs/USAGE_MATRIX.md
+++ b/docs/USAGE_MATRIX.md
@@ -1,0 +1,131 @@
+# Matrice Usages × Scénarios
+
+Comment les utilisateurs cibles consomment GISPulse au quotidien : qui, pour quoi faire, via quel canal, et quel preset comme point de départ.
+
+Complète [INTEGRATION_MATRIX.md](INTEGRATION_MATRIX.md) (échange de données) et [`templates/INDEX.md`](../templates/INDEX.md) (catalogue des 21 presets).
+
+Légende :
+- **Tier** : C = Community (AGPL, gratuit), P = Pro (paid features : isochrone réseau, raster lourd, ESB triggers)
+- **Canal** : CLI, Portal (SPA web), QGIS (plugin), ArcGIS (OGC API), MVT (web map), Webhook (sortie événementielle), SDK (Python/JS)
+- **Boucle** : One-shot (1×), Planifié (cron), DML (déclencheur sur changement)
+
+---
+
+## 1. Matrice Persona × Scénario × Canal
+
+Quatorze personas représentatifs des deals déjà signés ou en discussion. Le canal recommandé est celui qui ferme la boucle le plus vite — pas forcément le seul.
+
+> **Caveat parité 2026-05-03 (errata)** — l'audit initial a corrigé son verdict après vérification : l'activation du change-log depuis le portail (`POST /datasets/{id}/enable_tracking`) est shippée depuis v1.5.x avec auto-register `WatcherRegistry`. Donc la boucle "DML" portail-only **fonctionne déjà bout-en-bout** pour les 14 personas. Les 3 P0 restants ([`CLI_PORTAL_PARITY_AUDIT.md`](CLI_PORTAL_PARITY_AUDIT.md)) sont des features de debug / observabilité (changelog inspection, dashboard watchers, import triggers.yaml), pas des bloquants fonctionnels.
+
+| Persona | Pain quotidien | Preset(s) | Canal principal | Boucle | Tier |
+|---|---|---|---|---|---|
+| **Géomaticien collectivité (DDT, EPCI)** | Instruction PC, conformité PLU, livrables CNIG | `validation_plu_cnig`, `urbanisme_permis_conformite` | QGIS plugin (drag GPKG) | Manuel | C |
+| **Chef de projet ZAN** | Bilan trajectoire artificialisation T1/T2/2031 | `urbanisme_zan_bilan` | Portal + export GPKG vers QGIS | Planifié (annuel) | C |
+| **Opérateur FTTH (BE déploiement)** | Priorisation NRO, hotspots demande, taux de couverture | `ftth_demande_hotspots`, `ftth_network_analysis` | CLI batch + MVT pour dashboard | Planifié (hebdo) | P (isochrone) |
+| **Géomaticien SDIS** | SDACR, zones blanches secours, Voronoi CIS | `securite_sdis_couverture`, `securite_sdis_thiessen` | QGIS plugin + webhook DML | DML (nouvelle ZA) | P (isochrone) |
+| **Analyste foncier (EPF, promoteur)** | Détection friches, marché DVF par IRIS | `foncier_parcelles_vacantes`, `foncier_dvf_marche` | Portal + SDK Python | Planifié (mensuel) | C |
+| **Bureau d'études environnement** | TVB ruptures corridors, IOTA loi sur l'eau | `environnement_tvb_ruptures`, `environnement_iota_loi_eau` | CLI + GPKG sortie pour QGIS | One-shot (étude) | C |
+| **Agent État (préfecture risques)** | Bâti / pop / ERP exposés PPRI, alertes nouvelles autorisations | `risques_ppri_exposition` | Webhook + dashboard MapLibre | DML (nouveau permis) | C |
+| **Géomaticien santé publique (ARS)** | Déserts médicaux APL méthode DREES | `sante_apl_deserts` | Portal + export FileGDB ArcGIS | Planifié (trimestriel) | P (isochrone) |
+| **Agriculteur / OPA / DRAAF** | Contrôle conformité BCAE 1/8/9 | `agriculture_rpg_bcae` | CLI + GPKG vers Telepac/QGIS | One-shot (avant déclaration PAC) | C |
+| **Bureau d'études énergie** | Potentiel solaire toiture par bâtiment | `energie_solaire_toiture` | SDK Python (notebook) | One-shot | P (raster) |
+| **Mobilité / AOM** | Accessibilité 15/30 min services BPE, zones blanches | `mobilite_accessibilite_services` | Portal + MVT public | Planifié | P (isochrone) |
+| **Service rénovation énergétique (ANAH/PIG)** | Priorisation passoires DPE × précarité | `batiment_dpe_priorisation` | Portal + export Excel/GPKG | Planifié (annuel) | C |
+| **Géomarketing retail** | Modèle Huff, parts de marché, whitespace | `retail_huff_chalandise` | SDK Python + dashboard interne | One-shot (étude implantation) | P (isochrone) |
+| **Topographe / cadastreur** | Nettoyage géométrique avant analyse stricte | `cadastre_topology_cleanup`, `reseau_topology_prep` | CLI pre-flight + QGIS | Manuel (data prep) | C |
+
+---
+
+## 2. Matrice Scénario × Capabilities × Tier × Sortie
+
+Inverse de la matrice 1 : pour chaque preset, qu'est-ce qui le rend possible et comment il se diffuse.
+
+| Preset | Capabilities clés | Tier | Sortie | Trigger DML pertinent |
+|---|---|---|---|---|
+| `cadastre_topology_cleanup` | `make_valid`, `polygon_fix_*`, `polygon_remove_slivers` | C | GPKG nettoyé | non (data prep) |
+| `reseau_topology_prep` | `network_snap_endpoints`, `extend_dangles`, `connectivity_check` | C | GPKG graphe | non (data prep) |
+| `validation_plu_cnig` | `topology_check`, `attribute_validation`, `completeness_check` | C | rapport JSON + GPKG | sur INSERT zonage |
+| `urbanisme_zan_bilan` | `clip`, `spatial_aggregate`, `area_length` | C | GPKG ventilation T1/T2 | sur ENTER zone artificialisée |
+| `urbanisme_permis_conformite` | `spatial_join`, `intersects`, `area_length` | C | rapport conformité | sur INSERT permis |
+| `risques_ppri_exposition` | `spatial_join`, `spatial_aggregate`, `reproject` | C | GPKG bâti exposé + alerte webhook | ✅ DML INSERT permis OU UPDATE PPRI |
+| `environnement_tvb_ruptures` | `buffer`, `intersects`, `dissolve`, `connectivity_check` | C | GPKG corridors + ruptures | sur INSERT infrastructure |
+| `environnement_iota_loi_eau` | `buffer`, `intersects`, `clip`, `area_length` | C | rapport IOTA | sur INSERT projet |
+| `mobilite_accessibilite_services` | `isochrone`, `spatial_aggregate` | P | MVT zones blanches | planifié |
+| `foncier_dvf_marche` | `spatial_aggregate` (médiane/m²) | C | GPKG par IRIS | planifié (DVF semestriel) |
+| `foncier_parcelles_vacantes` | `spatial_join` cadastre×MAJIC×PLU×DVF, score | C | GPKG friches scorées | planifié + DML mutation MAJIC |
+| `agriculture_rpg_bcae` | `buffer`, `intersects`, `spatial_join` | C | rapport conformité BCAE | one-shot annuel |
+| `energie_solaire_toiture` | `zonal_stats` raster MNS, `area_length` | P | GPKG potentiel kWh/an/bât | one-shot |
+| `securite_sdis_couverture` | `isochrone` 10/20 min, zones blanches | P | GPKG couverture + MVT | sur INSERT route inondable |
+| `securite_sdis_thiessen` | `voronoi_polygons`, `spatial_aggregate` | C | GPKG zones premier appel | sur UPDATE CIS (ouverture/fermeture) |
+| `sante_apl_deserts` | `isochrone` 20 min, agrégation ETP/pop | P | GPKG APL par commune | planifié |
+| `batiment_dpe_priorisation` | `spatial_join` BDNB×FILOSOFI×OPAH | C | GPKG priorisation | planifié |
+| `retail_huff_chalandise` | `isochrone`, modèle Huff, `centroid` | P | GPKG parts de marché par IRIS | one-shot étude |
+| `ftth_network_analysis` | `connectivity_check`, isochrone NRO, `spatial_aggregate` | P | GPKG taux couverture par NRO | planifié |
+| `ftth_demande_hotspots` | `cluster_hdbscan`, `concave_hull`, `nearest_neighbor` | C | GPKG hotspots scorés | planifié |
+| `environmental_monitoring` | `zonal_stats` NDVI Sentinel-2, détection changement | P (raster) | GPKG diff temporel | planifié saison |
+
+---
+
+## 3. Matrice Canal × Boucle CDC
+
+Pour chaque canal d'export, quel type de feedback loop GISPulse ferme. Réf : [`docs/INTEGRATION_MATRIX.md`](INTEGRATION_MATRIX.md).
+
+| Canal | Latence | Cible | Boucle qu'il ferme |
+|---|---|---|---|
+| **CLI** (`gispulse run`) | secondes-minutes | terminal, scripts shell, CI | "j'ai un nouveau jeu de données → je veux le rapport tout de suite" |
+| **CLI** (`gispulse watch`) | 100 ms (poll GPKG) | watcher local | "le GPKG bouge → re-évalue les triggers, write-back via DML" |
+| **Portal SPA** (gispulse-portal) | quasi temps réel (WS) | navigateur, pas d'install | "métier sans QGIS veut explorer / lancer un preset / voir une carte" |
+| **QGIS plugin** (v1.4) | UI interactive | bureau analyste | "je travaille déjà dans QGIS → j'attache un GPKG, je stream les résultats" |
+| **OGC API Features / WFS** | pull HTTP | QGIS, ArcGIS, MapLibre | "je connecte un client GIS standard à un dataset GISPulse" |
+| **MVT + TileJSON** | tile cache | dashboard web public | "je publie une couche scoree pour des dizaines / centaines de vues" |
+| **Webhook (`POST /…`)** | <1 s sur DML | n8n, Zapier, ArcGIS GeoEvent, Slack/Teams | "un permis touche un PPRI → l'agent reçoit l'alerte avant le café" |
+| **WebSocket `/ws/events`** | <100 ms | MapLibre live, deck.gl | "tableau de bord temps réel pour PCO / dispatch / supervision" |
+| **SDK Python** (`pip install gispulse`) | API HTTP | Jupyter, pipelines internes, intégration métier | "je scripte une étude, je benchmark plusieurs scénarios" |
+
+---
+
+## 4. Quatre scénarios bout-en-bout
+
+Pour la communication big-launch et les démos, quatre histoires complètes qui combinent matrices 1 + 2 + 3.
+
+### A. Alerte PPRI temps réel (préfecture risques)
+
+1. Dataset `permis_construire` connecté en GPKG (ou PostGIS Pro).
+2. Preset `risques_ppri_exposition` chargé en pipeline.
+3. Trigger DML : `INSERT permis WHERE intersects(ppri_zone)`.
+4. Action : webhook → Teams de l'instructeur + entrée GeoEvent ArcGIS.
+5. Latence cible : < 2 s entre le `INSERT` et l'alerte. Boucle : DML.
+
+### B. Hotspots demande FTTH (BE déploiement)
+
+1. Dataset hebdo `demandes_eligibilite.csv` extrait du SI commercial.
+2. Preset `ftth_demande_hotspots` lancé via cron `gispulse run --once`.
+3. Sortie : GPKG hotspots + MVT publié sur portal interne.
+4. Vue MapLibre dans le dashboard SI commercial.
+5. Boucle : Planifié.
+
+### C. SDACR Voronoi → isochrones (SDIS)
+
+1. Pre-flight : `reseau_topology_prep` sur le graphe routier (data prep).
+2. Preset `securite_sdis_thiessen` (théorique Community).
+3. Si tier Pro disponible : `securite_sdis_couverture` (réseau réel).
+4. Comparaison Voronoi vs réseau dans QGIS plugin.
+5. Boucle : One-shot puis DML sur `UPDATE cis` (ouverture/fermeture caserne).
+
+### D. Bilan ZAN annuel (chef de projet EPCI)
+
+1. Données OCS GE T1 et T2 chargées dans le portal.
+2. Preset `urbanisme_zan_bilan` lancé en mode planifié (annuel).
+3. Sortie : GPKG ventilation + rapport. Trajectoire 2031 calculée.
+4. Diffusion : QGIS plugin pour les techniciens, MVT pour le dashboard élu.
+5. Boucle : Planifié.
+
+---
+
+## Voir aussi
+
+- [`templates/INDEX.md`](../templates/INDEX.md) — catalogue détaillé des 21 presets, format JSON
+- [`docs/INTEGRATION_MATRIX.md`](INTEGRATION_MATRIX.md) — matrice clients GIS × modes d'échange
+- [`docs/CLI_PORTAL_PARITY_AUDIT.md`](CLI_PORTAL_PARITY_AUDIT.md) — état de la dette de symétrie CLI ↔ Portal (5 P0 ouverts au 2026-05-03)
+- [`docs/TRIGGERS_GUIDE.md`](TRIGGERS_GUIDE.md) — sémantique des triggers DML / contrat webhook
+- [`docs-site/guide/walkthroughs/`](../docs-site/guide/walkthroughs/) — tutoriels pas-à-pas (audit, isochrone, parcels)

--- a/gispulse/adapters/http/app.py
+++ b/gispulse/adapters/http/app.py
@@ -40,6 +40,7 @@ from gispulse.adapters.http.routers.rules_router import router as rules_router
 from gispulse.adapters.http.routers.scenarios_router import router as scenarios_router
 from gispulse.adapters.http.routers.sessions_router import router as sessions_router
 from gispulse.adapters.http.routers.schedules_router import router as schedules_router
+from gispulse.adapters.http.routers.system_router import router as system_router
 from gispulse.adapters.http.routers.triggers_router import router as triggers_router
 from gispulse.adapters.http.routers.relations_router import router as relations_router
 from gispulse.adapters.http.routers.marketplace_router import router as marketplace_router
@@ -718,6 +719,7 @@ def create_app(
         app.include_router(filter_router)
         app.include_router(schedules_router)
         app.include_router(pipelines_router)
+        app.include_router(system_router)
         try:
             app.include_router(catalog_router)
         except Exception:
@@ -755,6 +757,7 @@ def create_app(
         app.include_router(filter_router)
         app.include_router(schedules_router, **write_protected)
         app.include_router(pipelines_router, **write_protected)
+        app.include_router(system_router, **protected)
 
         # Marketplace (read endpoints open, install/uninstall admin-gated internally)
         app.include_router(marketplace_router)

--- a/gispulse/adapters/http/routers/system_router.py
+++ b/gispulse/adapters/http/routers/system_router.py
@@ -1,0 +1,63 @@
+"""System diagnostics router — POST /system/doctor.
+
+HTTP surface of :func:`gispulse.diagnostics.system.run_checks`. Mirrors
+``gispulse doctor --json`` exactly: same selectors, same response schema.
+
+Closes P0-4 of the CLI ↔ Portal parity audit (issue #91 / EPIC #90).
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from gispulse.adapters.http.auth import require_role
+from gispulse.diagnostics import KNOWN_CHECKS, run_checks
+
+router = APIRouter(prefix="/system", tags=["system"])
+
+
+class DoctorRequest(BaseModel):
+    checks: list[str] | None = Field(
+        default=None,
+        description="Subset of checks to run. Omit / null to run all known checks.",
+    )
+
+
+class DoctorCheck(BaseModel):
+    name: str
+    status: str  # "ok" | "warning" | "error" | "skipped"
+    detail: str
+
+
+class DoctorResponse(BaseModel):
+    summary: dict[str, int]
+    checks: list[DoctorCheck]
+    ran_at: str
+    has_critical: bool
+
+
+@router.post("/doctor", response_model=DoctorResponse)
+async def doctor(
+    body: DoctorRequest | None = None,
+    _user=Depends(require_role("admin")),
+) -> DoctorResponse:
+    """Run system diagnostics and return per-check results.
+
+    Admin-only because the response leaks runtime versions (light recon).
+    In portal-mode local (``gispulse portal``) where auth is disabled, the
+    ``require_role`` dependency is a no-op and the endpoint is reachable.
+    """
+    requested = body.checks if body and body.checks is not None else None
+
+    if requested is not None:
+        unknown = [n for n in requested if n not in KNOWN_CHECKS]
+        if unknown:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Unknown checks: {sorted(unknown)}. "
+                       f"Known: {sorted(KNOWN_CHECKS.keys())}",
+            )
+
+    result = run_checks(requested)
+    return DoctorResponse(**result.to_dict())

--- a/gispulse/cli.py
+++ b/gispulse/cli.py
@@ -488,167 +488,35 @@ def info(
 
 
 @app.command()
-def doctor() -> None:
-    """Run system diagnostics and check environment health."""
-    import os
-    import platform
-    import shutil
-    import sys
+@app.command()
+def doctor(
+    json_output: bool = typer.Option(False, "--json", help="Emit JSON instead of the rich table."),
+) -> None:
+    """Run system diagnostics and check environment health.
 
-    has_critical = False
-    results: list[tuple[str, str, str]] = []  # (status_icon, check_name, detail)
+    Wraps :func:`gispulse.diagnostics.system.run_checks` so the CLI and the
+    ``POST /system/doctor`` HTTP endpoint produce identical results.
+    """
+    from gispulse.diagnostics import run_checks
 
-    # --- 1. GISPulse version ---
-    try:
-        from importlib.metadata import version as pkg_version
+    result = run_checks()
 
-        gp_version = pkg_version("gispulse")
-        results.append(("\u2713", "GISPulse", f"v{gp_version}"))
-    except Exception:
-        results.append(("\u2713", "GISPulse", "v0.1.0 (source)"))
-
-    # --- 2. Python version ---
-    py_ver = platform.python_version()
-    py_tuple = sys.version_info[:2]
-    if py_tuple >= (3, 10):
-        results.append(("\u2713", "Python", f"v{py_ver}"))
+    if json_output:
+        import json as _json
+        typer.echo(_json.dumps(result.to_dict(), default=str))
     else:
-        results.append(("\u2717", "Python", f"v{py_ver} (>= 3.10 required)"))
-        has_critical = True
+        _doctor_render(result.checks)
 
-    # --- 3. GDAL ---
-    try:
-        from osgeo import gdal
-
-        gdal_ver = gdal.VersionInfo("RELEASE_NAME")
-        results.append(("\u2713", "GDAL", f"v{gdal_ver}"))
-    except ImportError:
-        results.append(("\u26a0", "GDAL", "not installed (optional, needed for raster)"))
-
-    # --- 4. DuckDB + spatial extension ---
-    try:
-        import duckdb
-
-        ddb_ver = duckdb.__version__
-        detail = f"v{ddb_ver}"
-        try:
-            conn = duckdb.connect(":memory:")
-            conn.execute("INSTALL spatial; LOAD spatial;")
-            conn.execute("SELECT ST_Point(0, 0);")
-            detail += " + spatial extension"
-            conn.close()
-        except Exception:
-            detail += " (spatial extension NOT available)"
-        results.append(("\u2713", "DuckDB", detail))
-    except ImportError:
-        results.append(("\u2717", "DuckDB", "not installed (required)"))
-        has_critical = True
-
-    # --- 5. PostGIS connectivity ---
-    from core.config import settings as _cfg
-    db_url = _cfg.database.dsn or None
-    if db_url:
-        try:
-            import psycopg2
-
-            conn = psycopg2.connect(db_url)
-            cur = conn.cursor()
-            cur.execute("SELECT PostGIS_Version();")
-            pg_ver = cur.fetchone()[0]
-            cur.close()
-            conn.close()
-            results.append(("\u2713", "PostGIS", f"v{pg_ver}"))
-        except ImportError:
-            results.append(("\u26a0", "PostGIS", "psycopg2 not installed (pip install gispulse[postgis])"))
-        except Exception as e:
-            results.append(("\u2717", "PostGIS", f"connection failed: {e}"))
-            has_critical = True
-    else:
-        results.append(("\u26a0", "PostGIS", "GISPULSE_DATABASE_URL not set (optional)"))
-
-    # --- 6. Disk space ---
-    try:
-        usage = shutil.disk_usage(os.getcwd())
-        free_gb = usage.free / (1024**3)
-        if free_gb < 1.0:
-            results.append(("\u26a0", "Disk space", f"{free_gb:.1f} GB free (< 1 GB warning)"))
-        else:
-            results.append(("\u2713", "Disk space", f"{free_gb:.1f} GB free"))
-    except OSError:
-        results.append(("\u26a0", "Disk space", "unable to check"))
-
-    # --- 7. Optional dependencies ---
-    optional_deps = {
-        "geopandas": "geopandas",
-        "shapely": "shapely",
-        "fiona": "fiona",
-        "pyogrio": "pyogrio",
-        "rasterio": "rasterio",
-    }
-    for display_name, module_name in optional_deps.items():
-        try:
-            mod = __import__(module_name)
-            ver = getattr(mod, "__version__", getattr(mod, "gdal_version", "?"))
-            results.append(("\u2713", display_name, f"v{ver}"))
-        except ImportError:
-            results.append(("\u26a0", display_name, "not installed (optional)"))
-
-    # --- 7b. mod_spatialite (Linux loadable extension) ---
-    # Tracked GPKGs install SQLite triggers calling SpatiaLite functions
-    # (ST_IsEmpty, ...). On Linux, libspatialite ships without the loadable
-    # extension by default → DML on tracked layers crashes with
-    # "no such function: ST_IsEmpty". Verify the extension is loadable.
-    if platform.system() == "Linux":
-        import sqlite3 as _sqlite3
-
-        _conn = _sqlite3.connect(":memory:")
-        try:
-            _conn.enable_load_extension(True)
-            try:
-                _conn.load_extension("mod_spatialite")
-                results.append(("✓", "mod_spatialite", "loadable"))
-            except _sqlite3.OperationalError:
-                # Non-critical: only required for SQL editing of tracked GPKGs.
-                results.append((
-                    "⚠",
-                    "mod_spatialite",
-                    "not loadable — apt install libsqlite3-mod-spatialite (needed for tracked GPKG DML)",
-                ))
-        except (AttributeError, _sqlite3.NotSupportedError):
-            # Python compiled without enable_load_extension support — rare
-            results.append(("⚠", "mod_spatialite", "sqlite3 built without load_extension support"))
-        finally:
-            _conn.close()
-
-    # --- 8. OIDC / Session secret ---
-    from core.config import settings as _cfg2
-    oidc_issuer = _cfg2.oidc.issuer.strip()
-    session_secret = _cfg2.session.secret.strip()
-    if oidc_issuer:
-        if session_secret:
-            results.append(("\u2713", "OIDC session secret", "set"))
-        else:
-            results.append(("\u2717", "OIDC session secret", "GISPULSE_SESSION_SECRET not set — OIDC will refuse to start"))
-            has_critical = True
-    else:
-        results.append(("\u26a0", "OIDC", "not configured (optional)"))
-
-    # --- 9. Portal assets ---
-    portal_dist = Path(__file__).resolve().parent.parent / "portal" / "dist"
-    if portal_dist.exists() and any(portal_dist.iterdir()):
-        results.append(("\u2713", "Portal assets", str(portal_dist)))
-    else:
-        results.append(("\u26a0", "Portal assets", "portal/dist/ not found (run: cd portal && npm run build)"))
-
-    # --- Render output ---
-    _doctor_render(results)
-
-    if has_critical:
+    if result.has_critical:
         raise typer.Exit(1)
 
 
-def _doctor_render(results: list[tuple[str, str, str]]) -> None:
-    """Render doctor results as a formatted table, using rich if available."""
+_STATUS_ICON = {"ok": "\u2713", "error": "\u2717", "warning": "\u26a0", "skipped": "\u2026"}
+_STATUS_STYLE = {"ok": "green", "error": "red bold", "warning": "yellow", "skipped": "dim"}
+
+
+def _doctor_render(results) -> None:
+    """Render :class:`CheckResult` items as a rich table (with plain fallback)."""
     try:
         from rich.console import Console
         from rich.table import Table
@@ -658,22 +526,21 @@ def _doctor_render(results: list[tuple[str, str, str]]) -> None:
         table.add_column("Check", min_width=16)
         table.add_column("Detail")
 
-        style_map = {"\u2713": "green", "\u2717": "red bold", "\u26a0": "yellow"}
-        for icon, name, detail in results:
-            style = style_map.get(icon, "")
-            table.add_row(f"[{style}]{icon}[/{style}]", name, detail)
+        for r in results:
+            icon = _STATUS_ICON.get(r.status, "?")
+            style = _STATUS_STYLE.get(r.status, "")
+            table.add_row(f"[{style}]{icon}[/{style}]", r.name, r.detail)
 
         Console().print(table)
     except ImportError:
-        # Fallback: plain text
         typer.echo("")
         typer.echo("GISPulse Doctor")
         typer.echo("=" * 60)
-        name_width = max(len(r[1]) for r in results)
-        for icon, name, detail in results:
-            typer.echo(f"  {icon}  {name:<{name_width}}  {detail}")
+        name_width = max((len(r.name) for r in results), default=0)
+        for r in results:
+            icon = _STATUS_ICON.get(r.status, "?")
+            typer.echo(f"  {icon}  {r.name:<{name_width}}  {r.detail}")
         typer.echo("=" * 60)
-
 
 @app.command()
 def engine(

--- a/gispulse/diagnostics/__init__.py
+++ b/gispulse/diagnostics/__init__.py
@@ -1,0 +1,23 @@
+"""Runtime diagnostics — system health checks shared by CLI and HTTP API.
+
+The pure functions in :mod:`gispulse.diagnostics.system` are consumed by both
+``gispulse doctor`` (CLI surface) and ``POST /system/doctor`` (Portal HTTP
+surface). Keeping the logic in a single module is the contract that maintains
+the CLI ↔ Portal symmetry axiom for system diagnostics.
+"""
+
+from gispulse.diagnostics.system import (
+    CheckResult,
+    CheckStatus,
+    DoctorResult,
+    KNOWN_CHECKS,
+    run_checks,
+)
+
+__all__ = [
+    "CheckResult",
+    "CheckStatus",
+    "DoctorResult",
+    "KNOWN_CHECKS",
+    "run_checks",
+]

--- a/gispulse/diagnostics/system.py
+++ b/gispulse/diagnostics/system.py
@@ -19,7 +19,7 @@ import platform
 import shutil
 import sqlite3
 import sys
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable, Literal

--- a/gispulse/diagnostics/system.py
+++ b/gispulse/diagnostics/system.py
@@ -1,0 +1,233 @@
+"""Runtime / install diagnostics — pure functions consumed by CLI and HTTP.
+
+Each check returns a :class:`CheckResult` with a stable ``name`` (used as the
+selector in ``run_checks(names=…)`` and as the JSON key over the wire) and a
+human-readable ``detail`` string. The CLI renders these with rich; the HTTP
+surface returns the dataclass as JSON.
+
+Status conventions:
+    ok       — feature present and working
+    warning  — feature missing but non-blocking (optional dep, fallback ok)
+    error    — feature missing/broken and the runtime cannot work without it
+    skipped  — feature intentionally not configured (e.g. PostGIS without DSN)
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import sqlite3
+import sys
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Literal
+
+CheckStatus = Literal["ok", "warning", "error", "skipped"]
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    name: str
+    status: CheckStatus
+    detail: str
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class DoctorResult:
+    summary: dict[str, int]
+    checks: list[CheckResult]
+    ran_at: str
+    has_critical: bool = False
+
+    def to_dict(self) -> dict:
+        return {
+            "summary": self.summary,
+            "checks": [c.to_dict() for c in self.checks],
+            "ran_at": self.ran_at,
+            "has_critical": self.has_critical,
+        }
+
+
+def _check_gispulse() -> CheckResult:
+    try:
+        from importlib.metadata import version as pkg_version
+        return CheckResult("gispulse", "ok", f"v{pkg_version('gispulse')}")
+    except Exception:
+        return CheckResult("gispulse", "ok", "v0.1.0 (source)")
+
+
+def _check_python() -> CheckResult:
+    py_ver = platform.python_version()
+    if sys.version_info[:2] >= (3, 10):
+        return CheckResult("python", "ok", f"v{py_ver}")
+    return CheckResult("python", "error", f"v{py_ver} (>= 3.10 required)")
+
+
+def _check_gdal() -> CheckResult:
+    try:
+        from osgeo import gdal
+        return CheckResult("gdal", "ok", f"v{gdal.VersionInfo('RELEASE_NAME')}")
+    except ImportError:
+        return CheckResult("gdal", "warning", "not installed (optional, needed for raster)")
+
+
+def _check_duckdb() -> CheckResult:
+    try:
+        import duckdb
+    except ImportError:
+        return CheckResult("duckdb", "error", "not installed (required)")
+    detail = f"v{duckdb.__version__}"
+    try:
+        conn = duckdb.connect(":memory:")
+        conn.execute("INSTALL spatial; LOAD spatial;")
+        conn.execute("SELECT ST_Point(0, 0);")
+        conn.close()
+        detail += " + spatial extension"
+        return CheckResult("duckdb", "ok", detail)
+    except Exception:
+        detail += " (spatial extension NOT available)"
+        return CheckResult("duckdb", "warning", detail)
+
+
+def _check_postgis() -> CheckResult:
+    from core.config import settings as _cfg
+    db_url = _cfg.database.dsn or None
+    if not db_url:
+        return CheckResult("postgis", "skipped", "GISPULSE_DATABASE_URL not set (optional)")
+    try:
+        import psycopg2
+    except ImportError:
+        return CheckResult("postgis", "warning", "psycopg2 not installed (pip install gispulse[postgis])")
+    try:
+        conn = psycopg2.connect(db_url)
+        cur = conn.cursor()
+        cur.execute("SELECT PostGIS_Version();")
+        pg_ver = cur.fetchone()[0]
+        cur.close()
+        conn.close()
+        return CheckResult("postgis", "ok", f"v{pg_ver}")
+    except Exception as e:
+        return CheckResult("postgis", "error", f"connection failed: {e}")
+
+
+def _check_disk() -> CheckResult:
+    try:
+        usage = shutil.disk_usage(os.getcwd())
+        free_gb = usage.free / (1024**3)
+        if free_gb < 1.0:
+            return CheckResult("disk", "warning", f"{free_gb:.1f} GB free (< 1 GB warning)")
+        return CheckResult("disk", "ok", f"{free_gb:.1f} GB free")
+    except OSError:
+        return CheckResult("disk", "warning", "unable to check")
+
+
+def _make_optional_dep_check(display_name: str, module_name: str) -> Callable[[], CheckResult]:
+    def _check() -> CheckResult:
+        try:
+            mod = __import__(module_name)
+            ver = getattr(mod, "__version__", getattr(mod, "gdal_version", "?"))
+            return CheckResult(display_name, "ok", f"v{ver}")
+        except ImportError:
+            return CheckResult(display_name, "warning", "not installed (optional)")
+    return _check
+
+
+def _check_spatialite() -> CheckResult:
+    # mod_spatialite is only meaningful on Linux SQLite builds. Tracked GPKGs
+    # install SQLite triggers calling SpatiaLite functions — without the
+    # loadable extension, DML on tracked layers crashes with
+    # "no such function: ST_IsEmpty".
+    if platform.system() != "Linux":
+        return CheckResult("spatialite", "skipped", f"not applicable on {platform.system()}")
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.enable_load_extension(True)
+        try:
+            conn.load_extension("mod_spatialite")
+            return CheckResult("spatialite", "ok", "loadable")
+        except sqlite3.OperationalError:
+            return CheckResult(
+                "spatialite",
+                "warning",
+                "not loadable — apt install libsqlite3-mod-spatialite (needed for tracked GPKG DML)",
+            )
+    except (AttributeError, sqlite3.NotSupportedError):
+        return CheckResult("spatialite", "warning", "sqlite3 built without load_extension support")
+    finally:
+        conn.close()
+
+
+def _check_oidc() -> CheckResult:
+    from core.config import settings as _cfg
+    issuer = _cfg.oidc.issuer.strip()
+    secret = _cfg.session.secret.strip()
+    if not issuer:
+        return CheckResult("oidc", "skipped", "not configured (optional)")
+    if secret:
+        return CheckResult("oidc", "ok", "issuer + session secret set")
+    return CheckResult("oidc", "error", "GISPULSE_SESSION_SECRET not set — OIDC will refuse to start")
+
+
+def _check_assets() -> CheckResult:
+    # gispulse/diagnostics/system.py → parent.parent.parent gives gispulse repo root
+    portal_dist = Path(__file__).resolve().parent.parent.parent / "portal" / "dist"
+    if portal_dist.exists() and any(portal_dist.iterdir()):
+        return CheckResult("assets", "ok", str(portal_dist))
+    return CheckResult("assets", "warning", "portal/dist/ not found (run: cd portal && npm run build)")
+
+
+# Public, ordered registry. Names are stable and used as the API selector.
+KNOWN_CHECKS: dict[str, Callable[[], CheckResult]] = {
+    "gispulse": _check_gispulse,
+    "python": _check_python,
+    "gdal": _check_gdal,
+    "duckdb": _check_duckdb,
+    "postgis": _check_postgis,
+    "disk": _check_disk,
+    "geopandas": _make_optional_dep_check("geopandas", "geopandas"),
+    "shapely": _make_optional_dep_check("shapely", "shapely"),
+    "fiona": _make_optional_dep_check("fiona", "fiona"),
+    "pyogrio": _make_optional_dep_check("pyogrio", "pyogrio"),
+    "rasterio": _make_optional_dep_check("rasterio", "rasterio"),
+    "spatialite": _check_spatialite,
+    "oidc": _check_oidc,
+    "assets": _check_assets,
+}
+
+
+def run_checks(names: list[str] | None = None) -> DoctorResult:
+    """Run the named checks (or all when ``names`` is None) and return a result.
+
+    Pure function: no logging, no I/O beyond what each check needs. Both the
+    CLI and the HTTP endpoint render the returned :class:`DoctorResult`.
+
+    Unknown names in ``names`` are silently skipped — the caller is expected
+    to validate against :data:`KNOWN_CHECKS` before passing in user input.
+    """
+    selected = names if names is not None else list(KNOWN_CHECKS.keys())
+    results: list[CheckResult] = []
+    for name in selected:
+        check = KNOWN_CHECKS.get(name)
+        if check is None:
+            continue
+        try:
+            results.append(check())
+        except Exception as e:  # defensive: a buggy check should not abort the rest
+            results.append(CheckResult(name, "error", f"check raised {type(e).__name__}: {e}"))
+
+    summary = {"ok": 0, "warning": 0, "error": 0, "skipped": 0}
+    for r in results:
+        summary[r.status] = summary.get(r.status, 0) + 1
+    has_critical = summary["error"] > 0
+
+    return DoctorResult(
+        summary=summary,
+        checks=results,
+        ran_at=datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        has_critical=has_critical,
+    )

--- a/tests/unit/test_system_router.py
+++ b/tests/unit/test_system_router.py
@@ -1,0 +1,132 @@
+"""Tests for /system/doctor — closes P0-4 of the parity audit (issue #91).
+
+Validates:
+1. The pure ``run_checks()`` function returns a stable schema for selected names
+2. CLI ``gispulse doctor --json`` and HTTP ``POST /system/doctor`` produce the
+   same response shape (parity)
+3. The HTTP endpoint rejects unknown check names with 422
+4. In portal mode (auth disabled), the endpoint is reachable
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+
+from gispulse.adapters.http.app import create_app
+from gispulse.diagnostics import KNOWN_CHECKS, run_checks
+from gispulse.diagnostics.system import CheckResult, DoctorResult
+
+
+# ---------------------------------------------------------------------------
+# Pure function
+# ---------------------------------------------------------------------------
+
+
+def test_run_checks_all_returns_doctor_result() -> None:
+    result = run_checks()
+    assert isinstance(result, DoctorResult)
+    assert len(result.checks) == len(KNOWN_CHECKS)
+    # Summary covers every status that appears
+    for check in result.checks:
+        assert check.status in {"ok", "warning", "error", "skipped"}
+        assert result.summary[check.status] >= 1
+
+
+def test_run_checks_subset_runs_only_requested() -> None:
+    result = run_checks(["python", "disk"])
+    names = [c.name for c in result.checks]
+    assert names == ["python", "disk"]
+
+
+def test_run_checks_unknown_name_silently_skipped() -> None:
+    result = run_checks(["python", "does-not-exist", "disk"])
+    names = [c.name for c in result.checks]
+    assert names == ["python", "disk"]
+
+
+def test_run_checks_python_always_ok_on_supported_runtime() -> None:
+    result = run_checks(["python"])
+    py = result.checks[0]
+    assert py.name == "python"
+    if sys.version_info[:2] >= (3, 10):
+        assert py.status == "ok"
+    else:
+        assert py.status == "error"
+
+
+def test_check_result_to_dict_is_jsonable() -> None:
+    r = CheckResult("foo", "ok", "bar")
+    json.dumps(r.to_dict())  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# HTTP endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def portal_client(monkeypatch) -> TestClient:
+    """Portal mode = auth disabled, endpoint reachable without admin role."""
+    monkeypatch.setenv("GISPULSE_STORAGE", "memory")
+    from gispulse.adapters.http.rate_limit import limiter
+    limiter.enabled = False
+    app = create_app(mode="portal")
+    return TestClient(app)
+
+
+def test_post_doctor_default_runs_all(portal_client: TestClient) -> None:
+    resp = portal_client.post("/system/doctor")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert set(body.keys()) == {"summary", "checks", "ran_at", "has_critical"}
+    assert len(body["checks"]) == len(KNOWN_CHECKS)
+
+
+def test_post_doctor_subset(portal_client: TestClient) -> None:
+    resp = portal_client.post("/system/doctor", json={"checks": ["python", "disk"]})
+    assert resp.status_code == 200
+    body = resp.json()
+    names = [c["name"] for c in body["checks"]]
+    assert names == ["python", "disk"]
+
+
+def test_post_doctor_rejects_unknown_check_with_422(portal_client: TestClient) -> None:
+    resp = portal_client.post("/system/doctor", json={"checks": ["not-a-real-check"]})
+    assert resp.status_code == 422
+    body = resp.json()
+    # The app's error handler wraps HTTPException as {"error": {"message": ...}}
+    message = body.get("error", {}).get("message") or body.get("detail", "")
+    assert "not-a-real-check" in message
+
+
+def test_post_doctor_response_shape_matches_cli_json() -> None:
+    """CLI ``gispulse doctor --json`` and HTTP /system/doctor must agree on schema.
+
+    We compare the *keys* of the response, not the values, since the runtime
+    snapshot can change between calls (timestamps, versions).
+    """
+    cli_proc = subprocess.run(
+        [sys.executable, "-m", "gispulse.cli", "doctor", "--json"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert cli_proc.returncode == 0, cli_proc.stderr
+    cli_body = json.loads(cli_proc.stdout)
+
+    http_result = run_checks()  # same code path as the endpoint
+    http_body = http_result.to_dict()
+
+    # Top-level shape parity
+    assert set(cli_body.keys()) == set(http_body.keys())
+    # Per-check shape parity
+    cli_checks = {c["name"]: set(c.keys()) for c in cli_body["checks"]}
+    http_checks = {c["name"]: set(c.keys()) for c in http_body["checks"]}
+    assert cli_checks.keys() == http_checks.keys()
+    for name, keys in cli_checks.items():
+        assert keys == http_checks[name], f"keys differ for check {name!r}"


### PR DESCRIPTION
## Summary
Two `git clone` snippets in the QGIS plugin install docs pointed to `github.com/gispulse/gispulse` which 404s. Replaced with the correct org `imagodata/gispulse`.

## Changes
- `docs-site/plugins/qgis.md` (FR)
- `docs-site/en/plugins/qgis.md` (EN)

## Test plan
- [x] URLs resolve: <https://github.com/imagodata/gispulse>
- [ ] Optional: VitePress build still passes