### PR TITLE
feat(v1.6.0): DuckDB Spatial Inside foundation — DSL geom fcts + granular DML + validate

### DIFF
--- a/core/enums.py
+++ b/core/enums.py
@@ -92,10 +92,21 @@ class TriggerType(str, Enum):
 
 
 class ChangeOperation(str, Enum):
-    """DML operation that produced a ChangeRecord."""
+    """DML operation that produced a ChangeRecord.
+
+    v1.6.0 (#119) introduced ``UPDATE_GEOM`` / ``UPDATE_ATTR`` / ``BULK`` as
+    granular variants. ``UPDATE`` remains accepted for backward compatibility
+    on the config surface — the watcher resolves a coarse ``UPDATE`` row from
+    the change log to the matching granular value via the row's
+    ``geom_changed`` flag before handing the :class:`ChangeRecord` to the
+    evaluator.
+    """
     INSERT = "INSERT"
     UPDATE = "UPDATE"
+    UPDATE_GEOM = "UPDATE_GEOM"
+    UPDATE_ATTR = "UPDATE_ATTR"
     DELETE = "DELETE"
+    BULK = "BULK"
 
 
 class RuleScope(str, Enum):

--- a/docs-site/guide/dsl-geom-functions.md
+++ b/docs-site/guide/dsl-geom-functions.md
@@ -1,0 +1,114 @@
+---
+title: DSL geom functions
+description: Whitelisted geometry functions exposed by the GISPulse DSL — area, perimeter, centroid, validity, point count.
+---
+
+# DSL geom functions
+
+The GISPulse DSL exposes a small whitelist of geometry functions you can
+call from your `triggers.yaml`. Each function compiles down to a DuckDB
+spatial expression, runs against the dataset's geometry column, and
+returns a typed value usable in `set_field` or `validate:` rules.
+
+The compiler never executes user-supplied Python — expressions are
+parsed via Python's `ast` module and rejected unless every node fits
+the strict allowlist. See [DSL design notes](./dsl-design.md) for the
+gory details.
+
+## Quick reference
+
+| Function | Returns | CRS-aware | Default `epsg=` | DuckDB call |
+|---|---|---|---|---|
+| `geom_area_m2()` | double (m²) | yes | `EPSG:2154` | `ST_Area(ST_Transform(geom, src, target, true))` |
+| `geom_perimeter_m()` | double (m) | yes | `EPSG:2154` | `ST_Perimeter(...)` |
+| `geom_length_m()` | double (m) | yes | `EPSG:2154` | `ST_Length(...)` |
+| `geom_centroid_x()` | double | yes | `EPSG:2154` | `ST_X(ST_Transform(ST_Centroid(geom), …))` |
+| `geom_centroid_y()` | double | yes | `EPSG:2154` | `ST_Y(ST_Transform(ST_Centroid(geom), …))` |
+| `geom_npoints()` | integer | no | — | `ST_NPoints(geom)` |
+| `geom_is_valid()` | boolean | no | — | `ST_IsValid(geom)` |
+
+## Examples
+
+### Auto-fill the surface in hectares
+
+```yaml
+version: 1
+gpkg: ./data/parcels.gpkg
+triggers:
+  - name: parcels_set_surface
+    table: parcels
+    when: [INSERT, UPDATE_GEOM]
+    actions:
+      - type: set_field
+        field: surface_ha
+        value: "geom_area_m2() / 10000"
+```
+
+The compiler emits the SQL fragment
+`(ST_Area(ST_Transform("geom", 'EPSG:4326', 'EPSG:2154', true)) / 10000)`,
+which DuckDB pushes down on the underlying GeoPackage.
+
+### Tag invalid geometries
+
+```yaml
+version: 1
+gpkg: ./data/parcels.gpkg
+validate:
+  - id: shape_valid
+    rule: "geom_is_valid()"
+    mode: tag
+    tag_field: validation_status
+    message: "Geometry self-intersects"
+```
+
+Failing rows are tagged with `validation_status = 'failed:shape_valid'`
+without touching the rest of the row.
+
+### Override the metric CRS per call
+
+```yaml
+- type: set_field
+  field: distance_to_origin_m
+  value: "geom_centroid_x(epsg='EPSG:3857')"
+```
+
+## CRS handling
+
+Measure functions (`geom_area_m2`, `geom_perimeter_m`, `geom_length_m`)
+project the geometry to a metric CRS before calling DuckDB's `ST_Area`
+/ `ST_Perimeter` / `ST_Length`. The default target is **`EPSG:2154`**
+(Lambert 93) — the right pick for FR cadastre / topo data. Override
+per-call with `epsg='EPSG:NNNN'`, or change the per-dataset default in
+your trigger runtime configuration.
+
+The dataset's source CRS is never inferred from the file. The runtime
+reads it from the GeoPackage's `gpkg_geometry_columns.srs_id` (or the
+PostGIS `geometry_columns` row); you pass it through to the compiler
+via `CompilationContext.source_epsg`.
+
+## Allowed expression grammar
+
+Inside a `set_field` value or a `validate:` `rule:` you may write:
+
+- Integer / float / boolean literals (`50`, `1.2`, `True`).
+- Column references — bare identifiers like `price`, `tax_rate`. Names
+  must match `[A-Za-z_][A-Za-z0-9_]{0,62}` and SQL reserved words are
+  rejected (`SELECT`, `FROM`, …).
+- Arithmetic: `+ - * / %` plus parentheses.
+- Calls to whitelisted geom functions only (the seven above). Bare
+  references to a function name are rejected — call them with `()`.
+- Inside `validate:` rules, also: comparisons (`==` `!=` `<` `<=` `>`
+  `>=`) and boolean ops (`and`, `or`, `not`).
+
+Everything else is rejected at config-load time:
+
+- Method calls (`geom.area()`), attribute access (`row.x`), indexing
+  (`a[0]`), slicing.
+- Lambdas, comprehensions, f-strings, list/dict/set literals.
+- `__import__`, `eval`, `globals`, any function not on the whitelist.
+- The `**` exponent (use repeated multiplication if you really need it).
+
+This is by design: the parser exists to give you derived columns and
+declarative validation, not a sandbox for arbitrary computation. If
+you need that, use a `run_sql` action with a hand-written SQL statement
+that lives under your security review.

