### PR TITLE
feat(v1.6.0): #123 runtime — tag_field action with auto-create columns

### DIFF
--- a/core/graph.py
+++ b/core/graph.py
@@ -71,6 +71,10 @@ class ActionType(str, Enum):
     FLAG_FEATURE     = "flag_feature"
     BLOCK_COMMIT     = "block_commit"
     RUN_SQL          = "run_sql"
+    # v1.6.0 (#123): write a validation status onto the row, with
+    # auto-create of the target columns on first use. Distinct from
+    # SET_FIELD because the dispatcher manages the schema migration.
+    TAG_FIELD        = "tag_field"
 
 
 @dataclass

--- a/gispulse/adapters/esb/action_dispatcher.py
+++ b/gispulse/adapters/esb/action_dispatcher.py
@@ -8,6 +8,7 @@ run_job, run_graph, webhook, enqueue, log_event).
 from __future__ import annotations
 
 import json
+import threading
 from typing import Any, Callable
 from uuid import UUID
 
@@ -57,6 +58,12 @@ class ActionDispatcher(BaseDispatcher):
         self._event_hub = event_hub
         self._sql_executor = sql_executor
         self._webhook_client = webhook_client
+        # v1.6.0 (#123) — per-(table) set of columns we've already
+        # confirmed exist for tag_field auto-create. The lock guards
+        # the cache, not the schema migration itself (SQLite handles
+        # ALTER TABLE serialisation natively).
+        self._tag_field_known_columns: dict[str, set[str]] = {}
+        self._tag_field_lock = threading.Lock()
 
     def dispatch(self, action: ActionDef, context: TriggerContext) -> None:
         """Route an action to the appropriate handler."""
@@ -153,6 +160,125 @@ class ActionDispatcher(BaseDispatcher):
                 f'UPDATE "{ctx.table}" SET "{target_field}" = %s WHERE id = %s',
                 [value, ctx.row_id],
             )
+
+    def _tag_field(self, action: ActionDef, ctx: TriggerContext) -> None:
+        """Write a validation status onto the row, auto-creating the column.
+
+        v1.6.0 (#123) — wires the ``validate: mode: tag`` rules and
+        explicit ``tag_field:`` actions defined in ``triggers.yaml``.
+        Differs from :meth:`_set_field` in two ways:
+
+        - The target column (``column``, optional ``message_column``) is
+          auto-created with ``ALTER TABLE ADD COLUMN`` on first use. We
+          look at SQLite's ``PRAGMA table_info`` to decide; the result
+          is cached per ``(table, column)`` to avoid re-checking on
+          every event. The cache is process-local — across-process
+          contention is fine because ``ALTER TABLE ADD COLUMN`` on a
+          non-existing column races safely (SQLite raises ``duplicate
+          column name`` which we catch and treat as success).
+        - The write-back is multi-column: ``column`` and (optionally)
+          ``message_column`` updated in a single statement so the row
+          stays consistent for QGIS / portal observers.
+        """
+        column = action.config.get("column", "")
+        value = action.config.get("value")
+        message_column = action.config.get("message_column")
+        message = action.config.get("message")
+        if not column or not self._sql_executor:
+            return
+        _validate_identifier(ctx.table, "table")
+        _validate_identifier(column, "column")
+        if message_column:
+            _validate_identifier(message_column, "message_column")
+
+        wanted: list[str] = [column]
+        if message_column:
+            wanted.append(message_column)
+        self._ensure_columns(ctx.table, wanted)
+
+        # Origin-tagging M1 (B-02 / v1.5.3) — same guard as _set_field so
+        # tag_field writes do not loop through the AFTER UPDATE trigger.
+        trigger_marker = (
+            f"trigger:{ctx.trigger.id}"
+            if getattr(ctx, "trigger", None) is not None
+            and getattr(ctx.trigger, "id", None) is not None
+            else None
+        )
+        if message_column:
+            set_clause = (
+                f'"{column}" = %s, "{message_column}" = %s'
+            )
+            params: list[Any] = [value, message]
+        else:
+            set_clause = f'"{column}" = %s'
+            params = [value]
+
+        if trigger_marker is not None:
+            set_clause += ', "_gispulse_origin" = %s'
+            params.append(trigger_marker)
+        params.append(ctx.row_id)
+
+        self._sql_executor(
+            f'UPDATE "{ctx.table}" SET {set_clause} WHERE id = %s',
+            params,
+        )
+        if trigger_marker is not None:
+            self._sql_executor(
+                f'UPDATE "{ctx.table}" SET "_gispulse_origin" = NULL WHERE id = %s',
+                [ctx.row_id],
+            )
+
+    def _ensure_columns(self, table: str, columns: list[str]) -> None:
+        """Add ``columns`` to ``table`` if any are missing.
+
+        Each column is created as ``TEXT`` since the v1.6.0 surface only
+        writes status strings. Uses the per-instance cache to avoid
+        running ``PRAGMA table_info`` on every dispatch — the lock
+        protects the cache, not the SQL itself (SQLite serialises ALTER
+        TABLE writers on its own).
+        """
+        if not self._sql_executor:
+            return
+        cache = self._tag_field_known_columns
+        with self._tag_field_lock:
+            known = cache.setdefault(table, set())
+            missing = [c for c in columns if c not in known]
+        if not missing:
+            return
+        try:
+            existing = {
+                row[1] if not isinstance(row, dict) else row.get("name")
+                for row in self._sql_executor(
+                    f'PRAGMA table_info("{table}")', []
+                )
+                or []
+            }
+        except Exception as exc:  # noqa: BLE001 — driver-specific
+            log.warning("tag_field_pragma_failed", table=table, error=str(exc))
+            existing = set()
+
+        for col in missing:
+            if col in existing:
+                continue
+            try:
+                self._sql_executor(
+                    f'ALTER TABLE "{table}" ADD COLUMN "{col}" TEXT', []
+                )
+            except Exception as exc:  # noqa: BLE001
+                # SQLite raises ``duplicate column name`` when two
+                # workers race; treat as success.
+                if "duplicate column" in str(exc).lower():
+                    pass
+                else:
+                    log.warning(
+                        "tag_field_alter_failed",
+                        table=table,
+                        column=col,
+                        error=str(exc),
+                    )
+                    continue
+        with self._tag_field_lock:
+            cache.setdefault(table, set()).update(columns)
 
     def _update_aggregate(self, action: ActionDef, ctx: TriggerContext) -> None:
         target_table = action.config.get("target_table", "")
