### PR TITLE
feat(plugin): lifecycle hooks + MCP extension factories (cherry-pick from #23)

### DIFF
--- a/core/plugin_contracts.py
+++ b/core/plugin_contracts.py
@@ -5,8 +5,8 @@ implement to extend the OSS engine via Python entry-points. The core
 discovery / instantiation logic lives in :mod:`core.plugin_hub`.
 
 Pattern reference: ``gispulse.capabilities`` (existing) — see
-``capabilities/registry.py``. We extend the same mechanism to five new
-groups documented in ``docs/PLUGIN_CONTRACT.md``.
+``capabilities/registry.py``. The same mechanism extends the host app and
+MCP facade without hard-coding optional packages.
 
 Entry-point groups
 ------------------
@@ -16,6 +16,9 @@ Entry-point groups
 - ``gispulse.billing_provider``— :class:`BillingProvider`
 - ``gispulse.licence_provider``— :class:`LicenceProvider`
 - ``gispulse.connectors``      — :class:`Connector`
+- ``gispulse.lifecycle``       — :class:`LifecycleHook`
+- ``gispulse.mcp_tools``       — :class:`McpToolFactory`
+- ``gispulse.mcp_resources``   — :class:`McpResourceFactory`
 """
 from __future__ import annotations
 
@@ -29,7 +32,7 @@ if TYPE_CHECKING:
 # Bumped MAJOR on breaking change, MINOR on additive change. Plugins
 # declare ``requires_protocol = ">=1.0,<2.0"`` and the hub warns on
 # mismatch.
-PROTOCOL_VERSION = "1.0"
+PROTOCOL_VERSION = "1.1"
 
 
 # ---------------------------------------------------------------------------
@@ -84,6 +87,19 @@ class MiddlewareFactory(Protocol):
     name: str
 
     def install(self, app: "FastAPI") -> None:
+        ...
+
+
+@runtime_checkable
+class LifecycleHook(Protocol):
+    """Plugin with explicit FastAPI startup and shutdown hooks."""
+
+    name: str
+
+    def on_startup(self, app: "FastAPI") -> Any:
+        ...
+
+    def on_shutdown(self, app: "FastAPI") -> Any:
         ...
 
 
@@ -160,4 +176,29 @@ class Connector(Protocol):
     schema_version: str
 
     def supports(self, source_type: str) -> bool:
+        ...
+
+
+# ---------------------------------------------------------------------------
+# MCP extension points
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class McpToolFactory(Protocol):
+    """Plugin that registers tools on a FastMCP server instance."""
+
+    name: str
+
+    def register(self, mcp: Any) -> None:
+        ...
+
+
+@runtime_checkable
+class McpResourceFactory(Protocol):
+    """Plugin that registers resources on a FastMCP server instance."""
+
+    name: str
+
+    def register(self, mcp: Any) -> None:
         ...

--- a/core/plugin_hub.py
+++ b/core/plugin_hub.py
@@ -23,8 +23,11 @@ from core.plugin_contracts import (
     AuthProvider,
     BillingProvider,
     Connector,
+    LifecycleHook,
     LicenceProvider,
     LicenceState,
+    McpResourceFactory,
+    McpToolFactory,
     MiddlewareFactory,
     RouterFactory,
 )
@@ -119,6 +122,9 @@ class PluginHub:
     billing_provider: BillingProvider | None
     licence_provider: LicenceProvider
     connectors: dict[str, Connector]
+    lifecycle: list[LifecycleHook]
+    mcp_tools: list[McpToolFactory]
+    mcp_resources: list[McpResourceFactory]
 
     def __init__(self) -> None:
         self.routers = {}
@@ -127,6 +133,9 @@ class PluginHub:
         self.billing_provider = None
         self.licence_provider = NoOpLicenceProvider()
         self.connectors = {}
+        self.lifecycle = []
+        self.mcp_tools = []
+        self.mcp_resources = []
 
     # ------------------------------------------------------------------ API
 
@@ -153,6 +162,9 @@ class PluginHub:
         hub._load_billing_provider()
         hub._load_licence_provider()
         hub._load_connectors()
+        hub._load_lifecycle()
+        hub._load_mcp_tools()
+        hub._load_mcp_resources()
         log.info(
             "plugin_hub_initialized",
             routers=sorted(hub.routers),
@@ -161,6 +173,9 @@ class PluginHub:
             billing=(hub.billing_provider.name if hub.billing_provider else None),
             licence=hub.licence_provider.name,
             connectors=sorted(hub.connectors),
+            lifecycle=[p.name for p in hub.lifecycle],
+            mcp_tools=[p.name for p in hub.mcp_tools],
+            mcp_resources=[p.name for p in hub.mcp_resources],
         )
         return hub
 
@@ -208,6 +223,27 @@ class PluginHub:
             if obj is None:
                 continue
             self.connectors[ep.name] = obj
+
+    def _load_lifecycle(self) -> None:
+        for ep in _eps("gispulse.lifecycle"):
+            obj = _safe_load(ep, "lifecycle")
+            if obj is None:
+                continue
+            self.lifecycle.append(obj)
+
+    def _load_mcp_tools(self) -> None:
+        for ep in _eps("gispulse.mcp_tools"):
+            obj = _safe_load(ep, "mcp_tool")
+            if obj is None:
+                continue
+            self.mcp_tools.append(obj)
+
+    def _load_mcp_resources(self) -> None:
+        for ep in _eps("gispulse.mcp_resources"):
+            obj = _safe_load(ep, "mcp_resource")
+            if obj is None:
+                continue
+            self.mcp_resources.append(obj)
 
 
 # ---------------------------------------------------------------------------

--- a/gispulse/adapters/http/app.py
+++ b/gispulse/adapters/http/app.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import inspect
 import os
+import inspect
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, Literal
@@ -68,6 +69,34 @@ log = get_logger(__name__)
 
 _PORTAL_DIST = Path(__file__).resolve().parent.parent.parent.parent / "portal" / "dist"
 _VIEWER_DIST = Path(__file__).resolve().parent.parent.parent.parent / "viewer" / "dist"
+
+
+async def _run_plugin_startup(app: FastAPI) -> None:
+    hub = getattr(app.state, "plugin_hub", None)
+    if hub is None:
+        return
+    for plugin in hub.lifecycle:
+        try:
+            result = plugin.on_startup(app)
+            if inspect.isawaitable(result):
+                await result
+            log.info("plugin_lifecycle_startup_complete", plugin=plugin.name)
+        except Exception as exc:
+            log.warning("plugin_lifecycle_startup_failed", plugin=plugin.name, error=str(exc))
+
+
+async def _run_plugin_shutdown(app: FastAPI) -> None:
+    hub = getattr(app.state, "plugin_hub", None)
+    if hub is None:
+        return
+    for plugin in reversed(hub.lifecycle):
+        try:
+            result = plugin.on_shutdown(app)
+            if inspect.isawaitable(result):
+                await result
+            log.info("plugin_lifecycle_shutdown_complete", plugin=plugin.name)
+        except Exception as exc:
+            log.warning("plugin_lifecycle_shutdown_failed", plugin=plugin.name, error=str(exc))
 
 
 def _load_api_keys() -> set[str] | None:
@@ -464,7 +493,11 @@ def create_app(
                 except Exception as exc:
                     log.warning("change_log_watcher_failed", error=str(exc))
 
+        await _run_plugin_startup(app)
+
         yield
+
+        await _run_plugin_shutdown(app)
 
         if not is_portal:
             # Graceful watcher registry shutdown — stops every per-dataset

--- a/gispulse/adapters/mcp/server.py
+++ b/gispulse/adapters/mcp/server.py
@@ -42,6 +42,7 @@ except ImportError as exc:  # pragma: no cover
 
 from capabilities import list_all as _list_all_capabilities
 from capabilities.registry import REGISTRY
+from core.plugin_hub import PluginHub
 from core.models import Dataset, Job, JobStatus, Rule
 from core.logging import get_logger
 from persistence.repository import InMemoryRepository
@@ -63,10 +64,52 @@ _rule_engine = RuleEngine(repository=_rule_repo)
 _job_runner = JobRunner(repository=_rule_repo, rule_engine=_rule_engine)
 
 # ---------------------------------------------------------------------------
-# FastMCP server instance
+# FastMCP server helpers
 # ---------------------------------------------------------------------------
 
-mcp = FastMCP("GISPulse")
+
+def create_mcp_server(name: str = "GISPulse", *, include_plugins: bool = True):
+    """Create a FastMCP server with built-in and plugin-contributed surfaces."""
+    server = FastMCP(name)
+    register_builtin_mcp_surface(server)
+    if include_plugins:
+        register_plugin_mcp_surface(server)
+    return server
+
+
+def register_builtin_mcp_surface(server: Any) -> None:
+    """Register the built-in GISPulse MCP tools and resources."""
+    for fn in (
+        list_capabilities,
+        get_capability_info,
+        create_rule,
+        list_rules,
+        validate_rule,
+        delete_rule,
+        list_datasets,
+        load_gpkg,
+        run_job,
+    ):
+        server.tool()(fn)
+    server.resource("gispulse://capabilities")(resource_capabilities)
+    server.resource("gispulse://rules")(resource_rules)
+
+
+def register_plugin_mcp_surface(server: Any) -> None:
+    """Install MCP tools/resources provided through PluginHub entry-points."""
+    hub = PluginHub.get()
+    for factory in hub.mcp_tools:
+        try:
+            factory.register(server)
+            log.info("plugin_mcp_tools_registered", plugin=factory.name)
+        except Exception as exc:
+            log.warning("plugin_mcp_tools_failed", plugin=factory.name, error=str(exc))
+    for factory in hub.mcp_resources:
+        try:
+            factory.register(server)
+            log.info("plugin_mcp_resources_registered", plugin=factory.name)
+        except Exception as exc:
+            log.warning("plugin_mcp_resources_failed", plugin=factory.name, error=str(exc))
 
 
 # ===========================================================================
@@ -74,7 +117,6 @@ mcp = FastMCP("GISPulse")
 # ===========================================================================
 
 
-@mcp.tool()
 def list_capabilities() -> list[dict[str, Any]]:
     """List all registered GISPulse capabilities with their schemas.
 
@@ -84,7 +126,6 @@ def list_capabilities() -> list[dict[str, Any]]:
     return _list_all_capabilities()
 
 
-@mcp.tool()
 def get_capability_info(name: str) -> dict[str, Any]:
     """Return detail for a single capability.
 
@@ -113,7 +154,6 @@ def get_capability_info(name: str) -> dict[str, Any]:
 # ===========================================================================
 
 
-@mcp.tool()
 def create_rule(
     name: str,
     capability: str,
@@ -147,7 +187,6 @@ def create_rule(
         return {"error": str(exc)}
 
 
-@mcp.tool()
 def list_rules() -> list[dict[str, Any]]:
     """List all rules stored in the session repository.
 
@@ -168,7 +207,6 @@ def list_rules() -> list[dict[str, Any]]:
     ]
 
 
