### PR TITLE
fix(v1.6.x): #141 Q2 — centralize GPKG connection with WAL + busy_timeout

### DIFF
--- a/gispulse/adapters/http/routers/datasets_router.py
+++ b/gispulse/adapters/http/routers/datasets_router.py
@@ -394,8 +394,10 @@ def _layers_in_gpkg(path: Path) -> list[str]:
         # is layer name.
         names = [str(row[0]) for row in info]
     except Exception:
+        from persistence.gpkg_connection import connect_gpkg
+
         names = []
-        with sqlite3.connect(str(path)) as conn:
+        with connect_gpkg(path) as conn:
             try:
                 rows = conn.execute(
                     "SELECT table_name FROM gpkg_contents WHERE data_type='features'"
@@ -684,12 +686,13 @@ def _open_dataset_gpkg(ds: Dataset) -> sqlite3.Connection:
     """Open a SQLite connection on the dataset's GPKG with row factory.
 
     Mirrors the CLI's ``_open_gpkg`` (cli_track) so the HTTP path
-    keeps the same lifecycle. Caller owns the connection.
+    keeps the same lifecycle (WAL + busy_timeout). Caller owns the
+    connection.
     """
+    from persistence.gpkg_connection import connect_gpkg
+
     path = _resolve_gpkg_path(ds)
-    conn = sqlite3.connect(str(path), isolation_level=None)
-    conn.row_factory = sqlite3.Row
-    return conn
+    return connect_gpkg(path, row_factory=sqlite3.Row)
 
 
 @router.get("/{dataset_id}/changelog")

--- a/gispulse/adapters/http/routers/portal_datasets_router.py
+++ b/gispulse/adapters/http/routers/portal_datasets_router.py
@@ -233,9 +233,9 @@ def _write_gpkg_styles(gpkg_path: str, styles: list[tuple[str, str, float, dict 
     Each entry: (layer_name, color, opacity, style_def_or_none, geom_type_or_none)
     If style_def is provided, uses the full style_converter for rich QML.
     """
-    import sqlite3
+    from persistence.gpkg_connection import connect_gpkg
 
-    conn = sqlite3.connect(gpkg_path)
+    conn = connect_gpkg(gpkg_path)
     try:
         conn.execute("""
             CREATE TABLE IF NOT EXISTS layer_styles (
@@ -646,11 +646,10 @@ async def compute_breaks(
 
 def _upsert_layer_style(gpkg_path: str, layer_name: str, qml_xml: str) -> None:
     """DELETE existing styleQML for layer, then INSERT new one. Idempotent."""
-    import sqlite3
-
     from persistence.gpkg import _CREATE_LAYER_STYLES
+    from persistence.gpkg_connection import connect_gpkg
 
-    conn = sqlite3.connect(gpkg_path)
+    conn = connect_gpkg(gpkg_path)
     try:
         conn.execute(_CREATE_LAYER_STYLES)
         conn.execute(

--- a/gispulse/cli_track.py
+++ b/gispulse/cli_track.py
@@ -45,17 +45,17 @@ track_app = typer.Typer(
 def _open_gpkg(path: Path) -> sqlite3.Connection:
     """Open a GPKG with the same pragmas the engine uses (WAL + busy timeout).
 
-    We avoid instantiating ``GeoPackageEngine`` here because it pulls the full
-    pyogrio stack; for plain DDL we only need raw ``sqlite3``.
+    Delegates to :func:`persistence.gpkg_connection.connect_gpkg` so every
+    code path that touches a GeoPackage applies identical concurrency
+    pragmas. The CLI wrapper only adds the user-friendly "file not found"
+    exit before opening.
     """
     if not path.exists():
         _human(f"GPKG not found: {path}", err=True, style="red")
         raise typer.Exit(code=2)
-    conn = sqlite3.connect(str(path), timeout=5.0, isolation_level=None)
-    conn.row_factory = sqlite3.Row
-    conn.execute("PRAGMA journal_mode = WAL")
-    conn.execute("PRAGMA busy_timeout = 5000")
-    return conn
+    from persistence.gpkg_connection import connect_gpkg
+
+    return connect_gpkg(path, row_factory=sqlite3.Row)
 
 
 def _list_spatial_layers(conn: sqlite3.Connection) -> list[str]:

--- a/gispulse/cli_triggers.py
+++ b/gispulse/cli_triggers.py
@@ -363,8 +363,10 @@ def cmd_list(
     engine when ``enable_change_tracking()`` runs. Empty list = the GPKG
     is not yet tracked.
     """
+    from persistence.gpkg_connection import connect_gpkg
+
     try:
-        conn = sqlite3.connect(str(gpkg))
+        conn = connect_gpkg(gpkg)
         try:
             cur = conn.execute(
                 """

--- a/gispulse/runtime/headless_runtime.py
+++ b/gispulse/runtime/headless_runtime.py
@@ -232,8 +232,10 @@ def _list_user_tables(gpkg_path: Path) -> list[str]:
     pyogrio's ``list_layers`` returns everything including the
     ``_gispulse_*`` tables, which would confuse the auto-detect path.
     """
+    from persistence.gpkg_connection import connect_gpkg
+
     try:
-        conn = sqlite3.connect(str(gpkg_path))
+        conn = connect_gpkg(gpkg_path)
         try:
             cur = conn.execute(
                 "SELECT table_name FROM gpkg_contents "

--- a/persistence/gpkg_connection.py
+++ b/persistence/gpkg_connection.py
@@ -1,0 +1,69 @@
+"""Centralized SQLite/GPKG connection helper with WAL + busy_timeout pragmas.
+
+Closes part of #141 (Q2 of EPIC #139): every code path that opens a
+GeoPackage via raw ``sqlite3`` must apply the same concurrency-safety
+pragmas, otherwise concurrent QGIS edits race the GISPulse runtime and
+trigger ``SQLITE_BUSY`` (or the Py3.10 ``test_p02`` flake).
+
+Use :func:`connect_gpkg` instead of bare ``sqlite3.connect`` when the
+target is a GeoPackage.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+DEFAULT_BUSY_TIMEOUT_MS = 5000
+
+
+def connect_gpkg(
+    path: str | Path,
+    *,
+    isolation_level: str | None = None,
+    busy_timeout_ms: int = DEFAULT_BUSY_TIMEOUT_MS,
+    force_wal: bool = True,
+    row_factory: Any = None,
+    timeout: float = 5.0,
+    check_same_thread: bool = True,
+) -> sqlite3.Connection:
+    """Open a SQLite connection on a GPKG with safe defaults.
+
+    Defaults match :func:`gispulse.cli_track._open_gpkg`:
+
+    * ``timeout=5.0`` so the driver waits for the file lock instead of
+      raising ``OperationalError`` immediately.
+    * ``isolation_level=None`` (autocommit) — the engine and CLI both
+      manage their own transactions explicitly.
+    * ``PRAGMA busy_timeout = 5000`` so individual statements wait for
+      a competing writer (e.g. QGIS) instead of failing fast.
+    * ``PRAGMA journal_mode = WAL`` so concurrent readers do not block
+      a writer (QGIS holds an exclusive lock under the default
+      ``DELETE`` journal mode).
+
+    The WAL pragma is best-effort: on a read-only mount or if the
+    GPKG is opened over a filesystem that disallows shared-memory
+    files (some Windows network shares), the pragma silently fails
+    and the connection falls back to whatever the file currently
+    declares. Pass ``force_wal=False`` if the caller knows the GPKG
+    is read-only.
+    """
+    conn = sqlite3.connect(
+        str(path),
+        timeout=timeout,
+        isolation_level=isolation_level,
+        check_same_thread=check_same_thread,
+    )
+    if row_factory is not None:
+        conn.row_factory = row_factory
+    if force_wal:
+        try:
+            conn.execute("PRAGMA journal_mode = WAL")
+        except sqlite3.OperationalError:
+            pass
+    try:
+        conn.execute(f"PRAGMA busy_timeout = {int(busy_timeout_ms)}")
+    except sqlite3.OperationalError:
+        pass
+    return conn

--- a/persistence/project_io.py
+++ b/persistence/project_io.py
@@ -112,8 +112,9 @@ def export_project(
         else:
             format = "json"
 
-    conn = sqlite3.connect(str(gpkg_path))
-    conn.row_factory = sqlite3.Row
+    from persistence.gpkg_connection import connect_gpkg
+
+    conn = connect_gpkg(gpkg_path, row_factory=sqlite3.Row)
 
     project: dict[str, Any] = {
         "version": SCHEMA_VERSION,
@@ -211,8 +212,9 @@ def import_project(
     # Open/bootstrap GPKG
     from persistence.gpkg_schema import bootstrap_gpkg_project
 
-    conn = sqlite3.connect(str(gpkg_path))
-    conn.row_factory = sqlite3.Row
+    from persistence.gpkg_connection import connect_gpkg
+
+    conn = connect_gpkg(gpkg_path, row_factory=sqlite3.Row)
     bootstrap_gpkg_project(conn)
 
     stats: dict[str, int] = {}

--- a/tests/unit/test_gpkg_connection.py
+++ b/tests/unit/test_gpkg_connection.py
@@ -1,0 +1,166 @@
+"""Tests for ``persistence.gpkg_connection`` — issue #141.
+
+Validates that every code path that opens a GPKG via ``connect_gpkg``
+applies WAL + busy_timeout pragmas, and that the helper survives the
+concurrent-writer scenario that produced the Py3.10 ``test_p02`` flake.
+"""
+from __future__ import annotations
+
+import sqlite3
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from persistence.gpkg_connection import DEFAULT_BUSY_TIMEOUT_MS, connect_gpkg
+
+
+@pytest.fixture
+def fresh_gpkg(tmp_path: Path) -> Path:
+    """Create a minimal valid SQLite file (good enough for pragma tests)."""
+    path = tmp_path / "fixture.gpkg"
+    raw = sqlite3.connect(str(path))
+    try:
+        raw.execute("CREATE TABLE features (fid INTEGER PRIMARY KEY, name TEXT)")
+        raw.commit()
+    finally:
+        raw.close()
+    return path
+
+
+def test_connect_gpkg_sets_wal_mode(fresh_gpkg: Path) -> None:
+    conn = connect_gpkg(fresh_gpkg)
+    try:
+        mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+        assert mode.lower() == "wal"
+    finally:
+        conn.close()
+
+
+def test_connect_gpkg_sets_busy_timeout(fresh_gpkg: Path) -> None:
+    conn = connect_gpkg(fresh_gpkg)
+    try:
+        timeout = conn.execute("PRAGMA busy_timeout").fetchone()[0]
+        assert timeout == DEFAULT_BUSY_TIMEOUT_MS
+    finally:
+        conn.close()
+
+
+def test_connect_gpkg_custom_busy_timeout(fresh_gpkg: Path) -> None:
+    conn = connect_gpkg(fresh_gpkg, busy_timeout_ms=2000)
+    try:
+        timeout = conn.execute("PRAGMA busy_timeout").fetchone()[0]
+        assert timeout == 2000
+    finally:
+        conn.close()
+
+
+def test_connect_gpkg_force_wal_false_skips_pragma(tmp_path: Path) -> None:
+    """force_wal=False must not mutate journal_mode if the file is in DELETE."""
+    path = tmp_path / "delete.gpkg"
+    raw = sqlite3.connect(str(path))
+    try:
+        raw.execute("PRAGMA journal_mode = DELETE")
+        raw.execute("CREATE TABLE t (x INTEGER)")
+        raw.commit()
+    finally:
+        raw.close()
+
+    conn = connect_gpkg(path, force_wal=False)
+    try:
+        mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+        assert mode.lower() == "delete"
+    finally:
+        conn.close()
+
+
+def test_connect_gpkg_row_factory(fresh_gpkg: Path) -> None:
+    conn = connect_gpkg(fresh_gpkg, row_factory=sqlite3.Row)
+    try:
+        conn.execute("INSERT INTO features (name) VALUES ('a')")
+        row = conn.execute("SELECT * FROM features").fetchone()
+        assert row["name"] == "a"
+    finally:
+        conn.close()
+
+
+def test_connect_gpkg_autocommit_default(fresh_gpkg: Path) -> None:
+    """isolation_level=None means autocommit — caller does not need .commit()."""
+    conn1 = connect_gpkg(fresh_gpkg)
+    try:
+        conn1.execute("INSERT INTO features (name) VALUES ('autocommit')")
+    finally:
+        conn1.close()
+
+    conn2 = connect_gpkg(fresh_gpkg)
+    try:
+        rows = conn2.execute("SELECT name FROM features").fetchall()
+        assert ("autocommit",) in rows
+    finally:
+        conn2.close()
+
+
+def test_connect_gpkg_concurrent_writer_reader_no_busy(fresh_gpkg: Path) -> None:
+    """Writer + reader on the same GPKG must not raise SQLITE_BUSY.
+
+    Reproduces the contention pattern of QGIS-edit + watcher-poll. With
+    WAL + busy_timeout=5000, both threads should complete cleanly.
+    """
+    iterations = 50
+    errors: list[str] = []
+    barrier = threading.Barrier(2)
+
+    def writer() -> None:
+        conn = connect_gpkg(fresh_gpkg)
+        try:
+            barrier.wait(timeout=5.0)
+            for i in range(iterations):
+                try:
+                    conn.execute("INSERT INTO features (name) VALUES (?)", (f"w{i}",))
+                except sqlite3.OperationalError as exc:  # pragma: no cover
+                    errors.append(f"writer: {exc}")
+                    return
+                time.sleep(0.001)
+        finally:
+            conn.close()
+
+    def reader() -> None:
+        conn = connect_gpkg(fresh_gpkg)
+        try:
+            barrier.wait(timeout=5.0)
+            for _ in range(iterations):
+                try:
+                    conn.execute("SELECT COUNT(*) FROM features").fetchone()
+                except sqlite3.OperationalError as exc:  # pragma: no cover
+                    errors.append(f"reader: {exc}")
+                    return
+                time.sleep(0.001)
+        finally:
+            conn.close()
+
+    tw = threading.Thread(target=writer)
+    tr = threading.Thread(target=reader)
+    tw.start()
+    tr.start()
+    tw.join(timeout=30.0)
+    tr.join(timeout=30.0)
+
+    assert not errors, f"concurrent access produced errors: {errors}"
+
+    conn = connect_gpkg(fresh_gpkg)
+    try:
+        n = conn.execute("SELECT COUNT(*) FROM features").fetchone()[0]
+        assert n == iterations
+    finally:
+        conn.close()
+
+
+def test_connect_gpkg_string_path(fresh_gpkg: Path) -> None:
+    """Helper accepts both ``str`` and ``Path``."""
+    conn = connect_gpkg(str(fresh_gpkg))
+    try:
+        mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+        assert mode.lower() == "wal"
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary

Closes #141 (Q2 of EPIC #139). Centralises GPKG connection pragmas so every code path applies WAL + `busy_timeout=5000`, not just `gispulse track`.

**Root cause** : 7 sites ouvraient `sqlite3.connect(gpkg)` sans pragmas, dont l'`_open_dataset_gpkg` du HTTP qui pourtant prétend "Mirrors the CLI's `_open_gpkg`". Sous contention QGIS-edit + watcher-poll → `SQLITE_BUSY` immédiat (cause racine du flake Py3.10 `test_p02`, masqué par retry dans #86).

**Fix** : nouveau `persistence/gpkg_connection.connect_gpkg(path, *, force_wal=True, busy_timeout_ms=5000, ...)` comme single entry point. Migrés :

- `gispulse.cli_track._open_gpkg` → délègue (UX CLI préservée)
- `gispulse.cli_triggers._list_triggers`
- `gispulse.runtime.headless_runtime._list_user_tables`
- `gispulse.adapters.http.routers.datasets_router` (×2)
- `gispulse.adapters.http.routers.portal_datasets_router` (×2)
- `persistence.project_io` (×2)

Le legacy migration site `persistence/gpkg_schema.py:693` (one-time DB upgrade) et `diagnostics/system.py:153` (`:memory:`) restent inchangés — non concurrent-prone.

## Test plan

- [x] `tests/unit/test_gpkg_connection.py` — 8 tests dont concurrent writer+reader (50 ops, sans SQLITE_BUSY)
- [x] `tests/unit/test_gpkg_*.py` + `tests/unit/test_persistence_io.py` — 138 verts
- [x] `tests/unit/test_datasets_router.py` + `test_portal_datasets_router.py` — 63 verts
- [x] `test_p02_enable_tracking_full_lifecycle` confirmé vert

## Notes for reviewers

- `force_wal` est best-effort : try/except `OperationalError` pour tolérer les mounts read-only.
- `force_wal=False` opt-out documenté dans la docstring pour les routes purement read-only futures.
- Pas de `--no-verify`, pas de bypass DCO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
