### PR TITLE
feat(v1.6.1): #105 — SpatiaLite engine (Format Frontier T1, slice 1/4)

### DIFF
--- a/docs-site/guide/formats.md
+++ b/docs-site/guide/formats.md
@@ -40,7 +40,7 @@ gispulse formats
 | Format | Lecture | Écriture | Notes |
 |--------|:-------:|:--------:|-------|
 | PostGIS | oui | oui | Via `GISPULSE_DSN` (Pro) |
-| SpatiaLite | oui | oui | Mode portable, sessions éphémères |
+| SpatiaLite (`.sqlite`, `.db`) | oui | oui | Engine `spatialite` v1.6.1 — DML triggers AFTER INSERT/UPDATE/DELETE comme GPKG, write-back via pyogrio (`SQLite + SPATIALITE=YES`). Auto-détection : `.sqlite`/`.db` route automatiquement vers cet engine ; un `.gpkg` reste route GPKG. |
 | GeoDatabase ESRI (.gdb) | oui | non | Read-only |
 | OGC WFS | oui | non | Via `OGCLayerLoader` (lazy loading) |
 | OGC API Features | oui | non | Standard OGC moderne |

--- a/persistence/engine_factory.py
+++ b/persistence/engine_factory.py
@@ -104,12 +104,23 @@ def _gpkg_factory(*, dsn: str | None = None, duckdb_path: str = ":memory:", gpkg
     return GeoPackageEngine(path=path)
 
 
+def _spatialite_factory(*, dsn: str | None = None, duckdb_path: str = ":memory:", spatialite_path: str | None = None, gpkg_path: str | None = None, **_kw: Any) -> SpatialEngine:
+    # Accept ``gpkg_path`` as an alias to keep call sites uniform with
+    # the GPKG factory — both engines are file-based SQLite, only the
+    # geometry encoding differs.
+    path = spatialite_path or gpkg_path or settings.database.gpkg_path
+    from persistence.spatialite_engine import SpatiaLiteEngine
+
+    return SpatiaLiteEngine(path=path)
+
+
 def _register_builtins() -> None:
-    """Register the four built-in engine backends."""
+    """Register the five built-in engine backends."""
     register_engine_backend("duckdb", _duckdb_factory)
     register_engine_backend("postgis", _postgis_factory)
     register_engine_backend("hybrid", _hybrid_factory)
     register_engine_backend("gpkg", _gpkg_factory)
+    register_engine_backend("spatialite", _spatialite_factory)
 
 
 # ---------------------------------------------------------------------------

--- a/persistence/gpkg_schema.py
+++ b/persistence/gpkg_schema.py
@@ -442,6 +442,33 @@ def _migrate_v2_to_v3(conn: sqlite3.Connection) -> int:
     return len(layer_names)
 
 
+def _bootstrap_gispulse_internals(conn: sqlite3.Connection) -> None:
+    """Create _gispulse_* internal tables + apply pending migrations.
+
+    Shared by ``bootstrap_gpkg_project`` (GPKG file) and
+    ``bootstrap_spatialite_project`` (SpatiaLite file). The two callers
+    differ only in whether they also touch GPKG-specific structures
+    (application_id, gpkg_spatial_ref_sys, gpkg_contents,
+    gpkg_extensions) — those are GPKG identity markers and would
+    corrupt a SpatiaLite file.
+
+    Safe to call multiple times.
+    """
+    _migrate_v1_to_v2(conn)
+    _migrate_v2_to_v3(conn)
+
+    for table_name, ddl in _TABLE_DDL.items():
+        conn.execute(ddl)
+
+    conn.execute(
+        "INSERT INTO _gispulse_kv (key, value, updated_at) "
+        "VALUES ('schema_version', ?, datetime('now')) "
+        "ON CONFLICT(key) DO UPDATE SET value=excluded.value, "
+        "updated_at=datetime('now')",
+        (str(SCHEMA_VERSION),),
+    )
+
+
 def bootstrap_gpkg_project(conn: sqlite3.Connection) -> None:
     """Create all _gispulse_* tables and register them in gpkg_extensions.
 
@@ -452,39 +479,38 @@ def bootstrap_gpkg_project(conn: sqlite3.Connection) -> None:
     Safe to call multiple times (all DDL is IF NOT EXISTS) and applies any
     pending schema migration so existing v1 GPKGs are upgraded in-place.
     """
-    # Ensure valid GPKG structure first
     _ensure_gpkg_core_tables(conn)
-
-    # Ensure gpkg_extensions exists
     _ensure_gpkg_extensions_table(conn)
-
-    # Apply v1 → v2 migration BEFORE the IF NOT EXISTS DDL, so the column
-    # is added to existing tables (the DDL would skip the table entirely
-    # because it already exists).
-    _migrate_v1_to_v2(conn)
-    # B-02 (#103): v2 → v3 rebuilds per-layer triggers + adds the
-    # ``_gispulse_origin`` sentinel column. Runs after the internal
-    # tables exist (the migration relies on
-    # :func:`install_change_tracking`, which logs through the schema).
-    _migrate_v2_to_v3(conn)
-
-    # Create internal tables
-    for table_name, ddl in _TABLE_DDL.items():
-        conn.execute(ddl)
+    _bootstrap_gispulse_internals(conn)
+    for table_name in _TABLE_DDL:
         _register_extension(conn, table_name)
-
-    # Schema versioning — refresh to current version (idempotent).
-    conn.execute(
-        "INSERT INTO _gispulse_kv (key, value, updated_at) "
-        "VALUES ('schema_version', ?, datetime('now')) "
-        "ON CONFLICT(key) DO UPDATE SET value=excluded.value, "
-        "updated_at=datetime('now')",
-        (str(SCHEMA_VERSION),),
-    )
 
     conn.commit()
     logger.info(
         "gpkg_project_bootstrapped: %d internal tables (schema v%d)",
+        len(_TABLE_DDL),
+        SCHEMA_VERSION,
+    )
+
+
+def bootstrap_spatialite_project(conn: sqlite3.Connection) -> None:
+    """Create all _gispulse_* tables on a SpatiaLite database.
+
+    Unlike :func:`bootstrap_gpkg_project` this does NOT touch:
+
+    - ``PRAGMA application_id`` (would mark the file as GPKG and break
+      OGR / QGIS detection).
+    - ``gpkg_spatial_ref_sys`` / ``gpkg_contents`` / ``gpkg_extensions``
+      (SpatiaLite uses ``spatial_ref_sys`` / ``geometry_columns``).
+
+    The same ``_gispulse_*`` internal tables ship — change tracking
+    triggers, change_log, kv version, rules / triggers / scenarios.
+    Safe to call multiple times.
+    """
+    _bootstrap_gispulse_internals(conn)
+    conn.commit()
+    logger.info(
+        "spatialite_project_bootstrapped: %d internal tables (schema v%d)",
         len(_TABLE_DDL),
         SCHEMA_VERSION,
     )

--- a/persistence/spatialite_engine.py
+++ b/persistence/spatialite_engine.py
@@ -1,0 +1,268 @@
+"""SpatiaLite-backed spatial engine — first format-frontier addition (#105 v1.6.1).
+
+SpatiaLite is SQLite + the ``mod_spatialite`` extension, with a custom
+geometry encoding (Spatialite Blob) and its own catalog tables
+(``spatial_ref_sys`` / ``geometry_columns``) instead of GeoPackage's
+``gpkg_*`` family.
+
+For change tracking the picture is identical to GPKG: the underlying
+SQLite engine accepts the same ``AFTER INSERT/UPDATE/DELETE`` triggers
+that ``persistence.gpkg_schema._build_change_triggers`` already
+generates. So :class:`SpatiaLiteEngine` reuses the bulk of
+:class:`GeoPackageEngine` and only diverges on:
+
+- The bootstrap step (no GPKG ``application_id``, no ``gpkg_contents``).
+- The pyogrio write driver (``SQLite`` + ``SPATIALITE=YES`` instead of
+  ``GPKG``).
+- The "replace existing layer" cleanup path (``geometry_columns`` /
+  ``virts_geometry_columns`` instead of ``gpkg_geometry_columns``).
+
+Detection: a SQLite file is treated as SpatiaLite when ``geometry_columns``
+exists and ``gpkg_contents`` does not. See :func:`is_spatialite_file`.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import geopandas as gpd
+
+from core.logging import get_logger
+from persistence.gpkg_engine import GeoPackageEngine
+from persistence.gpkg_schema import (
+    bootstrap_spatialite_project,
+)
+
+logger = get_logger(__name__)
+
+
+def is_spatialite_file(path: str | Path) -> bool:
+    """Return True iff ``path`` is an existing SpatiaLite-formatted SQLite file.
+
+    Detection rule (intentionally narrow to avoid false positives):
+        * file exists, can be opened by ``sqlite3``;
+        * has a ``geometry_columns`` table (SpatiaLite catalog);
+        * does NOT have ``gpkg_contents`` (would be a GPKG instead).
+
+    A file that has neither table is treated as plain SQLite (return
+    False); the caller may still create SpatiaLite content there by
+    instantiating ``SpatiaLiteEngine`` explicitly.
+    """
+    p = Path(path)
+    if not p.exists() or not p.is_file():
+        return False
+    try:
+        with sqlite3.connect(str(p)) as conn:
+            row = conn.execute(
+                "SELECT "
+                "  EXISTS(SELECT 1 FROM sqlite_master "
+                "         WHERE type='table' AND name='geometry_columns') AS has_geom, "
+                "  EXISTS(SELECT 1 FROM sqlite_master "
+                "         WHERE type='table' AND name='gpkg_contents') AS has_gpkg"
+            ).fetchone()
+    except sqlite3.DatabaseError:
+        return False
+    if row is None:
+        return False
+    has_geom, has_gpkg = bool(row[0]), bool(row[1])
+    return has_geom and not has_gpkg
+
+
+class SpatiaLiteEngine(GeoPackageEngine):
+    """SpatiaLite-backed spatial engine.
+
+    Mirrors :class:`GeoPackageEngine` for everything that lives at the
+    SQLite layer (change tracking, internal ``_gispulse_*`` tables,
+    SQL execution, RTree). The two engines differ only at the file
+    format identity layer.
+    """
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def open(self) -> None:
+        """Open the SpatiaLite file and bootstrap (lazy on fresh paths).
+
+        On an existing file we connect immediately and install the
+        ``_gispulse_*`` internal tables. On a non-existent path we
+        defer file creation to the first :meth:`write_layer` call —
+        pyogrio's ``SQLite + SPATIALITE=YES`` driver requires creating
+        the file from scratch (mode="w") to initialise the SpatiaLite
+        catalog (``geometry_columns`` etc). If we created an empty
+        SQLite file here via ``sqlite3.connect``, pyogrio's later
+        ``mode="a"`` would skip the catalog and the file would never
+        register as SpatiaLite.
+
+        Does NOT set the GPKG ``application_id`` and does NOT create
+        ``gpkg_*`` catalog tables — those would corrupt SpatiaLite
+        identity for OGR / QGIS.
+        """
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        if self._path.exists():
+            self._open_conn()
+            bootstrap_spatialite_project(self._conn)
+
+        if self._use_duckdb_accel:
+            try:
+                import duckdb
+
+                self._duckdb_conn = duckdb.connect(":memory:")
+                self._duckdb_conn.install_extension("spatial")
+                self._duckdb_conn.load_extension("spatial")
+            except Exception as exc:
+                logger.warning("duckdb_accel_unavailable: %s", exc)
+                self._duckdb_conn = None
+                self._use_duckdb_accel = False
+
+        self._opened = True
+        logger.info("spatialite_engine_opened: %s", self._path)
+
+    # ------------------------------------------------------------------
+    # Layer I/O — diverge from GPKG on the OGR driver + catalog cleanup
+    # ------------------------------------------------------------------
+
+    def _has_spatialite_catalog(self) -> bool:
+        """Return True iff the file has the SpatiaLite ``geometry_columns``
+        catalog. The write path uses this to decide between ``mode="w"``
+        (initialise SpatiaLite) and ``mode="a"`` (append).
+
+        Uses a transient connection so the check is safe even when
+        :meth:`open` did not eagerly connect (fresh-file path).
+        """
+        if not self._path.exists():
+            return False
+        try:
+            with sqlite3.connect(str(self._path)) as probe:
+                row = probe.execute(
+                    "SELECT 1 FROM sqlite_master "
+                    "WHERE type='table' AND name='geometry_columns'"
+                ).fetchone()
+        except sqlite3.DatabaseError:
+            return False
+        return row is not None
+
+    def write_layer(
+        self,
+        gdf: gpd.GeoDataFrame,
+        target: str | None = None,
+        *,
+        layer: str = "result",
+        schema: str = "public",
+        if_exists: str = "replace",
+    ) -> str:
+        """Write a GeoDataFrame as a spatial layer in the SpatiaLite db.
+
+        Uses pyogrio's ``SQLite`` driver with ``SPATIALITE=YES`` so the
+        layer is registered in ``geometry_columns`` rather than
+        ``gpkg_geometry_columns``.
+        """
+        spatialite_kwargs = {"SPATIALITE": "YES"}
+
+        # Fresh-file path covers two cases that both need ``mode="w"``:
+        # (1) the file does not exist yet, (2) the file exists but
+        # :meth:`open` only created an empty SQLite skeleton with no
+        # ``geometry_columns`` catalog yet (pyogrio cannot append to a
+        # non-SpatiaLite SQLite file without losing spatial metadata).
+        if not self._has_spatialite_catalog():
+            self._close_conn()
+            gdf.to_file(
+                str(self._path),
+                layer=layer,
+                driver="SQLite",
+                mode="w",
+                **spatialite_kwargs,
+            )
+            self._open_conn()
+            bootstrap_spatialite_project(self._conn)
+        elif if_exists == "append":
+            self._close_conn()
+            gdf.to_file(
+                str(self._path),
+                layer=layer,
+                driver="SQLite",
+                mode="a",
+                **spatialite_kwargs,
+            )
+            self._open_conn()
+        else:
+            existing = self.list_layers()
+            if layer in existing:
+                conn = self._get_conn()
+                with self._lock:
+                    conn.execute(f'DROP TABLE IF EXISTS "{layer}"')
+                    # SpatiaLite catalog tables — defensive try/except
+                    # because not every SpatiaLite file carries every
+                    # virts_/views_ companion table.
+                    for catalog in (
+                        "geometry_columns",
+                        "views_geometry_columns",
+                        "virts_geometry_columns",
+                    ):
+                        try:
+                            conn.execute(
+                                f"DELETE FROM {catalog} WHERE f_table_name = ?",
+                                (layer,),
+                            )
+                        except sqlite3.OperationalError:
+                            pass
+                    # SpatiaLite RTree pattern: idx_<table>_<geom_col>
+                    # Drop any RTree we can find for this table.
+                    rtree_rows = conn.execute(
+                        "SELECT name FROM sqlite_master "
+                        "WHERE type='table' AND name LIKE ? ESCAPE '\\'",
+                        (f"idx\\_{layer}\\_%",),
+                    ).fetchall()
+                    for (rtree_name,) in rtree_rows:
+                        conn.execute(f'DROP TABLE IF EXISTS "{rtree_name}"')
+                    conn.commit()
+            self._close_conn()
+            gdf.to_file(
+                str(self._path),
+                layer=layer,
+                driver="SQLite",
+                mode="a",
+                **spatialite_kwargs,
+            )
+            self._open_conn()
+
+        logger.info("spatialite_layer_written: %s → %s", layer, self._path)
+        return layer
+
+    def list_layers(self, source: str | None = None, schema: str = "public") -> list[str]:
+        """List spatial layers (queries ``geometry_columns``, not GPKG catalog).
+
+        Falls back to pyogrio if the SpatiaLite catalog is missing —
+        e.g. a fresh file created via :meth:`write_layer` before any
+        DML.
+        """
+        if not self._path.exists():
+            return list(self._registered.keys())
+
+        try:
+            conn = self._get_conn()
+            rows = conn.execute(
+                "SELECT f_table_name FROM geometry_columns"
+            ).fetchall()
+            spatial_layers = [
+                str(r[0]) for r in rows if not str(r[0]).startswith("_gispulse_")
+            ]
+        except sqlite3.OperationalError:
+            # Catalog missing — fall back to pyogrio enumeration.
+            try:
+                import pyogrio
+
+                info = pyogrio.list_layers(str(self._path))
+                spatial_layers = [
+                    name for name, _ in info if not name.startswith("_gispulse_")
+                ]
+            except Exception:
+                spatial_layers = []
+
+        for name in self._registered:
+            if name not in spatial_layers:
+                spatial_layers.append(name)
+
+        return spatial_layers

--- a/tests/unit/test_spatialite_engine.py
+++ b/tests/unit/test_spatialite_engine.py
@@ -1,0 +1,263 @@
+"""Tests for ``persistence.spatialite_engine`` — issue #105 (Format Frontier T1).
+
+Covers:
+- :func:`is_spatialite_file` detection (returns True only for SpatiaLite,
+  not GPKG and not bare SQLite).
+- :func:`bootstrap_spatialite_project` creates ``_gispulse_*`` tables
+  WITHOUT GPKG identity markers.
+- :class:`SpatiaLiteEngine` lifecycle (open/close, layer write+read
+  roundtrip via pyogrio's ``SQLite`` driver with ``SPATIALITE=YES``).
+- Engine factory registration and tier gating (Community).
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import geopandas as gpd
+import pytest
+from shapely.geometry import Point
+
+from persistence.gpkg_schema import (
+    bootstrap_gpkg_project,
+    bootstrap_spatialite_project,
+)
+from persistence.spatialite_engine import SpatiaLiteEngine, is_spatialite_file
+
+
+@pytest.fixture
+def sample_gdf() -> gpd.GeoDataFrame:
+    return gpd.GeoDataFrame(
+        {
+            "name": ["A", "B", "C"],
+            "category": [1, 2, 3],
+            "geometry": [Point(0, 0), Point(1, 1), Point(2, 2)],
+        },
+        crs="EPSG:4326",
+    )
+
+
+@pytest.fixture
+def fresh_spatialite_path(tmp_path: Path, sample_gdf: gpd.GeoDataFrame) -> Path:
+    """Create a SpatiaLite file with one layer via pyogrio."""
+    path = tmp_path / "fixture.sqlite"
+    sample_gdf.to_file(
+        str(path),
+        driver="SQLite",
+        layer="places",
+        SPATIALITE="YES",
+    )
+    return path
+
+
+# ---------------------------------------------------------------------------
+# is_spatialite_file
+# ---------------------------------------------------------------------------
+
+
+class TestIsSpatialiteFile:
+    def test_detects_spatialite_file(self, fresh_spatialite_path: Path) -> None:
+        assert is_spatialite_file(fresh_spatialite_path) is True
+
+    def test_rejects_gpkg(self, tmp_path: Path, sample_gdf: gpd.GeoDataFrame) -> None:
+        gpkg = tmp_path / "x.gpkg"
+        sample_gdf.to_file(str(gpkg), driver="GPKG", layer="places")
+        assert is_spatialite_file(gpkg) is False
+
+    def test_rejects_plain_sqlite(self, tmp_path: Path) -> None:
+        path = tmp_path / "plain.sqlite"
+        with sqlite3.connect(str(path)) as conn:
+            conn.execute("CREATE TABLE t (x INTEGER)")
+            conn.commit()
+        assert is_spatialite_file(path) is False
+
+    def test_rejects_missing_file(self, tmp_path: Path) -> None:
+        assert is_spatialite_file(tmp_path / "ghost.sqlite") is False
+
+    def test_rejects_directory(self, tmp_path: Path) -> None:
+        assert is_spatialite_file(tmp_path) is False
+
+
+# ---------------------------------------------------------------------------
+# bootstrap_spatialite_project — does NOT corrupt SpatiaLite identity
+# ---------------------------------------------------------------------------
+
+
+class TestBootstrapSpatialite:
+    def test_creates_gispulse_internals(self, fresh_spatialite_path: Path) -> None:
+        with sqlite3.connect(str(fresh_spatialite_path)) as conn:
+            bootstrap_spatialite_project(conn)
+            tables = {
+                row[0]
+                for row in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table' "
+                    "AND name LIKE '_gispulse_%'"
+                )
+            }
+        assert "_gispulse_change_log" in tables
+        assert "_gispulse_kv" in tables
+
+    def test_does_not_set_gpkg_application_id(
+        self, fresh_spatialite_path: Path
+    ) -> None:
+        with sqlite3.connect(str(fresh_spatialite_path)) as conn:
+            bootstrap_spatialite_project(conn)
+            app_id = conn.execute("PRAGMA application_id").fetchone()[0]
+        # GPKG application_id is 0x47504B47 = 1196444487. SpatiaLite must
+        # NOT carry that marker — pyogrio SQLite driver leaves it 0 by
+        # default and bootstrap_spatialite_project must preserve that.
+        assert app_id != 1196444487
+
+    def test_does_not_create_gpkg_catalog(
+        self, fresh_spatialite_path: Path
+    ) -> None:
+        with sqlite3.connect(str(fresh_spatialite_path)) as conn:
+            bootstrap_spatialite_project(conn)
+            tables = {
+                row[0]
+                for row in conn.execute(
+                    "SELECT name FROM sqlite_master "
+                    "WHERE type='table' AND name LIKE 'gpkg_%'"
+                )
+            }
+        # We must not have polluted the SpatiaLite file with GPKG catalog
+        # tables — that would confuse OGR / QGIS auto-detection.
+        assert tables == set()
+
+    def test_idempotent(self, fresh_spatialite_path: Path) -> None:
+        with sqlite3.connect(str(fresh_spatialite_path)) as conn:
+            bootstrap_spatialite_project(conn)
+            bootstrap_spatialite_project(conn)  # second call must not raise
+
+    def test_gpkg_bootstrap_unchanged(
+        self, tmp_path: Path, sample_gdf: gpd.GeoDataFrame
+    ) -> None:
+        # Regression guard — the refactor that extracted
+        # _bootstrap_gispulse_internals must not have broken
+        # bootstrap_gpkg_project's GPKG-identity behaviour.
+        gpkg = tmp_path / "x.gpkg"
+        sample_gdf.to_file(str(gpkg), driver="GPKG", layer="places")
+        with sqlite3.connect(str(gpkg)) as conn:
+            bootstrap_gpkg_project(conn)
+            app_id = conn.execute("PRAGMA application_id").fetchone()[0]
+            tables = {
+                row[0]
+                for row in conn.execute(
+                    "SELECT name FROM sqlite_master "
+                    "WHERE name IN ('gpkg_contents', 'gpkg_extensions', "
+                    "'_gispulse_change_log')"
+                )
+            }
+        assert app_id == 1196444487
+        assert "gpkg_contents" in tables
+        assert "gpkg_extensions" in tables
+        assert "_gispulse_change_log" in tables
+
+
+# ---------------------------------------------------------------------------
+# SpatiaLiteEngine — lifecycle + I/O
+# ---------------------------------------------------------------------------
+
+
+class TestSpatiaLiteEngineLifecycle:
+    def test_open_creates_internal_tables(self, fresh_spatialite_path: Path) -> None:
+        engine = SpatiaLiteEngine(fresh_spatialite_path)
+        with engine:
+            with sqlite3.connect(str(fresh_spatialite_path)) as conn:
+                row = conn.execute(
+                    "SELECT 1 FROM sqlite_master "
+                    "WHERE type='table' AND name='_gispulse_change_log'"
+                ).fetchone()
+            assert row is not None
+
+    def test_open_does_not_corrupt_spatialite_identity(
+        self, fresh_spatialite_path: Path
+    ) -> None:
+        engine = SpatiaLiteEngine(fresh_spatialite_path)
+        with engine:
+            pass
+        # After open(), the file must still be detected as SpatiaLite.
+        assert is_spatialite_file(fresh_spatialite_path) is True
+
+    def test_open_then_close_cleanly(self, fresh_spatialite_path: Path) -> None:
+        engine = SpatiaLiteEngine(fresh_spatialite_path)
+        engine.open()
+        engine.close()
+        # Second close is a no-op
+        engine.close()
+
+    def test_list_layers_excludes_gispulse_internals(
+        self, fresh_spatialite_path: Path
+    ) -> None:
+        engine = SpatiaLiteEngine(fresh_spatialite_path)
+        with engine:
+            layers = engine.list_layers()
+        assert "places" in layers
+        assert not any(name.startswith("_gispulse_") for name in layers)
+
+
+class TestSpatiaLiteEngineIO:
+    def test_write_then_read_roundtrip(
+        self, tmp_path: Path, sample_gdf: gpd.GeoDataFrame
+    ) -> None:
+        path = tmp_path / "rt.sqlite"
+        engine = SpatiaLiteEngine(path)
+        with engine:
+            engine.write_layer(sample_gdf, layer="places")
+            loaded = engine.load_layer("places", layer="places")
+        assert len(loaded) == 3
+        assert set(loaded["name"]) == {"A", "B", "C"}
+
+    def test_replace_existing_layer(
+        self, tmp_path: Path, sample_gdf: gpd.GeoDataFrame
+    ) -> None:
+        path = tmp_path / "rt.sqlite"
+        engine = SpatiaLiteEngine(path)
+        # First write
+        with engine:
+            engine.write_layer(sample_gdf, layer="places", if_exists="replace")
+            engine.write_layer(
+                sample_gdf.head(1), layer="places", if_exists="replace"
+            )
+            loaded = engine.load_layer("places", layer="places")
+        assert len(loaded) == 1
+
+    def test_creates_fresh_file(
+        self, tmp_path: Path, sample_gdf: gpd.GeoDataFrame
+    ) -> None:
+        path = tmp_path / "fresh.sqlite"
+        assert not path.exists()
+        engine = SpatiaLiteEngine(path)
+        with engine:
+            engine.write_layer(sample_gdf, layer="places")
+        assert path.exists()
+        assert is_spatialite_file(path) is True
+
+
+# ---------------------------------------------------------------------------
+# Engine factory registration
+# ---------------------------------------------------------------------------
+
+
+class TestEngineFactoryRegistration:
+    def test_spatialite_factory_registered(self) -> None:
+        from persistence.engine_factory import _BACKENDS
+
+        assert "spatialite" in _BACKENDS
+
+    def test_factory_callable_returns_spatialite(self, tmp_path: Path) -> None:
+        # ``create_spatial_engine`` does not pass arbitrary kwargs to the
+        # backend factories (they read paths from settings). Test the
+        # registered factory directly to confirm it returns the right
+        # class for the right backend name.
+        from persistence.engine_factory import _BACKENDS
+
+        path = tmp_path / "x.sqlite"
+        engine = _BACKENDS["spatialite"](spatialite_path=str(path))
+        assert isinstance(engine, SpatiaLiteEngine)
+
+    def test_spatialite_is_community_tier(self) -> None:
+        from persistence.tier import enforce_engine_tier
+
+        # Must not raise TierError for community-tier callers.
+        enforce_engine_tier("spatialite")


### PR DESCRIPTION
## Summary

Première tranche de l'EPIC [#105](https://github.com/imagodata/gispulse/issues/105) (Format Frontier T1). Ajoute l'engine **SpatiaLite** pour que les fichiers `.sqlite` / `.db` partagent le pipeline DML triggers de GPKG.

**Pourquoi maintenant** : v1.6.0 a livré le DSL + cascade mais pas la promesse format-agnostic. Sans un engine non-GPKG livré, le pitch "DuckDB Spatial Inside, format-frontier" du HN body v1.5.2 est une vapor claim. SpatiaLite est le plus simple (même DDL trigger SQLite que GPKG) et prouve que l'architecture s'étend proprement. GeoJSON / FlatGeobuf suivent en PR séparées (ils requièrent l'abstraction FileBlobAdapter + DuckDB snapshot diff).

## Implementation

- `persistence/gpkg_schema.py` — extract `_bootstrap_gispulse_internals` ; nouveau `bootstrap_spatialite_project` qui installe les mêmes `_gispulse_*` tables SANS toucher à `application_id` GPKG ni aux catalog `gpkg_*`.
- `persistence/spatialite_engine.py` — nouveau `SpatiaLiteEngine(GeoPackageEngine)` :
  - Override `open()` lazy sur fresh path (pyogrio doit créer le catalog SpatiaLite via `mode="w"`)
  - Override `write_layer()` driver `SQLite` + `SPATIALITE=YES`, cleanup `geometry_columns` / `virts_geometry_columns` / `views_geometry_columns` sur replace
  - Override `list_layers()` lit `geometry_columns` au lieu de `gpkg_contents`
- `is_spatialite_file()` — détection narrow : `geometry_columns` présent ET `gpkg_contents` absent.
- `engine_factory.py` — `_spatialite_factory` enregistré comme 5e built-in. `enforce_engine_tier` permet déjà SpatiaLite en Community.
- `docs-site/guide/formats.md` — row SpatiaLite mise à jour.

URI inference déjà câblé dans `gispulse/runtime/engine_inference.py` (mappe `.sqlite`/`.db` → `spatialite`).

## Tests

20 nouveaux tests dans `tests/unit/test_spatialite_engine.py` :
- `is_spatialite_file` reject GPKG / plain SQLite / missing / directory
- `bootstrap_spatialite_project` does NOT set `application_id`, does NOT create `gpkg_*`, IS idempotent, **regression guard** confirme que GPKG bootstrap toujours valide
- Engine lifecycle preserves SpatiaLite identity
- write/read roundtrip + replace + fresh-file
- Factory registration + Community tier

**165 tests verts** sur tous les modules touchés (gpkg_schema/gpkg_helpers/gpkg_engine/persistence_io/gpkg_connection/cascade_depth). Aucune régression du refactor bootstrap.

## Roadmap EPIC #105

| Slice | Status |
|---|---|
| 1 — SpatiaLite engine | **this PR** |
| 2 — FileBlobAdapter scaffold (mtime + DuckDB snapshot diff) | TODO |
| 3 — GeoJSON adapter | TODO (depends slice 2) |
| 4 — FlatGeobuf adapter | TODO (depends slice 2) |

## Test plan

- [x] `pytest tests/unit/test_spatialite_engine.py` 20/20 vert
- [x] Régression `pytest tests/unit/test_gpkg_*` + `test_persistence_io` 165/165 vert
- [x] Manual roundtrip QGIS-style SQLite via pyogrio confirmé
- [ ] CI sur PR (test 3.10 + 3.12)

## Notes

- `mod_spatialite` (extension Python sqlite3) **n'est pas requis** pour cet engine. Pyogrio's OGR linkage gère le catalog SpatiaLite. Les opérations ST_* dans `run_sql` resteront limitées sans mod_spatialite mais GISPulse pousse les fonctions geom au niveau DuckDB de toute façon (cf [ADR 0001](https://github.com/imagodata/gispulse/blob/main/docs/adr/0001-dsl-sql-dialect.md)).
- DCO signed-off-by aligné `simon@imago.dev`.
- security-audit baseline sera ✅ une fois PR #149 mergé (pip 26.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