-@mcp.tool()
 def validate_rule(rule_id: str) -> dict[str, Any]:
     """Validate a stored rule against its capability's schema.
 
@@ -198,7 +236,6 @@ def validate_rule(rule_id: str) -> dict[str, Any]:
     }
 
 
-@mcp.tool()
 def delete_rule(rule_id: str) -> dict[str, Any]:
     """Delete a stored rule from the session repository.
 
@@ -224,7 +261,6 @@ def delete_rule(rule_id: str) -> dict[str, Any]:
 # ===========================================================================
 
 
-@mcp.tool()
 def list_datasets() -> list[dict[str, Any]]:
     """List all datasets loaded in the current session.
 
@@ -244,7 +280,6 @@ def list_datasets() -> list[dict[str, Any]]:
     ]
 
 
-@mcp.tool()
 def load_gpkg(path: str, name: str = "") -> dict[str, Any]:
     """Load a GeoPackage file into the session engine.
 
@@ -301,7 +336,6 @@ def load_gpkg(path: str, name: str = "") -> dict[str, Any]:
 # ===========================================================================
 
 
-@mcp.tool()
 def run_job(
     name: str,
     dataset_id: str,
@@ -381,13 +415,11 @@ def run_job(
 # ===========================================================================
 
 
-@mcp.resource("gispulse://capabilities")
 def resource_capabilities() -> str:
     """MCP resource: list of all registered GISPulse capabilities (JSON)."""
     return json.dumps(_list_all_capabilities(), indent=2)
 
 
-@mcp.resource("gispulse://rules")
 def resource_rules() -> str:
     """MCP resource: list of all rules stored in the session (JSON)."""
     rules = [
@@ -402,3 +434,7 @@ def resource_rules() -> str:
         for rule in _rule_repo.list_all()
     ]
     return json.dumps(rules, indent=2)
+
+
+# Module-level compatibility instance used by existing imports.
+mcp = create_mcp_server()

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -14,6 +14,7 @@ fastmcp = pytest.importorskip("fastmcp")
 # Only import after the skip guard so the module-level ImportError in
 # server.py is not triggered in environments without fastmcp.
 from gispulse.adapters.mcp import server as mcp_server  # noqa: E402
+from core import plugin_hub  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -72,6 +73,41 @@ def test_tools_registered():
     }
     missing = expected - tool_names
     assert not missing, f"Missing tools: {missing}"
+
+
+def test_plugin_tool_registered(monkeypatch):
+    """MCP tool entry-points can extend a freshly-created server."""
+    import asyncio
+
+    class FakeEntryPoint:
+        name = "fake-mcp-tool"
+
+        def load(self):
+            class FakeToolFactory:
+                name = "fake-mcp-tool"
+
+                def register(self, mcp):
+                    @mcp.tool()
+                    def plugin_ping() -> str:
+                        return "pong"
+
+            return FakeToolFactory
+
+    def fake_entry_points(group: str | None = None, **_kwargs):
+        if group == "gispulse.mcp_tools":
+            return [FakeEntryPoint()]
+        return []
+
+    monkeypatch.setattr(plugin_hub, "entry_points", fake_entry_points)
+    plugin_hub.PluginHub.reset()
+
+    server = mcp_server.create_mcp_server()
+    tools = asyncio.run(server.list_tools())
+    tool_names = {t.name for t in tools}
+
+    assert "plugin_ping" in tool_names
+
+    plugin_hub.PluginHub.reset()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_plugin_hub.py
+++ b/tests/unit/test_plugin_hub.py
@@ -64,6 +64,9 @@ class TestPluginHubDiscovery:
         assert hub.auth_providers == {}
         assert hub.billing_provider is None
         assert hub.connectors == {}
+        assert hub.lifecycle == []
+        assert hub.mcp_tools == []
+        assert hub.mcp_resources == []
         # Default licence provider is the OSS NoOp.
         assert hub.licence_provider.name == "noop"
 
@@ -164,6 +167,43 @@ class TestPluginHubDiscovery:
         )
         hub = plugin_hub.PluginHub.get()
         assert hub.routers["needs-stripe"].create(app=None) is None
