### PR TITLE
feat(v1.6.0): watcher hook + GPKG factory — wire validation runner E2E

### DIFF
--- a/gispulse/runtime/__init__.py
+++ b/gispulse/runtime/__init__.py
@@ -64,6 +64,7 @@ from gispulse.runtime.validation_runner import (
     ValidationFailure,
     ValidationRunner,
     compile_validate_rules,
+    make_gpkg_sql_evaluator,
 )
 
 __all__ = [
@@ -91,6 +92,7 @@ __all__ = [
     "build_runtime",
     "build_update_payload",
     "compile_validate_rules",
+    "make_gpkg_sql_evaluator",
     "evaluate_predicate",
     "get_spatial_connection",
     "infer_engine",

--- a/gispulse/runtime/validation_runner.py
+++ b/gispulse/runtime/validation_runner.py
@@ -305,3 +305,61 @@ class ValidationRunner:
                 failure.rule_id,
                 exc,
             )
+
+
+# ---------------------------------------------------------------------------
+# DuckDB sql_evaluator factory
+# ---------------------------------------------------------------------------
+
+
+def make_gpkg_sql_evaluator(
+    gpkg_path: str,
+    *,
+    alias: str = "gpkg",
+) -> Callable[[str, list[Any]], list[Any]]:
+    """Return a sql_evaluator that runs SQL against ``gpkg_path`` via DuckDB.
+
+    Opens a DuckDB connection with the spatial extension lazy-loaded
+    (cf :mod:`gispulse.runtime.duckdb_engine`) and ATTACHes the GPKG
+    as a SQLite catalog under ``alias``. Subsequent ``USE alias`` makes
+    bare-table references in the rule SQL resolve naturally — the
+    same ``"parcels"`` identifier compiled by
+    :func:`gispulse.dsl.compile_expression` works against the attached
+    GeoPackage without rewriting.
+
+    The connection is held by the closure for the evaluator's lifetime;
+    callers should treat the returned callable as owning the resource
+    and discard it (letting the conn close) when the runner stops.
+
+    Caveats:
+    - ATTACH on a SQLite database is read-only by default in DuckDB —
+      this is fine for validation. Concurrent SQLite writers (the GPKG
+      AFTER triggers populating ``_gispulse_change_log``) coexist with
+      this read connection because SQLite serialises around the WAL.
+    - Cross-source layers (``geom_within(layer='communes')`` referencing
+      a separate GPKG) require an additional ``ATTACH`` per layer —
+      handled by the cross-source plumbing in #122 follow-ups.
+    """
+    from gispulse.runtime.duckdb_engine import get_spatial_connection
+
+    if not gpkg_path or not isinstance(gpkg_path, str):
+        raise ValueError(f"gpkg_path must be a non-empty string, got {gpkg_path!r}")
+
+    conn = get_spatial_connection()
+    # Use parameter substitution where possible; the ATTACH form below
+    # has no SQL-parameter slot in DuckDB so we splice the path. We
+    # validate the alias as an identifier and reject paths containing
+    # single quotes that would break out of the literal.
+    if "'" in gpkg_path or "\x00" in gpkg_path:
+        raise ValueError(f"gpkg_path contains illegal characters: {gpkg_path!r}")
+    import re as _re
+
+    if not _re.match(r"^[A-Za-z_][A-Za-z0-9_]{0,62}$", alias):
+        raise ValueError(f"invalid alias {alias!r}")
+    conn.execute(f"ATTACH '{gpkg_path}' AS {alias} (TYPE SQLITE)")
+    conn.execute(f"USE {alias}")
+
+    def evaluator(sql: str, params: list[Any]) -> list[Any]:
+        return conn.execute(sql, params).fetchall()
+
+    return evaluator

--- a/persistence/change_log_watcher.py
+++ b/persistence/change_log_watcher.py
@@ -170,6 +170,7 @@ class ChangeLogWatcher:
         bulk_threshold: int = 0,
         bulk_eval: str = "skip",
         schema_drift_check_interval_s: float = 5.0,
+        validation_runner: Any | None = None,
     ) -> None:
         if poll_interval <= 0:
             raise ValueError("poll_interval must be > 0")
