### PR TITLE
fix(b-05): accept QGIS layer names with spaces / accents / dashes (#103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **B-05 — QGIS layer names with spaces, accents or dashes were rejected** (`v1.5.3` hotfix Beta). The change-tracking install path validated layer / column names against `^[A-Za-z_][A-Za-z0-9_]*$`, so common French desktop datasets (`Parcelles cadastrales 2024`, `voies-rapides`, `nb-bâtiments`) raised `ValueError` before any DDL ran — adoption blocker on QGIS / GDAL exports. The validator now delegates to a new `core.sql_safety.validate_layer_name()` that accepts any character safe inside a quoted identifier (`"..."`) and a quoted literal (`'...'`); only `"`, `'`, `;`, `\` and control chars are rejected. Trigger object names are derived through `core.sql_safety.slug_identifier()`, which preserves pre-B-05 ASCII names unchanged so existing v1.5.x GPKGs round-trip cleanly and rewrites Unicode names to `<safe-ascii>_<sha1[:8]>`. Same relaxation applied to `action_dispatcher`, `operation_executor`, `trigger_evaluator`; `relations_router` (HTTP-exposed) and PostgreSQL `NOTIFY` channels keep the strict regex. (#103)
+
 ## [1.5.2] - 2026-05-04
 
 Big-launch release. The runtime keeps the v1.5 surface; this release adds the QGIS plugin, three end-to-end walkthroughs, plugs a critical portal-mode middleware gap, and lands a `/system/doctor` health endpoint.

--- a/core/sql_safety.py
+++ b/core/sql_safety.py
@@ -7,6 +7,7 @@ helpers instead of rolling their own regexes.
 
 from __future__ import annotations
 
+import hashlib
 import re
 
 # ---------------------------------------------------------------------------
@@ -16,6 +17,15 @@ import re
 # Strict SQL identifier: letter/underscore start, alphanumeric/underscore/dot body.
 # Max 127 chars (PostgreSQL limit).
 SAFE_IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.]{0,126}$")
+
+# B-05: forbidden in any QGIS-friendly layer/column name. These are the
+# characters that would let the caller break out of a double-quoted
+# identifier (``"..."``), a single-quoted literal (``'...'``), or
+# terminate the statement boundary. Anything else (spaces, accents,
+# dashes, dots, leading digits, Unicode) is allowed because the GPKG
+# trigger DDL always wraps the value in quotes.
+_LAYER_NAME_FORBIDDEN: frozenset[str] = frozenset({'"', "'", ";", "\\"})
+_LAYER_NAME_MAX_LEN = 128
 
 # DDL / DCL keywords that must never appear in user-supplied expressions.
 SQL_BLOCKLIST = re.compile(
@@ -49,6 +59,85 @@ def validate_identifier(name: str, label: str = "identifier") -> str:
             "Must match ^[A-Za-z_][A-Za-z0-9_.]{0,126}$"
         )
     return name
