### PR TITLE
docs(v1.6.x): #140 Q1 — ADR 0001 + dsl-sql-dialect guide (DuckDB-spatial contract)

### DIFF
--- a/docs-site/guide/dsl-geom-functions.md
+++ b/docs-site/guide/dsl-geom-functions.md
@@ -15,6 +15,11 @@ parsed via Python's `ast` module and rejected unless every node fits
 the strict allowlist. See [DSL design notes](./dsl-design.md) for the
 gory details.
 
+> **Dialecte SQL** : ces fonctions compilent vers DuckDB-spatial par
+> construction (4-arg `ST_Transform`). Voir [Contrat de dialecte
+> SQL](./dsl-sql-dialect.md) pour les détails sur la portabilité
+> PostGIS / SpatiaLite et le mécanisme d'override `engine:`.
+
 ## Quick reference
 
 | Function | Returns | CRS-aware | Default `epsg=` | DuckDB call |

--- a/docs-site/guide/dsl-sql-dialect.md
+++ b/docs-site/guide/dsl-sql-dialect.md
@@ -1,0 +1,155 @@
+---
+title: SQL dialect contract
+description: GISPulse triggers.yaml is written in DuckDB-spatial dialect by default. Other engines require an explicit override.
+---
+
+# SQL dialect contract
+
+GISPulse routes the SQL inside your `triggers.yaml` through one of three
+spatial engines: **gpkg** (default Community), **duckdb** (Community
+acceleration), or **postgis** (Pro). They expose different `ST_*`
+surfaces and different argument signatures. To keep rule files portable
+between deployments, GISPulse declares a single contract dialect.
+
+> **TL;DR — write your DSL expressions and `run_sql` strings in
+> DuckDB-spatial dialect.** Set `engine: postgis` (or `engine: sqlite`)
+> at the top of your `triggers.yaml` only if you accept losing
+> cross-engine portability.
+
+The decision is recorded in [ADR 0001 — DuckDB-spatial is the contract
+SQL dialect of the DSL](https://github.com/imagodata/gispulse/blob/main/docs/adr/0001-dsl-sql-dialect.md).
+
+## What this means in practice
+
+### Geom functions (`set_field`, `validate:` rules)
+
+The whitelisted geom functions documented in
+[DSL geom functions](./dsl-geom-functions.md) are compiled to
+DuckDB-spatial SQL by construction. They will **not** evaluate
+correctly on a PostGIS engine without first transforming the templates
+yourself.
+
+Portable across engines = ❌ for now. Use `geom_*()` only when the
+runtime resolves to **gpkg** (auto via `*.gpkg`) or **duckdb**.
+
+### Free-form SQL in `run_sql` actions
+
+`run_sql` forwards your SQL string to the active engine verbatim. The
+**default contract** is DuckDB-spatial:
+
+```yaml
+- type: run_sql
+  sql: |
+    UPDATE parcels
+    SET surface_m2 = ST_Area(ST_Transform(geom, 'EPSG:4326', 'EPSG:2154', true))
+    WHERE fid = ?
+```
+
+The 4-argument `ST_Transform(geom, source_crs, target_crs, always_xy)`
+is DuckDB-spatial syntax. PostGIS uses the 2-argument form. SpatiaLite
+ditto. If you write the 2-arg form, your rule will only work when the
+file is routed through PostGIS / SpatiaLite — and you must declare it.
+
+### Engine override
+
+The `engine:` top-level key opts you out of the default contract:
+
+```yaml
+version: 1
+gpkg: postgresql://gispulse:secret@db.internal/gispulse
+engine: postgis
+triggers:
+  - name: parcels_set_surface
+    table: parcels
+    when: [INSERT, UPDATE_GEOM]
+    actions:
+      - type: run_sql
+        sql: |
+          UPDATE parcels SET surface_m2 = ST_Area(ST_Transform(geom, 2154))
+          WHERE fid = ?
+```
+
+When `engine:` is set explicitly:
+
+- The DSL **geom functions are not guaranteed to compile**. They emit
+  DuckDB-spatial templates and may produce SQL the target engine
+  rejects (notably `ST_Transform` arity).
+- Your `run_sql` and `predicate` strings may use the dialect of the
+  declared engine.
+- You own the cross-deployment portability story — if you also want
+  the file to run on a GPKG/DuckDB stack, keep a separate variant.
+
+## Portable function surface
+
+The following SQL fragments are safe across all GISPulse engines (they
+appear in every dialect with identical semantics for our use cases):
+
+```text
+ST_AsText, ST_AsBinary, ST_GeomFromText, ST_GeomFromWKB,
+ST_X, ST_Y, ST_StartPoint, ST_EndPoint,
+ST_Centroid, ST_PointOnSurface,
+ST_Area, ST_Length, ST_Perimeter,
+ST_Intersects, ST_Within, ST_Contains, ST_Crosses, ST_Overlaps,
+ST_Touches, ST_Disjoint, ST_Equals,
+ST_Distance, ST_DWithin,
+ST_Buffer, ST_Intersection, ST_Union, ST_Difference, ST_SymDifference,
+ST_Envelope, ST_ConvexHull, ST_Boundary,
+ST_GeometryType, ST_IsValid, ST_IsEmpty, ST_NPoints, ST_SRID,
+ST_Simplify, ST_SimplifyPreserveTopology
+```
+
+Use these in `run_sql` and you can move between engines by changing
+only `engine:` (and the `gpkg:` URI). Anything outside this list is
+engine-specific by default — check the active engine's documentation.
+
+## Known gotchas
+
+### `ST_Transform` arity
+
+| Engine | Signature |
+|---|---|
+| DuckDB-spatial | `ST_Transform(geom, src_crs::TEXT, tgt_crs::TEXT, always_xy::BOOL)` |
+| PostGIS | `ST_Transform(geom, target_srid::INTEGER)` |
+| SpatiaLite | `ST_Transform(geom, target_srid::INTEGER)` |
+
+If you write a portable rule, transform the geometry **outside** of
+the SQL via the `geom_*()` DSL helpers and avoid hand-rolled
+`ST_Transform`.
+
+### Geography vs. geometry
+
+PostGIS distinguishes `geography(...)` and `geometry(...)` types.
+DuckDB-spatial and SpatiaLite expose only `geometry`. Casting to
+`geography` is **PostGIS-only** — keep it inside an
+`engine: postgis` file.
+
+### Index hints
+
+DuckDB infers spatial indices from RTree extensions automatically.
+PostGIS requires explicit `CREATE INDEX ... USING GIST(...)` and you
+may want to write `WHERE geom && bbox` to leverage it. SpatiaLite uses
+`SpatialIndex` virtual tables. None of these hints transfer.
+
+### Date / time literals
+
+DuckDB and PostGIS both accept ISO 8601 (`'2026-05-07'`). SQLite
+accepts the same string but stores it as TEXT, not a typed date —
+`<` comparisons may surprise you. Use `julianday()` (SQLite) or
+`EXTRACT(epoch FROM ...)` (DuckDB / PostGIS) for arithmetic.
+
+## Roadmap
+
+A loader-time scanner that warns when `run_sql` references a
+PostGIS-only construct without an `engine: postgis` override is
+tracked in [issue #146](https://github.com/imagodata/gispulse/issues/146).
+Today the contract is documentary — errors surface at execution time,
+not at config-load time.
+
+## See also
+
+- [DSL geom functions](./dsl-geom-functions.md) — the whitelist that
+  always compiles to DuckDB.
+- [Spatial engines](./engines.md) — when each engine kicks in.
+- [DSL validation rules](./dsl-validation.md) — `validate:` syntax.
+- [ADR 0001](https://github.com/imagodata/gispulse/blob/main/docs/adr/0001-dsl-sql-dialect.md)
+  — full decision record.

--- a/docs-site/guide/dsl-validation.md
+++ b/docs-site/guide/dsl-validation.md
@@ -31,7 +31,7 @@ validate:
 | Field | Required | Notes |
 |---|---|---|
 | `id` | yes | Stable identifier used in log lines and tag values. |
-| `rule` | yes | Boolean DSL expression — see [DSL geom functions](./dsl-geom-functions.md). |
+| `rule` | yes | Boolean DSL expression — see [DSL geom functions](./dsl-geom-functions.md) and the [SQL dialect contract](./dsl-sql-dialect.md). |
 | `mode` | no (default `warn`) | `warn` logs and broadcasts. `tag` writes the failure on the row. |
 | `tag_field` | only when `mode: tag` | Column receiving `failed:<id>` on failure. |
 | `message` | no | Human-readable detail attached to the log / WS event. |

--- a/docs-site/guide/engines.md
+++ b/docs-site/guide/engines.md
@@ -7,6 +7,8 @@ description: Comprendre les trois modes d'exécution GISPulse — Python/DuckDB 
 
 GISPulse supporte trois modes d'exécution. Le moteur se configure par variable d'environnement, par ligne de commande ou par règle.
 
+> **À lire avant** : [Contrat de dialecte SQL](./dsl-sql-dialect.md). Le DSL `triggers.yaml` est écrit en dialecte DuckDB-spatial par défaut. Les règles `run_sql` et les fonctions `geom_*()` ne sont pas portables sur PostGIS sans déclarer explicitement `engine:`.
+
 ## Vue d'ensemble
 
 | Moteur | Tier | Usage | Volumes |

--- a/docs/adr/0001-dsl-sql-dialect.md
+++ b/docs/adr/0001-dsl-sql-dialect.md
@@ -1,0 +1,110 @@
+# ADR 0001 — DuckDB-spatial is the contract SQL dialect of the DSL
+
+**Status:** Accepted
+**Date:** 2026-05-07
+**Deciders:** GISPulse maintainers
+**Issue:** [#140](https://github.com/imagodata/gispulse/issues/140) (Q1 of EPIC [#139](https://github.com/imagodata/gispulse/issues/139))
+
+## Context
+
+`triggers.yaml` exposes two SQL surfaces to the user:
+
+1. **Whitelisted geom functions** in `set_field` and `validate:` rules
+   (`geom_area_m2()`, `geom_within(layer, …)`, …). These compile down to
+   SQL via `gispulse/dsl/geom_fcts.py`.
+2. **Free-form SQL** in `run_sql` actions (and the `predicate` field of
+   `change` triggers). The user writes the SQL; GISPulse forwards it to
+   the active engine.
+
+The active engine can be **gpkg** (SQLite + SpatiaLite via geopandas),
+**duckdb** (DuckDB-spatial), or **postgis** (PostgreSQL/PostGIS) — see
+[`docs-site/guide/engines.md`][engines]. Each engine ships a different
+ST_* surface:
+
+| Engine | ST_* surface | `ST_Transform` arity |
+|---|---|---|
+| DuckDB-spatial | ~140 functions (matches PostGIS naming) | 4-arg `(geom, src, target, always_xy)` |
+| PostGIS 3.x | ~300 functions, broader coverage | 2-arg `(geom, target_srid)` |
+| SpatiaLite | ~150 functions, partial coverage | 2-arg, plus engine-specific helpers |
+
+A `triggers.yaml` written against PostGIS today (e.g.
+`SELECT ST_Transform(geom, 4326)` in `run_sql`, or use of
+`geography(...)`) silently breaks when the same file routes through the
+gpkg/DuckDB engines — and vice versa.
+
+## Decision
+
+**DuckDB-spatial is the contract dialect of the DSL.**
+
+- Whitelisted geom functions in [`gispulse/dsl/geom_fcts.py`][geom_fcts]
+  emit DuckDB-spatial SQL (`ST_Transform(geom, src, target, always_xy)`)
+  by construction. They are not portable to PostGIS / SpatiaLite as-is.
+- `run_sql` actions and `change` predicates **MUST be written in
+  DuckDB-spatial dialect** unless the file declares `engine:` to
+  override the default routing.
+- The `engine:` top-level key in `GISPulseConfig` is the documented
+  escape hatch for users who run exclusively against PostGIS or
+  SpatiaLite. When set, the user owns the dialect contract and the DSL
+  geom functions may produce engine-incompatible SQL.
+
+We picked option **(a) — single portable surface** over options
+**(b) — runtime transpilation** and **(c) — per-rule `engine:` tag**:
+
+- **(b)** would mean shipping `sqlglot` (or equivalent) and maintaining
+  per-engine pretty-printers. Cost: a third-party dependency, a
+  permanent test matrix, and a class of subtle bugs (CTE handling,
+  geography vs. geometry, NULL semantics). Reward: portability that
+  almost no GISPulse user has asked for.
+- **(c)** would push complexity onto every rule author. The intended
+  primary user is a QGIS power-user with a GPKG, not a DBA polyglot.
+
+DuckDB-spatial is also the largest portable ST_* surface available
+without a server: ~140 functions, native GeoPackage reader, and
+embeddable in the wheel (cf. v1.6.0 lazy install of the spatial
+extension). It is the natural single dialect for the rule-author tier.
+
+## Consequences
+
+### Positive
+
+- One dialect to document, test, and teach.
+- DSL geom functions stay simple — no template-per-engine matrix.
+- Loader can introduce a single allow-list of portable function names
+  and warn on the rest (follow-up).
+
+### Negative
+
+- Users with an existing PostGIS-only stack cannot copy-paste
+  `triggers.yaml` between deployments without reading the migration
+  notes (`engine: postgis` + run_sql adapted).
+- DuckDB ST_* surface is smaller than PostGIS. Functions like
+  `ST_ClusterWithin` or `ST_3DDistance` have no DuckDB equivalent
+  today; rules that need them require `engine: postgis` and lose
+  cross-engine portability.
+
+### Mitigations
+
+- Document the portable surface explicitly in
+  [`docs-site/guide/dsl-sql-dialect.md`][dsl-sql-dialect].
+- Cross-link from
+  [`docs-site/guide/dsl-geom-functions.md`][dsl-geom-functions] and
+  [`docs-site/guide/engines.md`][engines] so users discover the
+  contract before writing `run_sql`.
+- Follow-up issue: parser pass that scans `run_sql` for known
+  PostGIS-only constructs (`geography(`, `ST_Transform(geom, INTEGER)`
+  signature, …) and warns when no `engine:` override is set.
+
+## Status of related work
+
+- v1.6.0 (#129) shipped the geom-function whitelist with DuckDB-spatial
+  templates — already aligned with this ADR.
+- `engine:` field in `GISPulseConfig` already exists (introduced
+  v1.6.x #115). No code change needed for this ADR.
+- The follow-up loader-time `run_sql` scanner is tracked in
+  [#146](https://github.com/imagodata/gispulse/issues/146) so this ADR
+  can land doc-only.
+
+[geom_fcts]: ../../gispulse/dsl/geom_fcts.py
+[engines]: ../../docs-site/guide/engines.md
+[dsl-geom-functions]: ../../docs-site/guide/dsl-geom-functions.md
+[dsl-sql-dialect]: ../../docs-site/guide/dsl-sql-dialect.md


### PR DESCRIPTION
## Summary

Closes #140 (Q1 of EPIC #139). Records the SQL dialect contract that v1.6.0 already enforces de facto.

**Décision** : DuckDB-spatial est le dialecte contrat du DSL.

- Geom fcts (`gispulse/dsl/geom_fcts.py`) compilent vers DuckDB-spatial par construction (4-arg `ST_Transform`) — déjà vrai depuis #129.
- `run_sql` et `predicate` strings doivent être écrits en DuckDB-spatial sauf si `engine:` est explicite.
- Pas de transpilation runtime (option b) — coût mainteneur > bénéfice utilisateur.
- Pas de tag `engine:` par règle (option c) — pousse complexité sur l'auteur de règle.

PR doc-only, pas de mutation code. Le scanner load-time (warnings dialect-drift sur `run_sql`) est tracké séparément en [#146](https://github.com/imagodata/gispulse/issues/146).

## Files

- `docs/adr/0001-dsl-sql-dialect.md` — ADR complet (decision record)
- `docs-site/guide/dsl-sql-dialect.md` — page utilisateur (portable surface + gotchas)
- `docs-site/guide/{engines,dsl-geom-functions,dsl-validation}.md` — cross-links

## Test plan

- [x] Markdown rendu localement (preview)
- [x] Cross-links résolvent (`./dsl-sql-dialect.md`, `./engines.md`)
- [x] DCO signed-off-by aligné sur author email

## Notes for reviewers

- `engine:` field already in `GISPulseConfig` (line 351 de `config_loader.py`) depuis #115 → pas de migration code.
- ADR 0001 = premier ADR du repo. J'ai créé `docs/adr/` à cette occasion.
- Page guide non ajoutée à la sidebar VitePress pour cohérence avec `dsl-geom-functions.md` et `dsl-validation.md` qui sont aussi orphan-pages cross-linkées.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