@@ -323,6 +449,7 @@ class ActionDispatcher(BaseDispatcher):
     _handlers: dict[ActionType, Callable] = {
         ActionType.NOTIFY:           _notify,
         ActionType.SET_FIELD:        _set_field,
+        ActionType.TAG_FIELD:        _tag_field,
         ActionType.UPDATE_AGGREGATE: _update_aggregate,
         ActionType.RUN_JOB:          _run_job,
         ActionType.RUN_GRAPH:        _run_graph,

--- a/gispulse/runtime/config_loader.py
+++ b/gispulse/runtime/config_loader.py
@@ -615,6 +615,7 @@ def to_triggers(config: GISPulseConfig) -> list["Trigger"]:
         "run_sql": ActionType.RUN_SQL,
         "log_event": ActionType.LOG_EVENT,
         "notify": ActionType.NOTIFY,
+        "tag_field": ActionType.TAG_FIELD,
     }
 
     triggers: list[Trigger] = []
@@ -633,6 +634,13 @@ def to_triggers(config: GISPulseConfig) -> list["Trigger"]:
                 cfg["channel"] = ac.channel or "gispulse_events"
                 if ac.payload_template is not None:
                     cfg["payload_template"] = ac.payload_template
+            elif ac.type == "tag_field":
+                cfg["column"] = ac.column or ""
+                cfg["value"] = ac.value
+                if ac.message_column:
+                    cfg["message_column"] = ac.message_column
+                if ac.message is not None:
+                    cfg["message"] = ac.message
             # log_event takes no required config
 
             actions.append(

--- a/tests/runtime/test_tag_field_runtime_v160.py
+++ b/tests/runtime/test_tag_field_runtime_v160.py
@@ -1,0 +1,247 @@
+"""Tests for v1.6.0 #123 runtime — tag_field action handler with auto-create.
+
+Coverage:
+- ``ActionType.TAG_FIELD`` registered in :class:`ActionDispatcher._handlers`.
+- Auto-create: missing target column ⇒ ``ALTER TABLE ADD COLUMN``.
+- Idempotent: second invocation reuses the cached column set, no extra
+  ``PRAGMA`` or ``ALTER`` calls.
+- Multi-column write: ``message_column`` populated when set.
+- Origin tagging: ``_gispulse_origin`` is set during the UPDATE so the
+  AFTER UPDATE trigger refire is skipped (B-02 contract).
+- ``config_loader.to_triggers`` maps a YAML ``tag_field`` action to an
+  ``ActionDef`` with the right config dict.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _SqlSpy:
+    """Wraps a sqlite3 connection and records every call."""
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self.conn = conn
+        self.calls: list[tuple[str, list[Any]]] = []
+
+    def __call__(self, sql: str, params: list[Any] | None = None) -> Any:
+        params = list(params or [])
+        self.calls.append((sql, list(params)))
+        # Translate %s placeholders to sqlite ? for the spy's pass-through
+        translated = sql.replace("%s", "?")
+        cur = self.conn.execute(translated, params)
+        if translated.strip().upper().startswith(("SELECT", "PRAGMA")):
+            rows = cur.fetchall()
+            return rows
+        self.conn.commit()
+        return None
+
+
+@pytest.fixture
+def conn():
+    c = sqlite3.connect(":memory:")
+    c.row_factory = sqlite3.Row
+    c.execute(
+        'CREATE TABLE "parcels" (id INTEGER PRIMARY KEY, label TEXT, _gispulse_origin TEXT)'
+    )
+    c.execute('INSERT INTO "parcels" (id, label) VALUES (1, "alpha"), (2, "beta")')
+    c.commit()
+    yield c
+    c.close()
+
+
+@pytest.fixture
+def dispatcher_with_spy(conn):
+    from gispulse.adapters.esb.action_dispatcher import ActionDispatcher
+
+    spy = _SqlSpy(conn)
+    return ActionDispatcher(sql_executor=spy), spy
+
+
+def _make_ctx(table: str = "parcels", row_id: int = 1):
+    from gispulse.core.dispatcher import TriggerContext
+    from core.models import Trigger
+
+    trigger = Trigger(name="t-validation")
+    return TriggerContext(
+        trigger=trigger,
+        table=table,
+        row_id=row_id,
+        operation="UPDATE",
+        eval_result=None,
+    )
+
+
+def _action(**cfg):
+    from core.graph import ActionDef, ActionType
+
+    return ActionDef(action_type=ActionType.TAG_FIELD, config=cfg)
+
+
+# ---------------------------------------------------------------------------
+# Registry & dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestActionTypeRegistry:
+    def test_tag_field_in_handlers(self) -> None:
+        from gispulse.adapters.esb.action_dispatcher import ActionDispatcher
+        from core.graph import ActionType
+
+        assert ActionType.TAG_FIELD in ActionDispatcher._handlers
+
+    def test_tag_field_action_type_value(self) -> None:
+        from core.graph import ActionType
+
+        assert ActionType.TAG_FIELD.value == "tag_field"
+
+
+# ---------------------------------------------------------------------------
+# Auto-create + write
+# ---------------------------------------------------------------------------
+
+
+class TestTagFieldAutoCreate:
+    def test_creates_missing_column_and_writes(self, dispatcher_with_spy, conn) -> None:
+        dispatcher, spy = dispatcher_with_spy
+        action = _action(column="validation_status", value="failed:surface_min")
+        ctx = _make_ctx(row_id=1)
+
+        dispatcher._tag_field(action, ctx)
+
+        # Column was added
+        cols = {row[1] for row in conn.execute('PRAGMA table_info("parcels")').fetchall()}
+        assert "validation_status" in cols
+        # Row was tagged
+        row = conn.execute(
+            'SELECT validation_status FROM "parcels" WHERE id = 1'
+        ).fetchone()
+        assert row[0] == "failed:surface_min"
+
+    def test_message_column_also_created_and_written(
+        self, dispatcher_with_spy, conn
+    ) -> None:
+        dispatcher, spy = dispatcher_with_spy
+        action = _action(
+            column="validation_status",
+            value="failed:shape_valid",
+            message_column="validation_message",
+            message="Geometry self-intersects",
+        )
+        ctx = _make_ctx(row_id=2)
+
+        dispatcher._tag_field(action, ctx)
+
+        cols = {row[1] for row in conn.execute('PRAGMA table_info("parcels")').fetchall()}
+        assert {"validation_status", "validation_message"} <= cols
+        row = conn.execute(
+            'SELECT validation_status, validation_message FROM "parcels" WHERE id = 2'
+        ).fetchone()
+        assert row[0] == "failed:shape_valid"
+        assert row[1] == "Geometry self-intersects"
+
+    def test_idempotent_second_call_skips_pragma(
+        self, dispatcher_with_spy, conn
+    ) -> None:
+        dispatcher, spy = dispatcher_with_spy
+        action = _action(column="validation_status", value="ok")
+
+        dispatcher._tag_field(action, _make_ctx(row_id=1))
+        n_calls_after_first = len(spy.calls)
+        n_pragma_after_first = sum(1 for s, _ in spy.calls if "PRAGMA" in s)
+
+        dispatcher._tag_field(action, _make_ctx(row_id=2))
+        n_pragma_after_second = sum(1 for s, _ in spy.calls if "PRAGMA" in s)
+
+        # The second invocation should not run PRAGMA again — it hits the cache
+        assert n_pragma_after_second == n_pragma_after_first
+        # ... and still UPDATEs row 2
+        row = conn.execute(
+            'SELECT validation_status FROM "parcels" WHERE id = 2'
+        ).fetchone()
+        assert row[0] == "ok"
+
+    def test_existing_column_is_not_recreated(
+        self, dispatcher_with_spy, conn
+    ) -> None:
+        dispatcher, spy = dispatcher_with_spy
+        # Pre-create the column manually
+        conn.execute('ALTER TABLE "parcels" ADD COLUMN validation_status TEXT')
+        conn.commit()
+        action = _action(column="validation_status", value="ok")
+
+        dispatcher._tag_field(action, _make_ctx(row_id=1))
+
+        # No ALTER call should have been issued
+        alter_calls = [s for s, _ in spy.calls if "ALTER TABLE" in s]
+        assert alter_calls == []
+
+    def test_origin_tag_written_for_loop_guard(
+        self, dispatcher_with_spy, conn
+    ) -> None:
+        """B-02 origin-tagging: tag_field must mark + clear ``_gispulse_origin``."""
+        dispatcher, spy = dispatcher_with_spy
+        action = _action(column="validation_status", value="ok")
+        dispatcher._tag_field(action, _make_ctx(row_id=1))
+
+        # Two UPDATE calls: one with origin set, one clearing it back to NULL.
+        update_calls = [s for s, _ in spy.calls if s.startswith('UPDATE "parcels"')]
+        assert len(update_calls) == 2
+        assert "_gispulse_origin" in update_calls[0]
+        assert "_gispulse_origin" in update_calls[1]
+
+
+# ---------------------------------------------------------------------------
+# config_loader → ActionDef
+# ---------------------------------------------------------------------------
+
+
+class TestToTriggersTagField:
+    def test_tag_field_action_mapped(self, tmp_path) -> None:
+        from gispulse.runtime.config_loader import (
+            ActionConfigModel,
+            GISPulseConfig,
+            TriggerConfigModel,
+            to_triggers,
+        )
+        from core.graph import ActionType
+
+        gpkg = tmp_path / "x.gpkg"
+        gpkg.write_bytes(b"")
+        cfg = GISPulseConfig(
+            version=1,
+            gpkg=str(gpkg),
+            triggers=[
+                TriggerConfigModel(
+                    name="t",
+                    table="parcels",
+                    when=["INSERT"],
+                    actions=[
+                        ActionConfigModel(
+                            type="tag_field",
+                            column="validation_status",
+                            value="failed:surface_min",
+                            message_column="validation_message",
+                            message="Surface < 50 m²",
+                        )
+                    ],
+                )
+            ],
+        )
+        trgs = to_triggers(cfg)
+        assert len(trgs[0].actions) == 1
+        a = trgs[0].actions[0]
+        assert a.action_type == ActionType.TAG_FIELD
+        assert a.config["column"] == "validation_status"
+        assert a.config["value"] == "failed:surface_min"
+        assert a.config["message_column"] == "validation_message"
+        assert a.config["message"] == "Surface < 50 m²"


### PR DESCRIPTION
## Summary

Wires the runtime side of #123 — closing the "auto-create columns + dispatch" half so a YAML `tag_field:` action actually writes to the row. Stacked on #129 (schema half).

- New `ActionType.TAG_FIELD` enum value
- New `_tag_field` handler in `ActionDispatcher` with PRAGMA-then-ALTER-then-UPDATE flow, lock-protected per-table column cache, and origin-tagging M1 preserved (B-02 contract)
- `config_loader.to_triggers` maps `tag_field` action to `ActionDef` with `column / value / message_column / message` config dict
- 8 new tests covering registry, auto-create, idempotency, multi-column write, origin-tag guard, and config_loader mapping

322/322 tests pass (8 new + existing runtime/dsl/cli/dispatcher suites). 0 regression.

## Out of scope (tracked separately)

The wiring of `validate: mode: tag` rules so a failing rule auto-emits a `tag_field` action through the watcher needs a dedicated validation runner inside the watcher — not bundled here. The schema is already in place (`ValidateRuleConfigModel.tag_field` is required when `mode=tag`), so configs continue to parse cleanly; the runtime gracefully degrades to mode `warn` until the validation runner lands.

## Test plan

- [x] `pytest tests/runtime/test_tag_field_runtime_v160.py` — 8 passed
- [x] `pytest tests/runtime/ tests/dsl/ tests/unit/test_cli.py tests/unit/test_change_log_watcher.py tests/unit/test_action_dispatcher.py` — 322 passed
- [ ] Stacked on #129 — wait for #129 to merge before set-ready
- [ ] CI green on push (lint + typecheck + full pytest matrix)

## Notes for review

- The "duplicate column name" race on concurrent `ALTER TABLE ADD COLUMN` is caught and treated as success — SQLite serialises ALTER writers internally so the actual on-disk state is consistent.
- The cache is process-local. Across processes, the worst case is a redundant PRAGMA on first hit per process; the `ALTER TABLE` itself remains race-safe.
- `_gispulse_origin` marking is identical to the `_set_field` handler so the AFTER UPDATE trigger refire skip continues to work. Tests assert two UPDATE statements (mark + clear).

🤖 Generated with [Claude Code](https://claude.com/claude-code)