### PR TITLE
feat(v1.6.0): #122 — geom_within / geom_overlaps_any registry + parser

### DIFF
--- a/gispulse/dsl/expression_parser.py
+++ b/gispulse/dsl/expression_parser.py
@@ -72,11 +72,25 @@ class CompilationContext:
         the user does not pass ``epsg=...``. Defaults to ``"EPSG:2154"``
         (Lambert 93) — appropriate for FR-centric datasets; override to
         ``"EPSG:3857"`` for global Web Mercator.
+    current_table:
+        Name of the table the rule is evaluated against. Required by
+        cross-layer fcts when the user writes ``layer='self'``.
+    pk_col:
+        Primary-key column of ``current_table``. Used by
+        ``geom_overlaps_any(exclude_self=True)`` to emit the self-row
+        guard. Defaults to ``"id"``.
+    default_layer_geom:
+        Default geometry column on the cross-source layer (``geom_within``
+        / ``geom_overlaps_any``). Override per-call with
+        ``layer_geom='other'``. Defaults to ``"geom"``.
     """
 
     geom_column: str = "geom"
     source_epsg: str | None = None
     default_metric_epsg: str = "EPSG:2154"
+    current_table: str | None = None
+    pk_col: str = "id"
+    default_layer_geom: str = "geom"
 
     def __post_init__(self) -> None:
         if not _IDENT_RE.match(self.geom_column):
@@ -91,6 +105,18 @@ class CompilationContext:
             raise DSLValidationError(
                 f"default_metric_epsg must look like 'EPSG:NNNN', got "
                 f"{self.default_metric_epsg!r}"
+            )
+        if self.current_table is not None and not _IDENT_RE.match(self.current_table):
+            raise DSLValidationError(
+                f"invalid current_table identifier {self.current_table!r}"
+            )
+        if not _IDENT_RE.match(self.pk_col):
+            raise DSLValidationError(
+                f"invalid pk_col identifier {self.pk_col!r}"
+            )
+        if not _IDENT_RE.match(self.default_layer_geom):
+            raise DSLValidationError(
+                f"invalid default_layer_geom identifier {self.default_layer_geom!r}"
             )
 
 
@@ -357,8 +383,11 @@ class _Compiler:
 
     def _collect_kwargs(
         self, node: ast.Call, spec: GeomFunctionSpec
-    ) -> dict[str, str]:
-        out: dict[str, str] = {}
+    ) -> dict[str, str | bool]:
+        # Subquery fcts (#122 — geom_within / geom_overlaps_any) accept a
+        # bool ``exclude_self`` flag in addition to string identifiers; the
+        # rest of the surface only takes strings.
+        out: dict[str, str | bool] = {}
         for kw in node.keywords:
             if kw.arg is None:
                 raise DSLValidationError(
@@ -372,25 +401,45 @@ class _Compiler:
                         f"{kw.arg!r}; allowed: {list(spec.accepted_kwargs)}",
                     )
                 )
-            if not isinstance(kw.value, ast.Constant) or not isinstance(
-                kw.value.value, str
-            ):
+            if not isinstance(kw.value, ast.Constant):
                 raise DSLValidationError(
                     self._explain(
                         node,
-                        f"{spec.name}({kw.arg}=...) requires a string literal",
+                        f"{spec.name}({kw.arg}=...) requires a literal",
                     )
                 )
-            out[kw.arg] = kw.value.value
+            v = kw.value.value
+            if isinstance(v, bool):
+                # bool is also int — guard before the int branch below
+                if kw.arg != "exclude_self":
+                    raise DSLValidationError(
+                        self._explain(
+                            node,
+                            f"{spec.name}({kw.arg}=...) does not accept a bool",
+                        )
+                    )
+                out[kw.arg] = v
+            elif isinstance(v, str):
+                out[kw.arg] = v
+            else:
+                raise DSLValidationError(
+                    self._explain(
+                        node,
+                        f"{spec.name}({kw.arg}=...) requires a string literal "
+                        f"(got {type(v).__name__})",
+                    )
+                )
         return out
 
     def _render_geom_call(
         self,
         spec: GeomFunctionSpec,
-        kwargs: dict[str, str],
+        kwargs: dict[str, str | bool],
         node: ast.AST,
     ) -> str:
-        epsg = kwargs.get("epsg", self.ctx.default_metric_epsg)
+        if spec.is_subquery:
+            return self._render_subquery_call(spec, kwargs, node)
+        epsg = str(kwargs.get("epsg", self.ctx.default_metric_epsg))
         if spec.crs_aware:
             if not _EPSG_RE.match(epsg):
                 raise DSLValidationError(
@@ -414,6 +463,85 @@ class _Compiler:
             }
         else:
             sub = {"geom": f'"{self.ctx.geom_column}"'}
+        return spec.sql_template.format(**sub)
+
+    def _render_subquery_call(
+        self,
+        spec: GeomFunctionSpec,
+        kwargs: dict[str, str | bool],
+        node: ast.AST,
+    ) -> str:
+        """Emit ``EXISTS (SELECT 1 FROM ... )`` for cross-layer fcts.
+
+        The ``layer`` kwarg is required. ``layer='self'`` resolves to the
+        current table from the compilation context. ``layer_geom`` defaults
+        to ``"geom"`` (override per-call). Each fct adds its own clause:
+
+        - :func:`geom_within` accepts ``match='col'`` to AND the layer
+          row's column with the current row's same-named column (SQL
+          self-reference).
+        - :func:`geom_overlaps_any` accepts ``exclude_self=True`` to skip
+          the row being evaluated using ``ctx.pk_col`` for the join key.
+        """
+        layer = kwargs.get("layer")
+        if not isinstance(layer, str):
+            raise DSLValidationError(
+                self._explain(node, f"{spec.name}() requires layer=<string>")
+            )
+        if layer == "self":
+            if self.ctx.current_table is None:
+                raise DSLValidationError(
+                    self._explain(
+                        node,
+                        f"{spec.name}(layer='self') needs current_table in "
+                        "CompilationContext",
+                    )
+                )
+            layer = self.ctx.current_table
+        if not _IDENT_RE.match(layer):
+            raise DSLValidationError(
+                self._explain(node, f"invalid layer name {layer!r}")
+            )
+
+        layer_geom = kwargs.get("layer_geom", self.ctx.default_layer_geom)
+        if not isinstance(layer_geom, str) or not _IDENT_RE.match(layer_geom):
+            raise DSLValidationError(
+                self._explain(node, f"invalid layer_geom {layer_geom!r}")
+            )
+
+        sub: dict[str, str] = {
+            "geom": f'"{self.ctx.geom_column}"',
+            "layer": layer,
+            "layer_geom": layer_geom,
+        }
+
+        if spec.name == "geom_within":
+            match = kwargs.get("match")
+            if match is not None:
+                if not isinstance(match, str) or not _IDENT_RE.match(match):
+                    raise DSLValidationError(
+                        self._explain(node, f"invalid match column {match!r}")
+                    )
+                sub["match_clause"] = f' AND _L."{match}" = "{match}"'
+            else:
+                sub["match_clause"] = ""
+        elif spec.name == "geom_overlaps_any":
+            exclude_self = kwargs.get("exclude_self", False)
+            if exclude_self is not False and not isinstance(exclude_self, bool):
+                raise DSLValidationError(
+                    self._explain(
+                        node,
+                        f"{spec.name}(exclude_self=...) requires a bool literal "
+                        f"(True / False)",
+                    )
+                )
+            if exclude_self:
+                sub["exclude_self_clause"] = (
+                    f' AND _L."{self.ctx.pk_col}" <> "{self.ctx.pk_col}"'
+                )
+            else:
+                sub["exclude_self_clause"] = ""
+
         return spec.sql_template.format(**sub)
 
     # -- error helpers --------------------------------------------------------

--- a/gispulse/dsl/geom_fcts.py
+++ b/gispulse/dsl/geom_fcts.py
@@ -43,6 +43,13 @@ class GeomFunctionSpec:
     crs_aware: bool
     """True when ``epsg=`` keyword is meaningful (measure / centroid fns)."""
     accepted_kwargs: tuple[str, ...] = ()
+    is_subquery: bool = False
+    """True for cross-layer fcts (``geom_within``, ``geom_overlaps_any``).
+
+    Subquery fcts emit ``EXISTS (SELECT 1 FROM ...)`` and need a richer
+    compilation context (``current_table``, ``pk_col``) to resolve
+    self-references (``layer='self'``, ``exclude_self=true``).
+    """
 
 
 _TEMPLATE_AREA_M2 = "ST_Area(ST_Transform({geom}, {src}, '{epsg}', true))"
@@ -52,6 +59,20 @@ _TEMPLATE_CENTROID_X = "ST_X(ST_Transform(ST_Centroid({geom}), {src}, '{epsg}', 
 _TEMPLATE_CENTROID_Y = "ST_Y(ST_Transform(ST_Centroid({geom}), {src}, '{epsg}', true))"
 _TEMPLATE_NPOINTS = "ST_NPoints({geom})"
 _TEMPLATE_IS_VALID = "ST_IsValid({geom})"
+
+# v1.6.0 #122: cross-layer subquery fcts. The compiler fills ``layer``
+# with the cross-source layer name (or the current table when the user
+# passes ``layer='self'``), ``layer_geom`` with the layer's geometry
+# column (defaults to ``geom``), and the optional clauses
+# ``match_clause`` / ``exclude_self_clause`` based on the kwargs.
+_TEMPLATE_GEOM_WITHIN = (
+    'EXISTS (SELECT 1 FROM "{layer}" AS _L '
+    'WHERE ST_Within({geom}, _L."{layer_geom}"){match_clause})'
+)
+_TEMPLATE_GEOM_OVERLAPS_ANY = (
+    'EXISTS (SELECT 1 FROM "{layer}" AS _L '
+    'WHERE ST_Overlaps({geom}, _L."{layer_geom}"){exclude_self_clause})'
+)
 
 
 GEOM_FUNCTIONS: dict[str, GeomFunctionSpec] = {
@@ -101,6 +122,22 @@ GEOM_FUNCTIONS: dict[str, GeomFunctionSpec] = {
         return_type="boolean",
         sql_template=_TEMPLATE_IS_VALID,
         crs_aware=False,
+    ),
+    "geom_within": GeomFunctionSpec(
+        name="geom_within",
+        return_type="boolean",
+        sql_template=_TEMPLATE_GEOM_WITHIN,
+        crs_aware=False,
+        accepted_kwargs=("layer", "match", "layer_geom"),
+        is_subquery=True,
+    ),
+    "geom_overlaps_any": GeomFunctionSpec(
+        name="geom_overlaps_any",
+        return_type="boolean",
+        sql_template=_TEMPLATE_GEOM_OVERLAPS_ANY,
+        crs_aware=False,
+        accepted_kwargs=("layer", "exclude_self", "layer_geom"),
+        is_subquery=True,
     ),
 }
 

--- a/tests/dsl/test_expression_parser.py
+++ b/tests/dsl/test_expression_parser.py
@@ -29,6 +29,7 @@ from gispulse.dsl import (
 class TestGeomFunctionRegistry:
     EXPECTED_T1 = {"geom_area_m2", "geom_perimeter_m", "geom_length_m"}
     EXPECTED_T2 = {"geom_centroid_x", "geom_centroid_y", "geom_npoints", "geom_is_valid"}
+    EXPECTED_SUBQUERY = {"geom_within", "geom_overlaps_any"}
 
     def test_t1_present(self) -> None:
         assert self.EXPECTED_T1 <= set(GEOM_FUNCTIONS)
@@ -36,12 +37,18 @@ class TestGeomFunctionRegistry:
     def test_t2_present(self) -> None:
         assert self.EXPECTED_T2 <= set(GEOM_FUNCTIONS)
 
-    def test_seven_total(self) -> None:
+    def test_subquery_present(self) -> None:
+        assert self.EXPECTED_SUBQUERY <= set(GEOM_FUNCTIONS)
+
+    def test_full_v160_surface(self) -> None:
         # Locks the v1.6.0 surface — adding a new fct must update tests/docs.
-        assert set(GEOM_FUNCTIONS) == self.EXPECTED_T1 | self.EXPECTED_T2
+        assert set(GEOM_FUNCTIONS) == (
+            self.EXPECTED_T1 | self.EXPECTED_T2 | self.EXPECTED_SUBQUERY
+        )
 
     def test_is_geom_function(self) -> None:
         assert is_geom_function("geom_area_m2")
+        assert is_geom_function("geom_within")
         assert not is_geom_function("eval")
         assert not is_geom_function("ST_Area")  # SQL name, not DSL name
 

--- a/tests/dsl/test_geom_subquery_v160.py
+++ b/tests/dsl/test_geom_subquery_v160.py
@@ -1,0 +1,237 @@
+"""Tests for v1.6.0 #122 — geom_within / geom_overlaps_any subquery fcts.
+
+Coverage:
+- Registry: both fcts present, ``is_subquery=True``, accepted kwargs.
+- ``geom_within(layer='communes')`` → emits ``EXISTS ... ST_Within ...``.
+- ``geom_within(layer='communes', match='code_insee')`` adds
+  ``AND _L."code_insee" = "code_insee"``.
+- ``geom_overlaps_any(layer='self', exclude_self=true)`` resolves
+  ``self`` to ``current_table`` and emits the pk-guard clause.
+- ``layer_geom='geom_3d'`` overrides the default geometry column.
+- ``layer='self'`` without ``current_table`` raises ``DSLValidationError``.
+- Invalid layer / match identifiers rejected.
+- ``exclude_self`` rejected on ``geom_within`` (kwargs allowlist).
+
+DuckDB E2E tests are deferred until the cross-source ATTACH plumbing
+lands (the validation runner). The compiled SQL is asserted as a string
+here so we lock the contract that downstream wiring will rely on.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gispulse.dsl import (
+    GEOM_FUNCTIONS,
+    CompilationContext,
+    DSLValidationError,
+    compile_expression,
+)
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class TestSubqueryFunctionsRegistered:
+    def test_geom_within_present(self) -> None:
+        spec = GEOM_FUNCTIONS["geom_within"]
+        assert spec.return_type == "boolean"
+        assert spec.is_subquery is True
+        assert spec.crs_aware is False
+        assert "layer" in spec.accepted_kwargs
+        assert "match" in spec.accepted_kwargs
+        assert "layer_geom" in spec.accepted_kwargs
+
+    def test_geom_overlaps_any_present(self) -> None:
+        spec = GEOM_FUNCTIONS["geom_overlaps_any"]
+        assert spec.return_type == "boolean"
+        assert spec.is_subquery is True
+        assert "layer" in spec.accepted_kwargs
+        assert "exclude_self" in spec.accepted_kwargs
+        assert "layer_geom" in spec.accepted_kwargs
+
+
+# ---------------------------------------------------------------------------
+# geom_within compilation
+# ---------------------------------------------------------------------------
+
+
+class TestGeomWithinCompilation:
+    def test_simple_within(self) -> None:
+        sql = compile_expression(
+            "geom_within(layer='communes')", mode="boolean"
+        )
+        assert "EXISTS" in sql
+        assert 'FROM "communes" AS _L' in sql
+        assert 'ST_Within("geom", _L."geom")' in sql
+
+    def test_with_match_attribute(self) -> None:
+        sql = compile_expression(
+            "geom_within(layer='communes', match='code_insee')",
+            mode="boolean",
+        )
+        assert 'AND _L."code_insee" = "code_insee"' in sql
+
+    def test_layer_geom_override(self) -> None:
+        sql = compile_expression(
+            "geom_within(layer='communes', layer_geom='geometry')",
+            mode="boolean",
+        )
+        assert '_L."geometry"' in sql
+
+    def test_layer_self_resolves_to_current_table(self) -> None:
+        ctx = CompilationContext(current_table="parcels")
+        sql = compile_expression(
+            "geom_within(layer='self', match='code_insee')", ctx, mode="boolean"
+        )
+        assert 'FROM "parcels" AS _L' in sql
+
+    def test_layer_self_without_current_table_raises(self) -> None:
+        with pytest.raises(DSLValidationError) as exc:
+            compile_expression(
+                "geom_within(layer='self')", mode="boolean"
+            )
+        assert "current_table" in str(exc.value)
+
+    def test_invalid_layer_identifier_rejected(self) -> None:
+        with pytest.raises(DSLValidationError):
+            compile_expression(
+                "geom_within(layer='communes; DROP TABLE x')", mode="boolean"
+            )
+
+    def test_invalid_match_identifier_rejected(self) -> None:
+        with pytest.raises(DSLValidationError):
+            compile_expression(
+                "geom_within(layer='communes', match='c; DROP')",
+                mode="boolean",
+            )
+
+    def test_layer_required(self) -> None:
+        with pytest.raises(DSLValidationError):
+            compile_expression("geom_within()", mode="boolean")
+
+    def test_exclude_self_rejected_on_within(self) -> None:
+        with pytest.raises(DSLValidationError) as exc:
+            compile_expression(
+                "geom_within(layer='self', exclude_self=True)", mode="boolean"
+            )
+        assert "exclude_self" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# geom_overlaps_any compilation
+# ---------------------------------------------------------------------------
+
+
+class TestGeomOverlapsAnyCompilation:
+    def test_overlaps_self_with_exclude(self) -> None:
+        ctx = CompilationContext(current_table="parcels", pk_col="id")
+        sql = compile_expression(
+            "geom_overlaps_any(layer='self', exclude_self=True)",
+            ctx,
+            mode="boolean",
+        )
+        assert 'FROM "parcels" AS _L' in sql
+        assert 'ST_Overlaps("geom", _L."geom")' in sql
+        assert 'AND _L."id" <> "id"' in sql
+
+    def test_overlaps_self_without_exclude(self) -> None:
+        ctx = CompilationContext(current_table="parcels")
+        sql = compile_expression(
+            "geom_overlaps_any(layer='self', exclude_self=False)",
+            ctx,
+            mode="boolean",
+        )
+        # No exclude clause emitted
+        assert "<>" not in sql
+
+    def test_overlaps_other_layer(self) -> None:
+        sql = compile_expression(
+            "geom_overlaps_any(layer='zonage_pli')", mode="boolean"
+        )
+        assert 'FROM "zonage_pli" AS _L' in sql
+
+    def test_pk_col_override_via_ctx(self) -> None:
+        ctx = CompilationContext(current_table="parcels", pk_col="fid")
+        sql = compile_expression(
+            "geom_overlaps_any(layer='self', exclude_self=True)",
+            ctx,
+            mode="boolean",
+        )
+        assert 'AND _L."fid" <> "fid"' in sql
+
+    def test_exclude_self_must_be_bool(self) -> None:
+        with pytest.raises(DSLValidationError) as exc:
+            compile_expression(
+                "geom_overlaps_any(layer='self', exclude_self='yes')",
+                CompilationContext(current_table="parcels"),
+                mode="boolean",
+            )
+        assert "string literal" in str(exc.value).lower() or "bool" in str(exc.value).lower()
+
+    def test_match_rejected_on_overlaps(self) -> None:
+        with pytest.raises(DSLValidationError):
+            compile_expression(
+                "geom_overlaps_any(layer='communes', match='code_insee')",
+                mode="boolean",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Combined with arithmetic / boolean ops
+# ---------------------------------------------------------------------------
+
+
+class TestSubquerysInBooleanExpressions:
+    def test_negation(self) -> None:
+        ctx = CompilationContext(current_table="parcels")
+        sql = compile_expression(
+            "not geom_overlaps_any(layer='self', exclude_self=True)",
+            ctx,
+            mode="boolean",
+        )
+        assert sql.startswith("(NOT")
+
+    def test_combined_with_geom_is_valid(self) -> None:
+        ctx = CompilationContext(current_table="parcels")
+        sql = compile_expression(
+            "geom_is_valid() and not geom_overlaps_any(layer='self', exclude_self=True)",
+            ctx,
+            mode="boolean",
+        )
+        assert "AND" in sql
+        assert "NOT" in sql
+        assert "EXISTS" in sql
+
+    def test_match_self_reference_via_validate_rule(self) -> None:
+        # End-to-end use case from docs-site/guide/dsl-validation.md
+        sql = compile_expression(
+            "geom_within(layer='communes', match='code_insee')",
+            CompilationContext(current_table="parcels"),
+            mode="boolean",
+        )
+        assert "EXISTS" in sql
+        assert 'AND _L."code_insee" = "code_insee"' in sql
+
+
+# ---------------------------------------------------------------------------
+# CompilationContext extensions
+# ---------------------------------------------------------------------------
+
+
+class TestCompilationContextExtensions:
+    def test_default_pk_is_id(self) -> None:
+        assert CompilationContext().pk_col == "id"
+
+    def test_default_layer_geom(self) -> None:
+        assert CompilationContext().default_layer_geom == "geom"
+
+    def test_invalid_current_table(self) -> None:
+        with pytest.raises(DSLValidationError):
+            CompilationContext(current_table="parcels; DROP")
+
+    def test_invalid_pk_col(self) -> None:
+        with pytest.raises(DSLValidationError):
+            CompilationContext(pk_col="id; --")


### PR DESCRIPTION
## Summary

Adds the cross-layer subquery primitives to the DSL whitelist so a `validate:` rule can use `geom_within(layer='communes', match='code_insee')` or `not geom_overlaps_any(layer='self', exclude_self=True)`. The compiler emits safe DuckDB SQL with strict identifier validation.

Stacked on **#130** (#123 runtime), itself stacked on **#129** (foundation).

## Closes (partially)

This PR closes the schema + compilation half of **#122**. The remaining cross-source ATTACH plumbing and the actual execution (validation runner inside the watcher) are tracked separately — locking the SQL contract here lets the downstream wiring proceed in parallel.

## Changes

| File | Highlight |
|---|---|
| `dsl/geom_fcts.py` | `GeomFunctionSpec.is_subquery` flag + 2 new entries with `EXISTS (SELECT 1 FROM "<layer>" AS _L WHERE …)` templates |
| `dsl/expression_parser.py` | `CompilationContext` gains `current_table` / `pk_col` / `default_layer_geom`; kwargs accept `bool` literals on `exclude_self` slot; `_render_subquery_call` validates every interpolated identifier against `[A-Za-z_]\w*` |
| `tests/dsl/test_geom_subquery_v160.py` | 25 new tests (registry + compilation + identifier validation + boolean combinators + ctx extensions) |
| `tests/dsl/test_expression_parser.py` | Locks the v1.6.0 surface at 9 fcts (T1+T2+subquery) |

## SQL output examples

```yaml
validate:
  - id: in_known_commune
    rule: "geom_within(layer='communes', match='code_insee')"
    mode: warn

  - id: no_overlap
    rule: "not geom_overlaps_any(layer='self', exclude_self=True)"
    mode: tag
    tag_field: validation_status
```

compiles to:

```sql
EXISTS (SELECT 1 FROM "communes" AS _L
        WHERE ST_Within("geom", _L."geom")
          AND _L."code_insee" = "code_insee")

(NOT EXISTS (SELECT 1 FROM "parcels" AS _L
             WHERE ST_Overlaps("geom", _L."geom")
               AND _L."id" <> "id"))
```

## Test plan

- [x] `pytest tests/dsl/` — 81 passed
- [x] `pytest tests/runtime/ tests/dsl/ tests/unit/test_cli.py tests/unit/test_change_log_watcher.py tests/unit/test_action_dispatcher.py` — 347 passed
- [ ] CI green on push
- [ ] Review base chain: merge #129 → retarget #130 → merge → retarget #131 (this PR) → merge

## Out of scope (tracked separately)

- Cross-source DuckDB ATTACH so a layer URI `./communes.gpkg` resolves at runtime — needed before the SQL output can actually execute against a non-current table.
- Validation runner inside the watcher that picks up `validate:` rules and dispatches warn / tag actions on rule failure (requires `_render_subquery_call` to bind to a real DuckDB session).
- #124 `layer_lookup` (depends on the same ATTACH plumbing).

## Notes for review

- Identifier injection guards are aggressive: every `layer`, `match`, `layer_geom`, and `pk_col` is checked against `^[A-Za-z_][A-Za-z0-9_]{0,62}$` before splicing.
- `exclude_self` only accepts a `bool` literal (`True` / `False`); a string `'yes'` is rejected. The corresponding test pins the rule.
- `layer='self'` without `current_table` in the ctx raises `DSLValidationError` with a hint at the missing piece — this is intentional so the validation runner enforces the contract upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)