### PR TITLE
feat(v1.6.0): mode=tag bridge — ValidationRunner emits TAG_FIELD action

### DIFF
--- a/docs-site/guide/dsl-validation.md
+++ b/docs-site/guide/dsl-validation.md
@@ -55,21 +55,23 @@ when a downstream pipeline filters on a status column. The column is
 auto-created on first use; subsequent failures of the same rule
 overwrite the value.
 
-> **Note (v1.6.0 scope):** the validation runner that picks up
-> `validate:` rules at runtime ships with v1.6.0 — every INSERT and
-> UPDATE event triggers a per-rule evaluation against the row, and
-> failures land in the log + a `validation.failed` broadcast over the
-> event hub.
+> **Note (v1.6.0 scope):** the validation runner ships end-to-end —
+> every INSERT and UPDATE event triggers a per-rule evaluation, every
+> failure logs and broadcasts `validation.failed` over the event hub,
+> and a `mode: tag` failure dispatches a synthetic `TAG_FIELD` action
+> through the regular `ActionDispatcher`. The dispatcher auto-creates
+> the target column on first use (PRAGMA + ALTER TABLE) and writes
+> `failed:<rule.id>` onto the row.
 >
-> The `mode: tag` dispatch (column auto-create + `tag_field` action
-> emit) is wired in two places independently: the schema accepts it
-> and the `tag_field` action dispatcher knows how to write it. The
-> bridge that connects a failing `mode: tag` rule to an automatic
-> `tag_field` action emit is the last mile and tracked as a follow-up.
-> Until it lands, `mode: tag` configs degrade to `mode: warn`
-> semantics — log + WS event, no row mutation. Track
-> [#123](https://github.com/imagodata/gispulse/issues/123) and the
-> validation-runner-in-watcher follow-up for status.
+> Wiring the validation runner from `GISPulseConfig.validate_rules`
+> at `build_runtime` time is a separate piece — the runtime accepts
+> a runner injection today, the auto-instantiation step is tracked
+> as a follow-up because it needs a product decision on how rules
+> map to tables when multiple triggers are configured.
+>
+> Without an `action_dispatcher` injected into the runner,
+> `mode: tag` configs degrade to `mode: warn` semantics (log + WS
+> event, no row mutation).
 
 ## Cross-source validation (preview)
 

--- a/gispulse/runtime/validation_runner.py
+++ b/gispulse/runtime/validation_runner.py
@@ -212,11 +212,18 @@ class ValidationRunner:
         *,
         hub: _EventHubProtocol | None = None,
         dataset_id: str = "",
+        action_dispatcher: Any | None = None,
     ) -> None:
         self._rules = rules
         self._sql_evaluator = sql_evaluator
         self._hub = hub
         self._dataset_id = dataset_id
+        # v1.6.0 — when set, ``mode: tag`` failures dispatch a synthetic
+        # ``ActionType.TAG_FIELD`` action through the dispatcher so the
+        # row receives ``failed:<rule.id>`` on the configured column.
+        # Without a dispatcher, tag failures degrade to warn (log + WS
+        # broadcast) per the dsl-validation.md docs.
+        self._action_dispatcher = action_dispatcher
 
     @property
     def rule_count(self) -> int:
@@ -255,7 +262,62 @@ class ValidationRunner:
             )
             failures.append(failure)
             self._broadcast(failure)
+            if rule.mode == "tag":
+                self._dispatch_tag(rule, row_id)
         return failures
