### PR TITLE
docs(v1.6.x): #142 Q3 — ADR 0002 + rules.md cascade section (records existing design)

### DIFF
--- a/docs-site/guide/rules.md
+++ b/docs-site/guide/rules.md
@@ -346,9 +346,52 @@ Les triggers réagissent aux événements sur les données et exécutent des act
 
 **Types d'actions** : `NOTIFY`, `SET_FIELD`, `UPDATE_AGGREGATE`, `RUN_JOB`, `RUN_GRAPH`, `WEBHOOK`, `ENQUEUE`, `LOG_EVENT`, `SEND_EMAIL`, `RUN_SQL`, etc.
 
-::: tip Cascade
-Les triggers peuvent déclencher d'autres triggers. La profondeur maximale de cascade est limitée à 3 niveaux pour éviter les boucles infinies.
-:::
+### Cascade behaviour of triggers
+
+Les triggers peuvent en déclencher d'autres : si la table `parcels` a un
+trigger `t_parcel_count_communes` qui fait un `UPDATE communes SET …`,
+puis qu'un trigger `t_recalc_density` est branché sur `communes`, alors
+`t_recalc_density` doit voir la modification. GISPulse gère ça en
+deux couches :
+
+1. **Couche fichier (SQLite trigger DDL)** — chaque AFTER UPDATE
+   trigger porte une clause `WHEN` qui suppresse les re-fires quand la
+   ligne vient juste d'être tagguée par un write-back de
+   l'`action_dispatcher` (cf. B-02, v1.5.3). Cela bloque les
+   self-loops sans option utilisateur.
+2. **Couche Python (`evaluate_cascade`)** — le runtime exécute une
+   boucle fixed-point bornée :
+   - À chaque profondeur, `evaluate_changeset_records()` produit la
+     liste des triggers qui fire.
+   - Tant que le passage produit de nouveaux changements, on
+     ré-évalue à profondeur + 1.
+   - Au-delà de `MAX_CASCADE_DEPTH = 3`, le runtime lève
+     `CascadeDepthExceeded` au lieu de tronquer silencieusement.
+
+| Tier | `cascade_depth` autorisé | Comportement |
+|---|---|---|
+| Community | 1 | single-pass effectif (les triggers en cascade ne fire pas dans le même cycle) |
+| Pro | jusqu'à 3 | fixed-point complet avec fail-fast au-delà |
+
+`Trigger.cascade_depth` vaut `1` par défaut — l'expérience hors-boîte
+correspond donc au comportement Community. Pour activer la cascade,
+mets explicitement `cascade_depth: 2` ou `3` sur le trigger qui doit
+réagir à un write-back.
+
+```json
+{
+  "name": "recalc_density",
+  "event": "DATA_CHANGED",
+  "trigger_type": "DML",
+  "cascade_depth": 2,
+  "actions": [
+    { "action_type": "RUN_JOB", "config": { "job_name": "density_per_commune" } }
+  ]
+}
+```
+
+Détails complets : [ADR 0002 — Trigger cascade is bounded fixed-point
+with origin-tagging](https://github.com/imagodata/gispulse/blob/main/docs/adr/0002-trigger-cascade-semantics.md).
 
 ### Webhook actions (Zapier, ArcGIS GeoEvent, Make, n8n, …)
 

--- a/docs/adr/0002-trigger-cascade-semantics.md
+++ b/docs/adr/0002-trigger-cascade-semantics.md
@@ -1,0 +1,163 @@
+# ADR 0002 — Trigger cascade is bounded fixed-point with origin-tagging
+
+**Status:** Accepted (records existing design)
+**Date:** 2026-05-07
+**Deciders:** GISPulse maintainers
+**Issue:** [#142](https://github.com/imagodata/gispulse/issues/142) (Q3 of EPIC [#139](https://github.com/imagodata/gispulse/issues/139))
+
+## Context
+
+Trigger A modifies a row that trigger B is also subscribed to. Two
+questions arise:
+
+1. **Within the same poll cycle**, does B see A's write?
+2. **What stops infinite loops** when A and B mutually trigger each
+   other?
+
+Issue #142 originally framed the choice as **single-pass vs. fixed-point**,
+but the existing v1.6.0 codebase already ships a third design that
+neither label captures cleanly: **bounded fixed-point with
+origin-tagging at the SQLite trigger DDL layer**. This ADR records
+that design so future contributors don't try to reinvent it.
+
+## Decision
+
+GISPulse uses a **two-layer cascade control**:
+
+### Layer 1 — origin-tagging at the SQLite trigger DDL
+
+Every `_gispulse_trg_<table>_update` trigger carries a `WHEN` clause
+that suppresses re-fires when the row was last touched by an
+`action_dispatcher` write-back (cf. B-02, v1.5.3, #103):
+
+```sql
+CREATE TRIGGER "_gispulse_trg_parcels_update"
+AFTER UPDATE ON "parcels"
+WHEN (NEW."_gispulse_origin" IS NULL
+      OR NEW."_gispulse_origin" NOT LIKE 'trigger:%')
+  AND NOT (
+    NEW."_gispulse_origin" IS NULL
+    AND OLD."_gispulse_origin" IS NOT NULL
+    AND OLD."_gispulse_origin" LIKE 'trigger:%'
+  )
+BEGIN
+  INSERT INTO _gispulse_change_log ...
+END;
+```
+
+This breaks **self-loops** at the file format level — the dispatcher
+tags rows it writes with `_gispulse_origin = 'trigger:<id>'`, the
+SQLite trigger sees that tag and skips the changelog INSERT.
+
+### Layer 2 — bounded fixed-point in the Python evaluator
+
+`rules/trigger_evaluator.py` exposes
+[`evaluate_cascade()`](../../rules/trigger_evaluator.py) which runs a
+fixed-point loop:
+
+```text
+depth = 1
+while current_records:
+    fired = evaluate(current_records, triggers, depth=depth)
+    matched = [ft for ft in fired if ft.matched]
+    if not matched:
+        break
+    next_depth = depth + 1
+    if next_depth > MAX_CASCADE_DEPTH:
+        if next_records_fn(matched):
+            raise CascadeDepthExceeded(next_depth)
+        break
+    current_records = next_records_fn(matched)
+    depth = next_depth
+```
+
+`MAX_CASCADE_DEPTH = 3`. Beyond that, `CascadeDepthExceeded` is raised
+— the runtime fails loudly rather than silently truncating user
+intent.
+
+### Tier semantics
+
+| Tier | Cascade depth | Notes |
+|---|---|---|
+| Community | Capped at 1 (`_LOCAL_TRIGGER_MAX_CASCADE_DEPTH = 1`) | Effectively single-pass. `cascade_depth > 1` rejected at HTTP create/update time. |
+| Pro | Up to `MAX_CASCADE_DEPTH = 3` | Full cascade with fail-fast at depth 4. |
+
+`Trigger.cascade_depth` defaults to `1` (`core/models.py:308`), so the
+out-of-the-box experience matches Community behaviour.
+
+## Why this layout
+
+Three concerns drove this two-layer design:
+
+1. **Self-loops vs. cross-trigger cascades are different problems.**
+   A trigger writing back to its own table is the common foot-gun and
+   deserves a zero-cost guard at the DDL level (origin-tagging). Real
+   cross-trigger cascades (A inserts into table X → B fires on X) are
+   rarer, justified user intent, and worth a Python-side loop.
+2. **Determinism over latency.** A pure single-pass design would push
+   cascading work to the *next* poll cycle, adding watcher latency.
+   Fixed-point with `max_depth = 3` keeps everything in the same
+   cycle, observable in one log span, predictable.
+3. **Loud failure beats silent truncation.** Raising
+   `CascadeDepthExceeded` instead of capping at 3 forces the user to
+   either lift the cap (Pro) or re-think their rule. We saw the
+   alternative on Beta — silent truncation produced "ghost" non-fires
+   that took days to debug.
+
+## Alternatives considered
+
+- **Pure single-pass.** Rejected: pushes cascade work to the next
+  poll cycle, breaks the one-cycle observability story, and the
+  cascade evaluator was already shipped + tested before #142 opened.
+- **Unbounded fixed-point.** Rejected: a self-referential trigger
+  (e.g. `set_field` referencing the same field) loops until file
+  size or wall-clock kills the watcher. The B-02 origin-tag breaks
+  most self-loops, but a 4-trigger cycle (A → B → C → D → A) would
+  still slip past it.
+- **Per-trigger `max_cascade` knob.** Rejected for v1.6.x — adds
+  config surface for a corner case. The tier-level cap (1 vs. 3) is
+  a coarser but adequate proxy.
+
+## Consequences
+
+### Positive
+
+- **Determinism.** Same `triggers.yaml` produces the same fired
+  sequence on Pattern A (SQLite triggers + watcher poll) and Pattern
+  B (DuckDB snapshot diff) — `evaluate_cascade()` is engine-agnostic.
+- **Observability.** `FiredTrigger.cascade_depth` is recorded on
+  every event, so the watcher dashboard (#95) can chart cascade
+  depth distributions per trigger.
+- **Self-loops are blocked at the file format level.** A Community
+  user editing in QGIS while running a `set_field` trigger never
+  sees a runaway loop, even without ever touching cascade depth.
+
+### Negative
+
+- **Two layers to learn.** Contributors must understand both the
+  SQLite `WHEN` clause and the Python loop to debug "why didn't my
+  cascade fire". Documented here + in [Cascade behaviour](../../docs-site/guide/rules.md#cascade-behaviour-of-triggers).
+- **Cap of 3.** A handful of pipelines (multi-step audit cascades)
+  may want depth 5-10. Today they must drop to direct
+  [`run_sql`](../../docs-site/guide/dsl-sql-dialect.md) chains. Worth
+  revisiting if Pro customers ask.
+
+## Status of related work
+
+- v1.6.0 (#129) ships the cascade evaluator unchanged from v1.5.x.
+- B-02 (v1.5.3, #103) origin-tagging on AFTER UPDATE was the missing
+  piece for self-loop suppression — already merged.
+- #142 implementation tasks ("force `PRAGMA recursive_triggers=0`",
+  "single-pass on Pattern A and B") are **moot**: the existing design
+  is more conservative than single-pass at the SQLite layer
+  (origin-tagging) and richer than single-pass at the Python layer
+  (bounded fixed-point with fail-fast).
+
+## See also
+
+- `rules/trigger_evaluator.py` — `MAX_CASCADE_DEPTH`, `evaluate_cascade`
+- `persistence/gpkg_schema.py:_build_change_triggers` — origin-tag DDL
+- `gispulse/adapters/http/routers/triggers_router.py` — Community cap
+- `tests/unit/test_cascade_depth.py` — depth limiter tests
+- `docs-site/guide/rules.md#cascade-behaviour-of-triggers`
+- ADR [0001](./0001-dsl-sql-dialect.md) — DSL SQL dialect contract


### PR DESCRIPTION
## Summary

Closes #142 (Q3 of EPIC #139). Records the cascade design that v1.6.0 already enforces — investigation a montré que mon hypothèse initiale "single-pass" était fausse : le runtime utilise déjà un **bounded fixed-point** avec origin-tagging.

## Découverte critique

L'issue #142 proposait d'implémenter single-pass. La réalité du code :

- **Couche SQLite trigger DDL** : chaque AFTER UPDATE trigger porte une `WHEN` clause qui suppresse les re-fires quand `_gispulse_origin = 'trigger:%'` (B-02, v1.5.3, [#103](https://github.com/imagodata/gispulse/issues/103)). Bloque les self-loops au niveau fichier.
- **Couche Python (`evaluate_cascade`)** : `rules/trigger_evaluator.py` fait un fixed-point loop borné par `MAX_CASCADE_DEPTH = 3`. Au-delà → `CascadeDepthExceeded` levée.
- **Tier semantics** : Community capé à `cascade_depth=1` (single-pass effectif), Pro jusqu'à 3.

Les tâches d'implémentation listées dans #142 (`PRAGMA recursive_triggers=0` + single-pass) sont donc **moot** — l'existant est plus conservateur au SQLite et plus riche au Python.

## Decision

PR doc-only :

- `docs/adr/0002-trigger-cascade-semantics.md` — ADR complet expliquant le design 2-layer, pourquoi single-pass / unbounded fixed-point / per-trigger knob ont été rejetés.
- `docs-site/guide/rules.md` — le simple tip "max 3 niveaux" devient une sous-section "Cascade behaviour of triggers" avec table des tiers, explication des 2 couches, exemple JSON `cascade_depth: 2`, lien vers ADR 0002.

## Test plan

- [x] Markdown rendu localement (preview)
- [x] Cross-links résolvent (`./0001-dsl-sql-dialect.md`, `../../rules/trigger_evaluator.py`, `tests/unit/test_cascade_depth.py`)
- [x] DCO signed-off-by aligné

## Notes for reviewers

- ADR 0002 référence du code (`rules/trigger_evaluator.py`) et un test (`tests/unit/test_cascade_depth.py`) qui existent déjà sur main → pas de mismatch.
- L'exemple JSON `cascade_depth: 2` dans `rules.md` matche `Trigger.cascade_depth` field défini dans `core/models.py:308`.
- Si tu veux que le scanner load-time côté #146 valide aussi `cascade_depth` vs tier, je peux mettre à jour le brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
