### PR TITLE
ci: upgrade pip to >=26.1 before pip-audit (CVE-2026-6357)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,9 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Upgrade pip (CVE-2026-6357 — fixed in 26.1)
+        run: python -m pip install -U "pip>=26.1"
+
       - name: Install pip-audit
         run: pip install pip-audit
 


### PR DESCRIPTION
## Why

PR #145 (#141 WAL/busy_timeout) and dependabot #136 (pip 26.0.1 → 26.1) both fail the required `security-audit` check on the same CVE-2026-6357 (pip self-update vuln, fix in pip 26.1).

Root cause: the workflow inspects the *runner's* live pip via `pip-audit` — the runner ships pip 26.0.1, and dependabot's lockfile bump can't change that. Until GitHub-hosted runners ship pip 26.1, we need an explicit upgrade step.

## What

Adds one step to the `security-audit` job:
```yaml
- name: Upgrade pip (CVE-2026-6357 — fixed in 26.1)
  run: python -m pip install -U "pip>=26.1"
```

Inserted before `Install pip-audit` so the audit runs against pip 26.1.

## After merge

- Re-trigger CI on dependabot #136 → should go green → merge → main has pip lockfile bumped
- Rebase #145 onto new main → security-audit re-runs green → merge (closes #141 WAL/busy_timeout, EPIC #139 Q2)

Refs: #136, #145, #141