@@ -236,6 +237,14 @@ class ChangeLogWatcher:
         self._evaluator = trigger_evaluator
         self._triggers_provider = triggers_provider
         self._action_dispatcher = action_dispatcher
+        # v1.6.0 — optional ValidationRunner that evaluates ``validate:``
+        # rules per row. The watcher calls ``evaluate(table, row_id)``
+        # after the trigger evaluator block on INSERT / UPDATE_GEOM /
+        # UPDATE_ATTR events. Failures broadcast on the event hub via
+        # the runner's own hub binding (we don't double-broadcast here).
+        # Typed as ``Any`` to avoid a circular import on the runtime
+        # package; the runner protocol is just ``evaluate(table, row_id)``.
+        self._validation_runner = validation_runner
         # Cache active triggers indexed by id within a tick so the
         # dispatcher can recover the full Trigger (with .actions) from
         # the FiredTrigger summary, without re-querying the repo.
@@ -747,6 +756,28 @@ class ChangeLogWatcher:
                         change_id=change_id,
                         ts=ts,
                     )
+
+        # v1.6.0 — declarative validate: rules. Runs *after* the trigger
+        # evaluator block so a tag_field action emitted by a future
+        # mode=tag bridge sees the post-trigger row state. DELETE is
+        # skipped because the row no longer exists; ditto for BULK
+        # which the watcher already collapses into a single summary
+        # event before this point. Any exception in the runner is
+        # contained so the tick keeps moving.
+        if (
+            self._validation_runner is not None
+            and fid is not None
+            and table
+            and op in ("INSERT", "UPDATE", "UPDATE_GEOM", "UPDATE_ATTR")
+        ):
+            try:
+                self._validation_runner.evaluate(table, fid)
+            except Exception as exc:
+                logger.warning(
+                    "change_log_validation_runner_failed change_id=%d: %s",
+                    change_id,
+                    exc,
+                )
 
         return change_id
 

