### PR TITLE
feat(v1.6.2): #106 — Format Frontier T2 partial (KML + CSV+WKT zero-code, MapInfo TAB companion-only)

### DIFF
--- a/docs-site/guide/formats.md
+++ b/docs-site/guide/formats.md
@@ -30,9 +30,9 @@ gispulse formats
 | Extension | Format | Lecture | Écriture | Notes |
 |-----------|--------|:-------:|:--------:|-------|
 | `.shp` | ESRI Shapefile | oui | oui | Héritage — préférer GPKG. **CDC v1.6.1** : engine `duckdb_diff` watche les 5 companions (`.shp`/`.dbf`/`.shx`/`.prj`/`.cpg`) en `max(mtime)` — un edit attributaire-seulement (qui ne touche que `.dbf`) est détecté. |
-| `.csv` | CSV (lat/lon ou WKT) | oui | oui | Détection auto colonnes géométrie |
+| `.csv` | CSV (lat/lon ou WKT) | oui | oui | Détection auto colonnes géométrie. **CDC v1.6.2** : engine `duckdb_diff` zero-code-change (à écrire avec `GEOMETRY=AS_WKT` côté pyogrio pour préserver la géométrie). |
 | `.dxf` | AutoCAD DXF | oui | oui | CAD |
-| `.kml` | KML / KMZ | oui | non | Google Earth |
+| `.kml` | KML / KMZ | oui | oui (KML) | Google Earth. **CDC v1.6.2** : engine `duckdb_diff` zero-code-change (single-file mtime). |
 | `.gml` | GML | oui | oui | OGC standard |
 | `.gpx` | GPX | oui | non | GPS tracks |
 

--- a/persistence/file_blob_cdc.py
+++ b/persistence/file_blob_cdc.py
@@ -72,10 +72,12 @@ SNAPSHOT_SUFFIX = ".gispulse-snapshot.duckdb"
 # :func:`_resolve_companion_paths` returns just the primary file.
 _COMPANION_EXTENSIONS: dict[str, tuple[str, ...]] = {
     ".shp": (".shp", ".dbf", ".shx", ".prj", ".cpg"),
-    # ``.tab`` (MapInfo) ships with ``.dat``, ``.id``, ``.map``, ``.ind``.
-    # Reserved for slice 4-bis if a customer asks; the current detector
-    # still produces correct events when only ``.tab`` mtime changes
-    # because pyogrio rewrites every companion on edit.
+    # MapInfo TAB ships as a 4-file set: the descriptor (``.tab``), the
+    # attribute table (``.dat``), the geometry index (``.map``), and the
+    # row index (``.id``). Some MapInfo writers also produce ``.ind`` for
+    # secondary indices — included defensively so it's watched if
+    # present. (#106 v1.6.2)
+    ".tab": (".tab", ".dat", ".map", ".id", ".ind"),
 }
 
 