--- a/docs-site/guide/dsl-validation.md
+++ b/docs-site/guide/dsl-validation.md
@@ -1,0 +1,90 @@
+---
+title: DSL validation rules
+description: The `validate:` top-level key — declarative rules with warn/tag modes for spatial data quality.
+---
+
+# Declarative validation
+
+`triggers.yaml` accepts a top-level `validate:` key that lists rules
+the runtime evaluates on every INSERT and UPDATE event. A rule is just
+a boolean DSL expression plus a mode telling the runtime what to do
+when the rule fails.
+
+## Schema
+
+```yaml
+version: 1
+gpkg: ./data/parcels.gpkg
+validate:
+  - id: surface_min
+    rule: "geom_area_m2() >= 50"
+    mode: warn
+    message: "Parcel surface < 50 m²"
+
+  - id: shape_valid
+    rule: "geom_is_valid()"
+    mode: tag
+    tag_field: validation_status
+    message: "Geometry self-intersects"
+```
+
+| Field | Required | Notes |
+|---|---|---|
+| `id` | yes | Stable identifier used in log lines and tag values. |
+| `rule` | yes | Boolean DSL expression — see [DSL geom functions](./dsl-geom-functions.md). |
+| `mode` | no (default `warn`) | `warn` logs and broadcasts. `tag` writes the failure on the row. |
+| `tag_field` | only when `mode: tag` | Column receiving `failed:<id>` on failure. |
+| `message` | no | Human-readable detail attached to the log / WS event. |
+| `enabled` | no (default `true`) | Toggle without removing the rule. |
+
+## Modes
+
+### `mode: warn`
+
+The default. Emits a structured log line and a `validation.failed`
+event over the runtime's event hub. Use this when downstream
+consumers (dashboards, alerts) need to know about failures but the
+data should keep flowing untouched.
+
+### `mode: tag`
+
+The runtime calls a `tag_field` action that writes `failed:<rule.id>`
+into the column you point at via `tag_field:`. This is the right
+default when QGIS / portal clients need to render bad rows in red, or
+when a downstream pipeline filters on a status column. The column is
+auto-created on first use; subsequent failures of the same rule
+overwrite the value.
+
+> **Note (v1.6.0 scope):** the runtime wiring for `mode: tag` (column
+> auto-create + dispatch to a SET_FIELD action) is being delivered
+> incrementally. Until it lands end-to-end, configs with `mode: tag`
+> still parse cleanly but the action is a no-op — the runtime logs a
+> warning and falls back to `mode: warn`. Track [#123]
+> (https://github.com/imagodata/gispulse/issues/123) for status.
+
+## Cross-source validation (preview)
+
+Two cross-source helpers are planned for the v1.6.x line:
+
+```yaml
+validate:
+  - id: in_known_commune
+    rule: "geom_within(layer='communes', match='code_insee')"
+    mode: warn
+
+  - id: no_overlap
+    rule: "not geom_overlaps_any(layer='self', exclude_self=true)"
+    mode: tag
+    tag_field: validation_status
+```
+
+Both compile to a DuckDB sub-query and require the engine to attach
+the cross-source layer; the runtime piece is tracked in
+[#122](https://github.com/imagodata/gispulse/issues/122). The schema
+side already accepts the syntax so you can prepare your YAML now.
+
+## Migration from ESRI Attribute Rules
+
+If you are coming from ESRI's Attribute Rules, see
+[Migrating from ESRI](./migration-from-esri.md) for a side-by-side
+table of `kind:` aliases and rule equivalents.

--- a/docs-site/guide/engines.md
+++ b/docs-site/guide/engines.md
@@ -241,3 +241,69 @@ gispulse run ... --verbose
 ```
 
 Les logs structurés (JSON) indiquent pour chaque capability quelle stratégie a été sélectionnée.
+
+## v1.6.0 — DuckDB Spatial Inside
+
+À partir de la v1.6.0, GISPulse traite **DuckDB Spatial** comme moteur compute
+universel sous-jacent à tous les engines vecteur. Le DSL `triggers.yaml`
+appelle des fonctions géométriques (`geom_area_m2`, `geom_within`, …)
+qui se compilent en SQL DuckDB push-down ; les write-back continuent de
+passer par l'adapter natif (pyogrio pour les fichiers, asyncpg pour PostGIS).
+
+### Lazy install de l'extension spatial
+
+L'extension `duckdb-spatial` n'est plus chargée au démarrage. Le premier appel
+à une fonction geom du DSL déclenche `INSTALL spatial; LOAD spatial;` (≈10 s
+sur réseau standard, puis cached). Le résultat est mis en cache pour la durée
+du processus.
+
+Pour pré-installer explicitement (CI, environnements air-gapped) :
+
+```bash
+gispulse doctor --install-spatial
+```
+
+La commande probe également quelques EPSG critiques (4326, 3857, 2154, 27572)
+et flague les transformations qui dévient au-delà de la tolérance —
+indicateur classique d'une grille de datum-shift manquante (NTF→RGF93 par ex.).
+
+### Inférence du moteur depuis l'URI
+
+En v1.6+, vous pouvez omettre `engine:` et laisser GISPulse inférer depuis l'URI :
+
+| URI | Engine inféré |
+|---|---|
+| `*.gpkg` | `gpkg` |
+| `*.sqlite`, `*.db` | `spatialite` |
+| `postgresql://…`, `postgres://…`, `postgis://…` | `postgis` |
+| `*.shp`, `*.geojson`, `*.fgb`, `*.kml`, `*.tab`, `*.csv` | `duckdb_diff` (file-blob CDC, v1.6.1+) |
+
+Override possible via `engine:` dans le YAML — la combinaison URI / override est
+validée à la lecture du config et lève une erreur si elle est incompatible
+(ex. `engine: postgis` sur un fichier `.gpkg`).
+
+### Verbes DML granulaires
+
+Les triggers acceptent maintenant `UPDATE_GEOM` et `UPDATE_ATTR` en plus de
+`UPDATE` (qui reste un alias catch-all). Le watcher résout chaque ligne du
+change log en variant fin via le flag `geom_changed` capturé au moment de
+l'AFTER UPDATE trigger SQLite. Voir
+[Migrating from ESRI](./migration-from-esri.md#triggering-events-granular-update).
+
+### Bench R1 — write-back DuckDB vs pyogrio
+
+Mesuré 2026-05-06 sur 1 M polygones EPSG:2154 :
+
+| Scénario | pyogrio (s) | DuckDB COPY (s) | Ratio | RSS pyogrio | RSS DuckDB |
+|---|---:|---:|---:|---:|---:|
+| Append +100k | 8.19 | **3.63** | 2.26× | 950 MB | **273 MB** |
+| Update attr | 6.94 | **2.75** | 2.52× | 839 MB | **255 MB** |
+| Update geom | 8.87 | **2.47** | 3.59× | 843 MB | **275 MB** |
+
+DuckDB `COPY (FORMAT GDAL, DRIVER 'GPKG', SRS 'EPSG:2154')` est **plus rapide
+que pyogrio sur les bulk writes ≤ 5 M lignes**. La doctrine "pyogrio-only
+write-back" v1.5.x est officiellement sub-optimale ; l'engine GPKG bascule
+sur DuckDB COPY pour les bulk imports en v1.6+, avec fallback pyogrio
+forcé sur les datasets >5 M lignes ou les GPKG portant des triggers / vues
+custom (write GDAL ne préserve pas tout).
+

--- a/docs-site/guide/migration-from-esri.md
+++ b/docs-site/guide/migration-from-esri.md
@@ -1,0 +1,112 @@
+---
+title: Migrating from ESRI Attribute Rules
+description: Mapping ESRI Attribute Rules → GISPulse triggers.yaml — kinds, triggering events, and the pieces that don't translate.
+---
+
+# Migrating from ESRI Attribute Rules
+
+ESRI's Attribute Rules and GISPulse's `triggers.yaml` solve the same
+problem (declarative reactions on edits) with different vocabularies.
+This page walks you through the renames and the cases that need
+rethinking when you bring an Attribute Rules file across.
+
+## TL;DR
+
+| ESRI concept | GISPulse equivalent | Notes |
+|---|---|---|
+| `type: constraint` | `kind: constraint` (alias of `validation`) | use `validate:` rule with `mode: tag` to land in the row |
+| `type: calculation` | `kind: calculation` (alias of `trigger`) | trigger with a `set_field` action |
+| `type: validation` | `kind: validation` (native) | trigger with a `validate:` rule |
+| `triggeringEvents: ["Insert"]` | `when: [INSERT]` | identical semantics |
+| `triggeringEvents: ["Update"]` | `when: [UPDATE]` (catch-all) | use `UPDATE_GEOM` / `UPDATE_ATTR` for granular dispatch |
+| `triggeringEvents: ["Delete"]` | `when: [DELETE]` | identical |
+| `evaluationOrder: 1` | not yet — order = YAML order | tracked in v1.7+ |
+| Arcade expression | DSL geom functions + arithmetic | see [DSL geom functions](./dsl-geom-functions.md) |
+| `subtype: 1` filter | `predicate: "subtype = 1"` | DSL predicate |
+
+## kind: aliases
+
+The `kind:` field on a trigger is optional — if omitted, the trigger
+defaults to the GISPulse-native `trigger` kind. ESRI users can keep
+their vocabulary by spelling out the alias:
+
+```yaml
+triggers:
+  - name: parcels_constraint_min_surface
+    kind: constraint           # alias of "validation"
+    table: parcels
+    when: [INSERT, UPDATE_GEOM]
+    actions: [...]
+```
+
+| Alias | Maps to | When to use it |
+|---|---|---|
+| `constraint` | `validation` | The rule rejects or tags rows that fail a check (ESRI "constraint" type) |
+| `calculation` | `trigger` | The rule writes a derived attribute (ESRI "calculation" type) |
+| `validation` | `validation` | Native — same as ESRI |
+| `trigger` | `trigger` | Native default for GISPulse |
+
+The alias is metadata only today: it does not change runtime
+behaviour. The GISPulse runtime decides what to do based on the
+trigger's `actions:` (and on a top-level `validate:` block); the
+`kind:` label is there to help operators read the YAML and to keep
+your migration diff small.
+
+## Triggering events: granular UPDATE
+
+ESRI fires `Update` whenever any field changes. GISPulse v1.6.0
+introduces `UPDATE_GEOM` and `UPDATE_ATTR` so you can react only to
+geometry edits or only to attribute edits:
+
+```yaml
+when: [UPDATE_GEOM]   # only when the geometry actually changed
+when: [UPDATE_ATTR]   # only when only attributes changed
+when: [UPDATE]        # catch-all (= UPDATE_GEOM ∪ UPDATE_ATTR), v1.5.x-compatible
+```
+
+The runtime resolves a coarse `UPDATE` change-log row to one of the
+granular variants by reading the `geom_changed` flag the GeoPackage
+trigger captured at edit time. Existing v1.5.x configs keep working
+because `UPDATE` is still accepted and expanded internally.
+
+`BULK` is a fourth value used by the watcher when many rows arrive at
+once (paste from QGIS, CSV import). Triggers that need to run a
+different code path on bulk events can declare `when: [BULK]`.
+
+## Arcade vs the GISPulse DSL
+
+The GISPulse DSL is intentionally smaller than Arcade. You get
+geometry helpers (`geom_area_m2`, `geom_is_valid`, …), arithmetic, and
+boolean/comparison operators inside `validate:` rules. You do **not**
+get `IIf`, lookups by `OID`, schema mutations, or arbitrary script
+execution — those land you in `run_sql` territory, where the YAML
+ships a hand-written SQL fragment that goes through your security
+review.
+
+Cross-source lookups (`layer_lookup`, `geom_within`,
+`geom_overlaps_any`) are coming in the v1.6.x line; track
+[#122](https://github.com/imagodata/gispulse/issues/122) and
+[#124](https://github.com/imagodata/gispulse/issues/124) for status.
+
+## What does not translate
+
+| Feature | Status | Workaround |
+|---|---|---|
+| Subtypes | not modelled | use `predicate:` to filter rows |
+| Domains | not modelled | use a `validate:` rule that compares against a list |
+| Editor tracking fields | not auto-managed | add `set_field` actions for `last_edited_user` etc. |
+| Attribute Rules error codes | not modelled | use `validate:` `id:` + `message:` + a tag column |
+| Asynchronous batch evaluation | not the GISPulse model | rules fire immediately on the change-log tail |
+
+## Checklist for a clean migration
+
+1. Export your Attribute Rules to JSON via `arcpy.management.ExportAttributeRules`.
+2. For each rule, decide whether it belongs in `triggers:` (mutates
+   the row, ESRI `calculation`) or `validate:` (just checks, ESRI
+   `constraint` or `validation`).
+3. Translate the Arcade expression: simple math + geom checks map
+   directly; anything Arcade-only goes into a `run_sql` action.
+4. Set `kind:` to the ESRI vocabulary if it helps your team read the
+   YAML — it is purely cosmetic.
+5. Run `gispulse triggers run --dry` to see the compile output before
+   wiring it to a live dataset.

--- a/gispulse/cli.py
+++ b/gispulse/cli.py
@@ -491,12 +491,26 @@ def info(
 @app.command()
 def doctor(
     json_output: bool = typer.Option(False, "--json", help="Emit JSON instead of the rich table."),
+    install_spatial: bool = typer.Option(
+        False,
+        "--install-spatial",
+        help="Pre-install the DuckDB spatial extension and verify EPSG roundtrips.",
+    ),
 ) -> None:
     """Run system diagnostics and check environment health.
 
     Wraps :func:`gispulse.diagnostics.system.run_checks` so the CLI and the
     ``POST /system/doctor`` HTTP endpoint produce identical results.
+
+    Pass ``--install-spatial`` to force the DuckDB spatial extension install
+    (instead of waiting for the first DSL geom function to trigger it lazily)
+    and probe a few common EPSG transforms — useful in CI or air-gapped
+    environments where the lazy install path would surprise users at runtime.
     """
+    if install_spatial:
+        _doctor_install_spatial(json_output=json_output)
+        return
+
     from gispulse.diagnostics import run_checks
 
     result = run_checks()
@@ -508,6 +522,74 @@ def doctor(
         _doctor_render(result.checks)
 
     if result.has_critical:
+        raise typer.Exit(1)
+
+
+def _doctor_install_spatial(*, json_output: bool) -> None:
+    """Install the DuckDB spatial extension and probe EPSG roundtrips.
+
+    Exits 1 if install fails (network, sandboxed) or any default EPSG check
+    falls outside tolerance — the latter usually means PROJ is missing the
+    IGN datum-shift grid required for high-precision French CRS.
+    """
+    from dataclasses import asdict
+
+    from gispulse.runtime.duckdb_engine import (
+        DuckDBSpatialUnavailable,
+        get_spatial_connection,
+        verify_epsg_roundtrip,
+    )
+
+    payload: dict[str, object] = {"install": "ok", "epsg": []}
+    try:
+        conn = get_spatial_connection()
+    except DuckDBSpatialUnavailable as exc:
+        payload["install"] = "error"
+        payload["error"] = str(exc)
+        if json_output:
+            import json as _json
+
+            typer.echo(_json.dumps(payload))
+        else:
+            typer.echo(f"✗ DuckDB spatial install failed: {exc}", err=True)
+        raise typer.Exit(1)
+
+    try:
+        import duckdb
+
+        version = duckdb.__version__
+        spatial_version_row = conn.execute(
+            "SELECT extension_version FROM duckdb_extensions() WHERE extension_name='spatial'"
+        ).fetchone()
+        spatial_version = spatial_version_row[0] if spatial_version_row else "?"
+
+        checks = verify_epsg_roundtrip(conn)
+    finally:
+        conn.close()
+
+    payload["duckdb_version"] = version
+    payload["spatial_version"] = spatial_version
+    payload["epsg"] = [asdict(c) for c in checks]
+    has_failures = any(not c.ok for c in checks)
+
+    if json_output:
+        import json as _json
+
+        typer.echo(_json.dumps(payload, default=str))
+    else:
+        typer.echo("")
+        typer.echo("GISPulse Doctor — DuckDB Spatial")
+        typer.echo("=" * 60)
+        typer.echo(f"  duckdb         v{version}")
+        typer.echo(f"  spatial ext    v{spatial_version}")
+        typer.echo("")
+        typer.echo("EPSG roundtrip probes (WGS84 → target CRS):")
+        for c in checks:
+            icon = _STATUS_ICON["ok"] if c.ok else _STATUS_ICON["error"]
+            typer.echo(f"  {icon}  EPSG:{c.epsg:<6}  {c.detail}")
+        typer.echo("=" * 60)
+
+    if has_failures:
         raise typer.Exit(1)
 
 

--- a/gispulse/diagnostics/system.py
+++ b/gispulse/diagnostics/system.py
@@ -82,13 +82,19 @@ def _check_duckdb() -> CheckResult:
     except ImportError:
         return CheckResult("duckdb", "error", "not installed (required)")
     detail = f"v{duckdb.__version__}"
+    from gispulse.runtime.duckdb_engine import (
+        DuckDBSpatialUnavailable,
+        get_spatial_connection,
+    )
     try:
-        conn = duckdb.connect(":memory:")
-        conn.execute("INSTALL spatial; LOAD spatial;")
+        conn = get_spatial_connection()
         conn.execute("SELECT ST_Point(0, 0);")
         conn.close()
         detail += " + spatial extension"
         return CheckResult("duckdb", "ok", detail)
+    except DuckDBSpatialUnavailable:
+        detail += " (spatial extension NOT available — `gispulse doctor --install-spatial`)"
+        return CheckResult("duckdb", "warning", detail)
     except Exception:
         detail += " (spatial extension NOT available)"
         return CheckResult("duckdb", "warning", detail)

--- a/gispulse/dsl/__init__.py
+++ b/gispulse/dsl/__init__.py
@@ -1,0 +1,40 @@
+"""GISPulse DSL — declarative expression layer for ``triggers.yaml``.
+
+The DSL exposes a tiny safe surface so user-written ``set_field`` /
+``validate`` rules can run as DuckDB SQL push-down without an ``eval``
+escape hatch:
+
+- :mod:`gispulse.dsl.geom_fcts` lists the whitelisted geometry functions
+  (``geom_area_m2``, ``geom_centroid_x``, ``geom_is_valid`` …) and maps
+  each to its ``ST_*`` SQL template.
+- :mod:`gispulse.dsl.expression_parser` parses the user expression into
+  a Python AST, validates it against a strict allowlist, and compiles it
+  into safe DuckDB SQL. No bytecode is ever executed.
+
+Public surface kept tiny on purpose: callers ask for ``compile_expression``
+and either get SQL or :class:`DSLError`.
+"""
+
+from __future__ import annotations
+
+from gispulse.dsl.expression_parser import (
+    CompilationContext,
+    DSLError,
+    DSLValidationError,
+    compile_expression,
+)
+from gispulse.dsl.geom_fcts import (
+    GEOM_FUNCTIONS,
+    GeomFunctionSpec,
+    is_geom_function,
+)
+
+__all__ = [
+    "CompilationContext",
+    "DSLError",
+    "DSLValidationError",
+    "GEOM_FUNCTIONS",
+    "GeomFunctionSpec",
+    "compile_expression",
+    "is_geom_function",
+]

--- a/gispulse/dsl/expression_parser.py
+++ b/gispulse/dsl/expression_parser.py
@@ -1,0 +1,425 @@
+"""Safe expression parser for ``triggers.yaml`` ``set_field`` / ``validate``.
+
+The parser is built on top of Python's :mod:`ast` so we can lean on the
+mature tokeniser without ever calling :func:`compile`/:func:`eval`. The
+input is parsed in ``mode='eval'`` and walked by :class:`_Validator`
+which rejects everything outside the strict allowlist:
+
+==============================  ========================================
+Allowed                         Forbidden
+==============================  ========================================
+int / float literals            string / bytes / list / dict literals
+column references (``Name``)    attribute access (``foo.bar``)
+``+ - * / %`` binary operators  ``** << >> & | ^`` and any other op
+unary ``-`` / ``+``             ``not`` / boolean ops
+parentheses                     comparisons, comprehensions, lambdas
+calls to whitelisted geom fcts  any other call (incl. user functions,
+                                ``__import__``, ``eval``, ``globals``)
+keyword args limited per spec   star args / **kwargs
+==============================  ========================================
+
+The output is a pure SQL string suitable for splicing into a DuckDB
+``UPDATE``/``SELECT``/``CASE WHEN`` clause. Column names are quoted with
+double quotes after a strict ``[A-Za-z_][A-Za-z0-9_]*`` validation; geom
+functions are expanded via :data:`gispulse.dsl.geom_fcts.GEOM_FUNCTIONS`.
+
+The compiler does not introspect the dataset schema — column references
+are quoted but not checked. The runtime catches typos at execution time
+when DuckDB raises ``Binder Error: column not found``.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from dataclasses import dataclass
+from typing import Literal
+
+from gispulse.dsl.geom_fcts import GEOM_FUNCTIONS, GeomFunctionSpec
+
+_IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,62}$")
+_EPSG_RE = re.compile(r"^EPSG:\d{3,6}$", re.IGNORECASE)
+
+
+class DSLError(ValueError):
+    """Base class for any DSL error surfaced by this module."""
+
+
+class DSLValidationError(DSLError):
+    """Raised when an expression violates the DSL allowlist.
+
+    The message points at the AST node by line/column when available so
+    operators can fix their YAML quickly.
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class CompilationContext:
+    """Context passed to :func:`compile_expression`.
+
+    Parameters
+    ----------
+    geom_column:
+        SQL identifier of the geometry column. Must be a valid identifier
+        — quoted with double quotes by the compiler. Defaults to
+        ``"geom"`` to match the GeoPackage convention.
+    source_epsg:
+        EPSG code of the dataset's geometry column (e.g. ``"EPSG:4326"``).
+        Required when an expression uses any CRS-aware geom function so
+        the emitted ``ST_Transform`` knows the source CRS.
+    default_metric_epsg:
+        Fallback EPSG used by measure functions (``geom_area_m2`` …) when
+        the user does not pass ``epsg=...``. Defaults to ``"EPSG:2154"``
+        (Lambert 93) — appropriate for FR-centric datasets; override to
+        ``"EPSG:3857"`` for global Web Mercator.
+    """
+
+    geom_column: str = "geom"
+    source_epsg: str | None = None
+    default_metric_epsg: str = "EPSG:2154"
+
+    def __post_init__(self) -> None:
+        if not _IDENT_RE.match(self.geom_column):
+            raise DSLValidationError(
+                f"invalid geom_column identifier {self.geom_column!r}"
+            )
+        if self.source_epsg is not None and not _EPSG_RE.match(self.source_epsg):
+            raise DSLValidationError(
+                f"source_epsg must look like 'EPSG:NNNN', got {self.source_epsg!r}"
+            )
+        if not _EPSG_RE.match(self.default_metric_epsg):
+            raise DSLValidationError(
+                f"default_metric_epsg must look like 'EPSG:NNNN', got "
+                f"{self.default_metric_epsg!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+CompileMode = Literal["scalar", "boolean"]
+
+
+def compile_expression(
+    expr: str,
+    ctx: CompilationContext | None = None,
+    *,
+    mode: "CompileMode" = "scalar",
+) -> str:
+    """Compile ``expr`` to safe DuckDB SQL.
+
+    Parameters
+    ----------
+    expr:
+        The user-written expression, e.g. ``"geom_area_m2() / 10000"``.
+    ctx:
+        Compilation context. Defaults to a no-source context — fine for
+        CRS-agnostic expressions (``geom_npoints()``, plain arithmetic on
+        columns); CRS-aware functions raise :class:`DSLValidationError`
+        when invoked without a source EPSG.
+    mode:
+        ``"scalar"`` (default) — arithmetic only, used for ``set_field``
+        expressions. ``"boolean"`` — also accepts ``==`` ``!=`` ``<``
+        ``<=`` ``>`` ``>=`` comparisons plus ``and`` / ``or`` / ``not``
+        and rejects pure-arithmetic expressions; used for ``validate:``
+        rules and trigger ``predicate:`` clauses.
+
+    Returns
+    -------
+    str
+        A SQL fragment safe to splice (no user input is interpolated
+        verbatim — column names are validated against ``[A-Za-z_]\\w*``,
+        EPSG codes against ``EPSG:NNNN``).
+
+    Raises
+    ------
+    DSLValidationError
+        On parse failure or any allowlist violation.
+    """
+    if ctx is None:
+        ctx = CompilationContext()
+    if mode not in ("scalar", "boolean"):
+        raise DSLValidationError(f"unsupported mode {mode!r}")
+    if not isinstance(expr, str):
+        raise DSLValidationError(
+            f"expression must be a string, got {type(expr).__name__}"
+        )
+    if not expr.strip():
+        raise DSLValidationError("expression is empty")
+    if "\x00" in expr:
+        raise DSLValidationError("expression contains NUL byte")
+    if len(expr) > 4096:
+        raise DSLValidationError(
+            f"expression too long ({len(expr)} chars > 4096)"
+        )
+    try:
+        tree = ast.parse(expr, mode="eval")
+    except SyntaxError as exc:
+        raise DSLValidationError(
+            f"syntax error at line {exc.lineno}, col {exc.offset}: {exc.msg}"
+        ) from exc
+    return _Compiler(ctx, mode=mode).visit(tree.body)
+
+
+# ---------------------------------------------------------------------------
+# Compiler implementation
+# ---------------------------------------------------------------------------
+
+
+_BIN_OPS: dict[type[ast.operator], str] = {
+    ast.Add: "+",
+    ast.Sub: "-",
+    ast.Mult: "*",
+    ast.Div: "/",
+    ast.Mod: "%",
+}
+
+_UNARY_OPS: dict[type[ast.unaryop], str] = {
+    ast.USub: "-",
+    ast.UAdd: "+",
+}
+
+# Boolean-mode-only allowlists. ``compile_expression(..., mode="boolean")``
+# unlocks comparisons + and/or/not for use inside ``validate:`` rules.
+_CMP_OPS: dict[type[ast.cmpop], str] = {
+    ast.Eq: "=",
+    ast.NotEq: "<>",
+    ast.Lt: "<",
+    ast.LtE: "<=",
+    ast.Gt: ">",
+    ast.GtE: ">=",
+}
+
+_BOOL_OPS: dict[type[ast.boolop], str] = {
+    ast.And: "AND",
+    ast.Or: "OR",
+}
+
+
+class _Compiler:
+    """Walks the AST produced by :func:`ast.parse` and emits SQL."""
+
+    def __init__(self, ctx: CompilationContext, *, mode: "CompileMode" = "scalar") -> None:
+        self.ctx = ctx
+        self.mode = mode
+
+    def visit(self, node: ast.AST) -> str:
+        method = getattr(self, f"visit_{type(node).__name__}", None)
+        if method is None:
+            raise DSLValidationError(
+                self._explain(node, f"unsupported node {type(node).__name__}")
+            )
+        return method(node)
+
+    # -- literals -------------------------------------------------------------
+
+    def visit_Constant(self, node: ast.Constant) -> str:
+        if isinstance(node.value, bool):
+            return "TRUE" if node.value else "FALSE"
+        if isinstance(node.value, int):
+            return str(node.value)
+        if isinstance(node.value, float):
+            return repr(node.value)
+        raise DSLValidationError(
+            self._explain(
+                node,
+                f"unsupported literal type {type(node.value).__name__}; "
+                "only int / float / bool are allowed",
+            )
+        )
+
+    # -- column reference -----------------------------------------------------
+
+    def visit_Name(self, node: ast.Name) -> str:
+        ident = node.id
+        if not _IDENT_RE.match(ident):
+            raise DSLValidationError(
+                self._explain(node, f"invalid identifier {ident!r}")
+            )
+        if ident in GEOM_FUNCTIONS:
+            raise DSLValidationError(
+                self._explain(
+                    node,
+                    f"{ident!r} is a function and must be called as "
+                    f"{ident}(...) — bare name reference rejected",
+                )
+            )
+        # Reject reserved DuckDB keywords-via-bareword as best-effort hygiene.
+        if ident.upper() in {"SELECT", "FROM", "WHERE", "OR", "AND", "NOT"}:
+            raise DSLValidationError(
+                self._explain(node, f"{ident!r} is a SQL keyword; rename the column")
+            )
+        return f'"{ident}"'
+
+    # -- arithmetic -----------------------------------------------------------
+
+    def visit_BinOp(self, node: ast.BinOp) -> str:
+        op_cls = type(node.op)
+        op_sym = _BIN_OPS.get(op_cls)
+        if op_sym is None:
+            raise DSLValidationError(
+                self._explain(node, f"binary operator {op_cls.__name__} not allowed")
+            )
+        left = self.visit(node.left)
+        right = self.visit(node.right)
+        return f"({left} {op_sym} {right})"
+
+    def visit_UnaryOp(self, node: ast.UnaryOp) -> str:
+        op_cls = type(node.op)
+        if op_cls is ast.Not:
+            if self.mode != "boolean":
+                raise DSLValidationError(
+                    self._explain(node, "'not' requires boolean mode")
+                )
+            operand = self.visit(node.operand)
+            return f"(NOT {operand})"
+        op_sym = _UNARY_OPS.get(op_cls)
+        if op_sym is None:
+            raise DSLValidationError(
+                self._explain(node, f"unary operator {op_cls.__name__} not allowed")
+            )
+        operand = self.visit(node.operand)
+        return f"({op_sym}{operand})"
+
+    # -- comparisons + boolean ops (boolean mode only) -----------------------
+
+    def visit_Compare(self, node: ast.Compare) -> str:
+        if self.mode != "boolean":
+            raise DSLValidationError(
+                self._explain(node, "comparisons require boolean mode")
+            )
+        if len(node.ops) != 1 or len(node.comparators) != 1:
+            raise DSLValidationError(
+                self._explain(
+                    node,
+                    "chained comparisons (e.g. ``a < b < c``) are not allowed",
+                )
+            )
+        op_cls = type(node.ops[0])
+        op_sym = _CMP_OPS.get(op_cls)
+        if op_sym is None:
+            raise DSLValidationError(
+                self._explain(
+                    node, f"comparison operator {op_cls.__name__} not allowed"
+                )
+            )
+        left = self.visit(node.left)
+        right = self.visit(node.comparators[0])
+        return f"({left} {op_sym} {right})"
+
+    def visit_BoolOp(self, node: ast.BoolOp) -> str:
+        if self.mode != "boolean":
+            raise DSLValidationError(
+                self._explain(node, "'and'/'or' require boolean mode")
+            )
+        op_cls = type(node.op)
+        op_sym = _BOOL_OPS.get(op_cls)
+        if op_sym is None:
+            raise DSLValidationError(
+                self._explain(node, f"boolean op {op_cls.__name__} not allowed")
+            )
+        parts = [self.visit(v) for v in node.values]
+        return "(" + f" {op_sym} ".join(parts) + ")"
+
+    # -- function calls -------------------------------------------------------
+
+    def visit_Call(self, node: ast.Call) -> str:
+        if not isinstance(node.func, ast.Name):
+            raise DSLValidationError(
+                self._explain(
+                    node,
+                    "only direct function calls are allowed "
+                    "(no method calls, no attribute access)",
+                )
+            )
+        fn_name = node.func.id
+        spec = GEOM_FUNCTIONS.get(fn_name)
+        if spec is None:
+            raise DSLValidationError(
+                self._explain(
+                    node,
+                    f"function {fn_name!r} is not in the DSL whitelist; "
+                    f"allowed: {sorted(GEOM_FUNCTIONS)}",
+                )
+            )
+        if node.args:
+            raise DSLValidationError(
+                self._explain(
+                    node,
+                    f"{fn_name}() takes no positional arguments; "
+                    "use keyword arguments only",
+                )
+            )
+        kwargs = self._collect_kwargs(node, spec)
+        return self._render_geom_call(spec, kwargs, node)
+
+    def _collect_kwargs(
+        self, node: ast.Call, spec: GeomFunctionSpec
+    ) -> dict[str, str]:
+        out: dict[str, str] = {}
+        for kw in node.keywords:
+            if kw.arg is None:
+                raise DSLValidationError(
+                    self._explain(node, "**kwargs splat is not allowed")
+                )
+            if kw.arg not in spec.accepted_kwargs:
+                raise DSLValidationError(
+                    self._explain(
+                        node,
+                        f"{spec.name}() does not accept keyword "
+                        f"{kw.arg!r}; allowed: {list(spec.accepted_kwargs)}",
+                    )
+                )
+            if not isinstance(kw.value, ast.Constant) or not isinstance(
+                kw.value.value, str
+            ):
+                raise DSLValidationError(
+                    self._explain(
+                        node,
+                        f"{spec.name}({kw.arg}=...) requires a string literal",
+                    )
+                )
+            out[kw.arg] = kw.value.value
+        return out
+
+    def _render_geom_call(
+        self,
+        spec: GeomFunctionSpec,
+        kwargs: dict[str, str],
+        node: ast.AST,
+    ) -> str:
+        epsg = kwargs.get("epsg", self.ctx.default_metric_epsg)
+        if spec.crs_aware:
+            if not _EPSG_RE.match(epsg):
+                raise DSLValidationError(
+                    self._explain(
+                        node,
+                        f"epsg must look like 'EPSG:NNNN', got {epsg!r}",
+                    )
+                )
+            if self.ctx.source_epsg is None:
+                raise DSLValidationError(
+                    self._explain(
+                        node,
+                        f"{spec.name}() needs the dataset CRS — pass "
+                        "source_epsg in CompilationContext",
+                    )
+                )
+            sub = {
+                "geom": f'"{self.ctx.geom_column}"',
+                "epsg": epsg,
+                "src": f"'{self.ctx.source_epsg}'",
+            }
+        else:
+            sub = {"geom": f'"{self.ctx.geom_column}"'}
+        return spec.sql_template.format(**sub)
+
+    # -- error helpers --------------------------------------------------------
+
+    @staticmethod
+    def _explain(node: ast.AST, msg: str) -> str:
+        line = getattr(node, "lineno", "?")
+        col = getattr(node, "col_offset", "?")
+        return f"line {line}, col {col}: {msg}"

--- a/gispulse/dsl/geom_fcts.py
+++ b/gispulse/dsl/geom_fcts.py
@@ -1,0 +1,110 @@
+"""Whitelisted geometry functions exposed by the GISPulse DSL.
+
+Each entry maps a user-facing function name (``geom_area_m2``,
+``geom_centroid_x``, …) to a SQL template that the expression compiler
+emits against DuckDB. The templates use named placeholders that the
+compiler fills with values pulled from the function call's keyword
+arguments and from the surrounding :class:`CompilationContext`:
+
+============  =======================================================
+Placeholder   Substituted with
+============  =======================================================
+``{geom}``    The geometry column reference (e.g. ``"geom"``). Quoted
+              by the compiler.
+``{epsg}``    The target EPSG code as ``EPSG:NNNN``. Defaults to the
+              context's metric CRS (``EPSG:2154`` when unspecified)
+              for measure functions; overridable via ``epsg=...``.
+``{src}``     The source EPSG of the dataset, taken verbatim from the
+              context. Always quoted as a string literal.
+============  =======================================================
+
+The templates intentionally call ``ST_Transform(... , true)`` so the
+``always_xy`` axis convention matches PROJ-system pyproj behaviour we
+already exercise in :func:`gispulse.runtime.duckdb_engine.verify_epsg_roundtrip`.
+
+Adding a new geom function = one entry here and one round-trip test.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+ReturnType = Literal["double", "integer", "boolean"]
+
+
+@dataclass(frozen=True, slots=True)
+class GeomFunctionSpec:
+    """Specification of a single geom function exposed in the DSL."""
+
+    name: str
+    return_type: ReturnType
+    sql_template: str
+    crs_aware: bool
+    """True when ``epsg=`` keyword is meaningful (measure / centroid fns)."""
+    accepted_kwargs: tuple[str, ...] = ()
+
+
+_TEMPLATE_AREA_M2 = "ST_Area(ST_Transform({geom}, {src}, '{epsg}', true))"
+_TEMPLATE_PERIMETER_M = "ST_Perimeter(ST_Transform({geom}, {src}, '{epsg}', true))"
+_TEMPLATE_LENGTH_M = "ST_Length(ST_Transform({geom}, {src}, '{epsg}', true))"
+_TEMPLATE_CENTROID_X = "ST_X(ST_Transform(ST_Centroid({geom}), {src}, '{epsg}', true))"
+_TEMPLATE_CENTROID_Y = "ST_Y(ST_Transform(ST_Centroid({geom}), {src}, '{epsg}', true))"
+_TEMPLATE_NPOINTS = "ST_NPoints({geom})"
+_TEMPLATE_IS_VALID = "ST_IsValid({geom})"
+
+
+GEOM_FUNCTIONS: dict[str, GeomFunctionSpec] = {
+    "geom_area_m2": GeomFunctionSpec(
+        name="geom_area_m2",
+        return_type="double",
+        sql_template=_TEMPLATE_AREA_M2,
+        crs_aware=True,
+        accepted_kwargs=("epsg",),
+    ),
+    "geom_perimeter_m": GeomFunctionSpec(
+        name="geom_perimeter_m",
+        return_type="double",
+        sql_template=_TEMPLATE_PERIMETER_M,
+        crs_aware=True,
+        accepted_kwargs=("epsg",),
+    ),
+    "geom_length_m": GeomFunctionSpec(
+        name="geom_length_m",
+        return_type="double",
+        sql_template=_TEMPLATE_LENGTH_M,
+        crs_aware=True,
+        accepted_kwargs=("epsg",),
+    ),
+    "geom_centroid_x": GeomFunctionSpec(
+        name="geom_centroid_x",
+        return_type="double",
+        sql_template=_TEMPLATE_CENTROID_X,
+        crs_aware=True,
+        accepted_kwargs=("epsg",),
+    ),
+    "geom_centroid_y": GeomFunctionSpec(
+        name="geom_centroid_y",
+        return_type="double",
+        sql_template=_TEMPLATE_CENTROID_Y,
+        crs_aware=True,
+        accepted_kwargs=("epsg",),
+    ),
+    "geom_npoints": GeomFunctionSpec(
+        name="geom_npoints",
+        return_type="integer",
+        sql_template=_TEMPLATE_NPOINTS,
+        crs_aware=False,
+    ),
+    "geom_is_valid": GeomFunctionSpec(
+        name="geom_is_valid",
+        return_type="boolean",
+        sql_template=_TEMPLATE_IS_VALID,
+        crs_aware=False,
+    ),
+}
+
+
+def is_geom_function(name: str) -> bool:
+    """Return True if ``name`` is a whitelisted DSL geom function."""
+    return name in GEOM_FUNCTIONS

--- a/gispulse/runtime/__init__.py
+++ b/gispulse/runtime/__init__.py
@@ -24,6 +24,18 @@ from gispulse.runtime.config_loader import (
     to_triggers,
     validate_against_gpkg,
 )
+from gispulse.runtime.duckdb_engine import (
+    DuckDBSpatialUnavailable,
+    get_spatial_connection,
+    is_spatial_loaded,
+)
+from gispulse.runtime.engine_inference import (
+    ALL_ENGINES,
+    EngineInferenceError,
+    EngineKind,
+    infer_engine,
+    resolve_engine,
+)
 from gispulse.runtime.headless_runtime import (
     HeadlessRuntime,
     NullEventHub,
@@ -47,9 +59,13 @@ from gispulse.runtime.sqlite_retry import (
 )
 
 __all__ = [
+    "ALL_ENGINES",
     "ConfigError",
     "DEFAULT_BACKOFF_SCHEDULE",
     "DEFAULT_JITTER_PCT",
+    "DuckDBSpatialUnavailable",
+    "EngineInferenceError",
+    "EngineKind",
     "GISPulseConfig",
     "HeadlessRuntime",
     "NullEventHub",
@@ -62,9 +78,13 @@ __all__ = [
     "build_runtime",
     "build_update_payload",
     "evaluate_predicate",
+    "get_spatial_connection",
+    "infer_engine",
     "is_busy_error",
+    "is_spatial_loaded",
     "load_config",
     "parse_predicate",
+    "resolve_engine",
     "to_triggers",
     "validate_against_gpkg",
 ]

--- a/gispulse/runtime/config_loader.py
+++ b/gispulse/runtime/config_loader.py
@@ -52,7 +52,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterable, Literal
 
 import yaml  # type: ignore[import-untyped]
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 if TYPE_CHECKING:  # pragma: no cover
     from core.graph import ActionDef
@@ -75,7 +75,39 @@ _SUPPORTED_ACTION_TYPES: tuple[str, ...] = (
 )
 
 # DML operations the watcher emits.
-_SUPPORTED_DML_OPS: tuple[str, ...] = ("INSERT", "UPDATE", "DELETE")
+_SUPPORTED_DML_OPS: tuple[str, ...] = (
+    "INSERT",
+    "UPDATE",
+    "UPDATE_GEOM",
+    "UPDATE_ATTR",
+    "DELETE",
+    "BULK",
+)
+
+
+def _expand_when_to_events(when: list[str]) -> list[str]:
+    """Map the user-facing ``when`` list to the internal ``events`` set.
+
+    The granular verbs (``UPDATE_GEOM``/``UPDATE_ATTR``) are passed through
+    unchanged. The coarse ``UPDATE`` is expanded so a v1.5.x config keeps
+    catching every UPDATE event the watcher resolves to a granular variant.
+    Order is preserved and duplicates are removed; the watcher resolves a
+    raw row's operation to ``UPDATE_GEOM`` or ``UPDATE_ATTR`` based on the
+    ``geom_changed`` change-log column before evaluation.
+    """
+    out: list[str] = []
+    seen: set[str] = set()
+    for verb in when:
+        if verb == "UPDATE":
+            for v in ("UPDATE", "UPDATE_GEOM", "UPDATE_ATTR"):
+                if v not in seen:
+                    seen.add(v)
+                    out.append(v)
+        else:
+            if verb not in seen:
+                seen.add(verb)
+                out.append(verb)
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -93,7 +125,14 @@ class ActionConfigModel(BaseModel):
 
     model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
 
-    type: Literal["webhook", "set_field", "run_sql", "log_event", "notify"]
+    type: Literal[
+        "webhook",
+        "set_field",
+        "run_sql",
+        "log_event",
+        "notify",
+        "tag_field",
+    ]
     # webhook
     url: str | None = None
     # set_field
@@ -104,6 +143,12 @@ class ActionConfigModel(BaseModel):
     # notify
     channel: str | None = None
     payload_template: dict[str, Any] | str | None = None
+    # tag_field (#123) — write a validation status onto the row.
+    # ``column`` / ``message_column`` are SQL identifiers, validated
+    # by the engine when the action runs.
+    column: str | None = None
+    message_column: str | None = None
+    message: str | None = None
 
     @field_validator("url")
     @classmethod
@@ -125,8 +170,35 @@ class TriggerConfigModel(BaseModel):
 
     name: str = Field(min_length=1, max_length=120)
     table: str = Field(min_length=1, max_length=120)
+    # ESRI Attribute Rules vocabulary aliases (#125):
+    # ``constraint`` ≡ ``validation`` (rule rejects/tags the row),
+    # ``calculation`` ≡ ``trigger`` (rule writes derived attributes),
+    # ``validation``  is the GISPulse-native name. ``trigger`` (default)
+    # is kept as a no-op label so v1.5.x configs without a ``kind:`` line
+    # keep loading. The runtime ignores the value today — it is exposed
+    # solely to ease ESRI migration; full semantic wiring is tracked in
+    # docs-site/guide/migration-from-esri.md.
+    kind: Literal[
+        "trigger",
+        "validation",
+        "constraint",
+        "calculation",
+    ] = "trigger"
     pk_col: str = Field(default="fid", min_length=1, max_length=64)
-    when: list[Literal["INSERT", "UPDATE", "DELETE"]] = Field(
+    when: list[
+        Literal[
+            "INSERT",
+            "UPDATE",
+            "UPDATE_GEOM",
+            "UPDATE_ATTR",
+            "DELETE",
+            "BULK",
+        ]
+    ] = Field(
+        # ``UPDATE`` is a backward-compatible alias kept for v1.5.x configs;
+        # config_loader expands it to ``UPDATE_GEOM + UPDATE_ATTR`` when
+        # building Trigger.conditions["events"] so dispatch stays granular
+        # under the hood (see ``to_triggers`` below).
         # mypy can't widen ``list[str]`` into the Literal[...] union mode
         # the BaseModel field expects; the runtime values are perfectly
         # fine because pydantic re-validates them at construction time.
@@ -144,7 +216,10 @@ class TriggerConfigModel(BaseModel):
     @classmethod
     def _no_empty_when(cls, v: list[str]) -> list[str]:
         if not v:
-            raise ValueError("when must list at least one of INSERT/UPDATE/DELETE")
+            raise ValueError(
+                "when must list at least one of INSERT/UPDATE/UPDATE_GEOM/"
+                "UPDATE_ATTR/DELETE/BULK"
+            )
         # Deduplicate while preserving order.
         seen: list[str] = []
         for op in v:
@@ -185,6 +260,59 @@ class SecurityConfigModel(BaseModel):
     webhook_allowlist: list[str] = Field(default_factory=list)
 
 
+class ValidateRuleConfigModel(BaseModel):
+    """One declarative validation rule under the ``validate:`` top-level key.
+
+    Validation rules fire on every INSERT and UPDATE event in the dataset
+    (granular ``when`` will be added later). ``mode: warn`` logs the
+    failure and broadcasts ``validation.failed`` over the event hub;
+    ``mode: tag`` writes the failure onto the row via a ``tag_field``
+    action so external consumers (QGIS, portal map) can render the
+    validation status.
+
+    The ``rule`` is compiled the same way as a ``set_field`` expression
+    (see :mod:`gispulse.dsl`) — the value at evaluation time must be a
+    boolean (``geom_is_valid()``, ``geom_area_m2() >= 50``…).
+    """
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    id: str = Field(min_length=1, max_length=120)
+    rule: str = Field(min_length=1, max_length=4096)
+    mode: Literal["warn", "tag"] = "warn"
+    tag_field: str | None = None
+    message: str | None = None
+    enabled: bool = True
+
+    @model_validator(mode="after")
+    def _validate_tag_field_required_for_tag_mode(self) -> "ValidateRuleConfigModel":
+        if self.mode == "tag" and not self.tag_field:
+            raise ValueError(
+                "validate rule with mode='tag' requires a tag_field column name"
+            )
+        return self
+
+    @field_validator("rule")
+    @classmethod
+    def _validate_rule_syntax(cls, v: str) -> str:
+        """Compile the rule at config-load time to surface syntax errors early.
+
+        We use a placeholder ``EPSG:4326`` source so CRS-aware fcts compile
+        cleanly without forcing operators to repeat the dataset CRS in every
+        rule. The real CRS is injected at runtime from the engine's
+        :class:`gispulse.dsl.CompilationContext`.
+        """
+        from gispulse.dsl import CompilationContext, compile_expression
+
+        try:
+            compile_expression(
+                v, CompilationContext(source_epsg="EPSG:4326"), mode="boolean"
+            )
+        except Exception as exc:  # noqa: BLE001
+            raise ValueError(f"validate rule failed to compile: {exc}") from exc
+        return v
+
+
 class RuntimeConfigModel(BaseModel):
     model_config = ConfigDict(extra="forbid")
     poll_interval_ms: int = Field(default=1000, ge=10, le=60_000)
@@ -198,9 +326,38 @@ class GISPulseConfig(BaseModel):
 
     version: Literal[1] = 1
     gpkg: str
+    engine: str | None = Field(
+        default=None,
+        description=(
+            "Optional explicit engine override. If unset, GISPulse infers "
+            "the engine from the dataset URI (`*.gpkg` → gpkg, "
+            "`postgresql://...` → postgis, etc). See "
+            "docs-site/guide/engines.md for the full mapping."
+        ),
+    )
     triggers: list[TriggerConfigModel] = Field(default_factory=list)
+    validate_rules: list[ValidateRuleConfigModel] = Field(
+        default_factory=list,
+        alias="validate",
+        description=(
+            "Declarative validation rules — see "
+            "docs-site/guide/dsl-validation.md."
+        ),
+    )
     security: SecurityConfigModel = Field(default_factory=SecurityConfigModel)
     runtime: RuntimeConfigModel = Field(default_factory=RuntimeConfigModel)
+
+    def resolved_engine(self) -> str:
+        """Return the engine that will actually run this config.
+
+        Wraps :func:`gispulse.runtime.engine_inference.resolve_engine` so
+        callers get a single source of truth. Raises
+        :class:`gispulse.runtime.engine_inference.EngineInferenceError` on
+        conflict between the URI and an explicit override.
+        """
+        from gispulse.runtime.engine_inference import resolve_engine
+
+        return resolve_engine(self.gpkg, self.engine)
 
 
 # ---------------------------------------------------------------------------
@@ -483,12 +640,16 @@ def to_triggers(config: GISPulseConfig) -> list["Trigger"]:
             )
 
         # Stash the user-friendly metadata on the trigger so log lines
-        # and validate output can reference the YAML name.
+        # and validate output can reference the YAML name. ``events`` is
+        # the expanded form consumed by ``DMLConditions.events`` (see #119)
+        # so a config with ``when: [UPDATE]`` keeps matching the watcher's
+        # granular ``UPDATE_GEOM`` / ``UPDATE_ATTR`` outputs.
         conditions: dict[str, Any] = {
             "yaml_name": entry.name,
             "table": entry.table,
             "pk_col": entry.pk_col,
             "when": list(entry.when),
+            "events": _expand_when_to_events(list(entry.when)),
         }
         if entry.predicate:
             conditions["predicate"] = entry.predicate

--- a/gispulse/runtime/duckdb_engine.py
+++ b/gispulse/runtime/duckdb_engine.py
@@ -1,0 +1,233 @@
+"""DuckDB spatial engine wrapper.
+
+Lazy-installs and loads the ``spatial`` DuckDB extension on first use so the
+DSL geom functions (``geom_area_m2``, ``geom_within``, …) can run without an
+explicit pre-install step. The first call pays the network round-trip
+(``INSTALL spatial`` ~10 s on a fresh house); subsequent calls within the
+same process are no-ops because we cache the install state per executable.
+
+Public surface (kept tiny on purpose):
+    - :func:`get_spatial_connection` — return a DuckDB connection with the
+      spatial extension loaded. Idempotent.
+    - :func:`is_spatial_loaded` — cheap probe used by diagnostics.
+    - :func:`verify_epsg_roundtrip` — sanity-check that bundled PROJ can
+      transform between EPSG:4326 and ``target_epsg`` within tolerance.
+      Used by ``gispulse doctor --install-spatial`` to flag silent grid
+      failures (PROJ network is disabled in the bundled extension).
+    - :class:`DuckDBSpatialUnavailable` — raised when install/load fails
+      (offline, sandboxed network, …) with a hint pointing at
+      ``gispulse doctor --install-spatial``.
+
+The wrapper is intentionally engine-agnostic: callers ask for a connection
+and run their own SQL. Higher-level helpers (DSL push-down, COPY/ATTACH for
+PostGIS federation) live in their own modules.
+"""
+
+from __future__ import annotations
+
+import math
+import threading
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from duckdb import DuckDBPyConnection
+
+_DOCTOR_HINT = (
+    "Run `gispulse doctor --install-spatial` to pre-install the DuckDB "
+    "spatial extension, or check network connectivity."
+)
+
+
+class DuckDBSpatialUnavailable(RuntimeError):
+    """Raised when the DuckDB spatial extension cannot be installed/loaded."""
+
+
+_install_lock = threading.Lock()
+_install_done: dict[str, bool] = {}
+
+
+def _key_for(executable: str) -> str:
+    return executable or "default"
+
+
+def _ensure_spatial_loaded(conn: "DuckDBPyConnection", executable: str) -> None:
+    """Install + load the spatial extension on ``conn``.
+
+    The DuckDB ``INSTALL`` command persists per executable (binary path), so
+    we cache success keyed on the executable identifier; ``LOAD`` is cheap
+    enough to run on every fresh connection and is required to expose the
+    ``ST_*`` symbols in the connection's catalog.
+    """
+    key = _key_for(executable)
+    with _install_lock:
+        already_installed = _install_done.get(key, False)
+        try:
+            if not already_installed:
+                conn.execute("INSTALL spatial;")
+                _install_done[key] = True
+            conn.execute("LOAD spatial;")
+        except Exception as exc:
+            raise DuckDBSpatialUnavailable(
+                f"DuckDB spatial extension unavailable: {exc}. {_DOCTOR_HINT}"
+            ) from exc
+
+
+def get_spatial_connection(database: str = ":memory:") -> "DuckDBPyConnection":
+    """Open a DuckDB connection with the ``spatial`` extension loaded.
+
+    Parameters
+    ----------
+    database:
+        DuckDB connection string. Defaults to ``:memory:`` for compute-only
+        sessions; pass a ``.duckdb`` path for persistent snapshots (e.g. the
+        file-blob CDC cache used by file-based adapters).
+    """
+    try:
+        import duckdb
+    except ImportError as exc:
+        raise DuckDBSpatialUnavailable(
+            "duckdb package not installed (this should not happen — duckdb "
+            "is a hard dependency of gispulse). "
+            "Reinstall via `pip install --force-reinstall gispulse`."
+        ) from exc
+
+    conn = duckdb.connect(database)
+    _ensure_spatial_loaded(conn, getattr(duckdb, "__file__", ""))
+    return conn
+
+
+def is_spatial_loaded() -> bool:
+    """Return True if a previous call to :func:`get_spatial_connection` succeeded.
+
+    Used by ``gispulse doctor`` to report status without re-paying the install
+    cost. A False return does not mean the extension is unavailable, only that
+    we have not installed it yet in this process.
+    """
+    return any(_install_done.values())
+
+
+def _reset_cache_for_tests() -> None:
+    """Clear the install cache. Intended for the test suite only."""
+    with _install_lock:
+        _install_done.clear()
+
+
+# ---------------------------------------------------------------------------
+# EPSG roundtrip checks (gispulse doctor --install-spatial)
+# ---------------------------------------------------------------------------
+
+# Reference probes used by ``verify_epsg_roundtrip``. We pick a single FR
+# point (Notre-Dame de Paris area) per CRS — pyproj computes the expected
+# value at runtime so the test surfaces the exact deviation between bundled
+# DuckDB-PROJ and the OS pyproj grid (which has the datum shifts).
+_DEFAULT_PROBE_LONLAT: tuple[float, float] = (2.35, 48.85)
+_DEFAULT_EPSG_CODES: tuple[int, ...] = (4326, 3857, 2154, 27572)
+# Tolerance in target-CRS units. Lambert93 + Lambert II étendu use the
+# NTF↔RGF93 datum shift; bundled DuckDB-PROJ misses the IGN grid and ends
+# up ~1 km off, while pyproj on Linux pulls the grid from system packages.
+_EPSG_TOLERANCE: dict[int, float] = {
+    4326: 1e-6,
+    3857: 5.0,  # meters
+    2154: 250.0,  # meters — flag misses > IGN grid magnitude
+    27572: 250.0,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class EPSGCheck:
+    """Result of a single ``ST_Transform`` roundtrip check."""
+
+    epsg: int
+    ok: bool
+    detail: str
+
+
+def _expected_coords(target_epsg: int, lon: float, lat: float) -> tuple[float, float] | None:
+    """Compute the expected ``(x, y)`` in ``target_epsg`` using pyproj.
+
+    Returns ``None`` if pyproj cannot build the transformer (missing grid,
+    unknown EPSG); the caller will report that as a check failure.
+    """
+    try:
+        from pyproj import Transformer
+
+        t = Transformer.from_crs("EPSG:4326", f"EPSG:{target_epsg}", always_xy=True)
+        x, y = t.transform(lon, lat)
+        if math.isnan(x) or math.isnan(y) or math.isinf(x) or math.isinf(y):
+            return None
+        return float(x), float(y)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def verify_epsg_roundtrip(
+    conn: "DuckDBPyConnection",
+    epsg_codes: tuple[int, ...] | None = None,
+    probe_lonlat: tuple[float, float] | None = None,
+) -> list[EPSGCheck]:
+    """Run ``ST_Transform`` against a fixed point per EPSG and check tolerance.
+
+    The bundled DuckDB spatial extension ships PROJ statically with **network
+    disabled**, so high-precision French datum shifts (NTF→RGF93) can fail
+    silently or return slightly off coordinates. This helper surfaces those
+    cases as ``ok=False`` with an explanation, instead of letting them rot
+    behind a green ``LOAD spatial;``.
+
+    Parameters
+    ----------
+    conn:
+        A DuckDB connection with the spatial extension already loaded.
+    epsg_codes:
+        Tuple of target EPSG codes to check. Defaults to FR-relevant codes
+        (``2154``, ``27572``) plus the universals (``3857``, ``4326``).
+    probe_lonlat:
+        Override the WGS84 probe point. Defaults to a Paris-area point that
+        is in-bounds for every default EPSG.
+    """
+    codes = epsg_codes if epsg_codes is not None else _DEFAULT_EPSG_CODES
+    lon, lat = probe_lonlat if probe_lonlat is not None else _DEFAULT_PROBE_LONLAT
+
+    checks: list[EPSGCheck] = []
+    for code in codes:
+        try:
+            row = conn.execute(
+                "SELECT ST_X(p), ST_Y(p) FROM ("
+                "SELECT ST_Transform(ST_Point(?, ?), 'EPSG:4326', ?, true) AS p"
+                ")",
+                [lon, lat, f"EPSG:{code}"],
+            ).fetchone()
+        except Exception as exc:  # noqa: BLE001 — duckdb errors are diverse
+            checks.append(EPSGCheck(code, False, f"ST_Transform failed: {exc}"))
+            continue
+
+        if row is None or row[0] is None or row[1] is None:
+            checks.append(EPSGCheck(code, False, "ST_Transform returned NULL"))
+            continue
+
+        x_got, y_got = float(row[0]), float(row[1])
+        if math.isnan(x_got) or math.isnan(y_got):
+            checks.append(EPSGCheck(code, False, "ST_Transform returned NaN"))
+            continue
+
+        expected = _expected_coords(code, lon, lat)
+        if expected is None:
+            checks.append(
+                EPSGCheck(code, False, "pyproj could not compute reference (missing grid?)")
+            )
+            continue
+
+        x_exp, y_exp = expected
+        dx, dy = abs(x_got - x_exp), abs(y_got - y_exp)
+        tol = _EPSG_TOLERANCE.get(code, 1.0)
+        if dx > tol or dy > tol:
+            checks.append(
+                EPSGCheck(
+                    code,
+                    False,
+                    f"off by ({dx:.1f}, {dy:.1f}) units > tol {tol} (PROJ grid missing?)",
+                )
+            )
+        else:
+            checks.append(EPSGCheck(code, True, f"Δ=({dx:.2f}, {dy:.2f}) ≤ tol {tol}"))
+    return checks

--- a/gispulse/runtime/engine_inference.py
+++ b/gispulse/runtime/engine_inference.py
@@ -1,0 +1,166 @@
+"""Engine inference from dataset URIs.
+
+GISPulse v1.6.0 introduces a multi-engine runtime: every dataset eventually
+maps to one of four engines that share the same DSL but differ in how DML
+is detected and how mutations are written back.
+
+================  =================================================
+Engine kind       Detection / write-back path
+================  =================================================
+``gpkg``          AFTER triggers in SQLite, write-back via pyogrio
+                  or DuckDB COPY (fast path, see Atlas R1 bench)
+``spatialite``    AFTER triggers in SQLite without GPKG metadata,
+                  write-back via pyogrio
+``postgis``       LISTEN/NOTIFY + asyncpg, BEFORE/AFTER triggers
+``duckdb_diff``   File-blob CDC: mtime watcher + DuckDB snapshot
+                  diff, write-back via pyogrio (Shapefile/GeoJSON/
+                  FlatGeobuf/...) — placeholder for v1.6.1
+================  =================================================
+
+Inference is purely string-based: we do not open the dataset. That keeps
+``gispulse run`` cheap when the file is on a remote NFS or about to be
+created. The downstream engine factory does the actual probing.
+
+A user can override inference with ``engine:`` in ``triggers.yaml``;
+:func:`resolve_engine` raises :class:`EngineInferenceError` when the
+override conflicts with the URI (e.g. ``engine: postgis`` on a ``.gpkg``
+file) so misconfigurations surface immediately rather than at runtime.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+from urllib.parse import urlsplit
+
+EngineKind = Literal["gpkg", "spatialite", "postgis", "duckdb_diff"]
+
+ALL_ENGINES: tuple[EngineKind, ...] = ("gpkg", "spatialite", "postgis", "duckdb_diff")
+
+# Filename suffix → engine. Lowercased before lookup. ``.sqlite`` defaults
+# to spatialite; the GPKG-vs-SpatiaLite distinction needs the file open
+# (presence of ``gpkg_geometry_columns``) so the engine factory decides.
+_SUFFIX_MAP: dict[str, EngineKind] = {
+    ".gpkg": "gpkg",
+    ".sqlite": "spatialite",
+    ".db": "spatialite",
+    ".geojson": "duckdb_diff",
+    ".json": "duckdb_diff",
+    ".fgb": "duckdb_diff",
+    ".shp": "duckdb_diff",
+    ".kml": "duckdb_diff",
+    ".kmz": "duckdb_diff",
+    ".tab": "duckdb_diff",
+    ".csv": "duckdb_diff",
+}
+
+_POSTGRES_SCHEMES: frozenset[str] = frozenset(
+    {"postgres", "postgresql", "postgis"}
+)
+
+
+class EngineInferenceError(ValueError):
+    """Raised when an explicit ``engine:`` override conflicts with the URI."""
+
+
+def infer_engine(uri: str) -> EngineKind | None:
+    """Return the engine inferred from ``uri`` or ``None`` if unrecognised.
+
+    The function is intentionally tolerant: unknown suffixes return ``None``
+    so callers can fall back to a default or surface a config error of their
+    own. Empty / whitespace input returns ``None``.
+    """
+    if not uri or not uri.strip():
+        return None
+
+    parsed = urlsplit(uri)
+    scheme = parsed.scheme.lower()
+
+    if scheme in _POSTGRES_SCHEMES:
+        return "postgis"
+
+    # ``urlsplit`` treats ``C:\foo.gpkg`` on Windows as scheme ``c``; treat
+    # any single-letter scheme as a path so suffix matching takes over.
+    if len(scheme) > 1 and scheme not in {"file"}:
+        # Schemes we do not recognise (``s3://``, ``http://``...) — bail out
+        # rather than guessing. Future v1.7+ may add object-store adapters.
+        return None
+
+    # Strip ``file://`` prefix; for plain paths ``parsed.path`` is fine.
+    path = parsed.path or uri
+    lower = path.lower()
+    for suffix, engine in _SUFFIX_MAP.items():
+        if lower.endswith(suffix):
+            return engine
+    return None
+
+
+def resolve_engine(uri: str, override: str | None = None) -> EngineKind:
+    """Return the engine for ``uri`` honouring an explicit ``override``.
+
+    Parameters
+    ----------
+    uri:
+        Dataset URI (``triggers.yaml`` ``gpkg:`` field or future
+        ``dataset:`` field). Required.
+    override:
+        Explicit ``engine:`` value from the YAML. If ``None``, inference
+        decides. If provided, it must either match the inferred engine or
+        belong to the broader compatible set (e.g. requesting ``duckdb_diff``
+        on a ``.gpkg`` file is allowed for advanced users who want CDC mode
+        instead of native triggers; requesting ``postgis`` on a file path
+        is not, because the wiring would mismatch).
+
+    Raises
+    ------
+    EngineInferenceError
+        When the URI cannot be classified at all (and no override supplies
+        the answer) or when the override is incompatible with the URI.
+    """
+    inferred = infer_engine(uri)
+
+    if override is None:
+        if inferred is None:
+            raise EngineInferenceError(
+                f"cannot infer engine for {uri!r}; "
+                f"set `engine:` explicitly to one of {sorted(ALL_ENGINES)}"
+            )
+        return inferred
+
+    if override not in ALL_ENGINES:
+        raise EngineInferenceError(
+            f"unknown engine {override!r}; expected one of {sorted(ALL_ENGINES)}"
+        )
+
+    if inferred is None:
+        # Unrecognised URI but explicit override → trust the user.
+        return override  # type: ignore[return-value]
+
+    if override == inferred:
+        return override  # type: ignore[return-value]
+
+    if not _is_override_compatible(override, inferred):
+        raise EngineInferenceError(
+            f"engine override {override!r} is incompatible with URI {uri!r} "
+            f"(inferred {inferred!r}). Either drop the override or change "
+            f"the dataset URI."
+        )
+
+    return override  # type: ignore[return-value]
+
+
+def _is_override_compatible(override: str, inferred: EngineKind) -> bool:
+    """Decide whether an override may legally replace the inferred engine.
+
+    Compatibility rules (v1.6.0):
+    - File-based formats (``gpkg``/``spatialite``/``duckdb_diff``) may be
+      forced into ``duckdb_diff`` mode when the user opts out of native
+      triggers and prefers file-blob CDC.
+    - ``gpkg`` ↔ ``spatialite`` swap is allowed: SQLite siblings.
+    - Anything → ``postgis`` requires a ``postgresql://`` URI; rejected.
+    - ``postgis`` URIs cannot be downgraded to file engines.
+    """
+    if override == "duckdb_diff" and inferred in {"gpkg", "spatialite"}:
+        return True
+    if {override, inferred} == {"gpkg", "spatialite"}:
+        return True
+    return False

--- a/persistence/change_log_watcher.py
+++ b/persistence/change_log_watcher.py
@@ -613,6 +613,13 @@ class ChangeLogWatcher:
         fid_raw = row.get("row_pk")
         fid = str(fid_raw) if fid_raw is not None else None
         ts = row.get("changed_at")
+        # v1.6.0 #119/#120: resolve coarse UPDATE → granular UPDATE_GEOM /
+        # UPDATE_ATTR via the change_log's ``geom_changed`` column. The
+        # column is INTEGER DEFAULT 0 (cf gpkg_schema.py v2 migration), so
+        # a missing column on legacy GPKGs degrades to UPDATE_ATTR.
+        geom_changed = bool(row.get("geom_changed"))
+        if op == "UPDATE":
+            op = "UPDATE_GEOM" if geom_changed else "UPDATE_ATTR"
 
         if broadcast_dml:
             # Payload is intentionally minimal: no field values, no
@@ -631,6 +638,7 @@ class ChangeLogWatcher:
                         "fid": fid,
                         "change_id": change_id,
                         "ts": ts,
+                        "geom_changed": geom_changed,
                     },
                 )
             except Exception as exc:

--- a/tests/dsl/test_expression_parser.py
+++ b/tests/dsl/test_expression_parser.py
@@ -1,0 +1,325 @@
+"""Tests for ``gispulse.dsl.expression_parser`` and the geom fcts registry.
+
+Coverage:
+- Happy paths: each whitelisted geom fct compiles, plus arithmetic.
+- CRS handling: source_epsg required for measure fcts; ``epsg=`` override.
+- Allowlist rejects: 10+ injection / unsupported AST patterns.
+- Geom fct registry contains the 7 documented v1.6.0 fcts (T1+T2).
+- DuckDB E2E: a compiled expression executes against a real geometry.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gispulse.dsl import (
+    GEOM_FUNCTIONS,
+    CompilationContext,
+    DSLValidationError,
+    compile_expression,
+    is_geom_function,
+)
+
+
+# ---------------------------------------------------------------------------
+# Registry sanity
+# ---------------------------------------------------------------------------
+
+
+class TestGeomFunctionRegistry:
+    EXPECTED_T1 = {"geom_area_m2", "geom_perimeter_m", "geom_length_m"}
+    EXPECTED_T2 = {"geom_centroid_x", "geom_centroid_y", "geom_npoints", "geom_is_valid"}
+
+    def test_t1_present(self) -> None:
+        assert self.EXPECTED_T1 <= set(GEOM_FUNCTIONS)
+
+    def test_t2_present(self) -> None:
+        assert self.EXPECTED_T2 <= set(GEOM_FUNCTIONS)
+
+    def test_seven_total(self) -> None:
+        # Locks the v1.6.0 surface — adding a new fct must update tests/docs.
+        assert set(GEOM_FUNCTIONS) == self.EXPECTED_T1 | self.EXPECTED_T2
+
+    def test_is_geom_function(self) -> None:
+        assert is_geom_function("geom_area_m2")
+        assert not is_geom_function("eval")
+        assert not is_geom_function("ST_Area")  # SQL name, not DSL name
+
+
+# ---------------------------------------------------------------------------
+# Compilation — happy paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def crs_ctx() -> CompilationContext:
+    return CompilationContext(source_epsg="EPSG:4326")
+
+
+class TestCompileGeomFunctions:
+    def test_geom_area_m2_default_epsg(self, crs_ctx: CompilationContext) -> None:
+        sql = compile_expression("geom_area_m2()", crs_ctx)
+        assert "ST_Area(ST_Transform" in sql
+        assert "'EPSG:4326'" in sql  # source
+        assert "'EPSG:2154'" in sql  # default metric
+
+    def test_geom_area_m2_with_override(self, crs_ctx: CompilationContext) -> None:
+        sql = compile_expression("geom_area_m2(epsg='EPSG:3857')", crs_ctx)
+        assert "'EPSG:3857'" in sql
+
+    def test_geom_perimeter(self, crs_ctx: CompilationContext) -> None:
+        sql = compile_expression("geom_perimeter_m()", crs_ctx)
+        assert "ST_Perimeter" in sql
+
+    def test_geom_length(self, crs_ctx: CompilationContext) -> None:
+        sql = compile_expression("geom_length_m()", crs_ctx)
+        assert "ST_Length" in sql
+
+    def test_centroid_x(self, crs_ctx: CompilationContext) -> None:
+        sql = compile_expression(
+            "geom_centroid_x(epsg='EPSG:4326')", crs_ctx
+        )
+        assert "ST_X(ST_Transform(ST_Centroid" in sql
+
+    def test_centroid_y(self, crs_ctx: CompilationContext) -> None:
+        sql = compile_expression(
+            "geom_centroid_y(epsg='EPSG:4326')", crs_ctx
+        )
+        assert "ST_Y(ST_Transform(ST_Centroid" in sql
+
+    def test_npoints_no_crs_needed(self) -> None:
+        sql = compile_expression("geom_npoints()")
+        assert sql == 'ST_NPoints("geom")'
+
+    def test_is_valid_no_crs_needed(self) -> None:
+        sql = compile_expression("geom_is_valid()")
+        assert sql == 'ST_IsValid("geom")'
+
+
+class TestArithmeticAndColumns:
+    def test_division(self, crs_ctx: CompilationContext) -> None:
+        sql = compile_expression("geom_area_m2() / 10000", crs_ctx)
+        assert sql.startswith("(")
+        assert sql.endswith(" / 10000)")
+
+    def test_mixed(self) -> None:
+        sql = compile_expression("price * (1 + tax_rate)")
+        assert '"price"' in sql
+        assert '"tax_rate"' in sql
+
+    def test_unary_minus(self) -> None:
+        sql = compile_expression("-counter + 1")
+        assert '(-"counter")' in sql
+
+    def test_modulo(self) -> None:
+        sql = compile_expression("counter % 7")
+        assert " % 7" in sql
+
+    def test_float_literal(self) -> None:
+        sql = compile_expression("price * 1.2")
+        assert "1.2" in sql
+
+    def test_bool_literal(self) -> None:
+        sql = compile_expression("True")
+        assert sql == "TRUE"
+
+    def test_negative_int(self) -> None:
+        sql = compile_expression("-42")
+        assert sql == "(-42)"
+
+    def test_column_double_quoted(self) -> None:
+        sql = compile_expression("price")
+        assert sql == '"price"'
+
+
+# ---------------------------------------------------------------------------
+# Compilation — reject patterns (security)
+# ---------------------------------------------------------------------------
+
+
+class TestRejectPatterns:
+    @pytest.mark.parametrize(
+        "expr",
+        [
+            "__import__('os')",
+            "eval('1+1')",
+            "globals()",
+            "geom.foo",            # attribute access
+            "[1, 2, 3]",            # list literal
+            "{1: 2}",               # dict literal
+            "'string'",             # string literal at top level
+            "1 == 1",               # comparison
+            "1 ** 2",               # power
+            "1 << 2",               # shift
+            "x and y",              # boolean op
+            "not x",                # boolean not
+            "lambda x: x",          # lambda
+            "[i for i in range(10)]",
+            "f'{x}'",               # f-string contains FormattedValue
+        ],
+    )
+    def test_rejected(self, expr: str) -> None:
+        with pytest.raises(DSLValidationError):
+            compile_expression(expr)
+
+    def test_unknown_function(self, crs_ctx: CompilationContext) -> None:
+        with pytest.raises(DSLValidationError) as exc:
+            compile_expression("len(geom)", crs_ctx)
+        assert "not in the DSL whitelist" in str(exc.value)
+
+    def test_unknown_kwarg(self, crs_ctx: CompilationContext) -> None:
+        with pytest.raises(DSLValidationError) as exc:
+            compile_expression("geom_area_m2(bogus='EPSG:2154')", crs_ctx)
+        assert "does not accept keyword" in str(exc.value)
+
+    def test_kwarg_not_string_literal(self, crs_ctx: CompilationContext) -> None:
+        with pytest.raises(DSLValidationError):
+            compile_expression("geom_area_m2(epsg=2154)", crs_ctx)
+
+    def test_invalid_epsg_format(self, crs_ctx: CompilationContext) -> None:
+        with pytest.raises(DSLValidationError) as exc:
+            compile_expression("geom_area_m2(epsg='2154')", crs_ctx)
+        assert "EPSG:NNNN" in str(exc.value)
+
+    def test_positional_arg_rejected(self, crs_ctx: CompilationContext) -> None:
+        with pytest.raises(DSLValidationError) as exc:
+            compile_expression("geom_area_m2('EPSG:2154')", crs_ctx)
+        assert "no positional arguments" in str(exc.value)
+
+    def test_geom_fct_as_bare_name(self) -> None:
+        with pytest.raises(DSLValidationError) as exc:
+            compile_expression("geom_area_m2 + 1")
+        assert "must be called as" in str(exc.value)
+
+    def test_sql_keyword_as_column(self) -> None:
+        with pytest.raises(DSLValidationError):
+            compile_expression("SELECT + 1")
+
+    def test_empty_expression(self) -> None:
+        with pytest.raises(DSLValidationError):
+            compile_expression("")
+
+    def test_nul_byte(self) -> None:
+        with pytest.raises(DSLValidationError):
+            compile_expression("price\x00 + 1")
+
+    def test_too_long(self) -> None:
+        with pytest.raises(DSLValidationError):
+            compile_expression("price + " + "1 + " * 2000 + "1")
+
+    def test_syntax_error_carries_location(self) -> None:
+        with pytest.raises(DSLValidationError) as exc:
+            compile_expression("price +")
+        msg = str(exc.value)
+        assert "line" in msg and "col" in msg
+
+    def test_crs_aware_without_source_epsg(self) -> None:
+        ctx = CompilationContext()  # no source_epsg
+        with pytest.raises(DSLValidationError) as exc:
+            compile_expression("geom_area_m2()", ctx)
+        assert "source_epsg" in str(exc.value)
+
+    def test_method_call_rejected(self) -> None:
+        with pytest.raises(DSLValidationError):
+            compile_expression("geom.buffer(1)")
+
+
+# ---------------------------------------------------------------------------
+# Context validation
+# ---------------------------------------------------------------------------
+
+
+class TestCompilationContext:
+    def test_invalid_geom_column(self) -> None:
+        with pytest.raises(DSLValidationError):
+            CompilationContext(geom_column="geom; DROP TABLE x")
+
+    def test_invalid_source_epsg(self) -> None:
+        with pytest.raises(DSLValidationError):
+            CompilationContext(source_epsg="lambert93")
+
+    def test_invalid_default_metric(self) -> None:
+        with pytest.raises(DSLValidationError):
+            CompilationContext(default_metric_epsg="2154")
+
+
+# ---------------------------------------------------------------------------
+# DuckDB E2E — compiled expressions actually execute
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def duckdb_conn():
+    from gispulse.runtime.duckdb_engine import (
+        _reset_cache_for_tests,
+        get_spatial_connection,
+    )
+
+    _reset_cache_for_tests()
+    conn = get_spatial_connection()
+    yield conn
+    conn.close()
+
+
+class TestDuckDBExecution:
+    def test_npoints_executes(self, duckdb_conn) -> None:
+        sql = compile_expression("geom_npoints()")
+        row = duckdb_conn.execute(
+            f"SELECT {sql} FROM (SELECT ST_GeomFromText('LINESTRING(0 0, 1 0, 2 0)') AS geom)"
+        ).fetchone()
+        assert row[0] == 3
+
+    def test_is_valid_executes(self, duckdb_conn) -> None:
+        sql = compile_expression("geom_is_valid()")
+        row = duckdb_conn.execute(
+            f"SELECT {sql} FROM (SELECT ST_GeomFromText('POINT(0 0)') AS geom)"
+        ).fetchone()
+        assert row[0] is True
+
+    def test_area_paris_commune(self, duckdb_conn) -> None:
+        """Area of the Paris commune polygon (rough rectangle) in Lambert93.
+
+        Test-data is a coarse bbox around the Paris commune (~105 km²) — the
+        precise IGN reference is 105.4 km². We assert ±10% tolerance, which
+        is dominated by the rectangular approximation rather than the
+        compilation pipeline's accuracy.
+        """
+        ctx = CompilationContext(source_epsg="EPSG:4326")
+        sql = compile_expression("geom_area_m2() / 1000000", ctx)
+        # Bounding box approximating Paris commune in WGS84 lon/lat.
+        wkt = (
+            "POLYGON((2.224 48.815, 2.469 48.815, "
+            "2.469 48.902, 2.224 48.902, 2.224 48.815))"
+        )
+        row = duckdb_conn.execute(
+            f"SELECT {sql} FROM (SELECT ST_GeomFromText(?) AS geom)",
+            [wkt],
+        ).fetchone()
+        area_km2 = row[0]
+        # The bounding box is larger than the actual commune — this asserts
+        # the compiler emits a working ST_Transform projecting WGS84 → L93.
+        assert 100.0 < area_km2 < 250.0
+
+    def test_arithmetic_with_geom_call(self, duckdb_conn) -> None:
+        ctx = CompilationContext(source_epsg="EPSG:4326")
+        sql = compile_expression("geom_area_m2() / 10000", ctx)
+        wkt = (
+            "POLYGON((2.224 48.815, 2.469 48.815, "
+            "2.469 48.902, 2.224 48.902, 2.224 48.815))"
+        )
+        row = duckdb_conn.execute(
+            f"SELECT {sql} FROM (SELECT ST_GeomFromText(?) AS geom)",
+            [wkt],
+        ).fetchone()
+        # Should be ~10000-25000 hectares (Paris bbox is ~100-250 km² above).
+        assert 10000.0 < row[0] < 25000.0
+
+    def test_centroid_x_executes(self, duckdb_conn) -> None:
+        ctx = CompilationContext(source_epsg="EPSG:4326")
+        sql = compile_expression(
+            "geom_centroid_x(epsg='EPSG:4326')", ctx
+        )
+        row = duckdb_conn.execute(
+            f"SELECT {sql} FROM (SELECT ST_GeomFromText('POINT(2.35 48.85)') AS geom)"
+        ).fetchone()
+        assert abs(row[0] - 2.35) < 1e-6

--- a/tests/integration/http/test_change_log_watcher_shadow_zones.py
+++ b/tests/integration/http/test_change_log_watcher_shadow_zones.py
@@ -242,11 +242,18 @@ class TestPayloadRedaction:
         )
         # Also assert allowed keys exactly. dataset_id added in Lot 2 v2 fix M1
         # to disambiguate multi-GPKG events; no leak risk since it's a UUID/
-        # known identifier, not a row value.
+        # known identifier, not a row value. v1.6.0 (#119/#120 plumbing) adds
+        # ``geom_changed`` — a metadata boolean, not a row attribute.
         data = payloads[0]["data"]
-        assert set(data.keys()) <= {"dataset_id", "table", "op", "fid", "change_id", "ts"}, (
-            f"Unexpected keys in dml.changed payload: {set(data.keys())}"
-        )
+        assert set(data.keys()) <= {
+            "dataset_id",
+            "table",
+            "op",
+            "fid",
+            "change_id",
+            "ts",
+            "geom_changed",
+        }, f"Unexpected keys in dml.changed payload: {set(data.keys())}"
 
     def test_no_include_values_query_param_unlocks_verbose_payload(
         self, gpkg_app

--- a/tests/runtime/test_dml_verbs_v160.py
+++ b/tests/runtime/test_dml_verbs_v160.py
@@ -1,0 +1,227 @@
+"""Tests for v1.6.0 #119/#120 plumbing — granular DML verbs + geom_changed.
+
+Two layers under test:
+
+1. ``gispulse.runtime.config_loader``
+   - YAML accepts the new verbs ``UPDATE_GEOM`` / ``UPDATE_ATTR`` / ``BULK``
+     in ``when:`` while keeping ``UPDATE`` working.
+   - ``_expand_when_to_events`` produces the granular events list that
+     downstream :class:`DMLConditions` matches against.
+
+2. ``persistence.change_log_watcher.ChangeLogWatcher``
+   - Resolves a coarse ``UPDATE`` row to ``UPDATE_GEOM`` / ``UPDATE_ATTR``
+     using the change_log's ``geom_changed`` column.
+   - Broadcasts the resolved op + ``geom_changed`` flag in the
+     ``dml.changed`` payload (#120 plumbing).
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Config loader — verb expansion + Pydantic schema
+# ---------------------------------------------------------------------------
+
+
+class TestConfigLoaderWhenVerbs:
+    def test_legacy_update_accepted(self) -> None:
+        from gispulse.runtime.config_loader import TriggerConfigModel
+
+        m = TriggerConfigModel(name="t", table="x", when=["UPDATE"])
+        assert m.when == ["UPDATE"]
+
+    def test_granular_verbs_accepted(self) -> None:
+        from gispulse.runtime.config_loader import TriggerConfigModel
+
+        m = TriggerConfigModel(
+            name="t",
+            table="x",
+            when=["INSERT", "UPDATE_GEOM", "UPDATE_ATTR", "DELETE", "BULK"],
+        )
+        assert "UPDATE_GEOM" in m.when
+        assert "BULK" in m.when
+
+    def test_unknown_verb_rejected(self) -> None:
+        from gispulse.runtime.config_loader import TriggerConfigModel
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            TriggerConfigModel(name="t", table="x", when=["UPSERT"])
+
+    def test_expand_when_to_events_legacy_update(self) -> None:
+        from gispulse.runtime.config_loader import _expand_when_to_events
+
+        assert _expand_when_to_events(["INSERT", "UPDATE", "DELETE"]) == [
+            "INSERT",
+            "UPDATE",
+            "UPDATE_GEOM",
+            "UPDATE_ATTR",
+            "DELETE",
+        ]
+
+    def test_expand_when_to_events_granular_only(self) -> None:
+        from gispulse.runtime.config_loader import _expand_when_to_events
+
+        assert _expand_when_to_events(["UPDATE_GEOM"]) == ["UPDATE_GEOM"]
+
+    def test_expand_when_to_events_dedup(self) -> None:
+        from gispulse.runtime.config_loader import _expand_when_to_events
+
+        # ``UPDATE`` expansion overlaps with ``UPDATE_GEOM`` already present.
+        assert _expand_when_to_events(["UPDATE_GEOM", "UPDATE"]) == [
+            "UPDATE_GEOM",
+            "UPDATE",
+            "UPDATE_ATTR",
+        ]
+
+
+class TestToTriggersEventsField:
+    def test_to_triggers_emits_events_list(self, tmp_path) -> None:
+        from gispulse.runtime.config_loader import (
+            GISPulseConfig,
+            TriggerConfigModel,
+            to_triggers,
+        )
+
+        gpkg_path = tmp_path / "x.gpkg"
+        gpkg_path.write_bytes(b"")
+        cfg = GISPulseConfig(
+            version=1,
+            gpkg=str(gpkg_path),
+            triggers=[TriggerConfigModel(name="t", table="parcels", when=["UPDATE"])],
+        )
+        trgs = to_triggers(cfg)
+        assert len(trgs) == 1
+        events = trgs[0].conditions.get("events")
+        assert events == ["UPDATE", "UPDATE_GEOM", "UPDATE_ATTR"]
+
+
+# ---------------------------------------------------------------------------
+# Watcher — UPDATE resolution + geom_changed plumbing
+# ---------------------------------------------------------------------------
+
+
+class _RecordingHub:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self.events: list[tuple[str, dict[str, Any]]] = []
+
+    def broadcast(self, event_type: str, data: dict[str, Any] | None = None) -> None:
+        with self._lock:
+            self.events.append((event_type, data or {}))
+
+
+class _FakeEngine:
+    """Engine stub that exposes the change-log API used by the watcher."""
+
+    backend_name = "gpkg"
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._rows: list[dict[str, Any]] = []
+        self._next_id = 1
+
+    def push(
+        self,
+        table: str,
+        op: str,
+        fid: str,
+        *,
+        geom_changed: bool = False,
+        ts: str = "2026-05-06T00:00:00",
+    ) -> int:
+        with self._lock:
+            row_id = self._next_id
+            self._next_id += 1
+            self._rows.append(
+                {
+                    "id": row_id,
+                    "table_name": table,
+                    "operation": op,
+                    "row_pk": fid,
+                    "changed_at": ts,
+                    "geom_changed": 1 if geom_changed else 0,
+                    "processed": 0,
+                }
+            )
+            return row_id
+
+    def get_pending_changes(self, limit: int = 100) -> list[dict]:
+        with self._lock:
+            pending = [r for r in self._rows if r["processed"] == 0]
+            return [dict(r) for r in pending[:limit]]
+
+    def mark_changes_processed(self, up_to_id: int) -> int:
+        with self._lock:
+            n = 0
+            for r in self._rows:
+                if r["id"] <= up_to_id and r["processed"] == 0:
+                    r["processed"] = 1
+                    n += 1
+            return n
+
+
+def _wait_until(predicate, timeout: float = 2.0, step: float = 0.02) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(step)
+    return predicate()
+
+
+@pytest.fixture
+def watcher_setup():
+    from persistence.change_log_watcher import ChangeLogWatcher
+
+    engine = _FakeEngine()
+    hub = _RecordingHub()
+    watcher = ChangeLogWatcher(
+        engine, hub, dataset_id="ds-test", poll_interval=0.05
+    )
+    yield watcher, engine, hub
+    watcher.stop()
+
+
+class TestWatcherUpdateResolution:
+    def test_update_geom_changed_resolves_to_update_geom(self, watcher_setup) -> None:
+        watcher, engine, hub = watcher_setup
+        engine.push("parcels", "UPDATE", "1", geom_changed=True)
+        watcher.start()
+        assert _wait_until(lambda: any(e[0] == "dml.changed" for e in hub.events))
+        payload = next(e[1] for e in hub.events if e[0] == "dml.changed")
+        assert payload["op"] == "UPDATE_GEOM"
+        assert payload["geom_changed"] is True
+
+    def test_update_attr_only_resolves_to_update_attr(self, watcher_setup) -> None:
+        watcher, engine, hub = watcher_setup
+        engine.push("parcels", "UPDATE", "2", geom_changed=False)
+        watcher.start()
+        assert _wait_until(lambda: any(e[0] == "dml.changed" for e in hub.events))
+        payload = next(e[1] for e in hub.events if e[0] == "dml.changed")
+        assert payload["op"] == "UPDATE_ATTR"
+        assert payload["geom_changed"] is False
+
+    def test_insert_passes_through_unchanged(self, watcher_setup) -> None:
+        watcher, engine, hub = watcher_setup
+        engine.push("parcels", "INSERT", "3")
+        watcher.start()
+        assert _wait_until(lambda: any(e[0] == "dml.changed" for e in hub.events))
+        payload = next(e[1] for e in hub.events if e[0] == "dml.changed")
+        assert payload["op"] == "INSERT"
+        # geom_changed is exposed even on INSERT for payload symmetry
+        assert payload["geom_changed"] is False
+
+    def test_delete_passes_through_unchanged(self, watcher_setup) -> None:
+        watcher, engine, hub = watcher_setup
+        engine.push("parcels", "DELETE", "4")
+        watcher.start()
+        assert _wait_until(lambda: any(e[0] == "dml.changed" for e in hub.events))
+        payload = next(e[1] for e in hub.events if e[0] == "dml.changed")
+        assert payload["op"] == "DELETE"

--- a/tests/runtime/test_duckdb_engine.py
+++ b/tests/runtime/test_duckdb_engine.py
@@ -1,0 +1,126 @@
+"""Tests for ``gispulse.runtime.duckdb_engine``.
+
+Covers:
+- happy path: connection returned with spatial loaded, ST_Point works
+- idempotency: a second call within the same session does not re-INSTALL
+- isolation: ``_reset_cache_for_tests`` clears the install marker
+- failure mode: when ``INSTALL spatial`` raises (offline / sandboxed),
+  ``DuckDBSpatialUnavailable`` is raised with a doctor hint in the message
+- public re-exports: ``runtime`` package exposes the new symbols
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gispulse.runtime import (
+    DuckDBSpatialUnavailable,
+    get_spatial_connection,
+    is_spatial_loaded,
+)
+from gispulse.runtime import duckdb_engine
+
+
+@pytest.fixture(autouse=True)
+def _reset_install_cache():
+    duckdb_engine._reset_cache_for_tests()
+    yield
+    duckdb_engine._reset_cache_for_tests()
+
+
+def test_get_spatial_connection_returns_connection_with_spatial_loaded():
+    conn = get_spatial_connection()
+    try:
+        result = conn.execute("SELECT ST_AsText(ST_Point(1, 2));").fetchone()
+    finally:
+        conn.close()
+    assert result is not None
+    assert "POINT" in result[0]
+
+
+def test_is_spatial_loaded_flips_to_true_after_first_call():
+    assert is_spatial_loaded() is False
+    conn = get_spatial_connection()
+    conn.close()
+    assert is_spatial_loaded() is True
+
+
+def test_second_call_skips_install_step():
+    """``INSTALL`` should run exactly once; ``LOAD`` runs on each fresh conn."""
+    conn1 = get_spatial_connection()
+    conn1.close()
+
+    with patch.object(
+        duckdb_engine,
+        "_install_done",
+        {"already": True},
+    ):
+        # Patch the install-marker; the function should detect the cached state
+        # via the executable key and skip ``INSTALL``.
+        executed: list[str] = []
+        original_execute = duckdb_engine._ensure_spatial_loaded
+
+        def spy(conn, executable):
+            from gispulse.runtime.duckdb_engine import _install_done, _key_for
+            key = _key_for(executable)
+            _install_done[key] = True  # simulate prior install
+            executed.append("LOAD spatial;")
+            conn.execute("LOAD spatial;")
+
+        with patch.object(duckdb_engine, "_ensure_spatial_loaded", side_effect=spy):
+            conn2 = duckdb_engine.get_spatial_connection()
+            conn2.close()
+        assert executed == ["LOAD spatial;"]
+
+
+def test_install_failure_raises_duckdb_spatial_unavailable():
+    """Network/sandbox failure on ``INSTALL spatial`` surfaces as the typed exception."""
+    fake_conn = MagicMock(name="conn")
+
+    def execute(sql: str, *a, **kw):
+        if "INSTALL spatial" in sql:
+            raise RuntimeError("network unreachable")
+        return fake_conn
+
+    fake_conn.execute.side_effect = execute
+
+    with patch("duckdb.connect", return_value=fake_conn):
+        with pytest.raises(DuckDBSpatialUnavailable) as excinfo:
+            get_spatial_connection()
+    msg = str(excinfo.value)
+    assert "network unreachable" in msg
+    assert "gispulse doctor --install-spatial" in msg
+
+
+def test_load_failure_when_already_installed_still_surfaces_clearly():
+    """If INSTALL was cached but LOAD now fails, surface as DuckDBSpatialUnavailable."""
+    import duckdb
+
+    key = duckdb_engine._key_for(getattr(duckdb, "__file__", ""))
+    duckdb_engine._install_done[key] = True
+
+    fake_conn = MagicMock(name="conn")
+
+    def execute(sql: str, *a, **kw):
+        if sql.strip().upper().startswith("LOAD SPATIAL"):
+            raise RuntimeError("extension binary corrupt")
+        return fake_conn
+
+    fake_conn.execute.side_effect = execute
+
+    with patch("duckdb.connect", return_value=fake_conn):
+        with pytest.raises(DuckDBSpatialUnavailable) as excinfo:
+            get_spatial_connection()
+    assert "extension binary corrupt" in str(excinfo.value)
+
+
+def test_runtime_package_reexports_public_symbols():
+    """The package ``__init__`` exposes the new wrapper for import-stability."""
+    import gispulse.runtime as runtime
+
+    assert hasattr(runtime, "get_spatial_connection")
+    assert hasattr(runtime, "is_spatial_loaded")
+    assert hasattr(runtime, "DuckDBSpatialUnavailable")
+    assert "DuckDBSpatialUnavailable" in runtime.__all__

--- a/tests/runtime/test_engine_inference.py
+++ b/tests/runtime/test_engine_inference.py
@@ -1,0 +1,131 @@
+"""Tests for ``gispulse.runtime.engine_inference``.
+
+Covers the URI → engine mapping table, the explicit-override conflict
+detection, and the integration with :class:`GISPulseConfig.resolved_engine`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gispulse.runtime.engine_inference import (
+    ALL_ENGINES,
+    EngineInferenceError,
+    infer_engine,
+    resolve_engine,
+)
+
+
+class TestInferEngineFromUri:
+    @pytest.mark.parametrize(
+        "uri,expected",
+        [
+            ("/data/parcels.gpkg", "gpkg"),
+            ("./parcels.GPKG", "gpkg"),  # case-insensitive
+            ("file:///data/parcels.gpkg", "gpkg"),
+            ("/data/parcels.sqlite", "spatialite"),
+            ("/data/parcels.db", "spatialite"),
+            ("postgresql://user:pwd@localhost:5432/gis", "postgis"),
+            ("postgres://user:pwd@localhost:5432/gis", "postgis"),
+            ("postgis://user:pwd@localhost:5432/gis", "postgis"),
+            ("/data/parcels.shp", "duckdb_diff"),
+            ("/data/parcels.geojson", "duckdb_diff"),
+            ("/data/parcels.json", "duckdb_diff"),
+            ("/data/parcels.fgb", "duckdb_diff"),
+            ("/data/parcels.kml", "duckdb_diff"),
+            ("/data/parcels.kmz", "duckdb_diff"),
+            ("/data/parcels.tab", "duckdb_diff"),
+            ("/data/parcels.csv", "duckdb_diff"),
+        ],
+    )
+    def test_known_uris(self, uri: str, expected: str) -> None:
+        assert infer_engine(uri) == expected
+
+    @pytest.mark.parametrize(
+        "uri",
+        [
+            "",
+            "   ",
+            "/data/parcels.unknown",
+            "s3://bucket/parcels.gpkg",  # explicit non-local scheme bails out
+            "https://example.com/parcels.gpkg",
+        ],
+    )
+    def test_unknown_uris_return_none(self, uri: str) -> None:
+        assert infer_engine(uri) is None
+
+
+class TestResolveEngineOverrides:
+    def test_inference_only(self) -> None:
+        assert resolve_engine("/data/parcels.gpkg") == "gpkg"
+
+    def test_explicit_match(self) -> None:
+        assert resolve_engine("/data/parcels.gpkg", "gpkg") == "gpkg"
+
+    def test_unknown_uri_no_override_raises(self) -> None:
+        with pytest.raises(EngineInferenceError) as exc:
+            resolve_engine("/data/parcels.weirdformat")
+        assert "cannot infer engine" in str(exc.value)
+
+    def test_unknown_uri_with_override_trusts_user(self) -> None:
+        assert resolve_engine("/data/x.weirdformat", "duckdb_diff") == "duckdb_diff"
+
+    def test_unknown_override_value_raises(self) -> None:
+        with pytest.raises(EngineInferenceError) as exc:
+            resolve_engine("/data/parcels.gpkg", "spark")
+        assert "unknown engine" in str(exc.value)
+
+    @pytest.mark.parametrize(
+        "uri,override",
+        [
+            ("/data/parcels.gpkg", "duckdb_diff"),  # opt-in CDC mode
+            ("/data/parcels.sqlite", "duckdb_diff"),
+            ("/data/parcels.gpkg", "spatialite"),  # SQLite siblings swap
+            ("/data/parcels.sqlite", "gpkg"),
+        ],
+    )
+    def test_compatible_override_allowed(self, uri: str, override: str) -> None:
+        assert resolve_engine(uri, override) == override
+
+    @pytest.mark.parametrize(
+        "uri,override",
+        [
+            ("/data/parcels.gpkg", "postgis"),  # file → server impossible
+            ("postgresql://localhost/gis", "gpkg"),  # server → file impossible
+            ("/data/parcels.geojson", "gpkg"),  # file format mismatch
+        ],
+    )
+    def test_incompatible_override_raises(self, uri: str, override: str) -> None:
+        with pytest.raises(EngineInferenceError) as exc:
+            resolve_engine(uri, override)
+        assert "incompatible" in str(exc.value)
+
+    def test_all_engines_constant_matches_literal(self) -> None:
+        assert set(ALL_ENGINES) == {"gpkg", "spatialite", "postgis", "duckdb_diff"}
+
+
+class TestGISPulseConfigResolvedEngine:
+    def test_resolved_engine_inferred(self) -> None:
+        from gispulse.runtime.config_loader import GISPulseConfig
+
+        cfg = GISPulseConfig(version=1, gpkg="/tmp/foo.gpkg")
+        assert cfg.resolved_engine() == "gpkg"
+
+    def test_resolved_engine_with_override(self) -> None:
+        from gispulse.runtime.config_loader import GISPulseConfig
+
+        cfg = GISPulseConfig(version=1, gpkg="/tmp/foo.gpkg", engine="duckdb_diff")
+        assert cfg.resolved_engine() == "duckdb_diff"
+
+    def test_resolved_engine_conflict(self) -> None:
+        from gispulse.runtime.config_loader import GISPulseConfig
+
+        cfg = GISPulseConfig(version=1, gpkg="/tmp/foo.gpkg", engine="postgis")
+        with pytest.raises(EngineInferenceError):
+            cfg.resolved_engine()
+
+    def test_postgresql_uri_inferred(self) -> None:
+        from gispulse.runtime.config_loader import GISPulseConfig
+
+        cfg = GISPulseConfig(version=1, gpkg="postgresql://localhost/gis")
+        assert cfg.resolved_engine() == "postgis"

--- a/tests/runtime/test_validate_rules_v160.py
+++ b/tests/runtime/test_validate_rules_v160.py
@@ -1,0 +1,258 @@
+"""Tests for v1.6.0 #121 — top-level ``validate:`` rules + #123 tag_field action.
+
+Coverage:
+- ``validate:`` accepted at the YAML root, parses each rule.
+- ``mode: tag`` requires ``tag_field``; ``mode: warn`` does not.
+- ``rule:`` is compiled at config-load time so syntax errors surface
+  before the runtime starts.
+- Backward compatibility: a YAML without ``validate:`` keeps loading.
+- The ``tag_field`` action type is accepted by ``ActionConfigModel``.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from gispulse.runtime.config_loader import (
+    ActionConfigModel,
+    ConfigError,
+    GISPulseConfig,
+    TriggerConfigModel,
+    ValidateRuleConfigModel,
+    load_config,
+)
+
+
+# ---------------------------------------------------------------------------
+# ValidateRuleConfigModel
+# ---------------------------------------------------------------------------
+
+
+class TestValidateRuleSchema:
+    def test_minimal_warn_rule(self) -> None:
+        m = ValidateRuleConfigModel(
+            id="surface_min", rule="geom_area_m2() >= 50"
+        )
+        assert m.mode == "warn"
+        assert m.tag_field is None
+        assert m.enabled is True
+
+    def test_tag_mode_requires_tag_field(self) -> None:
+        with pytest.raises(Exception) as exc:
+            ValidateRuleConfigModel(
+                id="surface_min", rule="geom_area_m2() >= 50", mode="tag"
+            )
+        assert "tag_field" in str(exc.value)
+
+    def test_tag_mode_with_field_ok(self) -> None:
+        m = ValidateRuleConfigModel(
+            id="surface_min",
+            rule="geom_area_m2() >= 50",
+            mode="tag",
+            tag_field="validation_status",
+        )
+        assert m.mode == "tag"
+        assert m.tag_field == "validation_status"
+
+    def test_unknown_mode_rejected(self) -> None:
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            ValidateRuleConfigModel(
+                id="x", rule="geom_is_valid()", mode="silent"
+            )
+
+    def test_rule_syntax_failure_surfaces_at_load(self) -> None:
+        with pytest.raises(Exception) as exc:
+            ValidateRuleConfigModel(id="bad", rule="__import__('os')")
+        assert "compile" in str(exc.value).lower() or "DSL" in str(exc.value)
+
+    def test_arithmetic_only_rule_rejected(self) -> None:
+        # Pure arithmetic without comparison cannot evaluate to boolean —
+        # the boolean mode rejects expressions that never produce a bool.
+        # (We currently accept expressions whose top-level node is BoolOp /
+        # Compare / NOT or a single bool-returning function.)
+        m = ValidateRuleConfigModel(
+            id="x", rule="geom_is_valid()"
+        )
+        assert m.id == "x"
+
+    def test_unknown_function_rejected(self) -> None:
+        with pytest.raises(Exception):
+            ValidateRuleConfigModel(
+                id="x", rule="banana() and geom_is_valid()"
+            )
+
+
+# ---------------------------------------------------------------------------
+# GISPulseConfig integration
+# ---------------------------------------------------------------------------
+
+
+class TestGISPulseConfigValidateKey:
+    def test_validate_key_accepted(self) -> None:
+        cfg = GISPulseConfig.model_validate(
+            {
+                "version": 1,
+                "gpkg": "/tmp/x.gpkg",
+                "validate": [
+                    {
+                        "id": "surface_min",
+                        "rule": "geom_area_m2() >= 50",
+                        "mode": "warn",
+                    },
+                    {
+                        "id": "shape_valid",
+                        "rule": "geom_is_valid()",
+                        "mode": "tag",
+                        "tag_field": "validation_status",
+                        "message": "Geometry invalid",
+                    },
+                ],
+            }
+        )
+        assert len(cfg.validate_rules) == 2
+        assert cfg.validate_rules[0].id == "surface_min"
+        assert cfg.validate_rules[1].mode == "tag"
+
+    def test_no_validate_section_loads_clean(self) -> None:
+        cfg = GISPulseConfig.model_validate(
+            {"version": 1, "gpkg": "/tmp/x.gpkg"}
+        )
+        assert cfg.validate_rules == []
+
+    def test_mixed_triggers_and_validate(self) -> None:
+        cfg = GISPulseConfig.model_validate(
+            {
+                "version": 1,
+                "gpkg": "/tmp/x.gpkg",
+                "triggers": [{"name": "t", "table": "parcels", "when": ["INSERT"]}],
+                "validate": [{"id": "v", "rule": "geom_is_valid()"}],
+            }
+        )
+        assert len(cfg.triggers) == 1
+        assert len(cfg.validate_rules) == 1
+
+
+# ---------------------------------------------------------------------------
+# YAML round-trip via load_config
+# ---------------------------------------------------------------------------
+
+
+class TestValidateYamlRoundTrip:
+    def test_yaml_with_validate_loads(self, tmp_path) -> None:
+        gpkg = tmp_path / "x.gpkg"
+        gpkg.write_bytes(b"")  # path-anchor only, never opened
+        yml = tmp_path / "triggers.yaml"
+        yml.write_text(
+            textwrap.dedent(
+                f"""
+                version: 1
+                gpkg: {gpkg}
+                validate:
+                  - id: surface_min
+                    rule: "geom_area_m2() >= 50"
+                    mode: warn
+                    message: "Surface < 50 m²"
+                """
+            )
+        )
+        cfg = load_config(yml)
+        assert len(cfg.validate_rules) == 1
+        assert cfg.validate_rules[0].rule == "geom_area_m2() >= 50"
+
+    def test_yaml_unknown_rule_rejected_at_load(self, tmp_path) -> None:
+        gpkg = tmp_path / "x.gpkg"
+        gpkg.write_bytes(b"")
+        yml = tmp_path / "triggers.yaml"
+        yml.write_text(
+            textwrap.dedent(
+                f"""
+                version: 1
+                gpkg: {gpkg}
+                validate:
+                  - id: bad
+                    rule: "eval('1+1')"
+                """
+            )
+        )
+        with pytest.raises(ConfigError):
+            load_config(yml)
+
+
+# ---------------------------------------------------------------------------
+# tag_field action type (#123 schema)
+# ---------------------------------------------------------------------------
+
+
+class TestTagFieldActionSchema:
+    def test_tag_field_action_accepted(self) -> None:
+        ac = ActionConfigModel(
+            type="tag_field",
+            column="validation_status",
+            value="failed:surface_min",
+            message_column="validation_message",
+            message="Surface < 50 m²",
+        )
+        assert ac.type == "tag_field"
+        assert ac.column == "validation_status"
+        assert ac.message_column == "validation_message"
+
+    def test_unknown_action_type_rejected(self) -> None:
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            ActionConfigModel(type="erase_universe")
+
+    def test_existing_action_types_still_work(self) -> None:
+        ac = ActionConfigModel(type="set_field", field="x", value=1)
+        assert ac.type == "set_field"
+
+        ac2 = ActionConfigModel(type="webhook", url="https://example.com/hook")
+        assert ac2.type == "webhook"
+
+    def test_tag_field_inside_trigger(self) -> None:
+        m = TriggerConfigModel(
+            name="t",
+            table="parcels",
+            when=["INSERT"],
+            actions=[
+                ActionConfigModel(
+                    type="tag_field",
+                    column="validation_status",
+                    value="ok",
+                ),
+            ],
+        )
+        assert m.actions[0].type == "tag_field"
+
+
+# ---------------------------------------------------------------------------
+# ESRI kind: alias (#125)
+# ---------------------------------------------------------------------------
+
+
+class TestEsriKindAlias:
+    def test_default_kind_is_trigger(self) -> None:
+        m = TriggerConfigModel(name="t", table="x", when=["INSERT"])
+        assert m.kind == "trigger"
+
+    def test_constraint_alias_accepted(self) -> None:
+        m = TriggerConfigModel(name="t", table="x", when=["INSERT"], kind="constraint")
+        assert m.kind == "constraint"
+
+    def test_calculation_alias_accepted(self) -> None:
+        m = TriggerConfigModel(name="t", table="x", when=["INSERT"], kind="calculation")
+        assert m.kind == "calculation"
+
+    def test_validation_alias_accepted(self) -> None:
+        m = TriggerConfigModel(name="t", table="x", when=["INSERT"], kind="validation")
+        assert m.kind == "validation"
+
+    def test_unknown_kind_rejected(self) -> None:
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            TriggerConfigModel(name="t", table="x", when=["INSERT"], kind="business")

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -60,6 +60,23 @@ class TestCliDoctor:
         assert result.exit_code == 0
         assert "python" in result.stdout.lower() or "geopandas" in result.stdout.lower()
 
+    def test_doctor_install_spatial(self) -> None:
+        result = runner.invoke(app, ["doctor", "--install-spatial"])
+        assert result.exit_code == 0, result.stdout
+        assert "DuckDB Spatial" in result.stdout
+        assert "EPSG:4326" in result.stdout
+        assert "EPSG:2154" in result.stdout
+
+    def test_doctor_install_spatial_json(self) -> None:
+        result = runner.invoke(app, ["doctor", "--install-spatial", "--json"])
+        assert result.exit_code == 0, result.stdout
+        # Skip the leading update-notifier banner if present.
+        json_line = result.stdout.strip().splitlines()[-1]
+        payload = json.loads(json_line)
+        assert payload["install"] == "ok"
+        assert {c["epsg"] for c in payload["epsg"]} >= {4326, 3857, 2154, 27572}
+        assert all(isinstance(c["ok"], bool) for c in payload["epsg"])
+
 
 class TestCliHelp:
     def test_help(self) -> None:


### PR DESCRIPTION
## Summary

Sprint v1.6.0 foundation closing **9/14 children** of EPIC #104. This PR delivers the **DuckDB Spatial Inside** pivot agreed on 2026-05-04 (cf. Q1-Q4 decision records, Atlas bench R1 verdict).

- **Atlas R1 verdict** — DuckDB COPY GDAL/GPKG measured **2-3.6× faster than pyogrio** on 1M EPSG:2154 polygons, with RSS÷3.4×. The pyogrio-only write-back doctrine of v1.5.x is officially sub-optimal for bulk paths (>5M and triggers/views custom remain on pyogrio).
- **324 tests passed** (130 baseline + 194 new). 0 regression on existing runtime / change-log / trigger evaluator suites.

## Closes

| # | Module | Highlight |
|---|---|---|
| #113 | `runtime/duckdb_engine.py` | Lazy `INSTALL spatial; LOAD spatial;` with session cache + typed `DuckDBSpatialUnavailable` |
| #114 | `gispulse doctor --install-spatial` | Pre-install + EPSG roundtrip probes (4326/3857/2154/27572) baselined with pyproj |
| #115 | `runtime/engine_inference.py` | URI-based engine inference + `engine:` override with conflict detection |
| #116 + #117 | `dsl/geom_fcts.py` | 7 whitelisted geom fcts (area/perimeter/length/centroid_x/y/npoints/is_valid) |
| #118 | `dsl/expression_parser.py` | AST-based safe parser, scalar + boolean modes |
| #119 | `config_loader` + `core/enums` | Granular `when:` verbs (UPDATE_GEOM/UPDATE_ATTR/BULK) with backward-compat catch-all |
| #120 (plumbing) | `change_log_watcher` | Resolve coarse UPDATE → granular variant via `geom_changed` + expose flag in payload |
| #121 | `ValidateRuleConfigModel` | Top-level `validate:` with warn/tag modes, rule compiles at load via boolean DSL |
| #123 (schema) | `ActionConfigModel` | `tag_field` action type accepted |
| #125 | `TriggerConfigModel.kind` | ESRI aliases (constraint / calculation / validation / trigger) |
| #126 | `docs-site/guide/` | 3 new pages + v1.6.0 section appended to engines.md |

## Deferred to follow-up PRs

These pieces carry elevated risk (GPKG migration v3, cross-source DuckDB ATTACH, AFTER trigger SQL refactor) and deserve dedicated review cycles:

- **#120 B-08** — DELETE OLD.* JSON predicate (migration v3)
- **#122** — `geom_within` / `geom_overlaps_any` cross-source push-down
- **#123 (runtime)** — Auto-create columns + dispatch tag_field action
- **#124** — `layer_lookup` spatial_within (depends on #122)

## Test plan

- [x] `pytest tests/runtime/ tests/dsl/ tests/unit/test_cli.py` — 324 passed
- [x] `pytest tests/unit/test_change_log_watcher.py tests/unit/test_change_tracking_payload.py tests/unit/test_changelog_reader.py tests/unit/test_trigger_evaluator.py` — 0 regression
- [x] `python -m gispulse.cli doctor --install-spatial` — installs spatial + EPSG probes pass
- [x] `python -m gispulse.cli doctor --install-spatial --json` — JSON envelope shape stable
- [ ] CI green on push (lint + typecheck + full pytest matrix)
- [ ] Beta sanity: a v1.5.x `triggers.yaml` (only INSERT/UPDATE/DELETE verbs, no `validate:`) loads and runs unchanged

## Notes for review

- The `engine` field on `GISPulseConfig` is opt-in (`None` keeps inference behaviour). Existing v1.5.x configs untouched.
- The `validate:` top-level uses pydantic alias (`Field(alias="validate")`) since `validate` is a method on `BaseModel`. The Python attribute is `validate_rules` — only relevant for callers of `cfg.validate_rules`.
- `mode: tag` rules currently parse cleanly but the runtime side (column auto-create + dispatch) lands in the deferred follow-up. The user-facing doc (`docs-site/guide/dsl-validation.md`) flags this loyally.
- ESRI `kind:` aliases are metadata-only today — they help operators read the YAML without changing runtime behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)