+
+    def test_lifecycle_plugins_are_registered(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class FakeLifecycle:
+            name = "fake-lifecycle"
+
+            def on_startup(self, app): return None
+
+            def on_shutdown(self, app): return None
+
+        _patch_eps(
+            monkeypatch,
+            {"gispulse.lifecycle": [_FakeEntryPoint("fake-lifecycle", FakeLifecycle)]},
+        )
+        hub = plugin_hub.PluginHub.get()
+        assert [p.name for p in hub.lifecycle] == ["fake-lifecycle"]
+
+    def test_mcp_plugins_are_registered(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class FakeTools:
+            name = "fake-tools"
+
+            def register(self, mcp): return None
+
+        class FakeResources:
+            name = "fake-resources"
+
+            def register(self, mcp): return None
+
+        _patch_eps(
+            monkeypatch,
+            {
+                "gispulse.mcp_tools": [_FakeEntryPoint("fake-tools", FakeTools)],
+                "gispulse.mcp_resources": [_FakeEntryPoint("fake-resources", FakeResources)],
+            },
+        )
+        hub = plugin_hub.PluginHub.get()
+        assert [p.name for p in hub.mcp_tools] == ["fake-tools"]
+        assert [p.name for p in hub.mcp_resources] == ["fake-resources"]
 
 
 # ---------------------------------------------------------------------------
@@ -299,7 +339,7 @@ class TestPluginHubSingleton:
 
 
 def test_protocol_version_exposed() -> None:
-    assert PROTOCOL_VERSION == "1.0"
+    assert PROTOCOL_VERSION == "1.1"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_plugin_runtime_mounting.py
+++ b/tests/unit/test_plugin_runtime_mounting.py
@@ -1,0 +1,91 @@
+"""Runtime tests for PluginHub surfaces consumed by the HTTP app."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+from fastapi import APIRouter
+from fastapi.testclient import TestClient
+
+from core import plugin_hub
+from gispulse.adapters.http.app import create_app
+
+
+@dataclass
+class _FakeEntryPoint:
+    name: str
+    value: Any
+
+    def load(self):  # noqa: D401 - match EntryPoint API
+        return self.value
+
+
+def _patch_eps(monkeypatch: pytest.MonkeyPatch, mapping: dict[str, list[_FakeEntryPoint]]) -> None:
+    def fake(group: str | None = None, **_kwargs):
+        if group is None:
+            return []
+        return mapping.get(group, [])
+
+    monkeypatch.setattr(plugin_hub, "entry_points", fake)
+    plugin_hub.PluginHub.reset()
+
+
+@pytest.fixture(autouse=True)
+def _memory_storage(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("GISPULSE_STORAGE", "memory")
+    monkeypatch.delenv("GISPULSE_API_KEYS", raising=False)
+    plugin_hub.PluginHub.reset()
+    yield
+    plugin_hub.PluginHub.reset()
+
+
+def test_create_app_mounts_plugin_router(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeRouterFactory:
+        name = "fake-router"
+
+        def create(self, app):
+            router = APIRouter()
+
+            @router.get("/plugin/ping")
+            def ping():
+                return {"plugin": self.name}
+
+            return router
+
+    _patch_eps(
+        monkeypatch,
+        {"gispulse.routers": [_FakeEntryPoint("fake-router", FakeRouterFactory)]},
+    )
+
+    client = TestClient(create_app())
+    response = client.get("/plugin/ping")
+
+    assert response.status_code == 200
+    assert response.json() == {"plugin": "fake-router"}
+
+
+def test_create_app_runs_plugin_lifecycle(monkeypatch: pytest.MonkeyPatch) -> None:
+    events: list[str] = []
+
+    class FakeLifecycle:
+        name = "fake-lifecycle"
+
+        def on_startup(self, app):
+            events.append("startup")
+
+        def on_shutdown(self, app):
+            events.append("shutdown")
+
+    _patch_eps(
+        monkeypatch,
+        {"gispulse.lifecycle": [_FakeEntryPoint("fake-lifecycle", FakeLifecycle)]},
+    )
+
+    with TestClient(create_app()) as client:
+        assert client.get("/health").status_code == 200
+        assert events == ["startup"]
+
+    assert events == ["startup", "shutdown"]
+


### PR DESCRIPTION
Cherry-pick of [Erwan's commit 6313ba2](https://github.com/imagodata/gispulse/pull/23/commits/6313ba22c411392f810c2bc47e9a93517aa81230) onto current main.

## Why a cherry-pick instead of a rebase of #23

PR #23's branch was branched from a stale upstream/main and would revert ~150 files (CHANGELOG, docs, walkthroughs, catalog GPU/SUP entries from #70, etc.). The single useful commit was extracted, replayed on current main, the conflict in `tests/unit/test_plugin_hub.py` was resolved (kept main's `TestVersionSatisfies` + `TestProtocolVersionHandshake` suites; merged in `test_lifecycle_plugins_are_registered` + `test_mcp_plugins_are_registered` next to existing discovery tests; PROTOCOL_VERSION assertion bumped to "1.1" to match the contracts file).

## Adds (vs current main)

- `core/plugin_contracts.py` — `LifecycleHook`, `McpToolFactory`, `McpResourceFactory` Protocols; bumps `PROTOCOL_VERSION = "1.1"` (additive — minor bump)
- `core/plugin_hub.py` — `lifecycle`, `mcp_tools`, `mcp_resources` slots on `PluginHub` + `_load_lifecycle` / `_load_mcp_tools` / `_load_mcp_resources` discovery
- `gispulse/adapters/http/app.py` — lifespan integrates `hub.lifecycle` (on_startup forward order, on_shutdown reverse order, both isolated by try/except)
- `gispulse/adapters/mcp/server.py` — `create_mcp_server(name, *, include_plugins=True)` factory; iterates `hub.mcp_tools` and `hub.mcp_resources` to register
- `tests/unit/test_plugin_runtime_mounting.py` (new, 91 LOC), `tests/unit/test_mcp_server.py` (+36), `test_plugin_hub.py` (+42 — lifecycle + mcp discovery tests)

## Co-author

Original work by @superWorldSavior (Erwan Lee Pesle) — credit preserved via author trailer. Maintainer signoff added (DCO) so this lands cleanly.

Closes #23.