### PR TITLE
fix(b-13): schema-drift watchdog rebuilds triggers on column changes (#103)

### DIFF
--- a/persistence/change_log_watcher.py
+++ b/persistence/change_log_watcher.py
@@ -40,8 +40,10 @@ Security:
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import threading
+import time
 from typing import Any, Callable, Protocol
 
 from core.models import ChangeOperation, ChangeRecord, Trigger
@@ -167,6 +169,7 @@ class ChangeLogWatcher:
         action_dispatcher: _ActionDispatcherProtocol | None = None,
         bulk_threshold: int = 0,
         bulk_eval: str = "skip",
+        schema_drift_check_interval_s: float = 5.0,
     ) -> None:
         if poll_interval <= 0:
             raise ValueError("poll_interval must be > 0")
@@ -178,6 +181,11 @@ class ChangeLogWatcher:
             raise ValueError(
                 "bulk_eval must be 'skip' (collapse batch, no eval — Mode 2)"
                 " or 'per_row' (1 bulk WS event + per-row trigger eval — Mode 3)"
+            )
+        if schema_drift_check_interval_s < 0:
+            raise ValueError(
+                "schema_drift_check_interval_s must be >= 0 "
+                "(0 disables the drift watchdog)"
             )
         # Lot 2 v2 (Beta E2E): ``dataset_id`` is mandatory. Multi-tenant
         # event consumers cannot tell two tables named ``parcels`` apart
@@ -212,6 +220,19 @@ class ChangeLogWatcher:
         #                     trigger still sees every row.
         self._bulk_threshold = int(bulk_threshold)
         self._bulk_eval = bulk_eval
+        # B-13 (#103, v1.5.3): schema-drift watchdog. Every
+        # :attr:`_schema_drift_check_interval_s` wall-clock seconds the
+        # watcher re-hashes ``PRAGMA table_info("<layer>")`` for every
+        # tracked layer; on mismatch it drops + re-installs change
+        # tracking and broadcasts a ``schema.changed`` event so
+        # subscribers (portal, plugin) can refresh. Set to 0 to disable
+        # entirely (tests / SaaS Pro where mutating DDL goes through a
+        # different code path).
+        self._schema_drift_check_interval_s = float(
+            schema_drift_check_interval_s
+        )
+        self._schema_hashes: dict[str, str] = {}
+        self._last_drift_check_ts = 0.0
         self._evaluator = trigger_evaluator
         self._triggers_provider = triggers_provider
         self._action_dispatcher = action_dispatcher
@@ -323,7 +344,13 @@ class ChangeLogWatcher:
         cause: a transient SQLite lock during a concurrent QGIS save) we
         sleep on :attr:`_stop_event` rather than ``time.sleep`` so the
         external stop signal is honoured without an extra poll.