--- a/tests/unit/test_format_frontier_t2.py
+++ b/tests/unit/test_format_frontier_t2.py
@@ -1,0 +1,212 @@
+"""Format Frontier T2 (#106 v1.6.2) — KML + CSV+WKT + MapInfo TAB.
+
+Slice 1 of EPIC #106. The infrastructure (`FileBlobChangeDetector` +
+`DuckDBDiffEngine`) shipped in EPIC #105 (v1.6.1) handles two of the
+T2 formats with **zero code change**:
+
+- KML (single file, mtime watched directly)
+- CSV+WKT (single file, mtime watched directly; pyogrio writes the
+  geometry as a WKT column when ``GEOMETRY=AS_WKT`` is passed)
+
+We also extend ``_COMPANION_EXTENSIONS`` for MapInfo TAB
+(``.tab / .dat / .map / .id / .ind``) so the companion-watching
+infrastructure resolves the file set correctly. The diff path itself
+hangs on this env's DuckDB GDAL build (no MapInfo driver compiled
+in), so the read-and-diff tests are skipped — but the companion
+resolution test still locks in the multi-file watch contract for the
+day we ship MapInfo via a different read path (or a DuckDB build that
+includes the driver).
+
+What we still don't ship in T2 today:
+
+- **MapInfo TAB read/diff**: blocked on DuckDB GDAL driver — the
+  ``ST_Read('places.tab')`` call hangs or fails on the bundled
+  build. Pyogrio reads TAB fine, so a future slice could route
+  ``.tab`` through pyogrio for read instead of DuckDB. Tracked as a
+  follow-up.
+- **DXF**: pyogrio's DXF writer raises ``FieldError`` on custom
+  attributes (CAD-format limitation). DuckDB's ``ST_Read`` reads DXF
+  fine, so a read-only CDC adapter is feasible — deferred to v1.7+
+  as a separate ticket.
+
+These tests live as a regression guard so a future change to the
+detector or engine doesn't silently break a format that was working
+through the existing infrastructure.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import geopandas as gpd
+import pytest
+from shapely.geometry import Point
+
+from core.models import ChangeOperation
+from persistence.duckdb_diff_engine import DuckDBDiffEngine
+from persistence.file_blob_cdc import (
+    FileBlobChangeDetector,
+    _resolve_companion_paths,
+)
+
+
+def _bump_mtime(path: Path) -> None:
+    stat = os.stat(path)
+    os.utime(path, (stat.st_atime, stat.st_mtime + 1.5))
+
+
+@pytest.fixture
+def sample_gdf() -> gpd.GeoDataFrame:
+    return gpd.GeoDataFrame(
+        {
+            "name": ["A", "B", "C"],
+            "category": [1, 2, 3],
+            "geometry": [Point(0, 0), Point(1, 1), Point(2, 2)],
+        },
+        crs="EPSG:4326",
+    )
+
+
+# ---------------------------------------------------------------------------
+# KML
+# ---------------------------------------------------------------------------
+
+
+class TestKML:
+    def test_first_poll_emits_inserts(
+        self, tmp_path: Path, sample_gdf: gpd.GeoDataFrame
+    ) -> None:
+        path = tmp_path / "places.kml"
+        sample_gdf.to_file(str(path), driver="KML")
+
+        det = FileBlobChangeDetector(path)
+        try:
+            records = det.poll()
+        finally:
+            det.close()
+        assert len(records) == 3
+        assert all(r.operation == ChangeOperation.INSERT for r in records)
+
+    def test_through_duckdb_diff_engine(
+        self, tmp_path: Path, sample_gdf: gpd.GeoDataFrame
+    ) -> None:
+        path = tmp_path / "places.kml"
+        sample_gdf.to_file(str(path), driver="KML")
+
+        engine = DuckDBDiffEngine(path)
+        with engine:
+            pending = engine.get_pending_changes()
+        assert len(pending) == 3
+        assert all(p["operation"] == "INSERT" for p in pending)
+
+
+# ---------------------------------------------------------------------------
+# CSV + WKT
+# ---------------------------------------------------------------------------
+
+
+class TestCSVWKT:
+    def test_first_poll_emits_inserts(
+        self, tmp_path: Path, sample_gdf: gpd.GeoDataFrame
+    ) -> None:
+        path = tmp_path / "places.csv"
+        # ``GEOMETRY=AS_WKT`` tells OGR to serialize geom as a WKT column
+        # rather than two lat/lon columns. DuckDB ``ST_Read`` then
+        # decodes it transparently.
+        sample_gdf.to_file(str(path), driver="CSV", GEOMETRY="AS_WKT")
+
+        det = FileBlobChangeDetector(path)
+        try:
+            records = det.poll()
+        finally:
+            det.close()
+        assert len(records) == 3
+        assert all(r.operation == ChangeOperation.INSERT for r in records)
+
+    def test_through_duckdb_diff_engine(
+        self, tmp_path: Path, sample_gdf: gpd.GeoDataFrame
+    ) -> None:
+        path = tmp_path / "places.csv"
+        sample_gdf.to_file(str(path), driver="CSV", GEOMETRY="AS_WKT")
+
+        engine = DuckDBDiffEngine(path)
+        with engine:
+            pending = engine.get_pending_changes()
+        assert len(pending) == 3
+
+
+# ---------------------------------------------------------------------------
+# MapInfo TAB — multi-file, companion watching
+# ---------------------------------------------------------------------------
+
+
+class TestMapInfoTAB:
+    def test_companion_paths_resolved(
+        self, tmp_path: Path, sample_gdf: gpd.GeoDataFrame
+    ) -> None:
+        path = tmp_path / "places.tab"
+        sample_gdf.to_file(str(path), driver="MapInfo File")
+
+        # All companion files OGR actually produced should be picked up.
+        # MapInfo File typically writes .tab / .dat / .map / .id (no .ind
+        # for fresh files); ``_resolve_companion_paths`` returns the
+        # ones that exist, in canonical order.
+        paths = _resolve_companion_paths(path)
+        names = sorted(p.name for p in paths)
+        assert "places.tab" in names
+        assert "places.dat" in names
+        assert "places.map" in names
+        # .id is also produced by OGR for MapInfo TAB
+        assert "places.id" in names
+
+    @pytest.mark.skip(
+        reason="DuckDB GDAL build does not include the MapInfo driver "
+        "in the wheel ST_Read('places.tab') hangs. Companion resolution "
+        "(test above) is independent and locks in the multi-file watch."
+    )
+    def test_first_poll_emits_inserts(
+        self, tmp_path: Path, sample_gdf: gpd.GeoDataFrame
+    ) -> None:  # pragma: no cover — gated by environment
+        path = tmp_path / "places.tab"
+        sample_gdf.to_file(str(path), driver="MapInfo File")
+
+        det = FileBlobChangeDetector(path)
+        try:
+            records = det.poll()
+        finally:
+            det.close()
+        assert len(records) == 3
+        assert all(r.operation == ChangeOperation.INSERT for r in records)
+
+    def test_dat_only_mtime_change_does_not_crash(
+        self, tmp_path: Path, sample_gdf: gpd.GeoDataFrame
+    ) -> None:
+        # The companion-watching layer must not crash the watcher even
+        # when the diff path can't actually read the .tab. Until we
+        # ship a pyogrio fallback for read-only TAB, ``has_pending_changes``
+        # must still report state correctly so the watcher loop can
+        # decide whether a poll is worth attempting. We exercise the
+        # mtime probe (cheap, no DuckDB call) and confirm it surfaces
+        # the .dat companion change.
+        path = tmp_path / "places.tab"
+        sample_gdf.to_file(str(path), driver="MapInfo File")
+
+        det = FileBlobChangeDetector(path)
+        try:
+            # Set the baseline mtime without doing the full poll
+            # (which would hang on this env). The watcher's actual
+            # "first tick" path would face the same hang and is the
+            # subject of the follow-up — for now we at least lock in
+            # the companion-mtime contract.
+            assert det.has_pending_changes() is True
+
+            dat = path.with_suffix(".dat")
+            assert dat.exists()
+            initial = det._max_companion_mtime()
+            assert initial is not None
+            _bump_mtime(dat)
+            after = det._max_companion_mtime()
+            assert after is not None
+            assert after > initial
+        finally:
+            det.close()


### PR DESCRIPTION
## Summary

First slice of EPIC [#106](https://github.com/imagodata/gispulse/issues/106) (v1.6.2 Format Frontier T2). Adds **KML** and **CSV+WKT** to the file-blob CDC surface, both zero-code-change through the `DuckDBDiffEngine` shipped in #152 (T1). Adds the **MapInfo TAB** companion-files entry — the read+diff path needs a DuckDB GDAL build with the MapInfo driver (the bundled wheel doesn't include it), so the read tests are skipped with a pointed reason and the companion-watching contract is still locked in for the day we route TAB through pyogrio instead.

**This branch is stacked on [#152](https://github.com/imagodata/gispulse/pull/152)** — must merge after #152 lands.

## What ships

| Format | Read | Write | CDC | Notes |
|---|---|---|---|---|
| `.kml` | ✅ DuckDB ST_Read | ✅ pyogrio | ✅ this PR | Single-file mtime |
| `.csv` (WKT) | ✅ DuckDB ST_Read | ✅ pyogrio (`GEOMETRY=AS_WKT`) | ✅ this PR | Single-file mtime |
| `.tab` (MapInfo) | ⚠️ DuckDB GDAL driver missing | ✅ pyogrio | ⚠️ companion-files only | 4-file companion watching ready |

## What's deferred

- **MapInfo TAB read** — DuckDB GDAL bundle has no MapInfo driver in this env. Future slice can route `.tab` through pyogrio for read while keeping DuckDB for diff hashing. Companion-files entry already in place; a single-file change to `_read_current_snapshot` would unblock.
- **DXF** — pyogrio's DXF writer raises `FieldError` on custom attribute fields (CAD-format limitation). DuckDB ST_Read works fine for read-only. Punted to v1.7+ as a read-only adapter (no write-back path).

## Implementation

- `persistence/file_blob_cdc.py` — extend `_COMPANION_EXTENSIONS` with `.tab` → `(.tab, .dat, .map, .id, .ind)`.
- `tests/unit/test_format_frontier_t2.py` — 7 tests (6 pass + 1 skip):
  - `TestKML` × 2 — through detector + through engine
  - `TestCSVWKT` × 2 — same coverage
  - `TestMapInfoTAB::test_companion_paths_resolved` — locks multi-file watch contract
  - `TestMapInfoTAB::test_first_poll_emits_inserts` — **SKIPPED** (DuckDB GDAL TAB driver)
  - `TestMapInfoTAB::test_dat_only_mtime_change_does_not_crash` — exercises cheap mtime probe path without invoking the failing DuckDB read
- `docs-site/guide/formats.md` — KML and CSV rows bump.

## Test plan

- [x] `pytest tests/unit/test_format_frontier_t2.py` — 6 pass + 1 skip
- [x] `pytest tests/unit/test_file_blob_cdc.py tests/unit/test_duckdb_diff_engine.py tests/unit/test_format_frontier_t2.py` — 46/46 (excl. skip)
- [ ] CI sur PR (test 3.10 + 3.12)

## Stack

```
main
 └─ feat/105-fileblob-geojson (PR #152) — 4 commits, EPIC #105
     └─ feat/106-format-frontier-t2 (this PR) — 1 commit, EPIC #106 partial
```

Retarget to main after #152 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
