### PR TITLE
docs(v1.6.x): #143 + #144 — ADRs 0003/0004 (changelog replay + DDL hooks scope)

### DIFF
--- a/docs-site/guide/architecture.md
+++ b/docs-site/guide/architecture.md
@@ -169,6 +169,15 @@ class Trigger:
 
 **14 types d'actions** : `NOTIFY`, `SET_FIELD`, `UPDATE_AGGREGATE`, `RUN_JOB`, `RUN_GRAPH`, `WEBHOOK`, `ENQUEUE`, `LOG_EVENT`, `SEND_EMAIL`, `RUN_SQL`, etc.
 
+#### Décisions de scope (ADRs)
+
+GISPulse documente les semantics de triggers via les ADRs :
+
+- **[ADR 0001](https://github.com/imagodata/gispulse/blob/main/docs/adr/0001-dsl-sql-dialect.md)** — DuckDB-spatial est le dialecte contrat du DSL (`set_field`, `validate:`, `run_sql`). `engine:` override autorisé pour PostGIS / SpatiaLite.
+- **[ADR 0002](https://github.com/imagodata/gispulse/blob/main/docs/adr/0002-trigger-cascade-semantics.md)** — Cascade = bounded fixed-point (max 3) avec origin-tagging au niveau SQLite. Community capé à 1, Pro jusqu'à 3, fail-fast au-delà.
+- **[ADR 0003](https://github.com/imagodata/gispulse/blob/main/docs/adr/0003-changelog-replay-out-of-scope.md)** — `_gispulse_change_log` reste un poll log, pas un event store. Replay / time-travel / mirror reportés à v1.7+ via table d'extension.
+- **[ADR 0004](https://github.com/imagodata/gispulse/blob/main/docs/adr/0004-ddl-hooks-out-of-scope.md)** — Pas de hooks `on_alter_table` / `on_drop_table`. La détection schema-drift passive (B-13, watchdog) couvre le cas commun ALTER TABLE ADD COLUMN.
+
 ### Scenario
 
 Pipeline multi-jobs composable. Supporte l'exécution séquentielle, indépendante et le mode graphe (DAG).

--- a/docs/adr/0003-changelog-replay-out-of-scope.md
+++ b/docs/adr/0003-changelog-replay-out-of-scope.md
@@ -1,0 +1,140 @@
+# ADR 0003 — `_gispulse_change_log` is a poll log, not an event store
+
+**Status:** Accepted
+**Date:** 2026-05-07
+**Deciders:** GISPulse maintainers
+**Issue:** [#143](https://github.com/imagodata/gispulse/issues/143) (Q4 of EPIC [#139](https://github.com/imagodata/gispulse/issues/139))
+
+## Context
+
+Issue #143 asked whether v1.6.x should formalise `_gispulse_change_log`
+as an event source — adding stable hashing, sub-second timestamps, and
+a `replay_changes()` primitive — to enable time-travel / mirror
+replication / audit re-execution.
+
+Investigation of the current schema shows the table already covers more
+of an event source than the issue brief assumed. Today's columns
+([`persistence/schema.py`][schema]):
+
+```text
+id              INTEGER PRIMARY KEY AUTOINCREMENT   -- stable global seq
+table_name      TEXT NOT NULL
+operation       TEXT NOT NULL                       -- INSERT/UPDATE/DELETE
+row_pk          TEXT
+old_values      TEXT                                -- JSON of OLD.*
+new_values      TEXT                                -- JSON of NEW.*
+changed_at      TEXT DEFAULT (datetime('now'))      -- ISO 8601 second-precision
+processed       INTEGER DEFAULT 0
+geom_changed    INTEGER DEFAULT 0
+```
+
+So we already have:
+
+- ✅ Append-only (the trigger DDL only INSERTs; no UPDATE / DELETE on
+  this table from inside GISPulse).
+- ✅ Stable global ordering (`id AUTOINCREMENT` is monotonic
+  per-database).
+- ✅ Stable timestamps (`changed_at` is ISO 8601 UTC).
+- ✅ Full JSON payload of old / new values.
+
+What is missing for a "real" event store:
+
+- ❌ Sub-second timestamp resolution (matters when many events fire in
+  the same second on bulk operations).
+- ❌ Tamper-evidence (no row hash, no signature chain).
+- ❌ Schema-versioning of the JSON payloads (rename a column → replay
+  against new schema breaks).
+- ❌ A documented `replay_changes()` primitive — there is no API that
+  takes a (since_id, until_id) range and reapplies the deltas to a
+  fresh GPKG / mirror.
+
+## Decision
+
+**`_gispulse_change_log` stays a poll log.** It is the buffer the
+watcher reads; it is *not* a Source-of-Truth event store, and v1.6.x
+does not promise it will be one.
+
+This means:
+
+- Public docs describe the table as the watcher's input queue
+  ([`docs-site/guide/track.md`][track]) — not as the audit trail of
+  truth.
+- We commit to **append-only** semantics (we will not break tools that
+  treat it as monotonic).
+- We do **not** commit to `(id, changed_at)` being suitable for replay
+  against a different GPKG file. Re-running deltas against a divergent
+  state is undefined.
+- Adding sub-second timestamps, hashing, or replay primitives requires
+  a new opt-in extension table — it will not silently change the
+  current schema.
+
+Why not turn it into an event store now?
+
+1. **No customer ask.** Replay / mirror / time-travel has not appeared
+   on Pro lead calls or Beta feedback. Building it on spec adds schema
+   churn risk on a column that triggers and runtime depend on.
+2. **Schema churn is a watcher hazard.** B-13 (#103) added a
+   schema-drift watchdog that hashes layer schemas; touching the
+   changelog DDL itself would need its own migration story.
+3. **Scope.** v1.6.x ships [DuckDB-spatial DSL][duckdb-pivot] +
+   [bounded fixed-point cascade][adr0002] + [WAL connection
+   safety][adr-pr-wal]. Adding event sourcing now would inflate the
+   release scope past the v1.6.x window.
+
+## Alternatives considered
+
+- **(a) In-scope v1.6.x — full event store.** Rejected: scope creep
+  + schema migration + replay primitive + extensive testing for a
+  feature with no current demand.
+- **(b) In-scope v1.6.x — partial (sub-second timestamp + row hash
+  only).** Rejected: half-step that exposes us to schema changes
+  without delivering the customer value (replay).
+- **(c) Out-of-scope, no future commitment.** Too aggressive — the
+  changelog is *already* event-source-ish and customers may eventually
+  ask. Better to leave the door open.
+- **(d) Out-of-scope v1.6.x, opt-in extension table later (chosen).**
+  Future event-source extensions live in a sibling table
+  (`_gispulse_change_event_extra` or similar) that links by `id`.
+  Keeps the core changelog stable while leaving room for v1.7+
+  audit/replay features.
+
+## Consequences
+
+### Positive
+
+- v1.6.x ships without schema churn on the changelog.
+- The current `id AUTOINCREMENT` + `changed_at` invariants are
+  promoted from "happens to exist" to documented contract.
+- Future event-store work has a clear place to live (extension table)
+  without breaking existing watchers.
+
+### Negative
+
+- Customers expecting "GISPulse = full audit log" will be disappointed
+  until v1.7+. We need to be clear in marketing that this is *change
+  capture for triggers*, not *audit trail of record*.
+
+## Status of related work
+
+- v1.6.0 (#129) ships the changelog schema unchanged from v1.5.x.
+- B-13 (#103) shipped the schema-drift watchdog — touching the
+  changelog DDL would interact with that subsystem and is best
+  deferred.
+- A v1.7+ "audit & replay" epic should be opened when the first
+  customer asks; until then, no work scheduled.
+- Issue #143 closed by this ADR.
+
+## See also
+
+- [`persistence/schema.py`][schema] — `change_log` table definition
+- [`docs-site/guide/track.md`][track] — user-facing description of the
+  poll-log model
+- ADR [0001][adr0001] — DSL SQL dialect
+- ADR [0002][adr0002] — Cascade semantics
+
+[schema]: ../../persistence/schema.py
+[track]: ../../docs-site/guide/track.md
+[duckdb-pivot]: ../../docs-site/guide/architecture.md
+[adr0001]: ./0001-dsl-sql-dialect.md
+[adr0002]: ./0002-trigger-cascade-semantics.md
+[adr-pr-wal]: https://github.com/imagodata/gispulse/pull/145

--- a/docs/adr/0004-ddl-hooks-out-of-scope.md
+++ b/docs/adr/0004-ddl-hooks-out-of-scope.md
@@ -1,0 +1,128 @@
+# ADR 0004 — DDL hooks are out of scope; passive schema-drift detection ships
+
+**Status:** Accepted
+**Date:** 2026-05-07
+**Deciders:** GISPulse maintainers
+**Issue:** [#144](https://github.com/imagodata/gispulse/issues/144) (Q5 of EPIC [#139](https://github.com/imagodata/gispulse/issues/139))
+
+## Context
+
+Issue #144 asked whether GISPulse should expose hooks on DDL operations
+— `ALTER TABLE ADD COLUMN`, `DROP TABLE`, `CREATE INDEX` — alongside
+the existing DML triggers. The motivation: a user evolves the GPKG
+schema in QGIS (add column, rename, drop layer), and rules /
+integrations downstream may want to react.
+
+Investigation shows v1.5.3 already ships the relevant *passive*
+behaviour via the schema-drift watchdog (B-13, #103,
+`persistence/change_log_watcher.py`):
+
+- Every `schema_drift_check_interval_s` (default 5 s) the watcher
+  hashes each tracked layer's `PRAGMA table_info(...)`.
+- On hash mismatch the watcher rebuilds the DML triggers for that
+  layer so newly-added columns appear in `new_values` JSON
+  immediately.
+- A missing layer (DROP TABLE) drops the cached hash so a re-creation
+  is treated as first sighting.
+
+So the DDL story is already 80 % covered: schema mutations propagate
+through the existing DML pipeline within one watchdog tick.
+
+## Decision
+
+**Active DDL hooks (e.g. `on_alter_table:`, `on_drop_table:`) are out
+of scope.** GISPulse keeps the design where DDL is detected
+*passively* by the schema-drift watchdog, never actively trapped at
+the SQLite trigger level.
+
+Concretely:
+
+1. The watchdog detection that ships in B-13 stays as the canonical
+   "GISPulse noticed a schema change" mechanism.
+2. We do not introduce SQLite `CREATE TRIGGER ... ON SCHEMA` (which
+   does not exist) nor a sniffer that intercepts `ALTER TABLE`
+   statements at the engine layer.
+3. We do not add `on_alter_table:` / `on_drop_table:` keys to
+   `triggers.yaml`.
+4. If a future Pro feature needs DDL hooks (e.g. compliance audit), it
+   ships as a sidecar service that diffs the watchdog's hash log — not
+   as a core DSL extension.
+
+## Why not active DDL hooks
+
+1. **No SQLite primitive.** SQLite has no DDL trigger surface.
+   Implementing one would require parsing `ALTER`/`CREATE`/`DROP`
+   statements at the connection layer and intercepting them. This
+   crosses every code path that touches the GPKG (CLI, HTTP, plugin),
+   and breaks the user's right to mutate the file in QGIS without
+   GISPulse running.
+2. **Use-case narrow.** The most common GIS schema change — ALTER
+   TABLE ADD COLUMN — is already invisible to the user with B-13:
+   triggers rebuild and the new column appears in subsequent events.
+3. **Active hooks would lie.** A QGIS user editing the file while
+   GISPulse is offline would later open it with GISPulse and see
+   `on_alter_table` *not fire* — because we never observed the DDL,
+   only the resulting state. Passive detection is honest about this:
+   "I notice the schema differs from last poll, here is the new
+   shape."
+4. **Composition with cascade.** Active DDL hooks would fight the
+   bounded fixed-point cascade design (cf. ADR 0002) — DDL changes
+   trigger structural drift, which is fundamentally different from
+   row-level cascading. Mixing them is a footgun.
+
+## Alternatives considered
+
+- **(a) Active hooks via SQL parsing.** Rejected: implementation
+  invasive, breaks offline-edits-in-QGIS story.
+- **(b) `gispulse track ddl` subcommand to diff schemas on demand.**
+  Deferred to Pro-tier audit features; the watchdog already exposes
+  the change via runtime events, no new CLI needed.
+- **(c) Passive detection only, DDL hooks documented as
+  out-of-scope (chosen).** Honest, low-risk, ships today.
+
+## Consequences
+
+### Positive
+
+- No new code surface to maintain.
+- B-13 watchdog gets called out as the canonical "schema drift"
+  mechanism — discoverable via the doctor (`gispulse track doctor`)
+  and observability.
+- Aligns with [ADR 0001][adr0001] (DuckDB-spatial dialect contract)
+  and [ADR 0003][adr0003] (changelog as poll log) — the rule writer
+  has a small, predictable contract surface.
+
+### Negative
+
+- Compliance use cases that need a "DDL audit log" must wait for a
+  future Pro feature.
+- A user who drops a tracked layer and never reads the watcher logs
+  may not notice that tracking silently went dormant — the watcher
+  keeps polling but gets no rows. Mitigation: `gispulse track doctor`
+  surfaces this state (cf. `_check_pragma`, `_changelog_table_exists`
+  in `gispulse/cli_track.py`).
+
+## Status of related work
+
+- B-13 (#103, v1.5.3) — schema-drift watchdog already shipped and
+  exercised in tests.
+- `gispulse track doctor` (#6) reports stale unprocessed rows + WAL
+  + busy_timeout, but does not currently flag dropped tables. A small
+  doctor enhancement (file an issue if needed) would close the
+  remaining gap.
+- Issue #144 closed by this ADR.
+
+## See also
+
+- [`persistence/change_log_watcher.py`][watcher] — `_schema_drift_check_interval_s`
+- [`docs-site/guide/architecture.md`][architecture] — passive
+  detection in the architecture overview
+- ADR [0001][adr0001] — DSL SQL dialect
+- ADR [0002][adr0002] — Cascade semantics
+- ADR [0003][adr0003] — Changelog scope
+
+[watcher]: ../../persistence/change_log_watcher.py
+[architecture]: ../../docs-site/guide/architecture.md
+[adr0001]: ./0001-dsl-sql-dialect.md
+[adr0002]: ./0002-trigger-cascade-semantics.md
+[adr0003]: ./0003-changelog-replay-out-of-scope.md


### PR DESCRIPTION
## Summary

Closes #143 (Q4 changelog replay) + #144 (Q5 DDL hooks) — les 2 dernières sous-issues de l'EPIC [#139](https://github.com/imagodata/gispulse/issues/139).

Les deux décisions = **out-of-scope v1.6.x avec design existant qui couvre le cas commun**. PR doc-only.

## #143 — `_gispulse_change_log` reste un poll log

Investigation : le schéma actuel a déjà
- ✅ Append-only + ordre global monotone (`id INTEGER PRIMARY KEY AUTOINCREMENT`)
- ✅ Timestamps ISO 8601 (`changed_at`)
- ✅ Payload JSON old/new

Manque pour event store complet : sub-second timestamps, row hash, replay primitive. **Reportés à v1.7+ via table d'extension** quand un client le demandera. Le contrat actuel (append-only + `id` monotone) est promu de "happy accident" à invariant documenté.

## #144 — Pas de hooks DDL actifs

SQLite n'a pas de DDL trigger primitive. Intercepter `ALTER`/`CREATE`/`DROP` au connection layer = casser le droit du user d'éditer le GPKG dans QGIS hors GISPulse.

Le **watchdog schema-drift B-13** (#103, v1.5.3) couvre déjà le cas commun (ALTER TABLE ADD COLUMN) via détection passive : la colonne apparaît dans les events suivants en une tick watchdog. Honnête sur ce qu'il fait, pas de mensonge si user édite offline.

## Files

- `docs/adr/0003-changelog-replay-out-of-scope.md` — 140 lignes
- `docs/adr/0004-ddl-hooks-out-of-scope.md` — 128 lignes
- `docs-site/guide/architecture.md` — sous-section "Décisions de scope (ADRs)" qui pointe vers les 4 ADRs (0001-0004)

## EPIC #139 close-out post-merge

| Issue | PR | Status |
|---|---|---|
| #140 Q1 dialect | #147 ADR 0001 | doc-only |
| #141 Q2 WAL | #145 | code (8 sites + 8 tests) |
| #142 Q3 cascade | #148 ADR 0002 | doc-only |
| #143 Q4 replay | **this PR** ADR 0003 | doc-only |
| #144 Q5 DDL | **this PR** ADR 0004 | doc-only |
| #146 scanner | OPEN | follow-up ~3-4d |

5/5 sous-issues fermées une fois mergé, EPIC #139 fermable.

## Test plan

- [x] Markdown rendu localement (preview)
- [x] Cross-links résolvent (`./0001-dsl-sql-dialect.md`, `./0002-...`, `../../persistence/schema.py`, `../../persistence/change_log_watcher.py`)
- [x] DCO signed-off-by aligné

🤖 Generated with [Claude Code](https://claude.com/claude-code)