+
+
+def validate_layer_name(name: str, label: str = "layer") -> str:
+    """Permissive identifier validator for QGIS-friendly layer/column names.
+
+    Accepts spaces, accents, dashes, dots, leading digits — any character
+    that is safe inside a *quoted* SQL identifier (``"..."``) **and** a
+    *quoted* literal (``'...'``). Use this for layer/column names that
+    originate from a local GPKG / SpatiaLite file edited by a desktop
+    tool (QGIS, Field Calculator) where the user controls the names.
+
+    DO NOT use for identifiers received over public HTTP — those go
+    through :func:`validate_identifier` (strict ASCII).
+
+    Forbidden: ``"``, ``'``, ``;``, ``\\``, plus all ASCII control
+    characters (NUL, ``\\n``, ``\\r``, ``\\t``, ...).
+
+    Args:
+        name:  Candidate name.
+        label: Human-readable label for the error message.
+
+    Returns:
+        The validated name unchanged.
+
+    Raises:
+        ValueError: If *name* is empty, longer than 128 chars, or
+            contains a forbidden character.
+    """
+    if not isinstance(name, str):
+        raise ValueError(f"Invalid {label}: {name!r} — must be str")
+    if not name:
+        raise ValueError(f"Invalid {label}: empty string")
+    if len(name) > _LAYER_NAME_MAX_LEN:
+        raise ValueError(
+            f"Invalid {label}: {name!r} longer than {_LAYER_NAME_MAX_LEN} chars"
+        )
+    for ch in name:
+        if ch in _LAYER_NAME_FORBIDDEN or ord(ch) < 0x20:
+            raise ValueError(
+                f"Invalid {label}: {name!r} contains forbidden character "
+                f"{ch!r} — accept any character except \", ', ;, \\, "
+                f"NUL or control chars"
+            )
+    return name
+
+
+def slug_identifier(name: str, *, max_safe_len: int = 32) -> str:
+    """Stable ASCII slug for use as an internal SQL object name.
+
+    When *name* is already a strict SQL identifier
+    (``[A-Za-z_][A-Za-z0-9_]*``), it is returned unchanged so legacy
+    GPKGs created with v1.5.x trigger names keep matching after the
+    B-05 relaxation. Otherwise a hash-based slug is returned of the
+    form ``<safe-prefix>_<hash8>`` where ``hash8`` is the first 8 hex
+    chars of SHA-1(name) and ``safe-prefix`` is the input lowercased
+    with non-``[a-z0-9_]`` chars replaced by ``_`` (truncated to
+    *max_safe_len* chars). The result is collision-resistant for
+    realistic dataset sizes and stable across processes (no randomness).
+
+    Args:
+        name:         Layer / column name (must be non-empty).
+        max_safe_len: Cap on the human-readable prefix length.
+
+    Returns:
+        A pure-ASCII identifier safe to embed in a trigger / index name
+        without quoting.
+
+    Raises:
+        ValueError: If *name* is empty or not a string.
+    """
+    if not isinstance(name, str) or not name:
+        raise ValueError(f"slug_identifier: empty or non-str input {name!r}")
+    if re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", name):
+        return name
+    digest = hashlib.sha1(name.encode("utf-8")).hexdigest()[:8]
+    safe = re.sub(r"[^A-Za-z0-9_]", "_", name).strip("_").lower()[:max_safe_len]
+    if not safe:
+        safe = "x"
+    return f"{safe}_{digest}"
 
 
 def validate_expression(expr: str) -> str:

--- a/gispulse/adapters/esb/action_dispatcher.py
+++ b/gispulse/adapters/esb/action_dispatcher.py
@@ -14,7 +14,15 @@ from uuid import UUID
 from gispulse.core.dispatcher import BaseDispatcher, TriggerContext
 from core.logging import get_logger
 from core.models import ActionDef, ActionType
-from core.sql_safety import validate_identifier as _validate_identifier
+from core.sql_safety import validate_identifier as _validate_strict_identifier
+from core.sql_safety import validate_layer_name as _validate_layer_name
+
+# B-05 (v1.5.3): table / column names that originate from a local GPKG
+# (QGIS desktop) flow through :func:`validate_layer_name` to accept
+# spaces, accents, dashes. ``_validate_strict_identifier`` is reserved
+# for fields that must match a SQL keyword shape (PG NOTIFY channels,
+# aggregate function names, ...).
+_validate_identifier = _validate_layer_name
 
 log = get_logger(__name__)
 
@@ -94,7 +102,7 @@ class ActionDispatcher(BaseDispatcher):
 
     def _notify(self, action: ActionDef, ctx: TriggerContext) -> None:
         channel = action.config.get("channel", "gispulse_events")
