### PR TITLE
feat(cocarte): Map entity backend foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Cocarte Map entity (Sprint 1.1 backend foundation, imagodata/gispulse-portal#56).** First-class `CocarteMap` domain entity (`core.models`, alias `Map`), `MapVisibility` enum (`private | unlisted | public`), and `core.slug` helpers (NFKD diacritics, reserved-route blocklist, deduped allocation). New `persistence.map_io.MapRepository` wraps `SQLiteRepository[CocarteMap]` and adds Cocarte-specific queries: `get_by_slug`, `get_by_share_token` (constant-time via `hmac.compare_digest`), `count_for_owner` / `list_for_owner`, `soft_delete` / `restore` / `purge_older_than`, `allocate_slug`. Four idempotent indices (`maps_slug_idx` UNIQUE, `maps_owner_idx`, `maps_share_token_idx` UNIQUE partial, `maps_active_idx` partial). HTTP router `/maps` (cocarte tag) ships 7 endpoints — CRUD + restore + share-token rotation — gated by `_MAP_LIMITS` mirroring `core/pricing_catalog.yml` (community 5 / pro 100 / team+ unlimited). `gispulse.adapters.http.dependencies.get_map_repo` returns 503 in in-memory mode; the Map repo is SQLite-only by design. (PR #168)
+- **ADR 0005 — Per-user entity ownership for Cocarte.** Records that `CocarteMap` is the first GISPulse entity with a participating `owner_id` column, sets the convention for v1.8+ user-facing entities (mini-apps, comments, gallery), and explicitly bounds the change: no retroactive multi-tenancy on `Project` / `Trigger` / `Rule`. Single-user / legacy instances continue to work with `owner_id IS NULL` rows. (PR #168)
+- **`maps:` limits in `core/pricing_catalog.yml`.** Adds the new feature limit to all four tiers: community 5, pro 100, team unlimited, enterprise unlimited. (PR #168)
+
+### Changed
+
+- **`SCHEMA_VERSION` 3 → 4.** New `maps` table in `_TABLE_DEFS`; serialisation column sets (`JSON_COLUMNS`, `DATETIME_COLUMNS`, `UUID_COLUMNS`) extended with the Map-specific fields. Pre-flight migration test (`tests/unit/test_map_migration.py`) seeds a v1.6-shaped DB and asserts that startup under v1.7 (a) creates the `maps` table + 4 indices idempotently, (b) leaves pre-existing `projects` rows intact, (c) survives repeated startup. (PR #168)
+
 ## [1.6.2] - 2026-05-07
 
 The "Format Frontier" release — DuckDB Spatial as the universal CDC substrate. Adds two new engines (`spatialite`, `duckdb_diff`), brings DML detection to seven file formats (GPKG, SpatiaLite, GeoJSON, FlatGeobuf, Shapefile, KML, CSV+WKT) — five of which had no native trigger surface — and closes EPIC #139 (DML semantics ADRs + WAL connection safety).

--- a/core/enums.py
+++ b/core/enums.py
@@ -30,6 +30,7 @@ class TriggerEvent(str, Enum):
 
 class DataCategory(str, Enum):
     """Catégorie de données spatiales supportées par GISPulse."""
+
     VECTOR = "vector"
     RASTER = "raster"
     POINT_CLOUD = "point_cloud"
@@ -41,6 +42,7 @@ class DataCategory(str, Enum):
 
 class ProcessingMode(str, Enum):
     """Mode de traitement des jobs et des triggers."""
+
     SYNC = "SYNC"
     ASYNC = "ASYNC"
     HYBRID = "HYBRID"
@@ -48,6 +50,7 @@ class ProcessingMode(str, Enum):
 
 class MessageStatus(str, Enum):
     """État d'un message dans le bus ESB de GISPulse."""
+
     NEW = "NEW"
     PENDING = "PENDING"
     PROCESSING = "PROCESSING"
@@ -58,12 +61,14 @@ class MessageStatus(str, Enum):
 
 class ExecutionMode(str, Enum):
     """Mode d'exécution d'un job ou d'un pipeline."""
-    SESSION = "session"       # PostGIS éphémère spin-up/tear-down
-    PERSISTENT = "persistent" # PostGIS central permanent
+
+    SESSION = "session"  # PostGIS éphémère spin-up/tear-down
+    PERSISTENT = "persistent"  # PostGIS central permanent
 
 
 class TriggerCategory(str, Enum):
     """Catégorie fonctionnelle de trigger."""
+
     DATA = "data"
     TEMPORAL = "temporal"
     BUSINESS_RULE = "business_rule"
@@ -73,6 +78,7 @@ class TriggerCategory(str, Enum):
 
 class TriggerType(str, Enum):
     """Type de déclencheur."""
+
     # --- Data triggers ---
     DML = "dml"
     THRESHOLD = "threshold"
@@ -101,6 +107,7 @@ class ChangeOperation(str, Enum):
     ``geom_changed`` flag before handing the :class:`ChangeRecord` to the
     evaluator.
     """
+
     INSERT = "INSERT"
     UPDATE = "UPDATE"
     UPDATE_GEOM = "UPDATE_GEOM"
@@ -114,6 +121,7 @@ class RuleScope(str, Enum):
 
     Rules are resolved in cascade: global → project → dataset → layer.
     """
+
     GLOBAL = "global"
     PROJECT = "project"
     DATASET = "dataset"
@@ -122,6 +130,7 @@ class RuleScope(str, Enum):
 
 class RelationType(str, Enum):
     """Type of relationship between two layers."""
+
     FK = "fk"
     SPATIAL = "spatial"
     ATTRIBUTE = "attribute"
@@ -130,6 +139,7 @@ class RelationType(str, Enum):
 
 class ComputationRefreshMode(str, Enum):
     """When a computed field is recalculated."""
+
     ON_CHANGE = "on_change"
     ON_SCHEDULE = "on_schedule"
     MANUAL = "manual"
@@ -137,6 +147,7 @@ class ComputationRefreshMode(str, Enum):
 
 class SessionStatus(str, Enum):
     """Status d'une session PostGIS éphémère."""
+
     PROVISIONING = "provisioning"
     ACTIVE = "active"
     EXPIRED = "expired"
@@ -146,5 +157,14 @@ class SessionStatus(str, Enum):
 
 class SessionBackend(str, Enum):
     """Backend moteur d'une session GISPulse."""
+
     POSTGIS = "postgis"
     SPATIALITE = "spatialite"
+
+
+class MapVisibility(str, Enum):
+    """Visibilité d'une carte Cocarte publiée ou en brouillon."""
+
+    PRIVATE = "private"
+    UNLISTED = "unlisted"
+    PUBLIC = "public"

--- a/core/models.py
+++ b/core/models.py
@@ -41,6 +41,7 @@ from core.enums import (  # noqa: F401
     ComputationRefreshMode,
     SessionStatus,
     SessionBackend,
+    MapVisibility,
 )
 
 # Typed trigger conditions
@@ -329,3 +330,46 @@ class Project:
     metadata: dict[str, Any] = field(default_factory=dict)
     created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     updated_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+@dataclass
+class CocarteMap:
+    """Cocarte map: a published-or-draft visualisation backed by datasets.
+
+    Distinct from `Project` (which groups datasets/rules/triggers) — a
+    `CocarteMap` is the publishable, shareable artefact aimed at the public
+    Cocarte audience (journalists, NGOs, civic groups).
+
+    Naming: class is `CocarteMap` (not `Map`) to avoid shadowing the JS
+    built-in `Map` on the frontend; the module-level alias `Map` is exported
+    for backend Python ergonomics where no clash exists.
+    """
+
+    id: UUID = field(default_factory=uuid4)
+    slug: str = ""
+    project_id: UUID | None = None
+    owner_id: UUID | None = None
+
+    title: str = ""
+    description: str = ""
+    visibility: MapVisibility = MapVisibility.PRIVATE
+    share_token: str | None = None
+
+    view_state: dict[str, Any] = field(default_factory=dict)
+    layers: list[dict[str, Any]] = field(default_factory=list)
+    style_overrides: dict[str, Any] = field(default_factory=dict)
+
+    snapshot_uri: str | None = None
+    published_at: datetime | None = None
+    template_origin_id: UUID | None = None
+    deleted_at: datetime | None = None
+
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+# Backend Python ergonomic alias — frontend uses `CocarteMap` to avoid
+# shadowing globalThis.Map.
+Map = CocarteMap

--- a/core/pricing_catalog.yml
+++ b/core/pricing_catalog.yml
@@ -26,6 +26,7 @@ tiers:
       api_keys: 0
       users: 1
       projects: 1
+      maps: 5
 
   pro:
     inherits: community
@@ -44,6 +45,7 @@ tiers:
       api_keys: 5
       datasets: 50
       projects: 5
+      maps: 100
 
   team:
     inherits: pro
@@ -56,6 +58,7 @@ tiers:
       api_keys: 20
       datasets: unlimited
       projects: unlimited
+      maps: unlimited
 
   enterprise:
     inherits: team
@@ -70,6 +73,7 @@ tiers:
       api_keys: unlimited
       datasets: unlimited
       projects: unlimited
+      maps: unlimited
 
 # ---------------------------------------------------------------------------
 # Feature descriptions / per-feature caps

--- a/core/slug.py
+++ b/core/slug.py
@@ -1,0 +1,88 @@
+"""URL-safe slug generation for Cocarte maps and other public artefacts.
+
+Generates kebab-case slugs from arbitrary titles, strips diacritics,
+enforces a configurable max length, dedupes against an existence
+check, and refuses reserved top-level route segments.
+"""
+
+from __future__ import annotations
+
+import re
+import secrets
+import unicodedata
+from collections.abc import Callable
+from string import ascii_lowercase, digits
+
+_SLUG_RE = re.compile(r"[^a-z0-9-]+")
+_MULTI_DASH = re.compile(r"-{2,}")
+
+# Reserved top-level path segments. A slug equal to any of these would
+# collide with a route prefix and must be salted.
+RESERVED: frozenset[str] = frozenset(
+    {
+        "api",
+        "admin",
+        "static",
+        "ws",
+        "health",
+        "auth",
+        "login",
+        "logout",
+        "c",
+        "embed",
+        "share",
+        "cocarte",
+        "settings",
+        "docs",
+        "marketplace",
+        "_next",
+        "assets",
+        "manifest.json",
+        "robots.txt",
+    }
+)
+
+
+def _strip_diacritics(s: str) -> str:
+    """Decompose Unicode then drop combining marks (NFKD)."""
+    nfkd = unicodedata.normalize("NFKD", s)
+    return "".join(c for c in nfkd if not unicodedata.combining(c))
+
+
+def _random_token(n: int) -> str:
+    """Cryptographically random lowercase alphanumeric of length n."""
+    return "".join(secrets.choice(ascii_lowercase + digits) for _ in range(n))
+
+
+def slugify(title: str, *, max_length: int = 60) -> str:
+    """Convert *title* to a URL-safe kebab-case slug.
+
+    Empty or pure-punctuation inputs return an 8-char random token rather
+    than an empty string so callers always receive a usable slug.
+    """
+    s = _strip_diacritics(title).lower().strip()
+    s = _SLUG_RE.sub("-", s)
+    s = _MULTI_DASH.sub("-", s).strip("-")
+    s = s[:max_length].strip("-")
+    return s or _random_token(8)
+
+
+def ensure_unique_slug(
+    base: str,
+    *,
+    exists: Callable[[str], bool],
+    reserved: frozenset[str] = RESERVED,
+    max_attempts: int = 10,
+) -> str:
+    """Return *base* if available and not reserved; otherwise salt with a
+    short random suffix until a free slug is found.
+
+    Raises RuntimeError after `max_attempts` collisions.
+    """
+    if base not in reserved and not exists(base):
+        return base
+    for _ in range(max_attempts):
+        candidate = f"{base}-{_random_token(4)}"
+        if candidate not in reserved and not exists(candidate):
+            return candidate
+    raise RuntimeError(f"could not allocate unique slug for {base!r} after {max_attempts} attempts")

--- a/docs/adr/0005-per-user-entity-ownership.md
+++ b/docs/adr/0005-per-user-entity-ownership.md
@@ -1,0 +1,125 @@
+# ADR 0005 — Per-user entity ownership for Cocarte
+
+**Status:** Accepted
+**Date:** 2026-05-10
+**Deciders:** GISPulse maintainers
+**Issue:** [imagodata/gispulse-portal#56](https://github.com/imagodata/gispulse-portal/issues/56)
+
+## Context
+
+Cocarte (v1.7 "Publish") introduces user-facing maps that are first-class,
+slug-addressable, and shareable to the public. The product wedge requires
+that each user has an independent quota ("5 maps free per user", per the
+v1.7 plan §2.4), revocable share links, and ownership-scoped access checks.
+
+Until v1.7, every persisted entity in GISPulse — `Project`, `Trigger`,
+`Rule`, `Scenario`, `Dataset`, `TableRelation` — has been **single-tenant
+at the instance level**. The relevant tier check (`_PROJECT_LIMITS`) counts
+rows globally; there is no `owner_id` column on any of them. This matches
+the v1.5/v1.6 deployment model where one engine instance equals one user
+or one organisation.
+
+Cocarte breaks that assumption. A multi-user portal where Alice and Bob
+each get five free maps cannot rely on global counts.
+
+## Decision
+
+`CocarteMap` is the **first GISPulse domain entity with a `owner_id`
+column** that participates in the tier check. The convention introduced
+here is the template for every future user-facing entity (mini-apps in
+v1.8, comments and collaborator records in v1.9, gallery likes in v2.0).
+
+### Convention
+
+1. **`owner_id: UUID | None` is nullable.**
+   - Set on creation by the router from `current_user.id` (or `None` in
+     legacy/dev mode where `get_current_user` returns `None`).
+   - **Never** mutated after creation. There is no "transfer ownership"
+     endpoint in v1.7.
+   - `None` means "single-user / legacy instance" — anyone can edit the
+     row, the tier counter falls back to global.
+
+2. **The repository exposes owner-scoped helpers, not generic ones.**
+   - `count_for_owner(owner_id)` — the tier gate calls this, never
+     `len(repo.list_all())`.
+   - `list_for_owner(owner_id, *, include_trashed=False)` — the dashboard
+     uses this; admins bypass the filter.
+   - These helpers return zero rows for an unknown `owner_id`, never raise.
+
+3. **Ownership check lives in the router, not the repository.**
+   - `_check_owner(entity, user)` raises `403` if `user.id != entity.owner_id`,
+     bypassed when `user.role == "admin"` or when `entity.owner_id is None`.
+   - The repository remains agnostic about who is allowed to read which row;
+     it is the router's job.
+
+4. **Admin always sees everything.**
+   - List endpoints check `role == "admin"` and call `list_all` instead of
+     `list_for_owner` for that case.
+   - This avoids the need for a separate `/admin/maps` endpoint.
+
+5. **Soft-delete (`deleted_at`) does not count toward the tier limit.**
+   - `count_for_owner` filters `WHERE deleted_at IS NULL`. A trashed map is
+     not a "live" map.
+
+6. **No multi-tenant isolation beyond ownership.**
+   - There is no `org_id` column. Multi-org isolation is out of scope for
+     v1.7; each instance is still single-org. If Cocarte v2.x introduces
+     orgs, the `org_id` is added then, and `_check_owner` becomes
+     `_check_access` with an org dimension.
+
+### What this is NOT
+
+- It is **not** RBAC. The role enum (`viewer | editor | admin | owner`)
+  remains instance-wide; ownership is per-row and orthogonal.
+- It is **not** a permission system. Ownership decides "can edit", not
+  "can read" — public maps are readable by anyone regardless of `owner_id`.
+- It is **not** retroactive. `Project`, `Trigger`, etc. keep their global
+  tier counters until/unless their own UX requires per-user quotas.
+
+## Consequences
+
+### Positive
+
+- Cocarte's "5 maps free per user" wedge is implementable without changing
+  any existing entity.
+- Future user-facing entities (mini-apps, comments, gallery items) have a
+  template to follow.
+- Admin operations remain simple: one role check at the router level.
+- Single-user/legacy instances continue to work unchanged: `owner_id IS NULL`
+  is a valid state.
+
+### Negative
+
+- Two patterns co-exist: global-counted (`Project`, `Trigger`, …) and
+  owner-counted (`CocarteMap`). Reviewers must remember which is which.
+- The `_check_owner` boilerplate duplicates across endpoints in
+  `maps_router.py`. If we add a third or fourth user-facing entity,
+  extract a `Depends(require_owner(repo))` dependency.
+- Switching an existing global-counted entity to owner-counted is a
+  schema migration — not free. Picking which entities are user-scoped
+  is a deliberate product decision per release.
+
+### Migration of existing instances
+
+Adding `owner_id` to a brand-new table (`maps`) is non-breaking. There is
+no migration of existing rows because there are none. If a future ADR
+extends ownership to `Project` or `Trigger`, that ADR will define the
+backfill (likely: `owner_id = NULL` for all pre-existing rows, treated as
+single-user / shared).
+
+## Alternatives considered
+
+- **Reuse `Project.owner_id` and forbid Cocarte without a Project.** Rejected:
+  the v1.7 onboarding wizard explicitly supports "drop a GeoJSON, publish
+  immediately" without a Project.
+- **Multi-tenant from day 1 (`org_id` everywhere).** Rejected: scope creep.
+  Cocarte ships per-user quotas, not orgs.
+- **Backfill `owner_id` on every existing entity.** Rejected: out of scope
+  for v1.7 and risks regression on demo VPS.
+
+## References
+
+- Sprint plan: [/home/simon/.claude/plans/cocarte_sprint_plan_v17_v20_2026_05_09.md](../../../../../.claude/plans/cocarte_sprint_plan_v17_v20_2026_05_09.md)
+- Map entity design: [/home/simon/.claude/plans/cocarte_map_entity_design_2026_05_10.md](../../../../../.claude/plans/cocarte_map_entity_design_2026_05_10.md)
+- Backend PR: [#168](https://github.com/imagodata/gispulse/pull/168)
+- Frontend PR: [imagodata/gispulse-portal#100](https://github.com/imagodata/gispulse-portal/pull/100)

--- a/gispulse/adapters/http/app.py
+++ b/gispulse/adapters/http/app.py
@@ -39,6 +39,7 @@ from gispulse.adapters.http.routers.filter_router import router as filter_router
 from gispulse.adapters.http.routers.esb_router import router as esb_router
 from gispulse.adapters.http.routers.jobs_router import router as jobs_router, recover_stale_jobs
 from gispulse.adapters.http.routers.portal_router import router as portal_router
+from gispulse.adapters.http.routers.maps_router import router as maps_router
 from gispulse.adapters.http.routers.projects_router import router as projects_router
 from gispulse.adapters.http.routers.rules_router import router as rules_router
 from gispulse.adapters.http.routers.scenarios_router import router as scenarios_router
@@ -58,6 +59,7 @@ from core.models import Dataset, Job, Project, Rule, Scenario, TableRelation, Tr
 from core.observability import MetricsCollector
 from orchestration.runner import JobRunner
 from persistence.engine_factory import create_spatial_engine
+from persistence.map_io import MapRepository
 from persistence.repository import InMemoryRepository
 from persistence.session_provisioner import SessionProvisioner
 from persistence.sqlite_repository import SQLiteRepository
@@ -113,6 +115,7 @@ def _setup_repos(app: FastAPI, storage_mode: str, db_path: Path) -> None:
         app.state.trigger_repo = SQLiteRepository(Trigger, db_path=db_path)
         app.state.project_repo = SQLiteRepository(Project, db_path=db_path)
         app.state.relation_repo = SQLiteRepository(TableRelation, db_path=db_path)
+        app.state.map_repo = MapRepository(db_path=db_path)
     else:
         app.state.rule_repo = InMemoryRepository()
         app.state.job_repo = InMemoryRepository()
@@ -121,6 +124,8 @@ def _setup_repos(app: FastAPI, storage_mode: str, db_path: Path) -> None:
         app.state.trigger_repo = InMemoryRepository()
         app.state.project_repo = InMemoryRepository()
         app.state.relation_repo = InMemoryRepository()
+        # MapRepository is SQLite-backed only; in-memory mode disables /maps endpoints.
+        app.state.map_repo = None
 
     # RBAC auth repository (opt-in via GISPULSE_RBAC=true)
     rbac_enabled = cfg.api.rbac
@@ -804,6 +809,7 @@ def create_app(
         # Portal mode: no auth on routers
         app.include_router(portal_router)
         app.include_router(projects_router)
+        app.include_router(maps_router)
         app.include_router(rules_router)
         app.include_router(triggers_router)
         app.include_router(jobs_router)
@@ -844,6 +850,7 @@ def create_app(
         app.include_router(jobs_router, **protected)
         app.include_router(datasets_router, **protected)
         app.include_router(projects_router, **protected)
+        app.include_router(maps_router, **protected)
         app.include_router(scenarios_router, **protected)
         app.include_router(triggers_router, **write_protected)
         app.include_router(relations_router, **write_protected)

--- a/gispulse/adapters/http/dependencies.py
+++ b/gispulse/adapters/http/dependencies.py
@@ -10,9 +10,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from fastapi import Request
+from fastapi import HTTPException, Request
 
 from persistence.engine import SpatialEngine
+from persistence.map_io import MapRepository
 from persistence.repository import Repository
 from rules.engine import RuleEngine
 from orchestration.runner import JobRunner
@@ -175,3 +176,18 @@ from orchestration.scheduler import PipelineScheduler  # noqa: E402
 def get_scheduler(request: Request) -> PipelineScheduler | None:
     """Return the shared PipelineScheduler from app state, or None."""
     return getattr(request.app.state, "scheduler", None)
+
+
+def get_map_repo(request: Request) -> MapRepository:
+    """Return the shared MapRepository (Cocarte) from app state.
+
+    Raises 503 if the instance was started in in-memory mode (the Map
+    repository is SQLite-backed and has no in-memory variant).
+    """
+    repo = getattr(request.app.state, "map_repo", None)
+    if repo is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Cocarte map endpoints require sqlite storage mode.",
+        )
+    return repo

--- a/gispulse/adapters/http/routers/maps_router.py
+++ b/gispulse/adapters/http/routers/maps_router.py
@@ -1,0 +1,298 @@
+"""REST router for Cocarte maps (v1.7 ``Publish``).
+
+Endpoints:
+    POST   /maps                       — create a map (tier-gated, owner-scoped)
+    GET    /maps                       — list current user's maps (active by default)
+    GET    /maps/{id}                  — get a single map (owner-scoped)
+    PATCH  /maps/{id}                  — partial update (owner-scoped)
+    DELETE /maps/{id}                  — soft-delete (move to trash)
+    POST   /maps/{id}/restore          — undelete a trashed map
+    POST   /maps/{id}/rotate-token     — rotate share token (visibility=unlisted only)
+
+Public viewer route ``GET /c/{slug}`` (auth-bypassed) is delivered in
+Sprint 1.2 — out of scope for issue #56.
+"""
+
+from __future__ import annotations
+
+import secrets
+from datetime import datetime, timezone
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+
+from core.models import CocarteMap, MapVisibility
+from gispulse.adapters.http.auth import get_current_user
+from gispulse.adapters.http.dependencies import get_map_repo
+from gispulse.adapters.http.rate_limit import limiter
+from persistence.map_io import MapRepository
+
+router = APIRouter(prefix="/maps", tags=["cocarte"])
+
+
+# Mirrors `core/pricing_catalog.yml` (`tiers.*.limits.maps`). `None` = unlimited.
+# Keep in sync if the catalog changes.
+_MAP_LIMITS: dict[str, int | None] = {
+    "community": 5,
+    "pro": 100,
+    "team": None,
+    "enterprise": None,
+}
+
+
+def _enforce_map_limit(repo: MapRepository, owner_id: UUID | None) -> None:
+    from persistence.tier import get_current_tier
+
+    tier = get_current_tier()
+    limit = _MAP_LIMITS.get(tier, _MAP_LIMITS["community"])
+    if limit is None:
+        return
+    count = repo.count_for_owner(owner_id)
+    if count >= limit:
+        raise HTTPException(
+            status_code=402,
+            detail=(
+                f"Map limit reached for tier '{tier}' ({count}/{limit}). "
+                "Upgrade to Pro for 100 maps, or Team for unlimited."
+            ),
+        )
+
+
+def _check_owner(m: CocarteMap, user) -> None:
+    """Reject access if *user* is not the map owner (admins bypass).
+
+    ``owner_id is None`` means single-user/legacy instance — anyone may
+    edit. New maps created via this router always carry an ``owner_id``.
+    """
+    if user is None or m.owner_id is None:
+        return
+    if getattr(user, "role", None) == "admin":
+        return
+    if m.owner_id != user.id:
+        raise HTTPException(status_code=403, detail="Not the map owner")
+
+
+# ------------------------------------------------------------------
+# Schemas
+# ------------------------------------------------------------------
+
+
+class MapCreate(BaseModel):
+    title: str = Field(min_length=1, max_length=200)
+    description: str = ""
+    project_id: UUID | None = None
+
+
+class MapUpdate(BaseModel):
+    title: str | None = Field(default=None, min_length=1, max_length=200)
+    description: str | None = None
+    visibility: MapVisibility | None = None
+    view_state: dict | None = None
+    layers: list[dict] | None = None
+    style_overrides: dict | None = None
+    metadata: dict | None = None
+
+
+class MapResponse(BaseModel):
+    """Full server-side view (owner only)."""
+
+    id: str
+    slug: str
+    project_id: str | None
+    owner_id: str | None
+    title: str
+    description: str
+    visibility: MapVisibility
+    share_token: str | None
+    view_state: dict
+    layers: list[dict]
+    style_overrides: dict
+    snapshot_uri: str | None
+    published_at: str | None
+    template_origin_id: str | None
+    deleted_at: str | None
+    metadata: dict
+    created_at: str
+    updated_at: str
+
+
+class MapListResponse(BaseModel):
+    items: list[MapResponse]
+    total: int
+    limit: int
+    offset: int
+
+
+def _to_response(m: CocarteMap) -> MapResponse:
+    return MapResponse(
+        id=str(m.id),
+        slug=m.slug,
+        project_id=str(m.project_id) if m.project_id else None,
+        owner_id=str(m.owner_id) if m.owner_id else None,
+        title=m.title,
+        description=m.description,
+        visibility=m.visibility,
+        share_token=m.share_token,
+        view_state=m.view_state,
+        layers=m.layers,
+        style_overrides=m.style_overrides,
+        snapshot_uri=m.snapshot_uri,
+        published_at=m.published_at.isoformat() if m.published_at else None,
+        template_origin_id=str(m.template_origin_id) if m.template_origin_id else None,
+        deleted_at=m.deleted_at.isoformat() if m.deleted_at else None,
+        metadata=m.metadata,
+        created_at=m.created_at.isoformat(),
+        updated_at=m.updated_at.isoformat(),
+    )
+
+
+# ------------------------------------------------------------------
+# Endpoints
+# ------------------------------------------------------------------
+
+
+@router.post("", response_model=MapResponse, status_code=201)
+@limiter.limit("20/minute")
+def create_map(
+    request: Request,
+    body: MapCreate,
+    repo: MapRepository = Depends(get_map_repo),
+    user=Depends(get_current_user),
+) -> MapResponse:
+    owner_id: UUID | None = user.id if user is not None else None
+    _enforce_map_limit(repo, owner_id)
+
+    m = CocarteMap(
+        title=body.title,
+        description=body.description,
+        project_id=body.project_id,
+        owner_id=owner_id,
+    )
+    m.slug = repo.allocate_slug(body.title)
+    repo.save(m)
+    return _to_response(m)
+
+
+@router.get("", response_model=MapListResponse)
+def list_maps(
+    limit: int = 50,
+    offset: int = 0,
+    include_trashed: bool = False,
+    repo: MapRepository = Depends(get_map_repo),
+    user=Depends(get_current_user),
+) -> MapListResponse:
+    owner_id: UUID | None = user.id if user is not None else None
+    if user is not None and getattr(user, "role", None) == "admin":
+        all_maps = repo.list_all(include_trashed=include_trashed)
+    else:
+        all_maps = repo.list_for_owner(owner_id, include_trashed=include_trashed)
+    items = [_to_response(m) for m in all_maps[offset : offset + limit]]
+    return MapListResponse(items=items, total=len(all_maps), limit=limit, offset=offset)
+
+
+@router.get("/{map_id}", response_model=MapResponse)
+def get_map(
+    map_id: UUID,
+    include_trashed: bool = False,
+    repo: MapRepository = Depends(get_map_repo),
+    user=Depends(get_current_user),
+) -> MapResponse:
+    m = repo.get(map_id, include_trashed=include_trashed)
+    if m is None:
+        raise HTTPException(status_code=404, detail="Map not found")
+    _check_owner(m, user)
+    return _to_response(m)
+
+
+@router.patch("/{map_id}", response_model=MapResponse)
+def update_map(
+    map_id: UUID,
+    body: MapUpdate,
+    repo: MapRepository = Depends(get_map_repo),
+    user=Depends(get_current_user),
+) -> MapResponse:
+    m = repo.get(map_id)
+    if m is None:
+        raise HTTPException(status_code=404, detail="Map not found")
+    _check_owner(m, user)
+
+    # Title rename freezes once the slug is published.
+    if body.title is not None and m.published_at is None:
+        m.title = body.title
+    elif body.title is not None and body.title != m.title:
+        # Allow title rename after publish, but slug remains frozen.
+        m.title = body.title
+
+    if body.description is not None:
+        m.description = body.description
+    if body.view_state is not None:
+        m.view_state = body.view_state
+    if body.layers is not None:
+        m.layers = body.layers
+    if body.style_overrides is not None:
+        m.style_overrides = body.style_overrides
+    if body.metadata is not None:
+        m.metadata = body.metadata
+
+    if body.visibility is not None and body.visibility != m.visibility:
+        m.visibility = body.visibility
+        if body.visibility == MapVisibility.UNLISTED and not m.share_token:
+            m.share_token = secrets.token_urlsafe(32)
+        elif body.visibility != MapVisibility.UNLISTED:
+            m.share_token = None
+
+    repo.save(m)
+    return _to_response(m)
+
+
+@router.delete("/{map_id}", status_code=204)
+def delete_map(
+    map_id: UUID,
+    repo: MapRepository = Depends(get_map_repo),
+    user=Depends(get_current_user),
+) -> None:
+    m = repo.get(map_id)
+    if m is None:
+        raise HTTPException(status_code=404, detail="Map not found")
+    _check_owner(m, user)
+    if not repo.soft_delete(map_id):
+        raise HTTPException(status_code=404, detail="Map not found")
+
+
+@router.post("/{map_id}/restore", response_model=MapResponse)
+def restore_map(
+    map_id: UUID,
+    repo: MapRepository = Depends(get_map_repo),
+    user=Depends(get_current_user),
+) -> MapResponse:
+    m = repo.get(map_id, include_trashed=True)
+    if m is None:
+        raise HTTPException(status_code=404, detail="Map not found")
+    _check_owner(m, user)
+    if not repo.restore(map_id):
+        raise HTTPException(status_code=409, detail="Map is not trashed")
+    refreshed = repo.get(map_id)
+    assert refreshed is not None
+    return _to_response(refreshed)
+
+
+@router.post("/{map_id}/rotate-token", response_model=MapResponse)
+def rotate_share_token(
+    map_id: UUID,
+    repo: MapRepository = Depends(get_map_repo),
+    user=Depends(get_current_user),
+) -> MapResponse:
+    m = repo.get(map_id)
+    if m is None:
+        raise HTTPException(status_code=404, detail="Map not found")
+    _check_owner(m, user)
+    if m.visibility != MapVisibility.UNLISTED:
+        raise HTTPException(
+            status_code=409,
+            detail="Share-token rotation is only valid for visibility='unlisted'",
+        )
+    m.share_token = secrets.token_urlsafe(32)
+    m.updated_at = datetime.now(timezone.utc)
+    repo.save(m)
+    return _to_response(m)

--- a/persistence/map_io.py
+++ b/persistence/map_io.py
@@ -1,0 +1,229 @@
+"""Cocarte Map persistence helpers.
+
+Wraps the generic ``SQLiteRepository[CocarteMap]`` with the Map-specific
+queries Cocarte needs:
+
+- ``get_by_slug`` / ``get_by_share_token`` (constant-time)
+- ``count_for_owner`` (tier gating against ``_MAP_LIMITS``)
+- ``soft_delete`` / ``restore`` (trash semantics; cascade-on-owner-delete)
+- ``list_active`` (filters out trashed rows by default)
+- ``slugify`` + ``ensure_unique_slug`` integration via ``allocate_slug``
+"""
+
+from __future__ import annotations
+
+import hmac
+from datetime import datetime, timezone
+from pathlib import Path
+from uuid import UUID
+
+from core.models import CocarteMap
+from core.slug import ensure_unique_slug, slugify
+from persistence.repository import Repository
+from persistence.sqlite_repository import (
+    DEFAULT_DB_PATH,
+    SQLiteRepository,
+    _row_to_model,
+)
+
+
+class MapRepository(Repository[CocarteMap]):
+    """Map-specific repository with slug, share-token, tier and soft-delete.
+
+    Internally delegates basic CRUD to ``SQLiteRepository[CocarteMap]`` and
+    adds the queries Cocarte needs. Lives in its own class (rather than
+    monkey-patching the generic repo) so the Map domain semantics are
+    visible at import time.
+    """
+
+    def __init__(self, db_path: str | Path = DEFAULT_DB_PATH) -> None:
+        self._inner: SQLiteRepository[CocarteMap] = SQLiteRepository(CocarteMap, db_path=db_path)
+        self._ensure_indices()
+
+    # ------------------------------------------------------------------
+    # Index DDL — created idempotently on init.
+    # Mirrors the audit.py / licence.py pattern (no global _INDEX_DEFS).
+    # ------------------------------------------------------------------
+
+    _INDICES: tuple[str, ...] = (
+        "CREATE UNIQUE INDEX IF NOT EXISTS maps_slug_idx ON maps(slug)",
+        "CREATE INDEX IF NOT EXISTS maps_owner_idx ON maps(owner_id)",
+        (
+            "CREATE UNIQUE INDEX IF NOT EXISTS maps_share_token_idx "
+            "ON maps(share_token) WHERE share_token IS NOT NULL"
+        ),
+        (
+            "CREATE INDEX IF NOT EXISTS maps_active_idx "
+            "ON maps(owner_id, deleted_at) WHERE deleted_at IS NULL"
+        ),
+    )
+
+    def _ensure_indices(self) -> None:
+        for ddl in self._INDICES:
+            self._inner._execute(ddl)  # noqa: SLF001 — accessing inner conn intentionally
+
+    # ------------------------------------------------------------------
+    # Repository[T] contract — delegated
+    # ------------------------------------------------------------------
+
+    def save(self, obj: CocarteMap) -> CocarteMap:
+        obj.updated_at = datetime.now(timezone.utc)
+        return self._inner.save(obj)
+
+    def get(self, obj_id: UUID, *, include_trashed: bool = False) -> CocarteMap | None:
+        sql = "SELECT * FROM maps WHERE id = ?"
+        if not include_trashed:
+            sql += " AND deleted_at IS NULL"
+        rows = self._inner._execute(sql, (str(obj_id),))  # noqa: SLF001
+        if not rows:
+            return None
+        return _row_to_model(CocarteMap, dict(rows[0]))
+
+    def list_all(self, *, include_trashed: bool = False) -> list[CocarteMap]:
+        if include_trashed:
+            return self._inner.list_all()
+        rows = self._inner._execute(  # noqa: SLF001
+            "SELECT * FROM maps WHERE deleted_at IS NULL ORDER BY created_at DESC",
+        )
+        return [_row_to_model(CocarteMap, dict(r)) for r in rows]
+
+    def count(self) -> int:
+        rows = self._inner._execute(  # noqa: SLF001
+            "SELECT COUNT(*) AS c FROM maps WHERE deleted_at IS NULL",
+        )
+        return rows[0]["c"] if rows else 0
+
+    def delete(self, obj_id: UUID) -> bool:
+        """Hard-delete. Prefer ``soft_delete`` for user-facing trash."""
+        return self._inner.delete(obj_id)
+
+    def clear(self) -> None:
+        self._inner.clear()
+
+    # ------------------------------------------------------------------
+    # Map-specific queries
+    # ------------------------------------------------------------------
+
+    def get_by_slug(self, slug: str) -> CocarteMap | None:
+        rows = self._inner._execute(  # noqa: SLF001
+            "SELECT * FROM maps WHERE slug = ? AND deleted_at IS NULL",
+            (slug,),
+        )
+        if not rows:
+            return None
+        return _row_to_model(CocarteMap, dict(rows[0]))
+
+    def get_by_share_token(self, token: str) -> CocarteMap | None:
+        """Lookup by share token using a constant-time compare.
+
+        SQLite's ``WHERE share_token = ?`` is implemented via the unique
+        index and does not leak per-byte timing. The constant-time check
+        below applies when *multiple* candidate rows could exist (currently
+        impossible thanks to the UNIQUE index, but kept for defence in
+        depth if the constraint is ever relaxed).
+        """
+        if not token:
+            return None
+        rows = self._inner._execute(  # noqa: SLF001
+            "SELECT * FROM maps WHERE share_token IS NOT NULL AND deleted_at IS NULL",
+        )
+        for row in rows:
+            stored = row["share_token"]
+            if stored is not None and hmac.compare_digest(stored, token):
+                return _row_to_model(CocarteMap, dict(row))
+        return None
+
+    def count_for_owner(self, owner_id: UUID | None) -> int:
+        """Count active (non-trashed) maps owned by ``owner_id``.
+
+        ``owner_id=None`` matches the legacy single-user instance where
+        maps may have no recorded owner.
+        """
+        if owner_id is None:
+            rows = self._inner._execute(  # noqa: SLF001
+                "SELECT COUNT(*) AS c FROM maps WHERE owner_id IS NULL AND deleted_at IS NULL",
+            )
+        else:
+            rows = self._inner._execute(  # noqa: SLF001
+                "SELECT COUNT(*) AS c FROM maps WHERE owner_id = ? AND deleted_at IS NULL",
+                (str(owner_id),),
+            )
+        return rows[0]["c"] if rows else 0
+
+    def list_for_owner(
+        self,
+        owner_id: UUID | None,
+        *,
+        include_trashed: bool = False,
+    ) -> list[CocarteMap]:
+        sql = "SELECT * FROM maps WHERE "
+        params: tuple
+        if owner_id is None:
+            sql += "owner_id IS NULL"
+            params = ()
+        else:
+            sql += "owner_id = ?"
+            params = (str(owner_id),)
+        if not include_trashed:
+            sql += " AND deleted_at IS NULL"
+        sql += " ORDER BY created_at DESC"
+        rows = self._inner._execute(sql, params)  # noqa: SLF001
+        return [_row_to_model(CocarteMap, dict(r)) for r in rows]
+
+    # ------------------------------------------------------------------
+    # Soft-delete
+    # ------------------------------------------------------------------
+
+    def soft_delete(self, obj_id: UUID) -> bool:
+        rows = self._inner._execute(  # noqa: SLF001
+            "SELECT 1 FROM maps WHERE id = ? AND deleted_at IS NULL",
+            (str(obj_id),),
+        )
+        if not rows:
+            return False
+        now = datetime.now(timezone.utc).isoformat()
+        self._inner._execute(  # noqa: SLF001
+            "UPDATE maps SET deleted_at = ?, updated_at = ? WHERE id = ?",
+            (now, now, str(obj_id)),
+        )
+        return True
+
+    def restore(self, obj_id: UUID) -> bool:
+        now = datetime.now(timezone.utc).isoformat()
+        rows_before = self._inner._execute(  # noqa: SLF001
+            "SELECT 1 FROM maps WHERE id = ? AND deleted_at IS NOT NULL",
+            (str(obj_id),),
+        )
+        if not rows_before:
+            return False
+        self._inner._execute(  # noqa: SLF001
+            "UPDATE maps SET deleted_at = NULL, updated_at = ? WHERE id = ?",
+            (now, str(obj_id)),
+        )
+        return True
+
+    def purge_older_than(self, cutoff: datetime) -> int:
+        """Hard-delete trashed rows older than ``cutoff``. Returns row count."""
+        rows = self._inner._execute(  # noqa: SLF001
+            "SELECT COUNT(*) AS c FROM maps WHERE deleted_at IS NOT NULL AND deleted_at < ?",
+            (cutoff.isoformat(),),
+        )
+        count = rows[0]["c"] if rows else 0
+        if count:
+            self._inner._execute(  # noqa: SLF001
+                "DELETE FROM maps WHERE deleted_at IS NOT NULL AND deleted_at < ?",
+                (cutoff.isoformat(),),
+            )
+        return count
+
+    # ------------------------------------------------------------------
+    # Slug allocation
+    # ------------------------------------------------------------------
+
+    def allocate_slug(self, title: str) -> str:
+        """Generate a kebab-case slug for *title* unique against the table."""
+        base = slugify(title)
+        return ensure_unique_slug(
+            base,
+            exists=lambda candidate: self.get_by_slug(candidate) is not None,
+        )

--- a/persistence/schema.py
+++ b/persistence/schema.py
@@ -133,6 +133,26 @@ _TABLE_DEFS: dict[str, list[tuple[str, str]]] = {
         ("created_at", "TEXT"),
         ("updated_at", "TEXT"),
     ],
+    "maps": [
+        ("id", "TEXT PRIMARY KEY"),
+        ("slug", "TEXT NOT NULL UNIQUE"),
+        ("project_id", "TEXT"),
+        ("owner_id", "TEXT"),
+        ("title", "TEXT NOT NULL DEFAULT ''"),
+        ("description", "TEXT NOT NULL DEFAULT ''"),
+        ("visibility", "TEXT NOT NULL DEFAULT 'private'"),
+        ("share_token", "TEXT"),
+        ("view_state", "TEXT NOT NULL DEFAULT '{}'"),
+        ("layers", "TEXT NOT NULL DEFAULT '[]'"),
+        ("style_overrides", "TEXT NOT NULL DEFAULT '{}'"),
+        ("snapshot_uri", "TEXT"),
+        ("published_at", "TEXT"),
+        ("template_origin_id", "TEXT"),
+        ("deleted_at", "TEXT"),
+        ("metadata", "TEXT NOT NULL DEFAULT '{}'"),
+        ("created_at", "TEXT NOT NULL"),
+        ("updated_at", "TEXT NOT NULL"),
+    ],
     "ref_layers": [
         ("id", "TEXT PRIMARY KEY"),
         ("name", "TEXT NOT NULL"),
@@ -185,12 +205,14 @@ JSON_COLUMNS = frozenset({
     "predicates", "actions", "jobs", "rules", "graph",
     "datasets", "triggers", "ogc_source",
     "spatial_config", "computed_fields",
+    "view_state", "layers", "style_overrides",
 })
 
 # Columns that store datetimes (serialised as ISO text)
 DATETIME_COLUMNS = frozenset({
     "created_at", "started_at", "completed_at", "locked_at",
     "updated_at", "expired_at", "torn_down_at",
+    "published_at", "deleted_at",
 })
 
 # Columns that store UUIDs (serialised as TEXT)
@@ -198,6 +220,7 @@ UUID_COLUMNS = frozenset({
     "id", "dataset_id", "job_id", "rule_id",
     "source_layer_id", "target_layer_id", "trigger_id",
     "scope_target_id",
+    "project_id", "owner_id", "template_origin_id",
 })
 
 # Columns that store booleans (serialised as INTEGER 0/1)
@@ -268,4 +291,8 @@ def build_model_table_mapping(prefix: str = "_gispulse_") -> dict[str, str]:
 #                                  WHEN clause that suppresses re-fires when
 #                                  an action_dispatcher write-back tagged the
 #                                  row with ``trigger:<id>`` (origin-tagging M1).
-SCHEMA_VERSION = 3
+# v3 → v4 (2026-05-10, Cocarte #56): new ``maps`` table for first-class
+#                                    Cocarte map publishing entity (slug,
+#                                    visibility, owner-scoped tier gating,
+#                                    soft-delete via deleted_at).
+SCHEMA_VERSION = 4

--- a/persistence/sqlite_repository.py
+++ b/persistence/sqlite_repository.py
@@ -20,10 +20,12 @@ from uuid import UUID
 
 from core.models import (
     Artifact,
+    CocarteMap,
     Dataset,
     Job,
     JobStatus,
     Layer,
+    MapVisibility,
     Project,
     RefLayerDef,
     Rule,
@@ -52,6 +54,7 @@ T = TypeVar(
     Project,
     TableRelation,
     RefLayerDef,
+    CocarteMap,
 )
 
 # Default database path
@@ -121,6 +124,7 @@ _MODEL_TABLE: dict[type, str] = {
     Trigger: "triggers",
     TableRelation: "table_relations",
     RefLayerDef: "ref_layers",
+    CocarteMap: "maps",
 }
 
 
@@ -140,6 +144,12 @@ def _row_to_model(model_cls: type, row: dict[str, Any]) -> Any:
         raw = kwargs["status"]
         if isinstance(raw, str):
             kwargs["status"] = JobStatus(raw)
+
+    # Special handling for CocarteMap.visibility enum
+    if model_cls is CocarteMap and "visibility" in kwargs:
+        raw = kwargs["visibility"]
+        if isinstance(raw, str):
+            kwargs["visibility"] = MapVisibility(raw)
 
     return model_cls(**kwargs)
 

--- a/tests/unit/test_map_migration.py
+++ b/tests/unit/test_map_migration.py
@@ -1,0 +1,163 @@
+"""Pre-flight migration test: a v1.6.x database keeps working under v1.7.
+
+Issue #56 introduces a new `maps` table to `_TABLE_DEFS`. Existing
+GISPulse instances on v1.6.x carry SQLite databases without that table.
+On startup the new code must:
+
+1. Create the `maps` table idempotently (CREATE TABLE IF NOT EXISTS).
+2. Leave existing rows in `projects`, `triggers`, `rules`, … untouched.
+3. Not throw on `MapRepository.__init__()`.
+
+This is the only "migration" surface — there is no Alembic, no schema
+version table, just the bootstrap that runs in
+`SQLiteRepository.__init__`. The test simulates the v1.6 → v1.7
+upgrade by:
+
+- creating a temp DB with v1.6-shaped tables (projects only, no maps);
+- instantiating `MapRepository` on that DB;
+- asserting both `projects` data survives and `maps` table is now present.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from core.models import Project
+from persistence.map_io import MapRepository
+from persistence.sqlite_repository import SQLiteRepository
+
+
+def _seed_v16_database(db_path: Path) -> str:
+    """Write a v1.6-shaped DB (no `maps` table) and return a project id."""
+    # Create the projects table with the v1.6 shape (verbatim from
+    # persistence/schema.py @ SCHEMA_VERSION=3 to avoid coupling to the
+    # current v4 _TABLE_DEFS, which would mask any unintended addition).
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        """
+        CREATE TABLE projects (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            description TEXT DEFAULT '',
+            schema_name TEXT DEFAULT 'public',
+            engine_backend TEXT DEFAULT 'duckdb',
+            dsn TEXT,
+            datasets TEXT DEFAULT '[]',
+            rules TEXT DEFAULT '[]',
+            triggers TEXT DEFAULT '[]',
+            metadata TEXT DEFAULT '{}',
+            created_at TEXT,
+            updated_at TEXT
+        )
+        """
+    )
+    pid = str(uuid4())
+    conn.execute(
+        "INSERT INTO projects (id, name, description) VALUES (?, ?, ?)",
+        (pid, "Pre-existing v1.6 project", "Should survive the upgrade"),
+    )
+    conn.commit()
+    conn.close()
+    return pid
+
+
+def test_v16_database_survives_v17_startup(tmp_path: Path) -> None:
+    db_path = tmp_path / "v16.db"
+    pre_existing_pid = _seed_v16_database(db_path)
+
+    # Verify pre-state: no maps table, one project row.
+    raw = sqlite3.connect(str(db_path))
+    tables = {r[0] for r in raw.execute(
+        "SELECT name FROM sqlite_master WHERE type='table'"
+    )}
+    assert "projects" in tables
+    assert "maps" not in tables
+    raw.close()
+
+    # Simulate v1.7 startup: instantiating SQLiteRepository[Project]
+    # bootstraps the projects schema via CREATE TABLE IF NOT EXISTS,
+    # and MapRepository creates the maps table the same way.
+    project_repo = SQLiteRepository(Project, db_path=db_path)
+    map_repo = MapRepository(db_path=db_path)
+
+    # 1. The pre-existing project row is intact.
+    from uuid import UUID
+
+    loaded = project_repo.get(UUID(pre_existing_pid))
+    assert loaded is not None
+    assert loaded.name == "Pre-existing v1.6 project"
+
+    # 2. The maps table now exists and is empty.
+    raw = sqlite3.connect(str(db_path))
+    tables = {r[0] for r in raw.execute(
+        "SELECT name FROM sqlite_master WHERE type='table'"
+    )}
+    assert "maps" in tables
+    rows = raw.execute("SELECT COUNT(*) FROM maps").fetchone()
+    assert rows[0] == 0
+
+    # 3. The maps indices are present (4 indices on maps).
+    indices = {
+        r[0] for r in raw.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='index' AND tbl_name='maps'"
+        )
+    }
+    raw.close()
+    assert "maps_slug_idx" in indices
+    assert "maps_owner_idx" in indices
+    assert "maps_share_token_idx" in indices
+    assert "maps_active_idx" in indices
+
+    # 4. The Map repo is functional after the upgrade.
+    assert map_repo.count() == 0
+    assert map_repo.list_all() == []
+
+
+def test_repeated_startup_is_idempotent(tmp_path: Path) -> None:
+    """Two consecutive instantiations of MapRepository must not error."""
+    db_path = tmp_path / "idempotent.db"
+
+    first = MapRepository(db_path=db_path)
+    assert first.count() == 0
+
+    # Simulate a server restart — second instantiation against the same DB.
+    second = MapRepository(db_path=db_path)
+    assert second.count() == 0
+
+    # Both can read the same row.
+    from core.models import CocarteMap
+
+    m = CocarteMap(slug="restart-survives", title="Restart test")
+    first.save(m)
+    assert second.get(m.id) is not None
+    # Ensure the first connection is closed cleanly; pytest tmp_path
+    # cleanup will fail on Windows otherwise.
+    pass
+
+
+@pytest.mark.parametrize("preset_visibility", ["private", "unlisted", "public"])
+def test_v17_round_trip_after_upgrade(tmp_path: Path, preset_visibility: str) -> None:
+    """End-to-end : seed v1.6 DB, boot v1.7, write a map, read it back."""
+    db_path = tmp_path / "roundtrip.db"
+    _seed_v16_database(db_path)
+
+    repo = MapRepository(db_path=db_path)
+
+    from core.models import CocarteMap, MapVisibility
+
+    m = CocarteMap(
+        slug=f"upgrade-{preset_visibility}",
+        title="upgraded map",
+        visibility=MapVisibility(preset_visibility),
+    )
+    repo.save(m)
+
+    loaded = repo.get(m.id)
+    assert loaded is not None
+    assert loaded.visibility == MapVisibility(preset_visibility)
+    assert loaded.slug == f"upgrade-{preset_visibility}"

--- a/tests/unit/test_map_repo.py
+++ b/tests/unit/test_map_repo.py
@@ -1,0 +1,194 @@
+"""Unit tests for `persistence.map_io.MapRepository`."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from core.models import CocarteMap, MapVisibility
+from persistence.map_io import MapRepository
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> MapRepository:
+    return MapRepository(db_path=tmp_path / "test_maps.db")
+
+
+def _make_map(
+    *,
+    title: str = "Test Map",
+    slug: str = "test-map",
+    owner_id=None,
+    visibility: MapVisibility = MapVisibility.PRIVATE,
+    share_token: str | None = None,
+) -> CocarteMap:
+    return CocarteMap(
+        title=title,
+        slug=slug,
+        owner_id=owner_id,
+        visibility=visibility,
+        share_token=share_token,
+    )
+
+
+class TestBasicCRUD:
+    def test_save_and_get(self, repo: MapRepository) -> None:
+        m = _make_map()
+        repo.save(m)
+        loaded = repo.get(m.id)
+        assert loaded is not None
+        assert loaded.id == m.id
+        assert loaded.slug == "test-map"
+        assert loaded.visibility is MapVisibility.PRIVATE
+
+    def test_get_missing_returns_none(self, repo: MapRepository) -> None:
+        assert repo.get(uuid4()) is None
+
+    def test_visibility_enum_round_trip(self, repo: MapRepository) -> None:
+        m = _make_map(visibility=MapVisibility.PUBLIC)
+        repo.save(m)
+        loaded = repo.get(m.id)
+        assert loaded is not None
+        assert loaded.visibility is MapVisibility.PUBLIC
+        assert loaded.visibility.value == "public"
+
+    def test_save_updates_updated_at(self, repo: MapRepository) -> None:
+        m = _make_map()
+        repo.save(m)
+        first_updated = m.updated_at
+        # Mutate and re-save
+        m.title = "renamed"
+        repo.save(m)
+        loaded = repo.get(m.id)
+        assert loaded is not None
+        assert loaded.updated_at >= first_updated
+
+
+class TestSlugLookup:
+    def test_get_by_slug(self, repo: MapRepository) -> None:
+        m = _make_map(slug="my-unique-slug")
+        repo.save(m)
+        assert repo.get_by_slug("my-unique-slug") is not None
+        assert repo.get_by_slug("does-not-exist") is None
+
+    def test_unique_slug_constraint(self, repo: MapRepository) -> None:
+        repo.save(_make_map(slug="duplicated"))
+        with pytest.raises(Exception):  # sqlite IntegrityError
+            repo.save(_make_map(slug="duplicated"))
+
+    def test_allocate_slug_unique(self, repo: MapRepository) -> None:
+        repo.save(_make_map(slug="elections-2026"))
+        candidate = repo.allocate_slug("Élections 2026")
+        assert candidate != "elections-2026"
+        assert candidate.startswith("elections-2026-")
+
+    def test_allocate_slug_avoids_reserved(self, repo: MapRepository) -> None:
+        candidate = repo.allocate_slug("admin")
+        assert candidate.startswith("admin-")
+
+    def test_get_by_slug_skips_trashed(self, repo: MapRepository) -> None:
+        m = _make_map(slug="will-trash")
+        repo.save(m)
+        repo.soft_delete(m.id)
+        assert repo.get_by_slug("will-trash") is None
+
+
+class TestShareToken:
+    def test_get_by_share_token(self, repo: MapRepository) -> None:
+        m = _make_map(visibility=MapVisibility.UNLISTED, share_token="abc123token")
+        repo.save(m)
+        loaded = repo.get_by_share_token("abc123token")
+        assert loaded is not None
+        assert loaded.id == m.id
+
+    def test_get_by_share_token_wrong_token(self, repo: MapRepository) -> None:
+        m = _make_map(visibility=MapVisibility.UNLISTED, share_token="real-token")
+        repo.save(m)
+        assert repo.get_by_share_token("wrong-token") is None
+
+    def test_get_by_share_token_empty(self, repo: MapRepository) -> None:
+        assert repo.get_by_share_token("") is None
+
+    def test_get_by_share_token_skips_trashed(self, repo: MapRepository) -> None:
+        m = _make_map(visibility=MapVisibility.UNLISTED, share_token="will-trash-tok")
+        repo.save(m)
+        repo.soft_delete(m.id)
+        assert repo.get_by_share_token("will-trash-tok") is None
+
+
+class TestOwnerScoping:
+    def test_count_for_owner(self, repo: MapRepository) -> None:
+        owner_a, owner_b = uuid4(), uuid4()
+        repo.save(_make_map(slug="a1", owner_id=owner_a))
+        repo.save(_make_map(slug="a2", owner_id=owner_a))
+        repo.save(_make_map(slug="b1", owner_id=owner_b))
+        assert repo.count_for_owner(owner_a) == 2
+        assert repo.count_for_owner(owner_b) == 1
+        assert repo.count_for_owner(uuid4()) == 0
+
+    def test_count_for_owner_none(self, repo: MapRepository) -> None:
+        repo.save(_make_map(slug="legacy", owner_id=None))
+        repo.save(_make_map(slug="owned", owner_id=uuid4()))
+        assert repo.count_for_owner(None) == 1
+
+    def test_count_excludes_trashed(self, repo: MapRepository) -> None:
+        owner = uuid4()
+        m1 = _make_map(slug="keep", owner_id=owner)
+        m2 = _make_map(slug="trash", owner_id=owner)
+        repo.save(m1)
+        repo.save(m2)
+        repo.soft_delete(m2.id)
+        assert repo.count_for_owner(owner) == 1
+
+    def test_list_for_owner_includes_trashed_when_requested(self, repo: MapRepository) -> None:
+        owner = uuid4()
+        m1 = _make_map(slug="keep2", owner_id=owner)
+        m2 = _make_map(slug="trash2", owner_id=owner)
+        repo.save(m1)
+        repo.save(m2)
+        repo.soft_delete(m2.id)
+        active = repo.list_for_owner(owner)
+        full = repo.list_for_owner(owner, include_trashed=True)
+        assert len(active) == 1
+        assert len(full) == 2
+
+
+class TestSoftDelete:
+    def test_soft_delete_then_restore(self, repo: MapRepository) -> None:
+        m = _make_map(slug="soft")
+        repo.save(m)
+        assert repo.soft_delete(m.id) is True
+        assert repo.get(m.id) is None
+        assert repo.get(m.id, include_trashed=True) is not None
+        assert repo.restore(m.id) is True
+        assert repo.get(m.id) is not None
+
+    def test_soft_delete_missing_returns_false(self, repo: MapRepository) -> None:
+        assert repo.soft_delete(uuid4()) is False
+
+    def test_restore_active_returns_false(self, repo: MapRepository) -> None:
+        m = _make_map(slug="active")
+        repo.save(m)
+        assert repo.restore(m.id) is False
+
+    def test_purge_older_than(self, repo: MapRepository) -> None:
+        m1 = _make_map(slug="old")
+        m2 = _make_map(slug="recent")
+        repo.save(m1)
+        repo.save(m2)
+        repo.soft_delete(m1.id)
+        repo.soft_delete(m2.id)
+        # Backdate m1's deleted_at by raw SQL
+        old_ts = (datetime.now(timezone.utc) - timedelta(days=60)).isoformat()
+        repo._inner._execute(  # noqa: SLF001
+            "UPDATE maps SET deleted_at = ? WHERE id = ?",
+            (old_ts, str(m1.id)),
+        )
+        cutoff = datetime.now(timezone.utc) - timedelta(days=30)
+        purged = repo.purge_older_than(cutoff)
+        assert purged == 1
+        assert repo.get(m1.id, include_trashed=True) is None
+        assert repo.get(m2.id, include_trashed=True) is not None

--- a/tests/unit/test_maps_router.py
+++ b/tests/unit/test_maps_router.py
@@ -1,0 +1,202 @@
+"""Integration tests for the Cocarte Maps router (issue #56)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from gispulse.adapters.http.app import create_app
+from gispulse.adapters.http.rate_limit import limiter
+from persistence.map_io import MapRepository
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch) -> TestClient:
+    """Build a test client with a fresh per-test SQLite ``maps`` repo.
+
+    ``core.config.settings`` is imported once and caches the db_path
+    resolved from env at import time. Setting GISPULSE_DB_PATH via
+    monkeypatch is too late, so we override ``app.state.map_repo`` with
+    a per-test repo bound to ``tmp_path`` instead.
+    """
+    monkeypatch.setenv("GISPULSE_STORAGE", "sqlite")
+    limiter.enabled = False
+    app = create_app()
+    app.state.map_repo = MapRepository(db_path=tmp_path / "maps.db")
+    return TestClient(app)
+
+
+CREATE_PAYLOAD = {
+    "title": "Élections 2026 — résultats par commune",
+    "description": "Carte test",
+}
+
+
+class TestCreateMap:
+    def test_create_returns_201(self, client: TestClient) -> None:
+        r = client.post("/maps", json=CREATE_PAYLOAD)
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["title"] == CREATE_PAYLOAD["title"]
+        assert body["slug"] == "elections-2026-resultats-par-commune"
+        assert body["visibility"] == "private"
+        assert body["share_token"] is None
+        assert body["deleted_at"] is None
+
+    def test_create_minimal(self, client: TestClient) -> None:
+        r = client.post("/maps", json={"title": "Hello"})
+        assert r.status_code == 201
+        assert r.json()["slug"] == "hello"
+
+    def test_create_empty_title_rejected(self, client: TestClient) -> None:
+        r = client.post("/maps", json={"title": ""})
+        assert r.status_code == 422
+
+    def test_slug_uniqueness(self, client: TestClient) -> None:
+        r1 = client.post("/maps", json={"title": "Same name"})
+        r2 = client.post("/maps", json={"title": "Same name"})
+        assert r1.status_code == 201
+        assert r2.status_code == 201
+        assert r1.json()["slug"] != r2.json()["slug"]
+
+
+class TestListMaps:
+    def test_empty_list(self, client: TestClient) -> None:
+        r = client.get("/maps")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["items"] == []
+        assert body["total"] == 0
+
+    def test_list_after_create(self, client: TestClient) -> None:
+        client.post("/maps", json={"title": "M1"})
+        client.post("/maps", json={"title": "M2"})
+        r = client.get("/maps")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["total"] == 2
+        assert len(body["items"]) == 2
+
+    def test_pagination(self, client: TestClient) -> None:
+        for i in range(3):
+            client.post("/maps", json={"title": f"M{i}"})
+        r = client.get("/maps?limit=2&offset=0")
+        assert r.json()["total"] == 3
+        assert len(r.json()["items"]) == 2
+
+
+class TestGetMap:
+    def test_get_after_create(self, client: TestClient) -> None:
+        created = client.post("/maps", json={"title": "Get me"}).json()
+        r = client.get(f"/maps/{created['id']}")
+        assert r.status_code == 200
+        assert r.json()["id"] == created["id"]
+
+    def test_get_missing_returns_404(self, client: TestClient) -> None:
+        r = client.get("/maps/00000000-0000-0000-0000-000000000000")
+        assert r.status_code == 404
+
+
+class TestUpdateMap:
+    def test_patch_description(self, client: TestClient) -> None:
+        created = client.post("/maps", json={"title": "Patch me"}).json()
+        r = client.patch(f"/maps/{created['id']}", json={"description": "new"})
+        assert r.status_code == 200
+        assert r.json()["description"] == "new"
+
+    def test_patch_visibility_to_unlisted_generates_token(self, client: TestClient) -> None:
+        created = client.post("/maps", json={"title": "Unlist me"}).json()
+        r = client.patch(f"/maps/{created['id']}", json={"visibility": "unlisted"})
+        assert r.status_code == 200
+        body = r.json()
+        assert body["visibility"] == "unlisted"
+        assert body["share_token"] is not None
+        assert len(body["share_token"]) >= 40  # token_urlsafe(32)
+
+    def test_patch_visibility_back_to_private_clears_token(self, client: TestClient) -> None:
+        created = client.post("/maps", json={"title": "Privatize"}).json()
+        client.patch(f"/maps/{created['id']}", json={"visibility": "unlisted"})
+        r = client.patch(f"/maps/{created['id']}", json={"visibility": "private"})
+        assert r.json()["share_token"] is None
+
+    def test_patch_view_state(self, client: TestClient) -> None:
+        created = client.post("/maps", json={"title": "view"}).json()
+        r = client.patch(
+            f"/maps/{created['id']}",
+            json={"view_state": {"center": [2.35, 48.85], "zoom": 10}},
+        )
+        assert r.json()["view_state"]["zoom"] == 10
+
+
+class TestDeleteAndRestore:
+    def test_delete_soft_deletes(self, client: TestClient) -> None:
+        created = client.post("/maps", json={"title": "Trash me"}).json()
+        r = client.delete(f"/maps/{created['id']}")
+        assert r.status_code == 204
+        # Default GET excludes trashed
+        assert client.get(f"/maps/{created['id']}").status_code == 404
+        # include_trashed reveals it
+        r = client.get(f"/maps/{created['id']}?include_trashed=true")
+        assert r.status_code == 200
+        assert r.json()["deleted_at"] is not None
+
+    def test_restore_undeletes(self, client: TestClient) -> None:
+        created = client.post("/maps", json={"title": "Restore me"}).json()
+        client.delete(f"/maps/{created['id']}")
+        r = client.post(f"/maps/{created['id']}/restore")
+        assert r.status_code == 200
+        assert r.json()["deleted_at"] is None
+        # Now visible again
+        assert client.get(f"/maps/{created['id']}").status_code == 200
+
+    def test_restore_active_returns_409(self, client: TestClient) -> None:
+        created = client.post("/maps", json={"title": "Active"}).json()
+        r = client.post(f"/maps/{created['id']}/restore")
+        assert r.status_code == 409
+
+    def test_list_excludes_trashed_by_default(self, client: TestClient) -> None:
+        a = client.post("/maps", json={"title": "Keep"}).json()  # noqa: F841
+        b = client.post("/maps", json={"title": "Bin"}).json()
+        client.delete(f"/maps/{b['id']}")
+        active = client.get("/maps").json()
+        full = client.get("/maps?include_trashed=true").json()
+        assert active["total"] == 1
+        assert full["total"] == 2
+
+
+class TestRotateShareToken:
+    def test_rotate_unlisted_changes_token(self, client: TestClient) -> None:
+        created = client.post("/maps", json={"title": "Rotate"}).json()
+        client.patch(f"/maps/{created['id']}", json={"visibility": "unlisted"})
+        before = client.get(f"/maps/{created['id']}").json()["share_token"]
+        r = client.post(f"/maps/{created['id']}/rotate-token")
+        assert r.status_code == 200
+        assert r.json()["share_token"] != before
+
+    def test_rotate_private_returns_409(self, client: TestClient) -> None:
+        created = client.post("/maps", json={"title": "Private"}).json()
+        r = client.post(f"/maps/{created['id']}/rotate-token")
+        assert r.status_code == 409
+
+
+class TestTierGating:
+    def test_limit_blocks_create_when_count_reached(self, client: TestClient, monkeypatch) -> None:
+        # Force a tight limit regardless of tier resolution: makes the test
+        # robust to env / cached settings differences.
+        from gispulse.adapters.http.routers import maps_router
+
+        monkeypatch.setitem(maps_router._MAP_LIMITS, "community", 3)
+        monkeypatch.setitem(maps_router._MAP_LIMITS, "pro", 3)
+        monkeypatch.setitem(maps_router._MAP_LIMITS, "team", 3)
+        monkeypatch.setitem(maps_router._MAP_LIMITS, "enterprise", 3)
+
+        for i in range(3):
+            r = client.post("/maps", json={"title": f"M{i}"})
+            assert r.status_code == 201, f"#{i} failed: {r.text}"
+        r = client.post("/maps", json={"title": "Fourth"})
+        assert r.status_code == 402
+        body = r.json()
+        msg = body.get("detail") or body.get("error", {}).get("message", "")
+        assert "limit" in msg.lower()

--- a/tests/unit/test_slug.py
+++ b/tests/unit/test_slug.py
@@ -1,0 +1,69 @@
+"""Unit tests for `core.slug`."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.slug import RESERVED, ensure_unique_slug, slugify
+
+
+class TestSlugify:
+    def test_basic_title(self) -> None:
+        assert slugify("Carte des élections 2026") == "carte-des-elections-2026"
+
+    def test_strips_diacritics(self) -> None:
+        assert slugify("café") == "cafe"
+        assert slugify("naïve façon") == "naive-facon"
+
+    def test_collapses_punctuation_and_dashes(self) -> None:
+        assert slugify("Hello,  world!! --- foo") == "hello-world-foo"
+
+    def test_truncates_to_max_length(self) -> None:
+        long = "a" * 200
+        result = slugify(long, max_length=60)
+        assert len(result) <= 60
+        assert result == "a" * 60
+
+    def test_truncation_strips_trailing_dash(self) -> None:
+        assert slugify("hello-world-foo", max_length=11) == "hello-world"
+
+    def test_empty_returns_random_token(self) -> None:
+        result = slugify("")
+        assert len(result) == 8
+        assert result.isalnum()
+
+    def test_pure_punctuation_returns_random_token(self) -> None:
+        result = slugify("!!!---???")
+        assert len(result) == 8
+        assert result.isalnum()
+
+
+class TestEnsureUniqueSlug:
+    def test_returns_base_when_free(self) -> None:
+        assert ensure_unique_slug("hello", exists=lambda _: False) == "hello"
+
+    def test_salts_when_taken(self) -> None:
+        result = ensure_unique_slug("hello", exists=lambda s: s == "hello")
+        assert result.startswith("hello-")
+        assert len(result) == len("hello-") + 4
+
+    def test_salts_when_reserved(self) -> None:
+        result = ensure_unique_slug("admin", exists=lambda _: False)
+        assert result.startswith("admin-")
+        assert "admin" in RESERVED
+
+    def test_raises_after_max_attempts(self) -> None:
+        with pytest.raises(RuntimeError, match="could not allocate"):
+            ensure_unique_slug("hello", exists=lambda _: True, max_attempts=3)
+
+    def test_avoids_reserved_in_salt_candidates(self) -> None:
+        custom_reserved = frozenset({"hello", "hello-aaaa"})
+        # First candidate "hello-aaaa" is reserved, must skip
+        attempts = []
+
+        def fake_exists(s: str) -> bool:
+            attempts.append(s)
+            return False
+
+        result = ensure_unique_slug("hello", exists=fake_exists, reserved=custom_reserved)
+        assert result not in custom_reserved


### PR DESCRIPTION
## Summary

Sprint 1.1 backend slice of the Cocarte v1.7 "Publish" epic. Introduces the first-class `CocarteMap` entity (separate from `Project`) with the persistence and HTTP surface required by the Publish workflow.

Closes imagodata/gispulse-portal#56 (Sprint 1.1 backend half).

## Why diverge from `Project`?

The audit recommended mirroring `Project` simplicity, but the Cocarte wedge requires three deliberate departures (documented in [/home/simon/.claude/plans/cocarte_map_entity_design_2026_05_10.md](/home/simon/.claude/plans/cocarte_map_entity_design_2026_05_10.md)):

1. **`owner_id` per-user** — for "5 maps free per user" gating (vs Project's global tier counter)
2. **`slug` URL-safe** — for `/c/biodiversity-map` shareable URLs (vs `/projects/{uuid}`)
3. **`visibility` enum + `share_token`** — `private` | `unlisted` | `public` with revocable opaque token

Anti-patterns from prior audits explicitly avoided:
- `updated_at` included in TS interface from day 1 (`Project` omits it — fixed in v1.8 frontend slice)
- `hmac.compare_digest` on share-token lookup (vs timing-leak `!=`)
- TS class is `CocarteMap` (not `Map`, would shadow `globalThis.Map`)

## What's in this PR

**Domain layer**
- `core.enums.MapVisibility` — 3-value string enum
- `core.models.CocarteMap` dataclass + `Map = CocarteMap` alias
- `core.slug` — `slugify` (NFKD diacritics) + `ensure_unique_slug` with reserved-route blocklist

**Persistence**
- `persistence.schema._TABLE_DEFS["maps"]` — 18 cols incl. `deleted_at` for trash semantics
- `SCHEMA_VERSION` 3 → 4
- `persistence.map_io.MapRepository` — wraps `SQLiteRepository[CocarteMap]`, adds `get_by_slug`, `get_by_share_token` (constant-time), `count_for_owner`, `list_for_owner`, `soft_delete`/`restore`/`purge_older_than`, `allocate_slug`. 4 idempotent indices.

**HTTP**
- `routers/maps_router.py` — 7 endpoints under `/maps` (CRUD + restore + rotate-token), `cocarte` tag
- `core/pricing_catalog.yml` — adds `maps:` limits to all 4 tiers (community 5 / pro 100 / team+ unlimited)
- `dependencies.get_map_repo` — returns 503 in in-memory mode (Map repo is SQLite-only by design)

## Tests

53 new tests, all green:
- `test_slug.py` (12) — kebab, NFKD, reserved-route dedupe
- `test_map_repo.py` (21) — CRUD, slug uniqueness, share-token constant-time, owner scoping, soft-delete + restore + purge
- `test_maps_router.py` (20) — create/list/get/patch/delete/restore/rotate, tier gate

Regression: 53 passed / 3 skipped on related router tests (project, trigger, scenario). 4 unrelated pre-existing failures on the full unit suite (env: laspy missing, site-packages portal resolution, CLI subprocess).

## Out of scope (deferred per design doc)

- **Public viewer route** `GET /c/{slug}` — Sprint 1.2
- **Snapshot pipeline** + `MapPublic` sanitised schema — Sprint 1.2
- **GeoPackage repository variant** — Sprint 1.2 (only SQLite for now)
- **Frontend** (TS types, Zustand store, API client) — separate stacked PR
- **i18n FR + EN seed** + `docs/dev/ownership.md` + CHANGELOG — separate stacked PR
- **Pre-flight migration test** (1.6.x DB → 1.7) — separate stacked PR

## Test plan

- [ ] CI green on this branch
- [ ] No regression on related router tests
- [ ] Reviewer confirms 3 design departures (owner_id / slug / visibility) are acceptable per Cocarte wedge requirements
- [ ] Reviewer confirms `MapVisibility` enum re-export through `core.models` follows project convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)