+
+    def _dispatch_tag(
+        self, rule: CompiledValidateRule, row_id: Any
+    ) -> None:
+        """Emit a synthetic ``TAG_FIELD`` action for a ``mode: tag`` failure.
+
+        Builds a one-off :class:`Trigger` + :class:`TriggerContext` so the
+        existing :class:`ActionDispatcher._tag_field` handler — already
+        battle-tested via #123 — can write the row without a special
+        code path. The synthetic trigger's ``id`` is logged as
+        ``trigger:<uuid>`` by the dispatcher for the origin-tagging
+        guard, so the AFTER UPDATE refire skip works exactly like a
+        regular tag_field action.
+
+        No-op when ``action_dispatcher`` is unset (degraded mode warn,
+        cf dsl-validation.md) or when ``rule.tag_field`` is missing
+        (the schema validator already enforces this; the runtime guard
+        is defence-in-depth).
+        """
+        if self._action_dispatcher is None or not rule.tag_field:
+            return
+        try:
+            from core.graph import ActionDef, ActionType, EvalResult
+            from core.models import Trigger
+            from gispulse.core.dispatcher import TriggerContext
+
+            synthetic = Trigger(
+                name=f"validate:{rule.id}",
+                description=f"Synthetic trigger for validate rule {rule.id!r}",
+            )
+            action = ActionDef(
+                action_type=ActionType.TAG_FIELD,
+                config={
+                    "column": rule.tag_field,
+                    "value": f"failed:{rule.id}",
+                    "message": rule.message,
+                },
+            )
+            ctx = TriggerContext(
+                trigger=synthetic,
+                eval_result=EvalResult(matched=True),
+                table=rule.table,
+                row_id=str(row_id),
+                operation="VALIDATE",
+            )
+            self._action_dispatcher.dispatch(action, ctx)
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                "validation_tag_dispatch_failed rule=%s row=%s err=%s",
+                rule.id,
+                row_id,
+                exc,
+            )
 
     def _evaluate_rule(self, rule: CompiledValidateRule, row_id: Any) -> bool:
         """Return True when the rule failed for ``row_id``.

--- a/tests/runtime/test_validation_tag_bridge_v160.py
+++ b/tests/runtime/test_validation_tag_bridge_v160.py
@@ -1,0 +1,219 @@
+"""Tests for v1.6.0 — mode=tag bridge from ValidationRunner to ActionDispatcher.
+
+Coverage:
+- ``mode: tag`` failure → ``ActionDispatcher.dispatch`` called with a
+  ``TAG_FIELD`` action whose config matches the rule (column / value /
+  message).
+- ``mode: warn`` failure → dispatcher NOT called.
+- ``action_dispatcher=None`` → graceful no-op (degrade to warn).
+- ``rule.tag_field`` missing on a ``mode: tag`` rule → defence-in-depth
+  no-op (the schema enforces this upstream).
+- Dispatcher exception → logged + batch keeps moving.
+- E2E: real ``ActionDispatcher`` over a sqlite ``_sql_executor`` mutates
+  the row's status column on a failing rule.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from gispulse.runtime.validation_runner import (
+    CompiledValidateRule,
+    ValidationRunner,
+)
+
+
+def _compiled(
+    *,
+    id: str = "r",
+    table: str = "parcels",
+    rule_sql: str = "TRUE",
+    mode: str = "tag",
+    tag_field: str | None = "validation_status",
+    message: str | None = "rule failed",
+    pk_col: str = "id",
+) -> CompiledValidateRule:
+    return CompiledValidateRule(
+        id=id,
+        table=table,
+        pk_col=pk_col,
+        rule_sql=rule_sql,
+        mode=mode,
+        tag_field=tag_field,
+        message=message,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bridge unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestTagDispatch:
+    def test_tag_failure_calls_dispatcher(self) -> None:
+        from core.graph import ActionType
+
+        evaluator = lambda sql, params: [(True,)]  # always fail
+        dispatcher = MagicMock()
+        runner = ValidationRunner(
+            [_compiled(id="surface_min", message="too small")],
+            evaluator,
+            action_dispatcher=dispatcher,
+        )
+        failures = runner.evaluate("parcels", row_id=1)
+        assert len(failures) == 1
+        dispatcher.dispatch.assert_called_once()
+        action, ctx = dispatcher.dispatch.call_args.args
+        assert action.action_type == ActionType.TAG_FIELD
+        assert action.config["column"] == "validation_status"
+        assert action.config["value"] == "failed:surface_min"
+        assert action.config["message"] == "too small"
+        assert ctx.table == "parcels"
+        assert ctx.row_id == "1"
+        assert ctx.operation == "VALIDATE"
+
+    def test_warn_failure_does_not_call_dispatcher(self) -> None:
+        evaluator = lambda sql, params: [(True,)]
+        dispatcher = MagicMock()
+        runner = ValidationRunner(
+            [_compiled(mode="warn", tag_field=None)],
+            evaluator,
+            action_dispatcher=dispatcher,
+        )
+        failures = runner.evaluate("parcels", row_id=1)
+        assert len(failures) == 1
+        dispatcher.dispatch.assert_not_called()
+
+    def test_no_dispatcher_degrades_gracefully(self) -> None:
+        """Without a dispatcher, mode=tag falls back to warn semantics."""
+        evaluator = lambda sql, params: [(True,)]
+        runner = ValidationRunner(
+            [_compiled()],
+            evaluator,
+            action_dispatcher=None,
+        )
+        # No exception, failure is still returned + broadcast (if hub set)
+        failures = runner.evaluate("parcels", row_id=1)
+        assert len(failures) == 1
+
+    def test_missing_tag_field_skips_dispatch(self) -> None:
+        """Defence-in-depth: pydantic validates this, but the runner guards too."""
+        evaluator = lambda sql, params: [(True,)]
+        dispatcher = MagicMock()
+        runner = ValidationRunner(
+            [_compiled(tag_field=None)],  # mode=tag but no column
+            evaluator,
+            action_dispatcher=dispatcher,
+        )
+        runner.evaluate("parcels", row_id=1)
+        dispatcher.dispatch.assert_not_called()
+
+    def test_dispatcher_exception_does_not_abort_batch(self) -> None:
+        evaluator = lambda sql, params: [(True,)]
+        dispatcher = MagicMock()
+        dispatcher.dispatch.side_effect = RuntimeError("dispatch boom")
+        runner = ValidationRunner(
+            [
+                _compiled(id="rule_a"),
+                _compiled(id="rule_b"),
+            ],
+            evaluator,
+            action_dispatcher=dispatcher,
+        )
+        # Both rules fail; both attempt to dispatch; both raise; runner
+        # still returns 2 failures and the batch keeps moving.
+        failures = runner.evaluate("parcels", row_id=1)
+        assert len(failures) == 2
+        assert dispatcher.dispatch.call_count == 2
+
+    def test_synthetic_trigger_name_includes_rule_id(self) -> None:
+        evaluator = lambda sql, params: [(True,)]
+        dispatcher = MagicMock()
+        runner = ValidationRunner(
+            [_compiled(id="shape_valid")],
+            evaluator,
+            action_dispatcher=dispatcher,
+        )
+        runner.evaluate("parcels", row_id=42)
+        _, ctx = dispatcher.dispatch.call_args.args
+        assert ctx.trigger.name == "validate:shape_valid"
+
+
+# ---------------------------------------------------------------------------
+# E2E with real ActionDispatcher + sqlite
+# ---------------------------------------------------------------------------
+
+
+class _SqlSpy:
+    """Wraps a sqlite3 connection and translates %s placeholders to ?."""
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self.conn = conn
+        self.calls: list[tuple[str, list[Any]]] = []
+
+    def __call__(self, sql: str, params: list[Any] | None = None) -> Any:
+        params = list(params or [])
+        self.calls.append((sql, list(params)))
+        translated = sql.replace("%s", "?")
+        cur = self.conn.execute(translated, params)
+        if translated.strip().upper().startswith(("SELECT", "PRAGMA")):
+            return cur.fetchall()
+        self.conn.commit()
+        return None
+
+
+@pytest.fixture
+def sqlite_conn():
+    c = sqlite3.connect(":memory:")
+    c.row_factory = sqlite3.Row
+    c.execute(
+        'CREATE TABLE "parcels" '
+        '(id INTEGER PRIMARY KEY, label TEXT, _gispulse_origin TEXT)'
+    )
+    c.execute('INSERT INTO "parcels" (id, label) VALUES (1, "alpha")')
+    c.commit()
+    yield c
+    c.close()
+
+
+class TestE2EWithRealDispatcher:
+    def test_tag_failure_writes_status_column(self, sqlite_conn) -> None:
+        """End-to-end: ValidationRunner failure → real ActionDispatcher → row tagged."""
+        from gispulse.adapters.esb.action_dispatcher import ActionDispatcher
+
+        spy = _SqlSpy(sqlite_conn)
+        dispatcher = ActionDispatcher(sql_executor=spy)
+
+        evaluator = lambda sql, params: [(True,)]  # rule fails for any row
+        runner = ValidationRunner(
+            [
+                _compiled(
+                    id="surface_min",
+                    message="surface < 50 m²",
+                    tag_field="validation_status",
+                )
+            ],
+            evaluator,
+            action_dispatcher=dispatcher,
+        )
+
+        failures = runner.evaluate("parcels", row_id=1)
+        assert len(failures) == 1
+
+        # The auto-create handler in ActionDispatcher (#123) added the
+        # column, then the UPDATE wrote the status.
+        cols = {
+            row[1]
+            for row in sqlite_conn.execute(
+                'PRAGMA table_info("parcels")'
+            ).fetchall()
+        }
+        assert "validation_status" in cols
+        row = sqlite_conn.execute(
+            'SELECT validation_status FROM "parcels" WHERE id = 1'
+        ).fetchone()
+        assert row[0] == "failed:surface_min"


### PR DESCRIPTION
## Summary

Closes the last user-visible piece of the v1.6.0 `validate:` story: a failing `mode: tag` rule now dispatches a synthetic `TAG_FIELD` action through the regular `ActionDispatcher` instead of degrading to warn. The dispatcher auto-creates the target column (PRAGMA + ALTER from #123) and writes `failed:<rule.id>` onto the row.

Stacked on **#133** (watcher hook), itself on the rest of the v1.6.0 cascade.

## How it lands end-to-end

```yaml
validate:
  - id: surface_min
    rule: "geom_area_m2() >= 50"
    mode: tag
    tag_field: validation_status
    message: "Surface < 50 m²"
```

```
QGIS edit → AFTER UPDATE trigger → _gispulse_change_log row
                                            │
                                            ▼
                          ChangeLogWatcher.process_row
                                            │
                                            ├── trigger evaluator (existing)
                                            └── ValidationRunner.evaluate(table, row_id)
                                                  │
                                                  ▼
                                       (rule fails → mode=tag)
                                                  │
                                                  ▼
                                ActionDispatcher.dispatch(
                                    ActionDef(TAG_FIELD, {
                                        column: "validation_status",
                                        value:  "failed:surface_min",
                                        message: "Surface < 50 m²",
                                    }),
                                    ctx{ trigger=validate:surface_min,
                                         table=parcels, row_id=42,
                                         operation=VALIDATE })
                                                  │
                                                  ▼
                                  _tag_field handler (#123)
                                  ├── PRAGMA / ALTER auto-create
                                  └── UPDATE parcels
                                      SET validation_status='failed:surface_min',
                                          _gispulse_origin='trigger:<uuid>'
                                      WHERE id=42
```

The dispatcher's origin-tagging M1 (B-02 / v1.5.3) keeps the AFTER UPDATE refire skip working — a tag write does not loop through the change log.

## Changes

| File | Highlight |
|---|---|
| `gispulse/runtime/validation_runner.py` | `__init__` accepts `action_dispatcher`; new `_dispatch_tag` builds synthetic Trigger + TriggerContext + TAG_FIELD ActionDef and routes through the dispatcher |
| `docs-site/guide/dsl-validation.md` | Note updated: tag dispatch is shipped end-to-end |
| `tests/runtime/test_validation_tag_bridge_v160.py` | 7 new tests |

## Defence-in-depth

- `action_dispatcher=None` → no-op (degrades to warn — documented).
- `rule.tag_field` missing on a `mode: tag` rule → no-op (the pydantic model already enforces this; runtime guard is belt-and-braces).
- Dispatcher exception → logged as `validation_tag_dispatch_failed` and swallowed; the batch keeps moving.

## Test plan

- [x] `pytest tests/runtime/test_validation_tag_bridge_v160.py` — 7 passed (dispatcher invoked / warn skip / no dispatcher / missing tag_field / dispatcher raises / synthetic trigger name + E2E with real `ActionDispatcher` writing the status column on sqlite)
- [x] `pytest tests/runtime/ tests/dsl/` — 325 passed
- [ ] CI green on push
- [ ] Stacked on #133 — review base chain: #129 → #130 → #131 → #132 → #133 → this PR

## Out of scope (last remaining piece)

- **`headless_runtime.build_runtime` auto-wiring** — instantiating a `ValidationRunner` from `GISPulseConfig.validate_rules` and passing it to the watcher. Blocked on a product decision: today the `validate:` schema doesn't carry a `table:` field, so when multiple triggers exist on different tables the runtime needs a rule for which table the rules apply to. Three options on the table:
  1. Add `table:` to `ValidateRuleConfigModel` (per-rule) — most explicit.
  2. Apply rules to the table of the first trigger (most concise, least flexible).
  3. Apply rules to every table that has a trigger — broadest (potential perf cost).

Until the decision lands, callers who want runtime validation can wire the runner manually with the new factory + dispatcher injection (a working pattern is in the E2E tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)