-        _validate_identifier(channel, "notify_channel")
+        _validate_strict_identifier(channel, "notify_channel")
         payload = self._render_payload(action, ctx)
         if self._event_hub:
             self._event_hub.broadcast(f"trigger:{channel}", {

--- a/persistence/gpkg_schema.py
+++ b/persistence/gpkg_schema.py
@@ -9,10 +9,10 @@ in ``gpkg_extensions`` per OGC GPKG Annex F.  They never appear in
 from __future__ import annotations
 
 import logging
-import re
 import sqlite3
 from pathlib import Path
 
+from core.sql_safety import slug_identifier, validate_layer_name
 from persistence.schema import (
     SCHEMA_VERSION,
     build_all_gpkg_schemas,
@@ -22,40 +22,34 @@ from persistence.schema import (
 # ---------------------------------------------------------------------------
 # Identifier validation
 # ---------------------------------------------------------------------------
-# P0-4c (Beta): layer/identifier names are interpolated into trigger DDL via
-# f-strings (CREATE TRIGGER + INSERT INTO ... VALUES('{layer}', ...)). A name
-# containing single-quotes, double-quotes or semicolons becomes a textbook
-# SQL injection vector. We refuse non-identifier names *up front* with
-# ValueError so callers (HTTP endpoints, engine wrappers) can surface a
-# clean 400 instead of a silently broken trigger or a dropped table.
-
-_IDENT_RE = re.compile(r"^[^\W\d][\w]*$", re.UNICODE)
-# Unicode-aware identifier rule (matches Python's ``str.isidentifier``-ish):
-# - first char: Unicode letter or underscore (no digit)
-# - body: Unicode word chars (letters, digits, underscore)
-# Rejects quotes, semicolons, spaces, dots, dashes — anything that would
-# break the f-string DDL or open an SQLi vector. Accented layer names like
-# ``parcelles_éàü`` are accepted; ``a'); DROP TABLE x; --`` is not.
+# P0-4c (Beta) + B-05 (v1.5.3): layer/identifier names are interpolated into
+# trigger DDL via f-strings (CREATE TRIGGER + INSERT INTO ... VALUES('{layer}',
+# ...)). A name containing single-quotes, double-quotes or semicolons becomes
+# a textbook SQL injection vector. We refuse such names up front with
+# ValueError so callers (HTTP endpoints, engine wrappers) can surface a clean
+# 400 instead of a silently broken trigger or a dropped table.
+#
+# B-05 (2026-05-04): the legacy regex ``^[^\W\d][\w]*$`` rejected QGIS
+# desktop layer names containing spaces ("Parcelles cadastrales 2024"),
+# dashes ("voies-rapides") or leading digits — killing FR adoption. The
+# validation now delegates to :func:`core.sql_safety.validate_layer_name`,
+# which accepts any character except those that break the quoted DDL
+# (``"``, ``'``, ``;``, ``\\``, NUL, control chars). Trigger names are
+# derived through :func:`core.sql_safety.slug_identifier` so they stay
+# pure-ASCII and stable across the original layer name's casing /
+# encoding.
 
 
 def _validate_identifier(name: str) -> str:
-    """Validate that *name* is a safe SQL identifier.
+    """Validate that *name* is a safe SQL layer/column identifier.
 
-    Args:
-        name: Candidate identifier (layer name, column name, etc.).
-
-    Returns:
-        The validated identifier (unchanged) for fluent use.
-
-    Raises:
-        ValueError: If *name* contains characters outside ``[A-Za-z0-9_]``
-            or starts with a digit. Quotes and semicolons are rejected.
+    Backward-compat shim — delegates to
+    :func:`core.sql_safety.validate_layer_name`. Kept as a module-level
+    import so existing tests
+    (``from persistence.gpkg_schema import _validate_identifier``) keep
+    working after the B-05 relaxation.
     """
-    if not isinstance(name, str) or not _IDENT_RE.match(name):
-        raise ValueError(
-            f"invalid identifier: {name!r} — must match [A-Za-z_][A-Za-z0-9_]*"
-        )
-    return name
+    return validate_layer_name(name)
 
 logger = logging.getLogger(__name__)
 
@@ -121,6 +115,15 @@ def _build_change_triggers(
     if geom_col is not None:
         _validate_identifier(geom_col)
 
+    # B-05: trigger object names must remain pure ASCII so they can be
+    # referenced without quoting in DROP TRIGGER and so SQLite's catalog
+    # ``sqlite_master`` stays readable. The layer reference in
+    # ``ON "{table_name}"`` and the literal in ``VALUES ('{table_name}',
+    # ...)`` keep the original (Unicode-safe) name because the validator
+    # has already refused single/double quotes that would close the
+    # surrounding quotes.
+    slug = slug_identifier(table_name)
+
     def _json_obj(ref: str) -> str:
         if not cols:
             return "json_object()"
@@ -135,7 +138,7 @@ def _build_change_triggers(
         gc_insert = gc_update = gc_delete = "0"
 
     insert_sql = (
-        f'CREATE TRIGGER IF NOT EXISTS "_gispulse_trg_{table_name}_insert"\n'
+        f'CREATE TRIGGER IF NOT EXISTS "_gispulse_trg_{slug}_insert"\n'
         f'AFTER INSERT ON "{table_name}"\n'
         f"BEGIN\n"
         f"  INSERT INTO _gispulse_change_log"
@@ -146,7 +149,7 @@ def _build_change_triggers(
     )
 
     update_sql = (
-        f'CREATE TRIGGER IF NOT EXISTS "_gispulse_trg_{table_name}_update"\n'
+        f'CREATE TRIGGER IF NOT EXISTS "_gispulse_trg_{slug}_update"\n'
         f'AFTER UPDATE ON "{table_name}"\n'
         f"BEGIN\n"
         f"  INSERT INTO _gispulse_change_log"
@@ -157,7 +160,7 @@ def _build_change_triggers(
     )
 
     delete_sql = (
-        f'CREATE TRIGGER IF NOT EXISTS "_gispulse_trg_{table_name}_delete"\n'
+        f'CREATE TRIGGER IF NOT EXISTS "_gispulse_trg_{slug}_delete"\n'
         f'AFTER DELETE ON "{table_name}"\n'
         f"BEGIN\n"
         f"  INSERT INTO _gispulse_change_log"
@@ -428,8 +431,9 @@ def install_change_tracking(
 
     Args:
         conn:       Open SQLite connection to the GPKG file.
-        layer_name: Spatial table to track. Must match
-                    ``[A-Za-z_][A-Za-z0-9_]*`` — see :func:`_validate_identifier`.
+        layer_name: Spatial table to track. Any string except those
+                    containing ``"``, ``'``, ``;``, ``\\`` or control
+                    chars — see :func:`_validate_identifier`.
         pk_col:     Primary key column (default ``fid`` per GPKG spec).
         columns:    Optional explicit list of columns to capture in the
                     JSON payload. When ``None``, all non-pk non-geom
@@ -473,8 +477,12 @@ def uninstall_change_tracking(conn: sqlite3.Connection, layer_name: str) -> None
         ValueError: If *layer_name* contains unsafe characters.
     """
     _validate_identifier(layer_name)
+    # B-05: derive the trigger name from the same slug used at install
+    # time so layer names with spaces / accents (post-B-05) and ASCII-safe
+    # legacy names (pre-B-05) both round-trip cleanly.
+    slug = slug_identifier(layer_name)
     for op in ("insert", "update", "delete"):
-        conn.execute(f'DROP TRIGGER IF EXISTS "_gispulse_trg_{layer_name}_{op}"')
+        conn.execute(f'DROP TRIGGER IF EXISTS "_gispulse_trg_{slug}_{op}"')
     conn.commit()
     logger.info("change_tracking_removed: %s", layer_name)
 

--- a/rules/operation_executor.py
+++ b/rules/operation_executor.py
@@ -40,7 +40,7 @@ from typing import Any, Callable
 
 from core.logging import get_logger
 from core.sql_safety import validate_expression as _validate_expression
-from core.sql_safety import validate_identifier as _validate_identifier
+from core.sql_safety import validate_layer_name as _validate_identifier  # B-05
 
 log = get_logger(__name__)
 

--- a/rules/trigger_evaluator.py
+++ b/rules/trigger_evaluator.py
@@ -36,7 +36,7 @@ from core.models import (
     parse_conditions,
 )
 from core.sql_safety import validate_expression as _validate_business_expression
-from core.sql_safety import validate_identifier as _validate_identifier
+from core.sql_safety import validate_layer_name as _validate_identifier  # B-05
 from rules.predicates import PredicateEvaluator
 
 MAX_CASCADE_DEPTH = 3

--- a/tests/integration/http/test_lot2_v2_smoke.py
+++ b/tests/integration/http/test_lot2_v2_smoke.py
@@ -275,8 +275,15 @@ def _drop_rtree_triggers(gpkg: Path, layer: str = "parcels") -> None:
     sqlite3 module. Called by tests that issue raw INSERTs through
     sqlite3 (the production path goes through pyogrio/GDAL which bundles
     SpatiaLite, so this is a *test-only* tweak — it does NOT alter what
-    the watcher observes)."""
-    con = sqlite3.connect(str(gpkg))
+    the watcher observes).
+
+    v1.5.3 hardening: route through :func:`_connect_with_retry` so we
+    don't race the upload-side pyogrio handle on slower CI runners
+    (Py 3.10 / 3.12 surfaced ``DatabaseError: file is not a database``
+    intermittently — same pattern as the ``_connect_with_retry`` callers
+    in the lifecycle assertions).
+    """
+    con = _connect_with_retry(gpkg)
     try:
         rows = con.execute(
             "SELECT name FROM sqlite_master WHERE type='trigger' AND name LIKE 'rtree_%'"

--- a/tests/unit/test_action_dispatcher.py
+++ b/tests/unit/test_action_dispatcher.py
@@ -126,14 +126,33 @@ class TestSetField:
         assert sql.calls == []
 
     def test_rejects_unsafe_field_name(self):
+        """B-05 (v1.5.3): field names go through ``validate_layer_name``,
+        which rejects only characters that break out of the surrounding
+        ``"..."`` quotes. ``--`` is fine inside a quoted identifier;
+        a literal ``"`` or ``;`` is not.
+        """
         sql = FakeSQL()
         d = ActionDispatcher(sql_executor=sql)
         action = ActionDef(
             action_type=ActionType.SET_FIELD,
-            config={"field": "evil--inject", "value": "x"},
+            config={"field": 'evil"; DROP TABLE--', "value": "x"},
         )
         d.dispatch(action, _make_context())
         assert sql.calls == []
+
+    def test_accepts_qgis_field_with_dash(self):
+        """B-05: column names like ``nb-bâtiments`` (Field Calculator
+        outputs) must reach the SQL executor — they are safe inside the
+        double-quoted ``"..."`` reference."""
+        sql = FakeSQL()
+        d = ActionDispatcher(sql_executor=sql)
+        action = ActionDef(
+            action_type=ActionType.SET_FIELD,
+            config={"field": "nb-bâtiments", "value": 12},
+        )
+        d.dispatch(action, _make_context(table="parcels", row_id="r1"))
+        assert len(sql.calls) == 1
+        assert '"nb-bâtiments"' in sql.calls[0][0]
 
     def test_missing_field_is_noop(self):
         sql = FakeSQL()

--- a/tests/unit/test_change_log_watcher_shadow_zones.py
+++ b/tests/unit/test_change_log_watcher_shadow_zones.py
@@ -437,10 +437,10 @@ class TestLayerNameEdgeCases:
     @pytest.mark.parametrize(
         "evil_name",
         [
-            'foo"; DROP TABLE x; --',
-            "o'malley",
-            "foo;bar",
-            "foo bar",
+            'foo"; DROP TABLE x; --',     # double-quote breaks identifier
+            "o'malley",                   # single-quote breaks the literal
+            "foo;bar",                    # semicolon ends statement
+            "back\\slash",               # backslash escape
             "",
             'evil\'); DROP TABLE _gispulse_change_log; --',
         ],
@@ -448,14 +448,16 @@ class TestLayerNameEdgeCases:
     def test_install_change_tracking_rejects_unsafe_identifiers(
         self, evil_name: str
     ) -> None:
-        """P0-4c fix verified: ``install_change_tracking`` interpolates
-        ``layer_name`` into trigger DDL via f-strings (DDL cannot use bound
-        parameters), so unsafe names were a textbook SQL injection vector.
+        """P0-4c (SQLi guard) + B-05 (v1.5.3 relaxation).
 
-        The ``_validate_identifier`` guard now rejects anything outside
-        ``[A-Za-z_]\\w*`` **before** any SQL runs — a malicious or simply
-        whitespace-bearing layer name raises ``ValueError`` and the
-        change_log table stays intact.
+        ``install_change_tracking`` interpolates ``layer_name`` into
+        trigger DDL via f-strings (DDL cannot use bound parameters),
+        so a name that closes the surrounding ``"..."`` /  ``'...'``
+        quotes is a textbook SQL injection vector.  The guard now
+        delegates to :func:`core.sql_safety.validate_layer_name` which
+        rejects only the four characters that would let a caller break
+        out (``"``, ``'``, ``;``, ``\\``) plus control chars; spaces /
+        accents / dashes are accepted (see B-05 acceptance tests).
         """
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "evil.gpkg"
@@ -477,13 +479,23 @@ class TestLayerNameEdgeCases:
                 conn.close()
 
     @pytest.mark.parametrize(
-        "good_name", ["parcelles", "parcelles_2024", "_test"]
+        "good_name",
+        [
+            # Pre-B-05 strict ASCII identifiers (no regression):
+            "parcelles",
+            "parcelles_2024",
+            "_test",
+            # B-05 (v1.5.3) — QGIS-friendly names:
+            "Parcelles cadastrales 2024",  # spaces
+            "voies-rapides",                # dash
+            "couche.QGIS",                  # dot
+        ],
     )
     def test_install_change_tracking_accepts_safe_identifiers(
         self, good_name: str
     ) -> None:
-        """Plain identifiers must continue to install cleanly. Catches
-        regressions in the validation regex."""
+        """Plain ASCII identifiers AND B-05-relaxed QGIS layer names
+        (spaces, dashes, dots, accents) must install cleanly."""
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "ok.gpkg"
             conn = self._bootstrap_gpkg(path)

--- a/tests/unit/test_gpkg_schema.py
+++ b/tests/unit/test_gpkg_schema.py
@@ -362,25 +362,32 @@ class TestMigration:
 
 
 class TestIdentifierValidation:
-    """Beta P0-4c: identifier guard. ``install_change_tracking`` interpolates
-    layer_name into trigger DDL via f-strings (DDL cannot use bound params),
-    so an unsafe name is a textbook SQLi vector. ``_validate_identifier``
-    rejects anything that isn't ``[A-Za-z_]\\w*`` (Unicode-aware)."""
+    """Beta P0-4c (SQLi guard) + B-05 v1.5.3 (QGIS-friendly relaxation).
+
+    ``install_change_tracking`` interpolates ``layer_name`` into trigger
+    DDL via f-strings (DDL cannot use bound parameters), so a name
+    containing ``"``, ``'``, ``;`` or ``\\`` is a textbook SQLi vector
+    and must always raise. **B-05** widened the validator to accept
+    QGIS desktop layer names with spaces, dashes, accents, leading
+    digits — anything safe inside a quoted identifier / literal — so
+    French datasets like ``"Parcelles cadastrales 2024"`` no longer
+    fail at install time.
+    """
 
     @pytest.mark.parametrize(
         "name",
         [
-            "a';DROP TABLE x;--",
-            'a"; DROP TABLE x; --',
+            "a';DROP TABLE x;--",      # closes single-quoted literal
+            'a"; DROP TABLE x; --',    # closes double-quoted identifier
             "evil'); DROP TABLE _gispulse_change_log; --",
-            "with space",
-            "with-dash",
-            "table.dot",
-            "1starts_with_digit",
-            "",
-            ";",
-            "--comment",
-            "table\nname",
+            ";",                        # bare statement terminator
+            "tbl;DROP",                # statement terminator + injection
+            "back\\slash",            # backslash escape
+            "",                         # empty
+            "table\nname",             # newline (control char)
+            "table\rname",             # carriage return
+            "tab\tname",                # tab
+            "\x00null",                # NUL byte
         ],
     )
     def test_rejects_unsafe_identifiers(self, name):
@@ -390,12 +397,21 @@ class TestIdentifierValidation:
     @pytest.mark.parametrize(
         "name",
         [
+            # Strict ASCII names already worked pre-B-05 (no regression):
             "parcels",
             "parcels_2024",
             "_internal_metric",
             "Parcelles",
-            "parcelles_éàü",  # Unicode word chars allowed
+            "parcelles_éàü",   # Unicode word chars
             "naïve_layer",
+            # B-05 — QGIS desktop layer names previously rejected:
+            "Parcelles cadastrales 2024",  # spaces
+            "voies-rapides",                # dash
+            "table.dot",                    # dot (no schema in GPKG)
+            "1starts_with_digit",          # leading digit
+            "--comment",                    # SQL-comment marker (safe inside "...")
+            "café",                          # accented + non-ASCII
+            "couche QGIS éàüç-2024",       # full mix
         ],
     )
     def test_accepts_safe_identifiers(self, name):
@@ -411,15 +427,71 @@ class TestIdentifierValidation:
         with pytest.raises(ValueError):
             install_change_tracking(conn, "tbl;DROP")
 
-    def test_install_change_tracking_rejects_space(self, conn):
+    def test_install_change_tracking_accepts_space(self, conn):
+        """B-05: layer names with spaces install + fire end-to-end."""
         bootstrap_gpkg_project(conn)
-        with pytest.raises(ValueError):
-            install_change_tracking(conn, "with space")
+        layer = "Parcelles cadastrales 2024"
+        conn.execute(f'CREATE TABLE "{layer}" (fid INTEGER PRIMARY KEY, name TEXT)')
+        conn.commit()
+        install_change_tracking(conn, layer)
+        conn.execute(f'INSERT INTO "{layer}"(name) VALUES (?)', ("alpha",))
+        conn.commit()
+        row = conn.execute(
+            "SELECT table_name FROM _gispulse_change_log ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+        assert row is not None and row["table_name"] == layer
+
+    def test_install_change_tracking_accepts_dash(self, conn):
+        """B-05: dashes are allowed (SQL identifier always quoted)."""
+        bootstrap_gpkg_project(conn)
+        layer = "voies-rapides"
+        conn.execute(f'CREATE TABLE "{layer}" (fid INTEGER PRIMARY KEY)')
+        conn.commit()
+        install_change_tracking(conn, layer)
+        # Round-trip: uninstall must drop the same triggers.
+        uninstall_change_tracking(conn, layer)
+        # No leftover trigger named after that layer.
+        leftovers = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='trigger' "
+            "AND name LIKE '_gispulse_trg_%'"
+        ).fetchall()
+        for r in leftovers:
+            assert "voies" not in r["name"], f"leftover trigger: {r['name']!r}"
 
     def test_uninstall_change_tracking_rejects_unsafe(self, conn):
         bootstrap_gpkg_project(conn)
         with pytest.raises(ValueError):
             uninstall_change_tracking(conn, "a';--")
+
+    def test_install_change_tracking_slug_stable(self, conn):
+        """B-05: same Unicode layer name → same trigger names across calls."""
+        from core.sql_safety import slug_identifier
+
+        bootstrap_gpkg_project(conn)
+        layer = "Parcelles cadastrales 2024"
+        conn.execute(f'CREATE TABLE "{layer}" (fid INTEGER PRIMARY KEY)')
+        conn.commit()
+        install_change_tracking(conn, layer)
+        slug = slug_identifier(layer)
+        names = {
+            r["name"]
+            for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='trigger'"
+            ).fetchall()
+        }
+        for op in ("insert", "update", "delete"):
+            assert f"_gispulse_trg_{slug}_{op}" in names
+
+    def test_install_change_tracking_legacy_ascii_unchanged(self, conn):
+        """B-05: pre-B-05 GPKGs use ``_gispulse_trg_<layer>_<op>`` trigger
+        names. The slug must keep returning the same identifier for
+        ASCII-safe layer names so legacy projects round-trip cleanly.
+        """
+        from core.sql_safety import slug_identifier
+
+        assert slug_identifier("parcels") == "parcels"
+        assert slug_identifier("my_table_2024") == "my_table_2024"
+        assert slug_identifier("_internal") == "_internal"
 
     def test_install_change_tracking_unicode_layer_still_works(self, conn):
         """Unicode word characters (accents) must remain valid identifiers

--- a/tests/unit/test_sql_safety.py
+++ b/tests/unit/test_sql_safety.py
@@ -12,8 +12,10 @@ import pytest
 from core.sql_safety import (
     SAFE_IDENT_RE,
     SQL_BLOCKLIST,
+    slug_identifier,
     validate_expression,
     validate_identifier,
+    validate_layer_name,
     validate_ref_filter,
 )
 
@@ -158,6 +160,111 @@ class TestValidateRefFilterRejects:
     def test_rejects_unsafe(self, expr: str):
         with pytest.raises(ValueError, match="Unsafe ref_filter"):
             validate_ref_filter(expr)
+
+
+class TestValidateLayerNameAccepts:
+    """B-05 (v1.5.3): permissive validator for QGIS-friendly layer/column
+    names — accepts spaces, accents, dashes, dots, leading digits."""
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "parcels",
+            "Parcelles",
+            "Parcelles cadastrales 2024",   # spaces (B-05)
+            "voies-rapides",                 # dash (B-05)
+            "couche.qgis",                   # dot (B-05)
+            "1starts_with_digit",            # leading digit (safe inside "...")
+            "café",
+            "naïve_layer",
+            "couche QGIS éàüç-2024",
+            "_internal",
+            "T" + "x" * 127,                  # 128 chars — max allowed
+        ],
+    )
+    def test_accepts(self, name: str) -> None:
+        assert validate_layer_name(name) == name
+
+
+class TestValidateLayerNameRejects:
+    """B-05: SQLi vectors must still raise. Forbidden: ``"`` ``'`` ``;``
+    ``\\`` plus control chars."""
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "",                              # empty
+            "a';DROP TABLE x;--",
+            'a"; DROP TABLE x; --',
+            "evil'); DROP TABLE _gispulse_change_log; --",
+            ";",
+            "back\\slash",                  # backslash escape
+            "table\nname",
+            "table\rname",
+            "tab\tname",
+            "\x00null",
+            "x" * 129,                       # over 128 chars
+        ],
+    )
+    def test_rejects(self, name: str) -> None:
+        with pytest.raises(ValueError):
+            validate_layer_name(name)
+
+    def test_label_in_message(self) -> None:
+        with pytest.raises(ValueError, match="layer"):
+            validate_layer_name("a'", label="layer")
+        with pytest.raises(ValueError, match="field"):
+            validate_layer_name("a'", label="field")
+
+    def test_rejects_non_str(self) -> None:
+        with pytest.raises(ValueError):
+            validate_layer_name(42)  # type: ignore[arg-type]
+
+
+class TestSlugIdentifier:
+    """B-05: ``slug_identifier`` returns a stable ASCII slug usable as
+    a SQL trigger / index name. Pre-B-05 ASCII identifiers must round-trip
+    unchanged so existing GPKGs keep matching their trigger names."""
+
+    @pytest.mark.parametrize(
+        "name",
+        ["parcels", "parcelles_2024", "_internal", "MixedCase_99"],
+    )
+    def test_legacy_ascii_unchanged(self, name: str) -> None:
+        """ASCII-strict identifiers must NOT be hashed — preserves
+        backward-compat with v1.5.x triggers named ``_gispulse_trg_<layer>_<op>``.
+        """
+        assert slug_identifier(name) == name
+
+    def test_unicode_layer_gets_hashed_slug(self) -> None:
+        """Layer names with spaces / accents → ``<safe>_<hash8>``."""
+        slug = slug_identifier("Parcelles cadastrales 2024")
+        assert slug != "Parcelles cadastrales 2024"
+        # ASCII-only output, no spaces, no slashes
+        assert all(c.isalnum() or c == "_" for c in slug)
+        # Suffix is 8-hex-char hash
+        assert len(slug.split("_")[-1]) == 8
+
+    def test_slug_is_deterministic(self) -> None:
+        a = slug_identifier("Parcelles cadastrales 2024")
+        b = slug_identifier("Parcelles cadastrales 2024")
+        assert a == b
+
+    def test_slug_different_for_different_names(self) -> None:
+        a = slug_identifier("Parcelles 2024")
+        b = slug_identifier("Parcelles 2025")
+        assert a != b
+
+    def test_slug_handles_pure_punctuation(self) -> None:
+        """An input made entirely of unsafe-prefix characters still
+        returns a valid slug (no empty prefix)."""
+        slug = slug_identifier("---")
+        assert slug.startswith("x_")
+        assert len(slug) > 2
+
+    def test_slug_rejects_empty(self) -> None:
+        with pytest.raises(ValueError):
+            slug_identifier("")
 
 
 class TestPatternShapes:


### PR DESCRIPTION
## Summary

Hotfix B-05 from EPIC #103 (v1.5.3 hotfix Beta). The change-tracking install path validated layer / column names against `^[A-Za-z_][A-Za-z0-9_]*$`, so common French QGIS desktop datasets (`Parcelles cadastrales 2024`, `voies-rapides`, `nb-bâtiments`) raised `ValueError` before any DDL ran — a hard adoption blocker on QGIS / GDAL exports.

## Changes

**New helpers in `core/sql_safety.py`** :
- `validate_layer_name(name, label)` — permissive validator. Accepts any character safe inside a quoted SQL identifier (`\"...\"`) **and** a quoted literal (`'...'`). Forbids only the four characters that would let a caller break out (`\"`, `'`, `;`, `\\`) plus control chars. Length cap 128.
- `slug_identifier(name)` — stable ASCII slug for internal trigger / index names. Strict ASCII inputs round-trip unchanged so legacy v1.5.x GPKGs keep matching `_gispulse_trg_<layer>_<op>`; Unicode / spaced inputs become `<safe-prefix>_<sha1[:8]>`.

**Rewired callers** (local QGIS layer/column names) :
- `persistence/gpkg_schema.py` — `_validate_identifier` is now a shim over `validate_layer_name`; `_build_change_triggers` and `uninstall_change_tracking` derive the trigger object name through `slug_identifier`.
- `gispulse/adapters/esb/action_dispatcher.py` — `SET_FIELD`, `UPDATE_AGGREGATE`, `RUN_SQL`, `ENQUEUE` use `validate_layer_name`. `_notify` keeps strict `validate_identifier` (PG `NOTIFY` channel name).
- `rules/operation_executor.py`, `rules/trigger_evaluator.py` — switched to `validate_layer_name`.

**Kept strict** :
- `gispulse/adapters/http/routers/relations_router.py` — HTTP-exposed PostGIS surface, multi-tenant.
- `capabilities/postgis_sql.py` — SQL template renderer for capability nodes.

## Test plan

- [x] `tests/unit/test_sql_safety.py` — 17 new tests (positive QGIS-style names, SQLi-vector rejections, slug stability + legacy ASCII round-trip).
- [x] `tests/unit/test_gpkg_schema.py` — accept lists widened (\"Parcelles cadastrales 2024\", \"voies-rapides\", \"table.dot\", \"1starts_with_digit\", \"--comment\", ...) ; new end-to-end install + roundtrip uninstall on layer with space; slug stability assertion.
- [x] `tests/unit/test_change_log_watcher_shadow_zones.py` — reject list updated to focus on the four real injection vectors (`\"`, `'`, `;`, `\\` + empty); accept list widened with B-05 names.
- [x] `tests/unit/test_action_dispatcher.py` — `test_rejects_unsafe_field_name` rewritten with a real injection vector; new `test_accepts_qgis_field_with_dash`.
- [x] **Full unit run** : 3789 pass, 12 skip, 1 deselected, 1 xfailed, 15 xpassed. The only fails (`test_cli_portal::test_resolver_falls_back...` and 2 pointcloud_capabilities) are pre-existing on main (env-local symlink and missing `pointcloud` extra, both unrelated).

## Acceptance vs EPIC #103

> Couche QGIS \`Parcelles cadastrales 2024\` → triggers installés sans ValueError ✅
> Slug stable hash-based pour le nom interne du trigger SQL ✅
> Tests names with spaces, accents, dashes, unicode ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)