--- a/tests/runtime/test_validation_runner_watcher_hook_v160.py
+++ b/tests/runtime/test_validation_runner_watcher_hook_v160.py
@@ -1,0 +1,278 @@
+"""Tests for v1.6.0 — ChangeLogWatcher → ValidationRunner hook + factory.
+
+Coverage:
+- Watcher accepts ``validation_runner`` kwarg (no-op when ``None``).
+- INSERT / UPDATE_GEOM / UPDATE_ATTR events trigger ``runner.evaluate``.
+- DELETE events skip the runner (row no longer exists).
+- Runner exception is contained — the tick keeps moving.
+- ``make_gpkg_sql_evaluator`` returns a working callable that ATTACHes
+  a real GPKG and runs the rule SQL emitted by the DSL compiler.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Watcher fixtures
+# ---------------------------------------------------------------------------
+
+
+class _RecordingHub:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self.events: list[tuple[str, dict[str, Any]]] = []
+
+    def broadcast(self, event_type: str, data: dict[str, Any] | None = None) -> None:
+        with self._lock:
+            self.events.append((event_type, data or {}))
+
+
+class _FakeRunner:
+    """Records every ``evaluate`` call so tests can assert dispatch."""
+
+    def __init__(self, raises: bool = False) -> None:
+        self.calls: list[tuple[str, Any]] = []
+        self.raises = raises
+
+    def evaluate(self, table: str, row_id: Any) -> list[Any]:
+        self.calls.append((table, row_id))
+        if self.raises:
+            raise RuntimeError("boom")
+        return []
+
+
+class _FakeEngine:
+    backend_name = "gpkg"
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._rows: list[dict[str, Any]] = []
+        self._next_id = 1
+
+    def push(
+        self,
+        table: str,
+        op: str,
+        fid: str,
+        *,
+        geom_changed: bool = False,
+    ) -> int:
+        with self._lock:
+            row_id = self._next_id
+            self._next_id += 1
+            self._rows.append(
+                {
+                    "id": row_id,
+                    "table_name": table,
+                    "operation": op,
+                    "row_pk": fid,
+                    "changed_at": "2026-05-06T00:00:00",
+                    "geom_changed": 1 if geom_changed else 0,
+                    "processed": 0,
+                }
+            )
+            return row_id
+
+    def get_pending_changes(self, limit: int = 100) -> list[dict]:
+        with self._lock:
+            pending = [r for r in self._rows if r["processed"] == 0]
+            return [dict(r) for r in pending[:limit]]
+
+    def mark_changes_processed(self, up_to_id: int) -> int:
+        with self._lock:
+            n = 0
+            for r in self._rows:
+                if r["id"] <= up_to_id and r["processed"] == 0:
+                    r["processed"] = 1
+                    n += 1
+            return n
+
+
+def _wait_until(predicate, timeout: float = 2.0, step: float = 0.02) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(step)
+    return predicate()
+
+
+@pytest.fixture
+def watcher_with_runner():
+    from persistence.change_log_watcher import ChangeLogWatcher
+
+    engine = _FakeEngine()
+    hub = _RecordingHub()
+    runner = _FakeRunner()
+    watcher = ChangeLogWatcher(
+        engine,
+        hub,
+        dataset_id="ds-validation",
+        poll_interval=0.05,
+        validation_runner=runner,
+    )
+    yield watcher, engine, hub, runner
+    watcher.stop()
+
+
+# ---------------------------------------------------------------------------
+# Watcher hook behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestWatcherValidationHook:
+    def test_insert_triggers_runner(self, watcher_with_runner) -> None:
+        watcher, engine, hub, runner = watcher_with_runner
+        engine.push("parcels", "INSERT", "1")
+        watcher.start()
+        assert _wait_until(lambda: runner.calls)
+        assert runner.calls == [("parcels", "1")]
+
+    def test_update_geom_triggers_runner(self, watcher_with_runner) -> None:
+        watcher, engine, hub, runner = watcher_with_runner
+        engine.push("parcels", "UPDATE", "2", geom_changed=True)
+        watcher.start()
+        assert _wait_until(lambda: runner.calls)
+        # The watcher resolves UPDATE → UPDATE_GEOM via geom_changed (#119)
+        # before the validation hook fires; runner sees the resolved table+row
+        assert runner.calls[0][0] == "parcels"
+        assert runner.calls[0][1] == "2"
+
+    def test_update_attr_triggers_runner(self, watcher_with_runner) -> None:
+        watcher, engine, hub, runner = watcher_with_runner
+        engine.push("parcels", "UPDATE", "3", geom_changed=False)
+        watcher.start()
+        assert _wait_until(lambda: runner.calls)
+        assert runner.calls[0] == ("parcels", "3")
+
+    def test_delete_skips_runner(self, watcher_with_runner) -> None:
+        watcher, engine, hub, runner = watcher_with_runner
+        engine.push("parcels", "DELETE", "4")
+        watcher.start()
+        # Wait until the DELETE event has been broadcast — runner must not see it
+        assert _wait_until(lambda: any(e[0] == "dml.changed" for e in hub.events))
+        # Give the watcher one extra tick to ensure the runner stays untouched
+        time.sleep(0.1)
+        assert runner.calls == []
+
+    def test_runner_exception_does_not_abort_tick(
+        self, watcher_with_runner
+    ) -> None:
+        watcher, engine, hub, _runner = watcher_with_runner
+        # Replace with a raising runner mid-fixture
+        watcher._validation_runner = _FakeRunner(raises=True)
+        engine.push("parcels", "INSERT", "5")
+        watcher.start()
+        # Despite the runner raising, the dml.changed broadcast still fires
+        assert _wait_until(lambda: any(e[0] == "dml.changed" for e in hub.events))
+
+
+class TestWatcherWithoutRunner:
+    def test_default_no_runner_no_op(self) -> None:
+        from persistence.change_log_watcher import ChangeLogWatcher
+
+        engine = _FakeEngine()
+        hub = _RecordingHub()
+        watcher = ChangeLogWatcher(
+            engine, hub, dataset_id="ds-no-validation", poll_interval=0.05
+        )
+        try:
+            engine.push("parcels", "INSERT", "1")
+            watcher.start()
+            # Runs cleanly without a validation_runner attribute set
+            assert _wait_until(lambda: any(e[0] == "dml.changed" for e in hub.events))
+        finally:
+            watcher.stop()
+
+
+# ---------------------------------------------------------------------------
+# make_gpkg_sql_evaluator factory
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def gpkg_with_parcels(tmp_path: Path) -> Path:
+    """Build a minimal SQLite file the DuckDB sqlite_scanner can ATTACH."""
+    p = tmp_path / "fixture.gpkg"
+    conn = sqlite3.connect(str(p))
+    try:
+        conn.execute(
+            "CREATE TABLE parcels (id INTEGER PRIMARY KEY, label TEXT, npts INTEGER)"
+        )
+        conn.execute(
+            "INSERT INTO parcels VALUES (1, 'alpha', 4), (2, 'beta', 3)"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return p
+
+
+class TestMakeGpkgSqlEvaluator:
+    def test_factory_returns_working_callable(self, gpkg_with_parcels: Path) -> None:
+        from gispulse.runtime.duckdb_engine import _reset_cache_for_tests
+        from gispulse.runtime.validation_runner import make_gpkg_sql_evaluator
+
+        _reset_cache_for_tests()
+        evaluator = make_gpkg_sql_evaluator(str(gpkg_with_parcels))
+        rows = evaluator('SELECT label FROM "parcels" WHERE "id" = ?', [1])
+        assert rows == [("alpha",)]
+
+    def test_factory_rejects_path_with_quote(self) -> None:
+        from gispulse.runtime.validation_runner import make_gpkg_sql_evaluator
+
+        with pytest.raises(ValueError):
+            make_gpkg_sql_evaluator("/tmp/foo'.gpkg")
+
+    def test_factory_rejects_invalid_alias(self, gpkg_with_parcels: Path) -> None:
+        from gispulse.runtime.validation_runner import make_gpkg_sql_evaluator
+
+        with pytest.raises(ValueError):
+            make_gpkg_sql_evaluator(str(gpkg_with_parcels), alias="my db")
+
+    def test_factory_rejects_empty_path(self) -> None:
+        from gispulse.runtime.validation_runner import make_gpkg_sql_evaluator
+
+        with pytest.raises(ValueError):
+            make_gpkg_sql_evaluator("")
+
+    def test_factory_used_by_validation_runner(self, gpkg_with_parcels: Path) -> None:
+        """End-to-end: compile a rule, run it via the factory evaluator."""
+        from gispulse.runtime.duckdb_engine import _reset_cache_for_tests
+        from gispulse.runtime.validation_runner import (
+            ValidationRunner,
+            compile_validate_rules,
+            make_gpkg_sql_evaluator,
+        )
+        from types import SimpleNamespace
+
+        _reset_cache_for_tests()
+        # Rule: npts >= 4 (passes for row 1 'alpha', fails for row 2 'beta')
+        rule = SimpleNamespace(
+            id="min_pts",
+            rule="npts >= 4",
+            mode="warn",
+            tag_field=None,
+            message="too few points",
+            enabled=True,
+        )
+        compiled = compile_validate_rules(
+            [rule], table="parcels", source_epsg=None
+        )
+        assert len(compiled.rules) == 1
+
+        evaluator = make_gpkg_sql_evaluator(str(gpkg_with_parcels))
+        runner = ValidationRunner(compiled.rules, evaluator)
+
+        assert runner.evaluate("parcels", 1) == []
+        failures = runner.evaluate("parcels", 2)
+        assert len(failures) == 1
+        assert failures[0].rule_id == "min_pts"


### PR DESCRIPTION
## Summary

Closes the last mile of the v1.6.0 `validate:` runtime: every INSERT / UPDATE_GEOM / UPDATE_ATTR row now drives an optional `ValidationRunner` through the watcher's `process_row`, and a `make_gpkg_sql_evaluator` factory provides the DuckDB-backed `sql_evaluator` the runner needs.

Stacked on **#132** (validation runner module), itself on the rest of the v1.6.0 cascade (#131 → #130 → #129).

## What lands

| File | Highlight |
|---|---|
| `persistence/change_log_watcher.py` | `ChangeLogWatcher.__init__(validation_runner=None)` + dispatch in `process_row` after the trigger evaluator block. Runner exceptions are logged and contained. |
| `gispulse/runtime/validation_runner.py` | New `make_gpkg_sql_evaluator(gpkg_path, *, alias='gpkg')` factory. Opens DuckDB + spatial + `ATTACH '...' AS gpkg (TYPE SQLITE)` + `USE gpkg` so rule SQL referencing `"parcels"` resolves naturally. Path + alias validated against quote injection / identifier shape. |
| `gispulse/runtime/__init__.py` | Re-exports the factory. |
| `tests/runtime/test_validation_runner_watcher_hook_v160.py` | 11 new tests. |

## How a config flows now

```
triggers.yaml validate:                     ChangeLogWatcher
       ↓                                            ↓ (after trigger eval)
compile_validate_rules → CompiledValidateRule[]
                                                    ↓
make_gpkg_sql_evaluator(gpkg) ─→ ValidationRunner ─→ runner.evaluate(table, row)
                                                    ↓
                                       (failures) → hub.broadcast("validation.failed")
```

## DML dispatch matrix

| Op | Runner.evaluate called? |
|---|---|
| INSERT | yes |
| UPDATE | resolved to UPDATE_GEOM / UPDATE_ATTR via `geom_changed` (#119), then yes |
| UPDATE_GEOM | yes |
| UPDATE_ATTR | yes |
| DELETE | no — row no longer exists |
| BULK | no — already collapsed into summary upstream |

## Out of scope (tracked separately)

- **mode=tag → tag_field auto-emit bridge**: the runner currently logs + broadcasts on `mode: tag`; the action emit (which would call into the dispatcher's `_tag_field` from #130) is a separate piece. The schema and the action handler are both ready.
- **`headless_runtime.build_runtime` wiring**: factory is plumbed and tested, but the build step still does not instantiate a `ValidationRunner` from `GISPulseConfig.validate_rules` because we need a product decision on "which table do rules apply to?" (today the schema doesn't carry a `table:` field; the watcher hook accepts a runner per dataset so multi-table support is a YAML-shape question).

## Test plan

- [x] `pytest tests/runtime/test_validation_runner_watcher_hook_v160.py` — 11 passed (INSERT / UPDATE_GEOM / UPDATE_ATTR dispatch + DELETE skip + exception isolation + no-runner no-op + factory happy / quote rejection / alias rejection / empty path / E2E "compile rule, run via factory, ValidationRunner.evaluate" roundtrip on a real GPKG)
- [x] `pytest tests/runtime/ tests/dsl/ tests/unit/test_change_log_watcher.py tests/unit/test_action_dispatcher.py` — 364 passed
- [ ] Stacked on #132 — review base chain: #129 → #130 → #131 → #132 → this PR

## Notes for review

- `validation_runner` is typed `Any` in the watcher signature to dodge a circular import (`runtime` → `persistence`). The runtime side imports the protocol; the watcher only calls `evaluate(table, row_id)`.
- The factory's ATTACH form has no SQL-parameter slot in DuckDB so we splice the path. The validation rejects single-quoted paths and NUL bytes; alias must match `[A-Za-z_]\w*`. `pytest tests/runtime/test_validation_runner_watcher_hook_v160.py::TestMakeGpkgSqlEvaluator` pins the negative cases.
- DuckDB ATTACH on a SQLite database is read-only by default — fine for validation. The active SQLite writer (the GPKG AFTER triggers) coexists via WAL serialisation. Documented in the factory docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)