+
+        B-13 (#103): the wall-clock-throttled schema-drift watchdog
+        runs at the start of every tick. It is a no-op until
+        :attr:`_schema_drift_check_interval_s` seconds have passed,
+        and again a no-op when the engine has no ``_get_conn`` shim.
         """
+        self._maybe_drift_check()
         try:
             rows = self._engine.get_pending_changes(self._batch_limit)
         except Exception as exc:
@@ -760,6 +787,155 @@ class ChangeLogWatcher:
                 trigger_id,
                 exc,
             )
+
+    # ------------------------------------------------------------------
+    # Schema-drift watchdog (B-13, v1.5.3 #103)
+    # ------------------------------------------------------------------
+
+    def _maybe_drift_check(self) -> None:
+        """Throttled entry point for the schema-drift check.
+
+        Runs :meth:`_drift_check_tick` no more than once every
+        :attr:`_schema_drift_check_interval_s` wall-clock seconds; a
+        ``0`` interval disables the watchdog entirely (used by tests
+        and for SaaS contexts where DDL is gated through a different
+        code path).
+        """
+        if self._schema_drift_check_interval_s <= 0:
+            return
+        now = time.time()
+        if now - self._last_drift_check_ts < self._schema_drift_check_interval_s:
+            return
+        self._last_drift_check_ts = now
+        try:
+            self._drift_check_tick()
+        except Exception as exc:  # pragma: no cover — defensive
+            logger.warning("schema_drift_check_failed: %s", exc)
+
+    def _drift_check_tick(self) -> list[str]:
+        """Re-hash every tracked layer; on mismatch drop+reinstall the
+        triggers and broadcast ``schema.changed``.
+
+        Returns the list of layer names that drifted (and were
+        repaired). Empty when nothing changed since the last tick.
+
+        B-13 reproducer: a QGIS user adds / drops / renames a column
+        via Field Calculator. Pre-B-13 the AFTER UPDATE trigger's
+        baked ``new_values`` JSON references a stale column list;
+        further edits crash with ``no such column`` or silently
+        omit the new column from the change_log payload. The watchdog
+        rebuilds the trigger DDL the next time it ticks (default
+        every 5 s), and pushes a ``schema.changed`` event so the
+        portal / plugin can refresh their layer panels.
+        """
+        get_conn = getattr(self._engine, "_get_conn", None)
+        if get_conn is None:
+            return []
+        try:
+            conn = get_conn()
+        except Exception as exc:
+            logger.warning("schema_drift_get_conn_failed: %s", exc)
+            return []
+
+        try:
+            rows = conn.execute(
+                "SELECT DISTINCT tbl_name FROM sqlite_master "
+                "WHERE type = 'trigger' "
+                "AND name LIKE '\\_gispulse\\_trg\\_%' ESCAPE '\\'"
+            ).fetchall()
+        except Exception as exc:
+            logger.warning("schema_drift_enumerate_failed: %s", exc)
+            return []
+
+        # Cope with both sqlite3.Row (subscriptable by index) and bare
+        # tuple results (e.g. when the engine wraps the conn).
+        tracked = [str(r[0]) for r in rows if r[0]]
+        drifted: list[str] = []
+        for layer in tracked:
+            cur_hash = self._compute_schema_hash(conn, layer)
+            if cur_hash is None:
+                # Layer disappeared mid-check or PRAGMA returned
+                # nothing — drop the cached entry so a future
+                # re-creation triggers a rebuild.
+                self._schema_hashes.pop(layer, None)
+                continue
+            cached = self._schema_hashes.get(layer)
+            if cached is None:
+                # First sighting since the watcher started — cache
+                # without firing. Mass-replay of schema.changed at
+                # boot would just spam subscribers.
+                self._schema_hashes[layer] = cur_hash
+                continue
+            if cached == cur_hash:
+                continue
+            # Drift detected — repair via install_change_tracking
+            # which drops the existing GISPulse triggers, ensures the
+            # ``_gispulse_origin`` column (B-02), and recreates the
+            # full trigger set with the v3 WHEN clause baked over the
+            # *new* column list.
+            try:
+                from persistence.gpkg_schema import install_change_tracking
+
+                install_change_tracking(conn, layer)
+                self._schema_hashes[layer] = cur_hash
+                drifted.append(layer)
+            except Exception as exc:
+                logger.warning(
+                    "schema_drift_repair_failed layer=%s err=%s",
+                    layer,
+                    exc,
+                )
+                continue
+
+        for layer in drifted:
+            try:
+                self._hub.broadcast(
+                    "schema.changed",
+                    {
+                        "dataset_id": self._dataset_id,
+                        "table": layer,
+                        "change_type": "columns_changed",
+                    },
+                )
+            except Exception as exc:
+                logger.error(
+                    "schema_changed_broadcast_failed layer=%s err=%s",
+                    layer,
+                    exc,
+                )
+
+        if drifted:
+            logger.info(
+                "schema_drift_repaired layers=%s", drifted
+            )
+        return drifted
+
+    @staticmethod
+    def _compute_schema_hash(conn: Any, layer: str) -> str | None:
+        """Hash the layer's column structure (cid, name, type, notnull,
+        default, pk) so add / drop / rename / type-change all flip the
+        hash.
+
+        Returns ``None`` if the table is missing or PRAGMA fails — the
+        caller drops any cached hash so a future re-creation goes
+        through the first-sighting path.
+        """
+        try:
+            cols = conn.execute(
+                f'PRAGMA table_info("{layer}")'
+            ).fetchall()
+        except Exception:
+            return None
+        if not cols:
+            return None
+        payload = "\n".join(
+            "|".join(
+                "" if r[i] is None else str(r[i])
+                for i in range(6)
+            )
+            for r in cols
+        )
+        return hashlib.sha1(payload.encode("utf-8")).hexdigest()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_change_log_watcher_schema_drift.py
+++ b/tests/unit/test_change_log_watcher_schema_drift.py
@@ -1,0 +1,347 @@
+"""B-13 (#103, v1.5.3) — schema-drift watchdog.
+
+The watcher periodically re-hashes ``PRAGMA table_info`` for every
+tracked layer; on mismatch it drops + re-installs change tracking and
+broadcasts a ``schema.changed`` event so subscribers (portal, plugin)
+can refresh their UI.
+
+Reproducer: a QGIS user adds / drops / renames a column via Field
+Calculator. Pre-B-13 the AFTER UPDATE trigger's baked ``new_values``
+JSON references a stale column list — further edits crash with
+``no such column`` or silently omit the new column. The watchdog
+rebuilds the trigger DDL the next time it ticks (default every 5 s).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from persistence.change_log_watcher import ChangeLogWatcher
+from persistence.gpkg_schema import (
+    bootstrap_gpkg_project,
+    install_change_tracking,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+class _RecordingHub:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self.events: list[tuple[str, dict[str, Any]]] = []
+
+    def broadcast(self, event_type: str, data: dict[str, Any] | None = None) -> None:
+        with self._lock:
+            self.events.append((event_type, data or {}))
+
+
+class _GpkgEngine:
+    """Minimal engine façade over a real GPKG SQLite connection.
+
+    Exposes the ``_get_conn`` shim the watcher uses for the drift check
+    and ``_load_row_values`` plus the polling API ``get_pending_changes``
+    / ``mark_changes_processed``.
+    """
+
+    backend_name = "gpkg"
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self.acked: list[int] = []
+
+    # --- Watcher polling API --------------------------------------------------
+
+    def get_pending_changes(self, limit: int) -> list[dict]:
+        with self._open() as conn:
+            rows = conn.execute(
+                "SELECT id, table_name, operation, row_pk, changed_at "
+                "FROM _gispulse_change_log "
+                "WHERE processed = 0 ORDER BY id LIMIT ?",
+                (limit,),
+            ).fetchall()
+            return [dict(r) for r in rows]
+
+    def mark_changes_processed(self, up_to_id: int) -> int:
+        self.acked.append(up_to_id)
+        with self._open() as conn:
+            conn.execute(
+                "UPDATE _gispulse_change_log SET processed = 1 WHERE id <= ?",
+                (up_to_id,),
+            )
+            conn.commit()
+        return 1
+
+    # --- Watcher schema-drift / row-load shim ---------------------------------
+
+    def _get_conn(self) -> sqlite3.Connection:
+        # The watcher does NOT close the connection — it does direct
+        # SELECT / DDL on it. Match the shape of the real gpkg_engine
+        # which returns a long-lived connection.
+        return self._open(close_after=False)
+
+    def _open(self, *, close_after: bool = True) -> sqlite3.Connection:
+        conn = sqlite3.connect(str(self._path), isolation_level=None)
+        conn.row_factory = sqlite3.Row
+        if close_after:
+
+            class _Ctx:
+                def __init__(self, c):
+                    self._c = c
+
+                def __enter__(self):
+                    return self._c
+
+                def __exit__(self, exc_type, exc, tb):
+                    self._c.close()
+
+            return _Ctx(conn)  # type: ignore[return-value]
+        return conn
+
+
+@pytest.fixture
+def gpkg(tmp_path: Path) -> Path:
+    path = tmp_path / "test.gpkg"
+    conn = sqlite3.connect(str(path))
+    bootstrap_gpkg_project(conn)
+    conn.execute(
+        'CREATE TABLE "parcels" '
+        "(fid INTEGER PRIMARY KEY, name TEXT, area REAL)"
+    )
+    conn.commit()
+    install_change_tracking(conn, "parcels")
+    conn.close()
+    return path
+
+
+def _make_watcher(
+    *,
+    gpkg_path: Path,
+    drift_interval_s: float = 0.001,
+    hub: _RecordingHub | None = None,
+) -> tuple[ChangeLogWatcher, _RecordingHub, _GpkgEngine]:
+    hub = hub or _RecordingHub()
+    engine = _GpkgEngine(gpkg_path)
+    watcher = ChangeLogWatcher(
+        engine=engine,
+        event_hub=hub,
+        dataset_id="ds-test",
+        poll_interval=0.05,
+        batch_limit=100,
+        schema_drift_check_interval_s=drift_interval_s,
+    )
+    return watcher, hub, engine
+
+
+# ---------------------------------------------------------------------------
+# Throttling
+# ---------------------------------------------------------------------------
+
+
+def test_drift_disabled_when_interval_zero(gpkg: Path) -> None:
+    """``schema_drift_check_interval_s=0`` disables the watchdog. The
+    watcher must not call ``_get_conn`` for drift checking."""
+    watcher, hub, _engine = _make_watcher(
+        gpkg_path=gpkg, drift_interval_s=0.0
+    )
+    # Add a column to provoke drift — but the watchdog is off so no
+    # event should fire.
+    conn = sqlite3.connect(str(gpkg))
+    conn.execute('ALTER TABLE "parcels" ADD COLUMN extra TEXT')
+    conn.commit()
+    conn.close()
+
+    watcher._tick()  # noqa: SLF001
+    types = [e[0] for e in hub.events]
+    assert "schema.changed" not in types
+
+
+def test_drift_throttled_within_interval(gpkg: Path) -> None:
+    """Two ticks back-to-back with a 60s interval must check at most
+    once. The second tick is throttled."""
+    watcher, _hub, _engine = _make_watcher(
+        gpkg_path=gpkg, drift_interval_s=60.0
+    )
+    # First tick caches the layer; second tick should skip the check.
+    watcher._tick()  # noqa: SLF001
+    cached_after_first = dict(watcher._schema_hashes)  # noqa: SLF001
+    # Mutate the schema between ticks.
+    conn = sqlite3.connect(str(gpkg))
+    conn.execute('ALTER TABLE "parcels" ADD COLUMN extra TEXT')
+    conn.commit()
+    conn.close()
+    watcher._tick()  # noqa: SLF001
+    # The second tick was throttled so the cached hash never refreshed.
+    assert watcher._schema_hashes == cached_after_first  # noqa: SLF001
+
+
+# ---------------------------------------------------------------------------
+# Drift detection — first sighting is silent
+# ---------------------------------------------------------------------------
+
+
+def test_first_tick_caches_without_event(gpkg: Path) -> None:
+    """The watcher caches schema hashes on first sight without firing
+    ``schema.changed`` (otherwise every boot would replay events)."""
+    watcher, hub, _engine = _make_watcher(gpkg_path=gpkg)
+    watcher._tick()  # noqa: SLF001
+    types = [e[0] for e in hub.events]
+    assert "schema.changed" not in types
+    # ``parcels`` should be cached.
+    assert "parcels" in watcher._schema_hashes  # noqa: SLF001
+
+
+# ---------------------------------------------------------------------------
+# Drift detection — ALTER TABLE add / drop / rename
+# ---------------------------------------------------------------------------
+
+
+def test_add_column_fires_schema_changed(gpkg: Path) -> None:
+    """ALTER TABLE ADD COLUMN flips the hash → drift event + repaired
+    triggers."""
+    watcher, hub, _engine = _make_watcher(gpkg_path=gpkg)
+    watcher._tick()  # noqa: SLF001 — first sighting (silent)
+
+    # ADD COLUMN behind the watcher's back, e.g. via Field Calculator.
+    conn = sqlite3.connect(str(gpkg))
+    conn.execute('ALTER TABLE "parcels" ADD COLUMN computed_area REAL')
+    conn.commit()
+    conn.close()
+
+    drifted = watcher._drift_check_tick()  # noqa: SLF001
+    assert drifted == ["parcels"]
+    # Event broadcast.
+    drift_events = [e for e in hub.events if e[0] == "schema.changed"]
+    assert len(drift_events) == 1
+    payload = drift_events[0][1]
+    assert payload["table"] == "parcels"
+    assert payload["change_type"] == "columns_changed"
+    assert payload["dataset_id"] == "ds-test"
+
+
+def test_rename_column_fires_schema_changed(gpkg: Path) -> None:
+    """SQLite supports ``ALTER TABLE ... RENAME COLUMN`` since 3.25;
+    the rename flips PRAGMA table_info, so the watchdog catches it."""
+    watcher, hub, _engine = _make_watcher(gpkg_path=gpkg)
+    watcher._tick()  # noqa: SLF001 — first sighting
+
+    conn = sqlite3.connect(str(gpkg))
+    conn.execute('ALTER TABLE "parcels" RENAME COLUMN name TO label')
+    conn.commit()
+    conn.close()
+
+    drifted = watcher._drift_check_tick()  # noqa: SLF001
+    assert drifted == ["parcels"]
+    assert any(e[0] == "schema.changed" for e in hub.events)
+
+
+def test_drop_column_fires_schema_changed(gpkg: Path) -> None:
+    """ALTER TABLE DROP COLUMN (SQLite ≥ 3.35) flips the hash."""
+    watcher, hub, _engine = _make_watcher(gpkg_path=gpkg)
+    watcher._tick()  # noqa: SLF001 — first sighting
+
+    conn = sqlite3.connect(str(gpkg))
+    try:
+        conn.execute('ALTER TABLE "parcels" DROP COLUMN area')
+    except sqlite3.OperationalError:
+        pytest.skip("SQLite build does not support DROP COLUMN")
+    conn.commit()
+    conn.close()
+
+    drifted = watcher._drift_check_tick()  # noqa: SLF001
+    assert drifted == ["parcels"]
+
+
+# ---------------------------------------------------------------------------
+# Drift repair — triggers reflect the new column list
+# ---------------------------------------------------------------------------
+
+
+def test_drift_repair_picks_up_new_column_in_payload(gpkg: Path) -> None:
+    """After a column is added and the watchdog repairs the trigger,
+    a subsequent UPDATE must include the new column in ``new_values``."""
+    watcher, _hub, _engine = _make_watcher(gpkg_path=gpkg)
+    watcher._tick()  # noqa: SLF001 — first sighting
+
+    conn = sqlite3.connect(str(gpkg))
+    conn.execute('ALTER TABLE "parcels" ADD COLUMN computed_area REAL')
+    conn.commit()
+    conn.close()
+
+    watcher._drift_check_tick()  # noqa: SLF001 — repair
+
+    # Now write a row with the new column populated and check the
+    # change-log captured it.
+    conn = sqlite3.connect(str(gpkg))
+    conn.execute(
+        'INSERT INTO "parcels"(fid, name, area, computed_area) '
+        "VALUES (1, 'A', 10.0, 100.0)"
+    )
+    conn.commit()
+    rows = conn.execute(
+        "SELECT new_values FROM _gispulse_change_log "
+        "WHERE table_name='parcels' ORDER BY id DESC LIMIT 1"
+    ).fetchall()
+    assert len(rows) == 1
+    new_values_json = rows[0][0] or ""
+    assert "computed_area" in new_values_json, (
+        "post-repair trigger DDL must include the new column "
+        f"(got: {new_values_json!r})"
+    )
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Idempotence — no drift means no event
+# ---------------------------------------------------------------------------
+
+
+def test_no_drift_no_event(gpkg: Path) -> None:
+    """Two consecutive drift checks on a stable schema must be silent."""
+    watcher, hub, _engine = _make_watcher(gpkg_path=gpkg)
+    watcher._tick()  # noqa: SLF001 — first sighting
+    drifted = watcher._drift_check_tick()  # noqa: SLF001
+    assert drifted == []
+    types = [e[0] for e in hub.events]
+    assert "schema.changed" not in types
+
+
+# ---------------------------------------------------------------------------
+# Engine without _get_conn shim is a soft no-op
+# ---------------------------------------------------------------------------
+
+
+def test_engine_without_get_conn_is_silent(gpkg: Path) -> None:
+    """Engines that don't expose ``_get_conn`` (rare — most concrete
+    engines do) must not crash the watchdog."""
+
+    class _NoConnEngine:
+        backend_name = "noop"
+
+        def get_pending_changes(self, _limit):
+            return []
+
+        def mark_changes_processed(self, _up):
+            return 0
+
+    hub = _RecordingHub()
+    watcher = ChangeLogWatcher(
+        engine=_NoConnEngine(),  # type: ignore[arg-type]
+        event_hub=hub,
+        dataset_id="ds-test",
+        schema_drift_check_interval_s=0.001,
+    )
+    # Force the wall-clock past the throttle window.
+    watcher._last_drift_check_ts = 0.0  # noqa: SLF001
+    time.sleep(0.005)
+    watcher._tick()  # noqa: SLF001
+    # No crash, no events.
+    assert hub.events == []


### PR DESCRIPTION
## Summary

Hotfix B-13 from EPIC #103 (v1.5.3 hotfix Beta). Stacked on top of #109 (B-01) which is itself stacked on #108 (B-02) → #107 (B-05). Retarget cascade after merges. **Last bug of v1.5.3**.

The reproducer from Beta : a QGIS user adds / drops / renames a column on a tracked layer via Field Calculator. Pre-B-13 the AFTER UPDATE trigger's baked `new_values` JSON references a stale column list — further edits crash with `no such column` or silently omit the new column from the change-log payload.

## Watchdog

`ChangeLogWatcher` gains a wall-clock-throttled drift check :

- New ctor param `schema_drift_check_interval_s: float = 5.0`. Set to `0` to disable (tests / SaaS Pro where DDL is gated). Negative rejected.
- `_maybe_drift_check()` runs at the start of every `_tick`. Hard no-op until the throttle window has elapsed.
- `_drift_check_tick()` enumerates tracked layers via `sqlite_master`, hashes each layer's `PRAGMA table_info` payload (cid | name | type | notnull | default | pk per column), compares against the cached hash.
- **First sighting is silent** — caches without firing so watcher boot doesn't spam `schema.changed` events on every restart.
- On real drift : drops + reinstalls change tracking via `persistence.gpkg_schema.install_change_tracking` (which already takes care of the B-02 `_gispulse_origin` column ensure path), then broadcasts `schema.changed` with `{dataset_id, table, change_type: \"columns_changed\"}`.

## Test plan

- [x] **`test_drift_disabled_when_interval_zero`** — `interval_s=0` is the disable knob.
- [x] **`test_drift_throttled_within_interval`** — 60s interval blocks the second back-to-back tick.
- [x] **`test_first_tick_caches_without_event`** — boot is silent.
- [x] **`test_add_column_fires_schema_changed`** — ALTER TABLE ADD COLUMN flips the hash.
- [x] **`test_rename_column_fires_schema_changed`** — RENAME COLUMN (SQLite ≥ 3.25).
- [x] **`test_drop_column_fires_schema_changed`** — DROP COLUMN (SQLite ≥ 3.35, gracefully skipped on older builds).
- [x] **`test_drift_repair_picks_up_new_column_in_payload`** — post-repair INSERT captures the new column in `new_values`.
- [x] **`test_no_drift_no_event`** — idempotent on stable schema.
- [x] **`test_engine_without_get_conn_is_silent`** — engines without `_get_conn` stay silent (no crash).
- [x] **Full unit run** : 3814 pass, 13 skip (incl. the DROP COLUMN skip on this SQLite build), 3 deselected, 1 xfailed, 15 xpassed.

## Acceptance vs EPIC #103

> Hash \`PRAGMA table_info\` per layer at boot + cache ✅
> Watcher tick N (e.g. toutes 5s) re-hash, si drift → drop+reinstall triggers + broadcast \`schema.changed\` ✅
> Tests ALTER TABLE add/drop/rename column ✅

## v1.5.3 close-out checkpoint

This is the last bug of EPIC #103. Stack snapshot :

- #107 — B-05 (QGIS layer names with spaces / accents / dashes)
- #108 — B-02 (origin-tagging M1, schema v3)
- #109 — B-01 (bulk threshold Mode 3)
- **#TBD — B-13 (this PR)**

Once all four merge, EPIC #103 closes and v1.5.3 can be tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)