### PR TITLE
[EPIC #175] Modèle de plugins unifié — plateforme ETL (source/capability/sink)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,44 @@ jobs:
           name: coverage-report
           path: coverage.xml
 
+  plugins:
+    # Issue #185 — bundled plugins are first-class: install each one for
+    # real and assert the PluginHub discovers them without a FAILED record.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install the engine
+        run: pip install -e ".[dev,api]"
+
+      - name: Install every bundled plugin
+        run: |
+          for plugin in plugins/*/; do
+            echo "::group::install ${plugin}"
+            pip install -e "${plugin}"
+            echo "::endgroup::"
+          done
+
+      - name: Lint the bundled plugins
+        run: ruff check plugins/
+
+      - name: Verify plugins are discovered without failure
+        run: python scripts/check_plugins.py
+
+      - name: Run plugin + gate tests
+        run: >
+          pytest -v
+          tests/unit/test_plugin_discovery.py
+          tests/unit/test_plugin_sdk_exports.py
+          tests/unit/test_plugin_hub_records.py
+          tests/unit/test_plugin_hub_gate.py
+          tests/unit/test_src_cadastre.py
+
   capability-matrix-drift:
     runs-on: ubuntu-latest
     steps:

--- a/capabilities/registry.py
+++ b/capabilities/registry.py
@@ -88,10 +88,36 @@ def list_all() -> list[dict]:
 
 
 def _discover_plugins() -> list[dict[str, str]]:
-    """Discover capabilities from installed packages via entry-points."""
-    # Reset flag to allow re-discovery (needed for testing with mocked entry-points)
-    REGISTRY._plugins_discovered = False
-    return REGISTRY.discover_plugins("gispulse.capabilities")
+    """Register capability plugins discovered by the unified PluginHub.
+
+    Issue #180 — end of the double discovery: the hub
+    (:class:`core.plugin_hub.PluginHub`) owns entry-point scanning for
+    all eleven groups. Here we simply invoke the ``register()`` callable
+    of every ACTIVE capability record so the capabilities land in
+    :data:`REGISTRY`. Records the hub marked FAILED were already logged
+    there and surface as errors in the returned report.
+    """
+    from core.plugin_hub import PluginHub
+    from core.plugin_model import PluginKind, PluginState
+
+    results: list[dict[str, str]] = []
+    for rec in PluginHub.get().records_by_kind(PluginKind.CAPABILITY):
+        module = getattr(rec.entry_point, "value", rec.name)
+        if rec.state is not PluginState.ACTIVE:
+            results.append(
+                {"name": rec.name, "module": module,
+                 "status": f"error: {rec.detail or 'plugin not active'}"}
+            )
+            continue
+        try:
+            rec.obj()  # the plugin's register() callable
+            results.append({"name": rec.name, "module": module, "status": "ok"})
+        except Exception as exc:  # noqa: BLE001 — isolate a bad plugin
+            log.warning("capability_plugin_register_failed", plugin=rec.name, error=str(exc))
+            results.append(
+                {"name": rec.name, "module": module, "status": f"error: {exc}"}
+            )
+    return results
 
 
 def list_plugins() -> list[dict[str, str]]:

--- a/catalog/source_bridge.py
+++ b/catalog/source_bridge.py
@@ -1,0 +1,99 @@
+"""Bridge: expose a legacy CatalogProvider as a DataSource (issue #179).
+
+The catalog subsystem predates the unified plugin model: a
+:class:`~catalog.providers.base.CatalogProvider` only *describes*
+datasets (search / list), it does not ingest them.
+
+:class:`CatalogProviderSource` adapts any provider to the
+:class:`~core.sources.DataSource` contract as a *discovery-only* source —
+``catalog()`` delegates to the provider while ``fetch()`` raises
+:class:`~core.sources.ProtocolNotSupported`. This folds the
+``gispulse.catalog_providers`` family into the source family without
+rewriting the seven built-in providers; providers that can actually
+ingest data are reimplemented as native ``DataSource`` subclasses over
+time (issue #184 pilot packages).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from catalog.models import CatalogDomain
+from catalog.providers.base import CatalogProvider
+from catalog.registry import PROVIDERS
+from core.plugin_model import FetchMode, Payload, SourceDomain, SourceResult
+from core.sources import ProtocolNotSupported
+
+# Legacy catalog domains are coarse — a bridged provider keeps
+# ``SourceDomain.BASE``. Native DataSource reimplementations carry the
+# precise domain (foncier, reglementaire, …).
+_DOMAIN_MAP: dict[CatalogDomain, SourceDomain] = {
+    CatalogDomain.PROJECTION: SourceDomain.BASE,
+    CatalogDomain.BASEMAP: SourceDomain.BASE,
+    CatalogDomain.FLUX: SourceDomain.BASE,
+    CatalogDomain.OPENDATA: SourceDomain.BASE,
+}
+
+# Best-effort payload per legacy domain — informational only, since a
+# bridged source refuses ``fetch()`` anyway.
+_PAYLOAD_MAP: dict[CatalogDomain, Payload] = {
+    CatalogDomain.PROJECTION: Payload.TABLE,
+    CatalogDomain.BASEMAP: Payload.TILES,
+    CatalogDomain.FLUX: Payload.TILES,
+    CatalogDomain.OPENDATA: Payload.VECTOR,
+}
+
+
+class CatalogProviderSource:
+    """A discovery-only :class:`~core.sources.DataSource` over a CatalogProvider.
+
+    Structurally satisfies the ``DataSource`` Protocol. ``fetch()`` is
+    deliberately unsupported: a catalog provider answers *what exists*,
+    not *how to ingest it*.
+    """
+
+    jurisdiction = "*"
+
+    def __init__(self, provider: CatalogProvider) -> None:
+        self._provider = provider
+        self.name = provider.name
+        self.domain = _DOMAIN_MAP.get(provider.domain, SourceDomain.BASE)
+        self.payload = _PAYLOAD_MAP.get(provider.domain, Payload.VECTOR)
+
+    def catalog(self, search: str | None = None) -> list[Any]:
+        """Delegate discovery to the wrapped provider."""
+        return self._provider.list_entries(search=search)
+
+    def fetch(
+        self,
+        entry_id: str,
+        *,
+        extent: Any | None = None,
+        mode: FetchMode = FetchMode.MATERIALIZE,
+    ) -> SourceResult:
+        """Always refused — a CatalogProvider describes, it does not ingest."""
+        raise ProtocolNotSupported(
+            f"'{self.name}' is a discovery-only catalog provider; it cannot "
+            f"fetch entry '{entry_id}' — use a native DataSource instead"
+        )
+
+    def schema(self, entry_id: str) -> dict[str, Any]:
+        """Empty schema; raises ``KeyError`` for an unknown entry."""
+        if self._provider.get_entry(entry_id) is None:
+            raise KeyError(f"{self.name}: unknown entry '{entry_id}'")
+        return {}
+
+    def revision(self, entry_id: str) -> str | None:
+        """Legacy catalog providers expose no freshness token."""
+        return None
+
+
+def bridge_catalog_providers() -> list[CatalogProviderSource]:
+    """Wrap every currently-registered catalog provider as a DataSource.
+
+    Snapshots ``catalog.registry.PROVIDERS`` at call time.
+    """
+    return [CatalogProviderSource(provider) for provider in PROVIDERS.values()]
+
+
+__all__ = ["CatalogProviderSource", "bridge_catalog_providers"]

--- a/core/enums.py
+++ b/core/enums.py
@@ -89,6 +89,8 @@ class TriggerType(str, Enum):
     API = "api"
     ESB_EVENT = "esb_event"
     WEBHOOK_IN = "webhook_in"
+    # --- External-source freshness (issue #186) ---
+    SOURCE_CHANGED = "source_changed"
 
 
 class ChangeOperation(str, Enum):

--- a/core/plugin_contracts.py
+++ b/core/plugin_contracts.py
@@ -26,13 +26,13 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
+# Single source of truth lives in ``core.plugin_model`` (epic #175).
+# Re-exported (redundant alias) so existing importers of
+# ``core.plugin_contracts`` — notably ``core.plugin_hub`` — keep working.
+from core.plugin_model import PROTOCOL_VERSION as PROTOCOL_VERSION
+
 if TYPE_CHECKING:
     from fastapi import APIRouter, FastAPI
-
-# Bumped MAJOR on breaking change, MINOR on additive change. Plugins
-# declare ``requires_protocol = ">=1.0,<2.0"`` and the hub warns on
-# mismatch.
-PROTOCOL_VERSION = "1.1"
 
 
 # ---------------------------------------------------------------------------

--- a/core/plugin_hub.py
+++ b/core/plugin_hub.py
@@ -31,8 +31,29 @@ from core.plugin_contracts import (
     MiddlewareFactory,
     RouterFactory,
 )
+from core.plugin_model import (
+    ENTRYPOINT_GROUPS,
+    PluginKind,
+    PluginRecord,
+    PluginState,
+)
 
 log = get_logger(__name__)
+
+# The nine host-extension entry-point groups. Every entry-point in these
+# maps to ``PluginKind.EXTENSION`` in the unified inventory; the four
+# ETL/single-group kinds come from :data:`core.plugin_model.ENTRYPOINT_GROUPS`.
+_EXTENSION_GROUPS: tuple[str, ...] = (
+    "gispulse.routers",
+    "gispulse.middleware",
+    "gispulse.auth_provider",
+    "gispulse.billing_provider",
+    "gispulse.licence_provider",
+    "gispulse.connectors",
+    "gispulse.lifecycle",
+    "gispulse.mcp_tools",
+    "gispulse.mcp_resources",
+)
 
 
 # ---------------------------------------------------------------------------
@@ -125,6 +146,9 @@ class PluginHub:
     lifecycle: list[LifecycleHook]
     mcp_tools: list[McpToolFactory]
     mcp_resources: list[McpResourceFactory]
+    # Unified inventory across all 11 entry-point groups (issue #177).
+    # Additive: the typed collections above remain the wiring surface.
+    records: list[PluginRecord]
 
     def __init__(self) -> None:
         self.routers = {}
@@ -136,6 +160,7 @@ class PluginHub:
         self.lifecycle = []
         self.mcp_tools = []
         self.mcp_resources = []
+        self.records = []
 
     # ------------------------------------------------------------------ API
 
@@ -165,6 +190,7 @@ class PluginHub:
         hub._load_lifecycle()
         hub._load_mcp_tools()
         hub._load_mcp_resources()
+        hub._discover_records()
         log.info(
             "plugin_hub_initialized",
             routers=sorted(hub.routers),
@@ -176,8 +202,85 @@ class PluginHub:
             lifecycle=[p.name for p in hub.lifecycle],
             mcp_tools=[p.name for p in hub.mcp_tools],
             mcp_resources=[p.name for p in hub.mcp_resources],
+            plugin_records=len(hub.records),
         )
         return hub
+
+    # ---------------------------------------------------- unified inventory
+
+    def _discover_records(self) -> None:
+        """Build the unified plugin inventory across all 11 entry-point groups.
+
+        Each entry-point becomes a :class:`~core.plugin_model.PluginRecord`
+        and runs the ``discover → resolve → gate → activate`` cycle. The
+        nine host-extension sub-groups collapse to
+        :attr:`~core.plugin_model.PluginKind.EXTENSION`; capabilities /
+        data_sources / data_sinks / protocols map to their own kind.
+
+        Additive by design: the typed collections (``routers``,
+        ``middleware``, …) populated by the ``_load_*`` methods stay the
+        wiring surface consumed by the app. Issues #180 and the extension
+        migration move consumers onto ``records``.
+        """
+        groups: list[tuple[str, PluginKind]] = [
+            (group, PluginKind.EXTENSION) for group in _EXTENSION_GROUPS
+        ]
+        groups += [(group, kind) for kind, group in ENTRYPOINT_GROUPS.items()]
+        for group, kind in groups:
+            for ep in _eps(group):
+                rec = PluginRecord(name=ep.name, kind=kind, entry_point=ep)
+                self._resolve(rec)
+                if self._gate(rec):
+                    self._activate(rec)
+                else:
+                    rec.state = PluginState.LOCKED
+                self.records.append(rec)
+
+    def _resolve(self, rec: PluginRecord) -> None:
+        """Resolve ``origin`` / ``trust`` / ``tier_required`` for a record.
+
+        Placeholder (issue #177): records keep the
+        :class:`~core.plugin_model.PluginRecord` defaults — external,
+        community trust, community tier. Issue #182 fills this from the
+        curated marketplace registry and the first-party distribution
+        allowlist.
+        """
+
+    def _gate(self, rec: PluginRecord) -> bool:
+        """Decide whether a record may be activated.
+
+        Placeholder (issue #177): always allows activation. Issue #182
+        implements the tier gate (``tier_satisfies`` against the licence
+        provider) and the trust gate (``GISPULSE_PLUGINS_ALLOW_UNVERIFIED``).
+        """
+        return True
+
+    def _activate(self, rec: PluginRecord) -> None:
+        """Load the entry-point to confirm importability; set ACTIVE/FAILED.
+
+        ``rec.obj`` holds the loaded callable/class. The actual wiring
+        (instantiation, routing, capability registration) still runs
+        through the existing ``_load_*`` paths and the capability
+        registry — issue #177 only establishes the inventory and its
+        lifecycle state.
+        """
+        try:
+            rec.obj = rec.entry_point.load()
+        except Exception as exc:  # noqa: BLE001 — isolate a bad plugin
+            rec.state = PluginState.FAILED
+            rec.detail = str(exc)
+            log.warning(
+                "plugin_record_load_failed",
+                name=rec.name,
+                kind=rec.kind.value,
+                error=str(exc),
+            )
+            return
+        rec.state = PluginState.ACTIVE
+
+    def records_by_kind(self, kind: PluginKind) -> list[PluginRecord]:
+        """Return the inventory records of a given :class:`PluginKind`."""
+        return [r for r in self.records if r.kind is kind]
 
     def _load_routers(self) -> None:
         for ep in _eps("gispulse.routers"):

--- a/core/plugin_hub.py
+++ b/core/plugin_hub.py
@@ -12,8 +12,11 @@ middleware, billing and licence providers at process start.
 """
 from __future__ import annotations
 
+import json
+import os
 import re
 from importlib.metadata import entry_points
+from pathlib import Path
 from threading import Lock
 from typing import Any, ClassVar
 
@@ -33,9 +36,13 @@ from core.plugin_contracts import (
 )
 from core.plugin_model import (
     ENTRYPOINT_GROUPS,
+    Origin,
     PluginKind,
     PluginRecord,
     PluginState,
+    Tier,
+    Trust,
+    tier_satisfies,
 )
 
 log = get_logger(__name__)
@@ -54,6 +61,75 @@ _EXTENSION_GROUPS: tuple[str, ...] = (
     "gispulse.mcp_tools",
     "gispulse.mcp_resources",
 )
+
+# Distributions shipped by GISPulse itself — their plugins are trusted
+# first-party code (issue #182).
+_FIRST_PARTY_DISTRIBUTIONS: frozenset[str] = frozenset(
+    {"gispulse", "gispulse-enterprise"}
+)
+
+# Curated marketplace registry — the tier/trust authority for external
+# plugins. Versioned in the OSS repo, hence tamper-evident.
+_REGISTRY_PATH = Path(__file__).resolve().parent.parent / "marketplace" / "registry.json"
+
+
+def _tier_from_str(value: object) -> Tier:
+    """Map a tier string to :class:`Tier`, defaulting to community."""
+    try:
+        return Tier(str(value).lower())
+    except ValueError:
+        return Tier.COMMUNITY
+
+
+def _trust_from_str(value: object) -> Trust:
+    """Map a trust string to :class:`Trust`, defaulting to community."""
+    try:
+        return Trust(str(value).lower())
+    except ValueError:
+        return Trust.COMMUNITY
+
+
+def _curated_registry() -> dict[str, dict[str, Any]]:
+    """Load ``marketplace/registry.json`` as ``{package: {tier, trust}}``.
+
+    Reads the explicit v3 ``tier`` / ``trust`` fields when present, else
+    derives them from the v2 ``requires_pro`` / ``verified`` flags — so
+    the gate is correct before and after issue #181. A missing or
+    malformed file degrades to an empty mapping (no plugin gated).
+    """
+    try:
+        raw = json.loads(_REGISTRY_PATH.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    out: dict[str, dict[str, Any]] = {}
+    for entry in raw.get("plugins", []):
+        package = str(entry.get("package", "")).lower()
+        if not package:
+            continue
+        tier = entry.get("tier")
+        trust = entry.get("trust")
+        out[package] = {
+            "tier": _tier_from_str(tier)
+            if tier
+            else (Tier.PRO if entry.get("requires_pro") else Tier.COMMUNITY),
+            "trust": _trust_from_str(trust)
+            if trust
+            else (Trust.VERIFIED if entry.get("verified") else Trust.COMMUNITY),
+        }
+    return out
+
+
+def _record_package(rec: PluginRecord) -> str:
+    """Best-effort distribution name backing a record's entry-point."""
+    dist = getattr(rec.entry_point, "dist", None)
+    name = getattr(dist, "name", None)
+    return str(name).lower() if name else ""
+
+
+def _allow_unverified() -> bool:
+    """Whether community-trust plugins may activate (default: yes)."""
+    raw = os.environ.get("GISPULSE_PLUGINS_ALLOW_UNVERIFIED", "true")
+    return raw.strip().lower() not in {"0", "false", "no", "off"}
 
 
 # ---------------------------------------------------------------------------
@@ -161,6 +237,8 @@ class PluginHub:
         self.mcp_tools = []
         self.mcp_resources = []
         self.records = []
+        # Licence tier resolved once per discovery for the activation gate.
+        self._licence_tier: Tier = Tier.COMMUNITY
 
     # ------------------------------------------------------------------ API
 
@@ -222,6 +300,7 @@ class PluginHub:
         wiring surface consumed by the app. Issues #180 and the extension
         migration move consumers onto ``records``.
         """
+        self._licence_tier = _tier_from_str(self.licence_provider.current().tier)
         groups: list[tuple[str, PluginKind]] = [
             (group, PluginKind.EXTENSION) for group in _EXTENSION_GROUPS
         ]
@@ -239,20 +318,42 @@ class PluginHub:
     def _resolve(self, rec: PluginRecord) -> None:
         """Resolve ``origin`` / ``trust`` / ``tier_required`` for a record.
 
-        Placeholder (issue #177): records keep the
-        :class:`~core.plugin_model.PluginRecord` defaults — external,
-        community trust, community tier. Issue #182 fills this from the
-        curated marketplace registry and the first-party distribution
-        allowlist.
+        First-party distributions (:data:`_FIRST_PARTY_DISTRIBUTIONS`) are
+        trusted internal code. For every other plugin the curated
+        ``marketplace/registry.json`` is the tier/trust authority — an
+        external plugin cannot grant itself a tier. Plugins absent from
+        the registry keep the community defaults.
         """
+        package = _record_package(rec)
+        if package in _FIRST_PARTY_DISTRIBUTIONS:
+            rec.origin = Origin.INTERNAL
+            rec.trust = Trust.FIRST_PARTY
+        meta = _curated_registry().get(package)
+        if meta is not None:
+            rec.tier_required = meta["tier"]
+            if rec.trust is not Trust.FIRST_PARTY:
+                rec.trust = meta["trust"]
 
     def _gate(self, rec: PluginRecord) -> bool:
-        """Decide whether a record may be activated.
+        """Decide whether a record may be activated (issue #182).
 
-        Placeholder (issue #177): always allows activation. Issue #182
-        implements the tier gate (``tier_satisfies`` against the licence
-        provider) and the trust gate (``GISPULSE_PLUGINS_ALLOW_UNVERIFIED``).
+        Tier gate: the licence tier must satisfy ``rec.tier_required``.
+        Trust gate: a community-trust plugin is refused when
+        ``GISPULSE_PLUGINS_ALLOW_UNVERIFIED`` is disabled. A refused
+        record is marked LOCKED by the caller — its code is never loaded.
         """
+        if not tier_satisfies(self._licence_tier, rec.tier_required):
+            rec.detail = (
+                f"requires the '{rec.tier_required.value}' tier "
+                f"(licence: '{self._licence_tier.value}')"
+            )
+            return False
+        if rec.trust is Trust.COMMUNITY and not _allow_unverified():
+            rec.detail = (
+                "unverified community plugin blocked by "
+                "GISPULSE_PLUGINS_ALLOW_UNVERIFIED"
+            )
+            return False
         return True
 
     def _activate(self, rec: PluginRecord) -> None:
@@ -261,8 +362,8 @@ class PluginHub:
         ``rec.obj`` holds the loaded callable/class. The actual wiring
         (instantiation, routing, capability registration) still runs
         through the existing ``_load_*`` paths and the capability
-        registry — issue #177 only establishes the inventory and its
-        lifecycle state.
+        registry. After a successful load the plugin's declared
+        ``requires_protocol`` is checked (warn-only, issue #182).
         """
         try:
             rec.obj = rec.entry_point.load()
@@ -277,6 +378,7 @@ class PluginHub:
             )
             return
         rec.state = PluginState.ACTIVE
+        _check_protocol_version(rec.obj, rec.name, rec.kind.value)
 
     def records_by_kind(self, kind: PluginKind) -> list[PluginRecord]:
         """Return the inventory records of a given :class:`PluginKind`."""

--- a/core/plugin_model.py
+++ b/core/plugin_model.py
@@ -1,0 +1,337 @@
+"""Typed vocabulary for the unified GISPulse plugin model.
+
+This module is the dependency-free foundation of the plugin platform
+(epic #175). It defines *what* a plugin is — its kind, origin, trust
+level, lifecycle state — and the data shapes exchanged across the ETL
+graph ``source → capability → sink``.
+
+Deliberately importless beyond the stdlib: no geopandas, no fastapi, no
+network client. Every other plugin module (``core.plugin_hub``,
+``core.plugin_contracts``, ``core.sources``) builds on this one, so it
+must stay cheap to import and free of circular dependencies.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+# Protocol version of the host plugin contract. Bumped MAJOR on a
+# breaking change, MINOR on an additive one. Plugins declare
+# ``requires_protocol = ">=1.0,<2.0"`` and the hub warns on mismatch.
+# Single source of truth — ``core.plugin_contracts`` re-imports it.
+PROTOCOL_VERSION = "1.1"
+
+
+# ---------------------------------------------------------------------------
+# Enums — the classification axes of a plugin
+# ---------------------------------------------------------------------------
+
+
+class PluginKind(str, Enum):
+    """The five roles a plugin can play in the GISPulse runtime."""
+
+    SOURCE = "source"          # Extract — yields data into the ETL graph
+    CAPABILITY = "capability"  # Transform — operates on a dataset
+    SINK = "sink"              # Load — writes data to a destination
+    PROTOCOL = "protocol"      # Transport adapter (fetch / write)
+    EXTENSION = "extension"    # Extends the host FastAPI app
+
+
+class Origin(str, Enum):
+    """Where a plugin comes from."""
+
+    INTERNAL = "internal"  # first-party, shipped by GISPulse / gispulse-enterprise
+    EXTERNAL = "external"  # third-party package
+
+
+class Trust(str, Enum):
+    """How much the host trusts a plugin's code."""
+
+    FIRST_PARTY = "first_party"  # maintained by GISPulse
+    VERIFIED = "verified"        # listed in the curated marketplace registry
+    COMMUNITY = "community"      # unknown third-party package
+
+
+class PluginState(str, Enum):
+    """Lifecycle state of a plugin within the discovery cycle.
+
+    ``discovered → resolve → gate → activate`` — a record ends in exactly
+    one of ``ACTIVE``, ``LOCKED`` or ``FAILED``.
+    """
+
+    DISCOVERED = "discovered"  # entry-point seen, code not loaded
+    LOCKED = "locked"          # tier/trust gate refused activation
+    FAILED = "failed"          # load or instantiation raised
+    ACTIVE = "active"          # loaded, instantiated and routed
+
+
+class Tier(str, Enum):
+    """Commercial tier required to activate a plugin.
+
+    Ordered: ``community < pro < team < enterprise`` — see
+    :func:`tier_satisfies`. Mirrors ``core/pricing_catalog.yml``.
+    """
+
+    COMMUNITY = "community"
+    PRO = "pro"
+    TEAM = "team"
+    ENTERPRISE = "enterprise"
+
+
+class SourceDomain(str, Enum):
+    """Thematic domain of a data source. Open enum — a new theme is a new
+    value and requires no contract change (epic #175 design axiom)."""
+
+    BASE = "base"                    # BD TOPO, ROUTE 500, OSM base
+    FONCIER = "foncier"              # cadastre, Parcellaire Express, RPG
+    REGLEMENTAIRE = "reglementaire"  # PLU/zoning, permits, SUP, PPR
+    RESEAU = "reseau"                # FTTH, telecom, utility networks
+    ELEVATION = "elevation"          # MNT / MNS / DEM
+    IMAGERIE = "imagerie"            # orthophotos, satellite
+    ENVIRONNEMENT = "environnement"  # protected areas, land cover, forests
+    OBSERVATION = "observation"      # OSM POI, field surveys, IoT
+    STATISTIQUE = "statistique"      # DVF, INSEE, demographics
+
+
+class Payload(str, Enum):
+    """Shape of the data a source yields — discriminates :class:`SourceResult`."""
+
+    VECTOR = "vector"
+    RASTER = "raster"
+    POINTCLOUD = "pointcloud"
+    TILES = "tiles"
+    TABLE = "table"  # attribute-only rows, spatially joined via a key
+
+
+class AccessProtocol(str, Enum):
+    """Transport protocol by which an entry is fetched or written.
+
+    Resolved per :class:`AccessSpec` to a registered protocol adapter,
+    so a source package stays declarative.
+    """
+
+    # OGC cartographic services
+    WFS = "wfs"
+    WMS = "wms"
+    WMTS = "wmts"
+    TMS = "tms"
+    XYZ = "xyz"
+    OGC_FEATURES = "ogc-features"
+    OGC_TILES = "ogc-tiles"
+    # catalogues / APIs
+    STAC = "stac"
+    REST_API = "rest-api"
+    OVERPASS = "overpass"
+    # files
+    DOWNLOAD = "download"          # remote zip/shp/gpkg/geojson/csv
+    COG = "cog"                    # Cloud-Optimized GeoTIFF (raster reference)
+    PMTILES = "pmtiles"            # single-file vector/raster tiles
+    # databases / lakehouse
+    REMOTE_TABLE = "remote-table"  # remote parquet/flatgeobuf read by DuckDB
+    DB = "db"                      # PostGIS / DuckDB / SpatiaLite
+
+
+class FetchMode(str, Enum):
+    """Whether :meth:`DataSource.fetch` materializes or references data."""
+
+    MATERIALIZE = "materialize"  # download into a dataset
+    REFERENCE = "reference"      # return a COG/WMTS handle, consumed live
+
+
+class WriteMode(str, Enum):
+    """Write semantics for :meth:`DataSink.write`."""
+
+    UPSERT = "upsert"
+    APPEND = "append"
+    REPLACE = "replace"
+
+
+# Entry-point group per single-group kind. ``EXTENSION`` spans nine
+# sub-groups (``gispulse.routers``, ``.middleware``, …) handled directly
+# by ``core.plugin_contracts`` and is intentionally absent here.
+ENTRYPOINT_GROUPS: dict[PluginKind, str] = {
+    PluginKind.SOURCE: "gispulse.data_sources",
+    PluginKind.CAPABILITY: "gispulse.capabilities",
+    PluginKind.SINK: "gispulse.data_sinks",
+    PluginKind.PROTOCOL: "gispulse.protocols",
+}
+
+# Tier ordering for the activation gate.
+_TIER_RANK: dict[Tier, int] = {
+    Tier.COMMUNITY: 0,
+    Tier.PRO: 1,
+    Tier.TEAM: 2,
+    Tier.ENTERPRISE: 3,
+}
+
+
+def tier_satisfies(current: Tier, required: Tier) -> bool:
+    """Return True if ``current`` licence tier may activate a ``required`` plugin.
+
+    ``enterprise`` satisfies everything; ``community`` only satisfies
+    ``community``. Used by the load-time gate (issue #182).
+    """
+    return _TIER_RANK[current] >= _TIER_RANK[required]
+
+
+# ---------------------------------------------------------------------------
+# Data shapes — exchanged across the ETL graph
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PluginManifest:
+    """Declarative metadata a plugin ships in ``[tool.gispulse.plugin]``.
+
+    For *external* plugins the authoritative ``tier`` / ``trust`` come
+    from the curated ``marketplace/registry.json`` — an external plugin
+    cannot grant itself a tier here. *Internal* (first-party) plugins
+    may assert ``tier`` directly, their code being trusted.
+    """
+
+    name: str
+    kind: PluginKind
+    protocol: str = ">=1.0,<2.0"      # requires_protocol specifier
+    display_name: str = ""
+    origin: Origin = Origin.EXTERNAL
+    tier: Tier | None = None          # asserted only by internal plugins
+    domain: SourceDomain | None = None  # source kind only
+    payload: Payload | None = None      # source kind only
+    jurisdiction: str = "*"             # ISO-3166 alpha-2, or "*" for global
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class AccessSpec:
+    """How to reach one catalog entry — dispatched to a protocol adapter."""
+
+    protocol: AccessProtocol
+    endpoint: str
+    params: dict[str, Any] = field(default_factory=dict)
+    format: str | None = None
+    auth: str | None = None  # token/key name, resolved via LicenceProvider for pro
+
+
+@dataclass
+class SourceResult:
+    """Typed return of :meth:`DataSource.fetch`.
+
+    ``data`` is left untyped (``Any``) on purpose — this module imports
+    no geopandas/rasterio. Depending on ``payload`` it is a GeoDataFrame,
+    a raster handle, a file path or ``None`` when ``mode`` is
+    :attr:`FetchMode.REFERENCE` (then ``reference`` carries the live URL).
+    """
+
+    payload: Payload
+    mode: FetchMode = FetchMode.MATERIALIZE
+    data: Any = None
+    reference: str | None = None  # COG/WMTS URL when mode is REFERENCE
+    crs: str | None = None
+    extent: tuple[float, float, float, float] | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class WriteSpec:
+    """Where and how a sink writes its output."""
+
+    protocol: AccessProtocol
+    destination: str
+    layer: str | None = None
+    mode: WriteMode = WriteMode.UPSERT
+    options: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class WriteReport:
+    """Outcome of a :meth:`DataSink.write` call."""
+
+    destination: str
+    rows_written: int = 0
+    rows_failed: int = 0
+    created: bool = False  # True when the destination layer/table was created
+    detail: str = ""
+
+
+@dataclass
+class RuleClause:
+    """One applicable regulatory clause returned by ``RegulatorySource.ruleset``.
+
+    Jurisdiction-agnostic on purpose: a French PLU zone and a Dutch
+    ``Bestemmingsplan`` zone both fill ``constraints`` with whatever is
+    machine-readable and point ``source_doc`` at the rest.
+    """
+
+    zone_code: str
+    jurisdiction: str = "*"
+    constraints: dict[str, Any] = field(default_factory=dict)
+    source_doc: str | None = None  # e.g. "reglement_UB.pdf#p14"
+    label: str = ""
+
+
+@dataclass
+class PluginRecord:
+    """Runtime view of one discovered plugin — the hub's source of truth.
+
+    A record is created at ``discover`` time with only ``name``/``kind``/
+    ``entry_point`` known; ``resolve`` fills origin/trust/tier from the
+    curated registry; ``gate`` may flip it to :attr:`PluginState.LOCKED`;
+    ``activate`` loads the code and sets ``obj`` + :attr:`PluginState.ACTIVE`.
+    """
+
+    name: str
+    kind: PluginKind
+    origin: Origin = Origin.EXTERNAL
+    trust: Trust = Trust.COMMUNITY
+    tier_required: Tier = Tier.COMMUNITY
+    state: PluginState = PluginState.DISCOVERED
+    detail: str = ""              # lock reason or load error
+    entry_point: Any = None       # importlib.metadata.EntryPoint (untyped)
+    manifest: PluginManifest | None = None
+    obj: Any = None               # loaded instance, None until ACTIVE
+
+    @property
+    def available(self) -> bool:
+        """True when the plugin is loaded and usable."""
+        return self.state is PluginState.ACTIVE
+
+    def as_dict(self) -> dict[str, Any]:
+        """Serialize the record for the marketplace / API surface.
+
+        Omits ``entry_point`` and ``obj`` — neither is JSON-safe.
+        """
+        return {
+            "name": self.name,
+            "kind": self.kind.value,
+            "origin": self.origin.value,
+            "trust": self.trust.value,
+            "tier_required": self.tier_required.value,
+            "state": self.state.value,
+            "detail": self.detail,
+        }
+
+
+__all__ = [
+    "PROTOCOL_VERSION",
+    "PluginKind",
+    "Origin",
+    "Trust",
+    "PluginState",
+    "Tier",
+    "SourceDomain",
+    "Payload",
+    "AccessProtocol",
+    "FetchMode",
+    "WriteMode",
+    "ENTRYPOINT_GROUPS",
+    "tier_satisfies",
+    "PluginManifest",
+    "AccessSpec",
+    "SourceResult",
+    "WriteSpec",
+    "WriteReport",
+    "RuleClause",
+    "PluginRecord",
+]

--- a/core/sources.py
+++ b/core/sources.py
@@ -1,0 +1,335 @@
+"""Contracts and registry for the GISPulse ETL plugin families.
+
+Issue #178 (epic #175). Defines the runtime Protocols for the three
+data-facing plugin kinds and the registry that keeps sources and sinks
+*declarative*:
+
+- :class:`Fetcher` / :class:`Writer` — transport adapters, one per
+  :class:`~core.plugin_model.AccessProtocol` (the ``protocol`` kind;
+  absorbs the former ``Connector`` contract).
+- :class:`DataSource` / :class:`RegulatorySource` — the ``source`` kind
+  (Extract).
+- :class:`DataSink` — the ``sink`` kind (Load).
+
+A plugin author declares *what* entries exist and *how* they are reached
+(an :class:`~core.plugin_model.AccessSpec` each); :class:`DeclarativeSource`
+and :class:`DeclarativeSink` implement ``fetch`` / ``write`` once, by
+delegating to :data:`PROTOCOLS`. No geopandas import here — the payload
+travels untyped inside :class:`~core.plugin_model.SourceResult`.
+"""
+
+from __future__ import annotations
+
+import threading
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+from core.logging import get_logger
+from core.plugin_model import (
+    AccessProtocol,
+    AccessSpec,
+    FetchMode,
+    Payload,
+    RuleClause,
+    SourceDomain,
+    SourceResult,
+    WriteReport,
+    WriteSpec,
+)
+
+log = get_logger(__name__)
+
+
+class ProtocolNotSupported(LookupError):
+    """Raised when no adapter is registered for a requested protocol/direction."""
+
+
+# ---------------------------------------------------------------------------
+# Transport adapters — the ``protocol`` plugin kind
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class Fetcher(Protocol):
+    """Reads data for one :class:`~core.plugin_model.AccessProtocol`."""
+
+    protocol: AccessProtocol
+
+    def fetch(
+        self,
+        access: AccessSpec,
+        *,
+        extent: Any | None = None,
+        mode: FetchMode = FetchMode.MATERIALIZE,
+    ) -> SourceResult:
+        ...
+
+
+@runtime_checkable
+class Writer(Protocol):
+    """Writes data for one :class:`~core.plugin_model.AccessProtocol`."""
+
+    protocol: AccessProtocol
+
+    def write(self, result: SourceResult, spec: WriteSpec) -> WriteReport:
+        ...
+
+
+class ProtocolRegistry:
+    """Thread-safe registry of transport adapters, keyed by protocol.
+
+    An adapter may implement :class:`Fetcher`, :class:`Writer`, or both —
+    it is filed under whichever role(s) it structurally satisfies. A
+    single process shares one instance: :data:`PROTOCOLS`.
+    """
+
+    def __init__(self) -> None:
+        self._fetchers: dict[AccessProtocol, Fetcher] = {}
+        self._writers: dict[AccessProtocol, Writer] = {}
+        self._lock = threading.Lock()
+
+    def register(self, adapter: Fetcher | Writer, *, override: bool = False) -> None:
+        """File ``adapter`` under its ``protocol`` for every role it satisfies.
+
+        Raises:
+            ValueError: if ``adapter`` declares no ``protocol``, or the
+                slot is taken and ``override`` is False.
+            TypeError: if ``adapter`` is neither a Fetcher nor a Writer.
+        """
+        protocol = getattr(adapter, "protocol", None)
+        if not isinstance(protocol, AccessProtocol):
+            raise ValueError(
+                f"adapter {adapter!r} must declare a 'protocol: AccessProtocol'"
+            )
+        is_fetcher = isinstance(adapter, Fetcher)
+        is_writer = isinstance(adapter, Writer)
+        if not (is_fetcher or is_writer):
+            raise TypeError(f"adapter {adapter!r} is neither a Fetcher nor a Writer")
+        with self._lock:
+            for filed, table in (
+                (is_fetcher, self._fetchers),
+                (is_writer, self._writers),
+            ):
+                if filed:
+                    if protocol in table and not override:
+                        raise ValueError(
+                            f"protocol '{protocol.value}' already registered; "
+                            f"pass override=True to replace"
+                        )
+                    table[protocol] = adapter  # type: ignore[assignment]
+        log.debug(
+            "protocol_adapter_registered",
+            protocol=protocol.value,
+            fetcher=is_fetcher,
+            writer=is_writer,
+        )
+
+    def get_fetcher(self, protocol: AccessProtocol) -> Fetcher:
+        try:
+            return self._fetchers[protocol]
+        except KeyError:
+            raise ProtocolNotSupported(
+                f"no fetcher for protocol '{protocol.value}'; "
+                f"available: {sorted(p.value for p in self._fetchers)}"
+            ) from None
+
+    def get_writer(self, protocol: AccessProtocol) -> Writer:
+        try:
+            return self._writers[protocol]
+        except KeyError:
+            raise ProtocolNotSupported(
+                f"no writer for protocol '{protocol.value}'; "
+                f"available: {sorted(p.value for p in self._writers)}"
+            ) from None
+
+    def dispatch_fetch(
+        self,
+        access: AccessSpec,
+        *,
+        extent: Any | None = None,
+        mode: FetchMode = FetchMode.MATERIALIZE,
+    ) -> SourceResult:
+        """Resolve ``access.protocol`` to a fetcher and run it."""
+        return self.get_fetcher(access.protocol).fetch(access, extent=extent, mode=mode)
+
+    def dispatch_write(self, result: SourceResult, spec: WriteSpec) -> WriteReport:
+        """Resolve ``spec.protocol`` to a writer and run it."""
+        return self.get_writer(spec.protocol).write(result, spec)
+
+
+# Process-wide registry. Core fetchers (WFS / WMS / STAC / download / …)
+# register here at import time; plugins of kind ``protocol`` add more
+# through the ``gispulse.protocols`` entry-point group (issue #177).
+PROTOCOLS = ProtocolRegistry()
+
+
+# ---------------------------------------------------------------------------
+# Sources — the ``source`` plugin kind (Extract)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SourceEntryRef:
+    """One catalog entry of a source, with its declarative access block.
+
+    This is the *minimal* internal handle a :class:`DeclarativeSource`
+    indexes. The richer ``catalog.models.CatalogEntry`` is mapped onto
+    these by issue #179.
+    """
+
+    id: str
+    name: str
+    access: AccessSpec
+    revision_token: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@runtime_checkable
+class DataSource(Protocol):
+    """A data source — answers *where data comes from* (Extract).
+
+    ``catalog()`` returns entries (``catalog.models.CatalogEntry`` once
+    issue #179 lands; typed ``Any`` here to keep ``core`` free of a
+    ``catalog`` import). ``fetch()`` materializes or references one
+    entry; ``revision()`` is the cheap freshness token consumed by the
+    source watcher (issue #187).
+    """
+
+    name: str
+    domain: SourceDomain
+    payload: Payload
+    jurisdiction: str
+
+    def catalog(self, search: str | None = None) -> list[Any]:
+        ...
+
+    def fetch(
+        self,
+        entry_id: str,
+        *,
+        extent: Any | None = None,
+        mode: FetchMode = FetchMode.MATERIALIZE,
+    ) -> SourceResult:
+        ...
+
+    def schema(self, entry_id: str) -> dict[str, Any]:
+        ...
+
+    def revision(self, entry_id: str) -> str | None:
+        ...
+
+
+@runtime_checkable
+class RegulatorySource(DataSource, Protocol):
+    """A thematic source whose zones carry an applicable rule.
+
+    Implemented by PLU/PLUi, SUP, PPR, building-code sources. ``ruleset``
+    returns jurisdiction-agnostic :class:`~core.plugin_model.RuleClause`
+    objects for the zone(s) intersecting ``at``.
+    """
+
+    def ruleset(self, entry_id: str, *, at: Any) -> list[RuleClause]:
+        ...
+
+
+@runtime_checkable
+class DataSink(Protocol):
+    """A data sink — answers *where results go* (Load)."""
+
+    name: str
+
+    def write(self, result: SourceResult, spec: WriteSpec) -> WriteReport:
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Declarative base classes — fetch()/write() implemented once
+# ---------------------------------------------------------------------------
+
+
+class DeclarativeSource(ABC):
+    """Base for sources that are a pure declaration of entries.
+
+    A subclass implements only :meth:`entries` (and the source-level
+    ``domain`` / ``payload`` / ``jurisdiction`` attributes). ``fetch`` and
+    ``revision`` are provided here by delegating to :data:`PROTOCOLS` —
+    the plugin author writes no network code.
+    """
+
+    name: str
+    domain: SourceDomain
+    payload: Payload
+    jurisdiction: str = "*"
+
+    def __init__(self, registry: ProtocolRegistry | None = None) -> None:
+        self._registry = registry or PROTOCOLS
+        self._index: dict[str, SourceEntryRef] | None = None
+
+    @abstractmethod
+    def entries(self) -> list[SourceEntryRef]:
+        """Return the declarative entries this source exposes."""
+
+    def _entry(self, entry_id: str) -> SourceEntryRef:
+        if self._index is None:
+            self._index = {e.id: e for e in self.entries()}
+        try:
+            return self._index[entry_id]
+        except KeyError:
+            raise KeyError(
+                f"{getattr(self, 'name', type(self).__name__)}: "
+                f"unknown entry '{entry_id}'"
+            ) from None
+
+    def catalog(self, search: str | None = None) -> list[SourceEntryRef]:
+        items = self.entries()
+        if search:
+            q = search.lower()
+            items = [e for e in items if q in e.id.lower() or q in e.name.lower()]
+        return items
+
+    def fetch(
+        self,
+        entry_id: str,
+        *,
+        extent: Any | None = None,
+        mode: FetchMode = FetchMode.MATERIALIZE,
+    ) -> SourceResult:
+        entry = self._entry(entry_id)
+        return self._registry.dispatch_fetch(entry.access, extent=extent, mode=mode)
+
+    def schema(self, entry_id: str) -> dict[str, Any]:
+        """Default: no static schema. Subclasses override when known."""
+        self._entry(entry_id)  # validates the id
+        return {}
+
+    def revision(self, entry_id: str) -> str | None:
+        """Default: the declared token. Live sources override to poll."""
+        return self._entry(entry_id).revision_token
+
+
+class DeclarativeSink(ABC):
+    """Base for sinks that delegate writing to a registered :class:`Writer`."""
+
+    name: str
+
+    def __init__(self, registry: ProtocolRegistry | None = None) -> None:
+        self._registry = registry or PROTOCOLS
+
+    def write(self, result: SourceResult, spec: WriteSpec) -> WriteReport:
+        return self._registry.dispatch_write(result, spec)
+
+
+__all__ = [
+    "ProtocolNotSupported",
+    "Fetcher",
+    "Writer",
+    "ProtocolRegistry",
+    "PROTOCOLS",
+    "SourceEntryRef",
+    "DataSource",
+    "RegulatorySource",
+    "DataSink",
+    "DeclarativeSource",
+    "DeclarativeSink",
+]

--- a/examples/plugin-template/pyproject.toml
+++ b/examples/plugin-template/pyproject.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 description = "Example GISPulse capability plugin"
 requires-python = ">=3.10"
 dependencies = [
+    "gispulse",
     "fastapi>=0.100,<1.0",
     "geopandas>=0.14",
 ]
@@ -18,3 +19,7 @@ example = "gispulse_cap_example:register"
 
 [project.entry-points."gispulse.routers"]
 example = "gispulse_cap_example.routers:ExampleRouterFactory"
+
+[tool.gispulse.plugin]
+kind = "capability"
+protocol = ">=1.0,<2.0"

--- a/gispulse/adapters/http/app.py
+++ b/gispulse/adapters/http/app.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import inspect
 import os
-import inspect
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, Literal

--- a/gispulse/adapters/http/routers/marketplace_router.py
+++ b/gispulse/adapters/http/routers/marketplace_router.py
@@ -93,38 +93,53 @@ def _validate_plugin_name(name: str) -> str:
 # ----------------------------------------------------------------------
 
 
+def _record_package(rec: Any) -> str:
+    """Best-effort distribution name backing a plugin record's entry-point."""
+    dist = getattr(rec.entry_point, "dist", None)
+    name = getattr(dist, "name", None)
+    return str(name).lower() if name else ""
+
+
 @router.get("/plugins", summary="List installed plugins")
 def list_installed_plugins() -> list[dict[str, Any]]:
-    """Return metadata for all installed GISPulse plugins (entry-point scan).
+    """Return metadata for all installed plugins from the unified PluginHub.
 
-    Enriches basic entry-point data with registry metadata so the Portal
-    UI has everything it needs (description, category, tags, etc.).
+    Each entry carries the hub's classification — ``kind`` / ``tier`` /
+    ``trust`` / ``origin`` / ``state`` — so the Portal UI can surface
+    tier-gated (``locked``) plugins with an upgrade prompt. Curated
+    registry metadata enriches the descriptive fields.
     """
-    from capabilities.registry import list_plugins
+    from core.plugin_hub import PluginHub
 
-    installed = list_plugins()
     registry_plugins = {p["package"]: p for p in _load_registry_plugins()}
 
     enriched = []
-    for plugin in installed:
-        short_name = plugin["name"]
-        package = f"{_PLUGIN_PREFIX}{short_name}"
+    for rec in PluginHub.get().records:
+        package = _record_package(rec)
         registry_entry = registry_plugins.get(package, {})
+        state = rec.state.value
 
         enriched.append({
-            "id": registry_entry.get("id", package),
-            "name": registry_entry.get("name", short_name),
+            "id": registry_entry.get("id", package or rec.name),
+            "name": registry_entry.get("name", rec.name),
             "description": registry_entry.get("description", ""),
             "author": registry_entry.get("author", ""),
             "version": registry_entry.get("version", "0.0.0"),
             "category": registry_entry.get("category", "utilities"),
-            "verified": registry_entry.get("verified", False),
-            "requires_pro": registry_entry.get("requires_pro", False),
+            "kind": rec.kind.value,
+            "tier": rec.tier_required.value,
+            "trust": rec.trust.value,
+            "origin": rec.origin.value,
+            "state": state,
+            "locked": state == "locked",
+            "detail": rec.detail,
+            "verified": rec.trust.value in ("verified", "first_party"),
+            "requires_pro": rec.tier_required.value != "community",
             "tags": registry_entry.get("tags", []),
             "homepage_url": registry_entry.get("homepage_url"),
             "install_count": registry_entry.get("install_count", 0),
             "installed_at": None,  # Not tracked yet
-            "enabled": True,
+            "enabled": state == "active",
         })
 
     return enriched

--- a/gispulse/plugins/api.py
+++ b/gispulse/plugins/api.py
@@ -1,12 +1,35 @@
-"""Transitional public API for external GISPulse plugin authors.
+"""Public API for external GISPulse plugin authors.
 
-The goal is to give plugins one documented import path while the runtime
-keeps its existing internal module layout.
+The single documented import path for every plugin kind — capability,
+source, sink, protocol adapter — while the runtime keeps its internal
+module layout. Plugins import from here, never from ``capabilities.*``
+or ``core.*`` directly (issue #183).
 """
 
 from capabilities.base import Capability
 from capabilities.registry import register as register_capability
 from core.plugin_contracts import PluginHostContext
+from core.plugin_model import (
+    AccessProtocol,
+    AccessSpec,
+    Payload,
+    PluginManifest,
+    RuleClause,
+    SourceDomain,
+    SourceResult,
+    WriteSpec,
+)
+from core.sources import (
+    DataSink,
+    DataSource,
+    DeclarativeSink,
+    DeclarativeSource,
+    Fetcher,
+    ProtocolRegistry,
+    RegulatorySource,
+    SourceEntryRef,
+    Writer,
+)
 
 _LAZY_EXPORTS = {
     "ApiCartoGeoJsonClient": "gispulse.plugins.sources",
@@ -35,8 +58,29 @@ def __getattr__(name: str) -> object:
     return value
 
 __all__ = [
+    # capability authoring
     "Capability",
-    "PluginHostContext",
     "register_capability",
+    # host extension context
+    "PluginHostContext",
+    # plugin manifest + ETL data shapes
+    "PluginManifest",
+    "AccessProtocol",
+    "AccessSpec",
+    "Payload",
+    "RuleClause",
+    "SourceDomain",
+    "SourceResult",
+    "WriteSpec",
+    # source / sink / protocol contracts
+    "DataSource",
+    "RegulatorySource",
+    "DataSink",
+    "Fetcher",
+    "Writer",
+    "ProtocolRegistry",
+    "SourceEntryRef",
+    "DeclarativeSource",
+    "DeclarativeSink",
     *_LAZY_EXPORTS,
 ]

--- a/marketplace/registry.json
+++ b/marketplace/registry.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "plugins": [
     {
       "id": "gispulse-cap-ftth",
@@ -11,10 +11,20 @@
       "category": "analysis",
       "verified": true,
       "requires_pro": true,
-      "tags": ["telecom", "ftth", "network"],
+      "tags": [
+        "telecom",
+        "ftth",
+        "network"
+      ],
       "homepage_url": "https://gispulse.dev/plugins/fibreflow",
       "install_count": 312,
-      "capabilities": ["ftth_coverage", "ftth_nearest_node"]
+      "capabilities": [
+        "ftth_coverage",
+        "ftth_nearest_node"
+      ],
+      "kind": "capability",
+      "tier": "pro",
+      "trust": "verified"
     },
     {
       "id": "gispulse-cap-filtermate",
@@ -26,10 +36,20 @@
       "category": "utilities",
       "verified": true,
       "requires_pro": false,
-      "tags": ["filter", "export", "gpkg"],
+      "tags": [
+        "filter",
+        "export",
+        "gpkg"
+      ],
       "homepage_url": "https://gispulse.dev/plugins/filtermate",
       "install_count": 841,
-      "capabilities": ["spatial_filter", "attribute_prep"]
+      "capabilities": [
+        "spatial_filter",
+        "attribute_prep"
+      ],
+      "kind": "capability",
+      "tier": "community",
+      "trust": "verified"
     },
     {
       "id": "gispulse-cap-osm-import",
@@ -41,10 +61,20 @@
       "category": "import",
       "verified": false,
       "requires_pro": false,
-      "tags": ["osm", "import", "openstreetmap"],
+      "tags": [
+        "osm",
+        "import",
+        "openstreetmap"
+      ],
       "homepage_url": null,
       "install_count": 156,
-      "capabilities": ["osm_import", "osm_tag_extract"]
+      "capabilities": [
+        "osm_import",
+        "osm_tag_extract"
+      ],
+      "kind": "capability",
+      "tier": "community",
+      "trust": "community"
     },
     {
       "id": "gispulse-cap-h3",
@@ -56,10 +86,19 @@
       "category": "analysis",
       "verified": true,
       "requires_pro": true,
-      "tags": ["h3", "hexgrid", "aggregation"],
+      "tags": [
+        "h3",
+        "hexgrid",
+        "aggregation"
+      ],
       "homepage_url": "https://gispulse.dev/plugins/h3",
       "install_count": 98,
-      "capabilities": ["h3_aggregate"]
+      "capabilities": [
+        "h3_aggregate"
+      ],
+      "kind": "capability",
+      "tier": "pro",
+      "trust": "verified"
     },
     {
       "id": "gispulse-cap-stac",
@@ -71,10 +110,19 @@
       "category": "import",
       "verified": false,
       "requires_pro": false,
-      "tags": ["stac", "satellite", "catalog"],
+      "tags": [
+        "stac",
+        "satellite",
+        "catalog"
+      ],
       "homepage_url": null,
       "install_count": 74,
-      "capabilities": ["stac_search"]
+      "capabilities": [
+        "stac_search"
+      ],
+      "kind": "capability",
+      "tier": "community",
+      "trust": "community"
     },
     {
       "id": "gispulse-cap-report",
@@ -86,10 +134,19 @@
       "category": "export",
       "verified": true,
       "requires_pro": true,
-      "tags": ["report", "html", "export"],
+      "tags": [
+        "report",
+        "html",
+        "export"
+      ],
       "homepage_url": "https://gispulse.dev/plugins/report-builder",
       "install_count": 203,
-      "capabilities": ["report_build"]
+      "capabilities": [
+        "report_build"
+      ],
+      "kind": "capability",
+      "tier": "pro",
+      "trust": "verified"
     }
   ]
 }

--- a/persistence/source_watcher.py
+++ b/persistence/source_watcher.py
@@ -1,0 +1,191 @@
+"""SourceWatcherRegistry — poll external data-source freshness (issue #187).
+
+The freshness-detection counterpart of :class:`WatcherRegistry` (which
+watches local DML in ``_gispulse_change_log``). Where the change-log
+watcher polls a SQLite table every 200 ms, the source watcher polls a
+:class:`~core.sources.DataSource`'s ``revision()`` on a *human*
+timescale — hours to days, never sub-minute — because external open
+data (cadastre millésimes, BD TOPO releases, PLU revisions) changes
+that slowly.
+
+On a revision change it broadcasts a ``source.changed`` event into the
+EventHub; the EventRouter then matches it against ``SOURCE_CHANGED``
+triggers (issue #186)::
+
+    DataSource.revision()  ──poll──▶  SourceWatcherRegistry
+        │ revision differs
+        ▼
+    EventHub.broadcast("source.changed", {...})  ──▶  EventRouter
+        ▼
+    SOURCE_CHANGED trigger fires  ──▶  pipeline re-run
+
+``revision()`` must be cheap (HTTP HEAD / ETag / millésime token) — the
+watcher never calls ``fetch()``.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from core.logging import get_logger
+
+log = get_logger(__name__)
+
+# Sources change on a human timescale. The floor is deliberate: a
+# sub-minute poll of an external API is abuse, not freshness detection.
+_MIN_INTERVAL_S = 60.0
+_DEFAULT_INTERVAL_S = 6 * 3600.0  # 6 hours
+
+# Map a catalog ``update_frequency`` label to a poll interval (seconds).
+_FREQUENCY_INTERVALS: dict[str, float] = {
+    "temps-reel": 300.0,
+    "quotidien": 3600.0,
+    "hebdomadaire": 6 * 3600.0,
+    "mensuel": 24 * 3600.0,
+    "trimestriel": 24 * 3600.0,
+    "annuel": 24 * 3600.0,
+    "pluriannuel": 24 * 3600.0,
+}
+
+
+def interval_from_frequency(frequency: str | None) -> float:
+    """Resolve a poll interval (seconds) from a catalog frequency label."""
+    if not frequency:
+        return _DEFAULT_INTERVAL_S
+    return _FREQUENCY_INTERVALS.get(frequency.strip().lower(), _DEFAULT_INTERVAL_S)
+
+
+class _EventHub(Protocol):
+    def broadcast(self, event_type: str, data: dict[str, Any] | None = None) -> Any: ...
+
+
+@dataclass
+class _WatchEntry:
+    source: Any  # DataSource
+    entry_id: str
+    interval_s: float
+    last_revision: str | None = None
+
+
+class SourceWatcherRegistry:
+    """Polls registered data-source entries and emits ``source.changed``.
+
+    One :class:`_WatchEntry` per ``(source, entry_id)`` pair. The baseline
+    revision is captured at registration so only *subsequent* changes
+    emit an event.
+    """
+
+    def __init__(self, event_hub: _EventHub | None = None) -> None:
+        self._hub = event_hub
+        self._entries: dict[str, _WatchEntry] = {}
+        self._lock = threading.Lock()
+        self._thread: threading.Thread | None = None
+        self._stop = threading.Event()
+
+    # ------------------------------------------------------------------ API
+
+    def register(
+        self,
+        source: Any,
+        entry_id: str,
+        *,
+        interval_s: float | None = None,
+        frequency: str | None = None,
+    ) -> str:
+        """Watch ``entry_id`` of ``source``; return the registration key.
+
+        ``interval_s`` wins over ``frequency``; absent both, a 6 h default
+        applies. Sub-minute intervals are rejected.
+        """
+        interval = interval_s if interval_s is not None else interval_from_frequency(frequency)
+        if interval < _MIN_INTERVAL_S:
+            raise ValueError(
+                f"source poll interval must be >= {_MIN_INTERVAL_S:.0f}s — "
+                f"external sources do not change sub-minute"
+            )
+        key = f"{source.name}:{entry_id}"
+        with self._lock:
+            self._entries[key] = _WatchEntry(
+                source=source,
+                entry_id=entry_id,
+                interval_s=interval,
+                last_revision=source.revision(entry_id),
+            )
+        log.info("source_watch_registered", source=key, interval_s=interval)
+        return key
+
+    def unregister(self, key: str) -> None:
+        with self._lock:
+            self._entries.pop(key, None)
+
+    def list_watched(self) -> list[str]:
+        return sorted(self._entries)
+
+    def poll(self) -> list[dict[str, Any]]:
+        """Poll every registered entry once; broadcast + return the changes.
+
+        A failing ``revision()`` is logged and skipped — one unreachable
+        source never stalls the others.
+        """
+        changes: list[dict[str, Any]] = []
+        for key, entry in list(self._entries.items()):
+            try:
+                current = entry.source.revision(entry.entry_id)
+            except Exception as exc:  # noqa: BLE001 — isolate one bad source
+                log.warning("source_revision_poll_failed", source=key, error=str(exc))
+                continue
+            if current is None or current == entry.last_revision:
+                continue
+            payload = {
+                "source": f"{entry.source.name}://{entry.entry_id}",
+                "entry": entry.entry_id,
+                "revision": current,
+                "previous": entry.last_revision,
+            }
+            entry.last_revision = current
+            changes.append(payload)
+            log.info("source_changed", **payload)
+            if self._hub is not None:
+                try:
+                    self._hub.broadcast("source.changed", payload)
+                except Exception as exc:  # noqa: BLE001
+                    log.warning("source_changed_broadcast_failed", source=key, error=str(exc))
+        return changes
+
+    # ------------------------------------------------------------- daemon
+
+    def start(self, tick_s: float | None = None) -> None:
+        """Run :meth:`poll` on a daemon thread until :meth:`stop`."""
+        if self._thread is not None and self._thread.is_alive():
+            return
+        interval = tick_s or min(
+            (e.interval_s for e in self._entries.values()), default=_DEFAULT_INTERVAL_S
+        )
+        self._stop.clear()
+
+        def _loop() -> None:
+            while not self._stop.wait(interval):
+                try:
+                    self.poll()
+                except Exception as exc:  # noqa: BLE001
+                    log.warning("source_watch_tick_failed", error=str(exc))
+
+        self._thread = threading.Thread(
+            target=_loop, name="source-watcher", daemon=True
+        )
+        self._thread.start()
+        log.info("source_watcher_started", tick_s=interval)
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=5.0)
+            self._thread = None
+
+    def is_running(self) -> bool:
+        return self._thread is not None and self._thread.is_alive()
+
+
+__all__ = ["SourceWatcherRegistry", "interval_from_frequency"]

--- a/persistence/spatialite_engine.py
+++ b/persistence/spatialite_engine.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 
 import sqlite3
 from pathlib import Path
-from typing import Any
 
 import geopandas as gpd
 

--- a/plugins/gispulse-cap-filtermate/gispulse_cap_filtermate/capabilities.py
+++ b/plugins/gispulse-cap-filtermate/gispulse_cap_filtermate/capabilities.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import geopandas as gpd
 
-from capabilities.base import Capability
-from capabilities.registry import register
+from gispulse.plugins.api import Capability
+from gispulse.plugins.api import register_capability as register
 
 
 @register

--- a/plugins/gispulse-cap-filtermate/pyproject.toml
+++ b/plugins/gispulse-cap-filtermate/pyproject.toml
@@ -10,9 +10,14 @@ requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"
 authors = [{ name = "GISPulse", email = "dev@gispulse.io" }]
 dependencies = [
+    "gispulse",
     "geopandas>=0.14",
     "shapely>=2.0",
 ]
 
 [project.entry-points."gispulse.capabilities"]
 filtermate = "gispulse_cap_filtermate:register"
+
+[tool.gispulse.plugin]
+kind = "capability"
+protocol = ">=1.0,<2.0"

--- a/plugins/gispulse-cap-ftth/gispulse_cap_ftth/capabilities.py
+++ b/plugins/gispulse-cap-ftth/gispulse_cap_ftth/capabilities.py
@@ -7,8 +7,8 @@ from __future__ import annotations
 
 import geopandas as gpd
 
-from capabilities.base import Capability
-from capabilities.registry import register
+from gispulse.plugins.api import Capability
+from gispulse.plugins.api import register_capability as register
 
 
 @register

--- a/plugins/gispulse-cap-ftth/pyproject.toml
+++ b/plugins/gispulse-cap-ftth/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"
 authors = [{ name = "GISPulse", email = "dev@gispulse.io" }]
 dependencies = [
+    "gispulse",
     "geopandas>=0.14",
     "shapely>=2.0",
     "networkx>=3.0",
@@ -17,3 +18,7 @@ dependencies = [
 
 [project.entry-points."gispulse.capabilities"]
 ftth = "gispulse_cap_ftth:register"
+
+[tool.gispulse.plugin]
+kind = "capability"
+protocol = ">=1.0,<2.0"

--- a/plugins/gispulse-cap-h3/gispulse_cap_h3/capabilities.py
+++ b/plugins/gispulse-cap-h3/gispulse_cap_h3/capabilities.py
@@ -11,7 +11,7 @@ from gispulse.plugins.api import register_capability as register
 
 def _h3_available() -> bool:
     try:
-        import h3
+        import h3  # noqa: F401 — availability probe, not a real use
         return True
     except ImportError:
         return False

--- a/plugins/gispulse-cap-h3/gispulse_cap_h3/capabilities.py
+++ b/plugins/gispulse-cap-h3/gispulse_cap_h3/capabilities.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import geopandas as gpd
 from shapely.geometry import Polygon
 
-from capabilities.base import Capability
-from capabilities.registry import register
+from gispulse.plugins.api import Capability
+from gispulse.plugins.api import register_capability as register
 
 
 def _h3_available() -> bool:

--- a/plugins/gispulse-cap-h3/pyproject.toml
+++ b/plugins/gispulse-cap-h3/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"
 authors = [{ name = "GISPulse", email = "dev@gispulse.io" }]
 dependencies = [
+    "gispulse",
     "geopandas>=0.14",
     "shapely>=2.0",
     "h3>=3.7",
@@ -17,3 +18,7 @@ dependencies = [
 
 [project.entry-points."gispulse.capabilities"]
 h3_analysis = "gispulse_cap_h3:register"
+
+[tool.gispulse.plugin]
+kind = "capability"
+protocol = ">=1.0,<2.0"

--- a/plugins/gispulse-cap-osm-import/gispulse_cap_osm_import/capabilities.py
+++ b/plugins/gispulse-cap-osm-import/gispulse_cap_osm_import/capabilities.py
@@ -6,8 +6,8 @@ import json
 
 import geopandas as gpd
 
-from capabilities.base import Capability
-from capabilities.registry import register
+from gispulse.plugins.api import Capability
+from gispulse.plugins.api import register_capability as register
 
 
 @register

--- a/plugins/gispulse-cap-osm-import/pyproject.toml
+++ b/plugins/gispulse-cap-osm-import/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.10"
 license = "MIT"
 authors = [{ name = "osm-community" }]
 dependencies = [
+    "gispulse",
     "geopandas>=0.14",
     "shapely>=2.0",
     "requests>=2.28",
@@ -17,3 +18,7 @@ dependencies = [
 
 [project.entry-points."gispulse.capabilities"]
 osm_import = "gispulse_cap_osm_import:register"
+
+[tool.gispulse.plugin]
+kind = "capability"
+protocol = ">=1.0,<2.0"

--- a/plugins/gispulse-cap-report/gispulse_cap_report/capabilities.py
+++ b/plugins/gispulse-cap-report/gispulse_cap_report/capabilities.py
@@ -6,8 +6,8 @@ from pathlib import Path
 
 import geopandas as gpd
 
-from capabilities.base import Capability
-from capabilities.registry import register
+from gispulse.plugins.api import Capability
+from gispulse.plugins.api import register_capability as register
 
 
 @register

--- a/plugins/gispulse-cap-report/pyproject.toml
+++ b/plugins/gispulse-cap-report/pyproject.toml
@@ -10,9 +10,14 @@ requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"
 authors = [{ name = "GISPulse", email = "dev@gispulse.io" }]
 dependencies = [
+    "gispulse",
     "geopandas>=0.14",
     "jinja2>=3.1",
 ]
 
 [project.entry-points."gispulse.capabilities"]
 report_builder = "gispulse_cap_report:register"
+
+[tool.gispulse.plugin]
+kind = "capability"
+protocol = ">=1.0,<2.0"

--- a/plugins/gispulse-cap-stac/gispulse_cap_stac/capabilities.py
+++ b/plugins/gispulse-cap-stac/gispulse_cap_stac/capabilities.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import geopandas as gpd
 from shapely.geometry import shape
 
-from capabilities.base import Capability
-from capabilities.registry import register
+from gispulse.plugins.api import Capability
+from gispulse.plugins.api import register_capability as register
 
 
 @register

--- a/plugins/gispulse-cap-stac/pyproject.toml
+++ b/plugins/gispulse-cap-stac/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.10"
 license = "MIT"
 authors = [{ name = "community-geo" }]
 dependencies = [
+    "gispulse",
     "geopandas>=0.14",
     "shapely>=2.0",
     "pystac-client>=0.6",
@@ -17,3 +18,7 @@ dependencies = [
 
 [project.entry-points."gispulse.capabilities"]
 stac_import = "gispulse_cap_stac:register"
+
+[tool.gispulse.plugin]
+kind = "capability"
+protocol = ">=1.0,<2.0"

--- a/plugins/gispulse-src-cadastre/gispulse_src_cadastre/__init__.py
+++ b/plugins/gispulse-src-cadastre/gispulse_src_cadastre/__init__.py
@@ -1,0 +1,17 @@
+"""GISPulse data-source plugin — French cadastre (issue #184, pilot wave 1).
+
+First pilot of the ``gispulse-src-*`` family: it validates the
+``DeclarativeSource`` contract end-to-end on a pure ``fetch()`` source.
+"""
+
+from __future__ import annotations
+
+
+def register() -> None:
+    """Entry-point hook for the ``gispulse.data_sources`` group.
+
+    Importing the module is enough — :class:`CadastreSource` is a plain
+    declarative class; the PluginHub records the source from this
+    callable.
+    """
+    from gispulse_src_cadastre import source  # noqa: F401

--- a/plugins/gispulse-src-cadastre/gispulse_src_cadastre/source.py
+++ b/plugins/gispulse-src-cadastre/gispulse_src_cadastre/source.py
@@ -1,0 +1,70 @@
+"""French cadastre DataSource — parcels, communes and buildings.
+
+A :class:`~gispulse.plugins.api.DeclarativeSource`: the plugin only
+*declares* the available entries and their :class:`AccessSpec`; the
+actual WFS request is delegated to the registered protocol adapter, so
+this package ships zero network code.
+
+Data: IGN Géoplateforme WFS, ``CADASTRALPARCELS.PARCELLAIRE_EXPRESS``.
+"""
+
+from __future__ import annotations
+
+from gispulse.plugins.api import (
+    AccessProtocol,
+    AccessSpec,
+    DeclarativeSource,
+    Payload,
+    SourceDomain,
+    SourceEntryRef,
+)
+
+# IGN Géoplateforme — public WFS endpoint (no API key required).
+_GEOPLATEFORME_WFS = "https://data.geopf.fr/wfs/ows"
+_LAYER_PREFIX = "CADASTRALPARCELS.PARCELLAIRE_EXPRESS"
+
+# Millésime token surfaced by revision() — drives the source watcher
+# (issue #187). Parcellaire Express is refreshed twice a year.
+_MILLESIME = "2026-01"
+
+
+class CadastreSource(DeclarativeSource):
+    """French cadastre (Parcellaire Express) exposed as a GISPulse source."""
+
+    name = "cadastre"
+    domain = SourceDomain.FONCIER
+    payload = Payload.VECTOR
+    jurisdiction = "FR"
+
+    def entries(self) -> list[SourceEntryRef]:
+        return [
+            self._entry_ref("parcelles", "Parcelles cadastrales", "parcelle"),
+            self._entry_ref("communes", "Communes cadastrales", "commune"),
+            self._entry_ref("batiments", "Bâtiments cadastraux", "batiment"),
+        ]
+
+    @staticmethod
+    def _entry_ref(entry_id: str, label: str, layer: str) -> SourceEntryRef:
+        return SourceEntryRef(
+            id=entry_id,
+            name=label,
+            access=AccessSpec(
+                protocol=AccessProtocol.WFS,
+                endpoint=_GEOPLATEFORME_WFS,
+                params={"typename": f"{_LAYER_PREFIX}:{layer}"},
+                format="application/json",
+            ),
+            revision_token=_MILLESIME,
+            metadata={"provider": "IGN", "dataset": "Parcellaire Express"},
+        )
+
+    def schema(self, entry_id: str) -> dict:
+        """Normalised attribute schema of a cadastre layer."""
+        self._entry(entry_id)  # validates the id
+        common = {"idu": "str", "geometry": "geometry"}
+        if entry_id == "parcelles":
+            return {**common, "commune": "str", "section": "str", "numero": "str",
+                    "contenance": "int"}
+        if entry_id == "communes":
+            return {**common, "nom": "str", "code_insee": "str"}
+        return {**common, "nature": "str"}  # batiments

--- a/plugins/gispulse-src-cadastre/pyproject.toml
+++ b/plugins/gispulse-src-cadastre/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gispulse-src-cadastre"
+version = "0.1.0"
+description = "French cadastre data source for GISPulse (IGN Parcellaire Express)"
+requires-python = ">=3.10"
+license = "AGPL-3.0-or-later"
+authors = [{ name = "GISPulse", email = "dev@gispulse.io" }]
+dependencies = [
+    "gispulse",
+]
+
+# Registered as a data source — discovered by core.plugin_hub.PluginHub.
+[project.entry-points."gispulse.data_sources"]
+cadastre = "gispulse_src_cadastre:register"
+
+[tool.gispulse.plugin]
+kind = "source"
+protocol = ">=1.0,<2.0"
+domain = "foncier"
+jurisdiction = "FR"
+display_name = "Cadastre (France)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,9 @@ line-length = 100
 "capabilities/postgis_sql.py" = ["E402", "F401"]
 "capabilities/registry.py" = ["E402"]
 "rules/predicates.py" = ["E402", "F401"]
-"plugins/**/*.py" = ["F401"]
+# NB: the blanket "plugins/**/*.py" = ["F401"] ignore was removed in #185 —
+# bundled plugins are now first-class, linted and CI-installed. Their
+# register() hooks carry an explicit `# noqa: F401` where needed.
 # Optional-feature workers / routers register handlers after a runtime
 # import check; module-level imports below the guard are intentional.
 "gispulse/adapters/esb/workers/base_worker.py" = ["E402"]

--- a/rules/trigger_evaluator.py
+++ b/rules/trigger_evaluator.py
@@ -510,6 +510,38 @@ class TriggerEvaluator:
         """Generic handler for schedule, api, esb_event, webhook_in — always matches."""
         return True
 
+    def _eval_source_changed(
+        self, record: ChangeRecord, trigger: Trigger, typed_cond: Any = None
+    ) -> bool:
+        """SOURCE_CHANGED: fire when a watched external source has a new revision.
+
+        The event ``record`` carries the source identity and its current
+        revision token in ``new_values`` (keys ``source`` and
+        ``revision``) — emitted by the source watcher (issue #187). The
+        trigger fires when:
+
+        - the event source matches the trigger's configured ``source``
+          (when one is set), and
+        - the event ``revision`` differs from the trigger's last-seen
+          ``last_revision`` (an absent ``last_revision`` means this is
+          the first observation, which fires).
+
+        An event without a ``revision`` token never fires — there is
+        nothing to compare against.
+        """
+        cond = trigger.conditions or {}
+        values = record.new_values or {}
+
+        want_source = cond.get("source")
+        event_source = values.get("source")
+        if want_source and event_source and want_source != event_source:
+            return False
+
+        new_revision = values.get("revision")
+        if new_revision is None:
+            return False
+        return new_revision != cond.get("last_revision")
+
     # Handler dispatch table
     _TYPE_HANDLERS: dict[str, Callable[..., bool]] = {
         "dml": _eval_dml,
@@ -523,6 +555,7 @@ class TriggerEvaluator:
         "api": _eval_generic,
         "esb_event": _eval_generic,
         "webhook_in": _eval_generic,
+        "source_changed": _eval_source_changed,
     }
 
 

--- a/scripts/check_plugins.py
+++ b/scripts/check_plugins.py
@@ -1,0 +1,50 @@
+"""CI smoke check — every installed plugin is discovered without failure.
+
+Run after ``pip install -e`` of each bundled plugin (issue #185): it
+builds the unified PluginHub and asserts no plugin record landed in the
+FAILED state. LOCKED records (tier-gated) are reported but accepted —
+that is the gate working as designed.
+
+Exit code 0 = all good, 1 = at least one plugin failed to load.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from core.plugin_hub import PluginHub
+from core.plugin_model import PluginKind, PluginState
+
+
+def main() -> int:
+    records = PluginHub.get().records
+    if not records:
+        print("::warning::no plugin records discovered")
+        return 0
+
+    for rec in sorted(records, key=lambda r: (r.kind.value, r.name)):
+        print(f"  {rec.kind.value:11} {rec.name:26} {rec.state.value:10} {rec.detail}")
+
+    # Host-extension plugins ship in separately-installed packages
+    # (e.g. gispulse-enterprise). A dangling extension entry-point is
+    # that package's concern — warn, do not fail the bundled-plugin job.
+    failed = [r for r in records if r.state is PluginState.FAILED]
+    ext_failed = [r for r in failed if r.kind is PluginKind.EXTENSION]
+    bundled_failed = [r for r in failed if r.kind is not PluginKind.EXTENSION]
+
+    if ext_failed:
+        print(f"::warning::{len(ext_failed)} host-extension plugin(s) unavailable: "
+              f"{', '.join(r.name for r in ext_failed)}")
+    if bundled_failed:
+        print(f"::error::{len(bundled_failed)} bundled plugin(s) failed to load: "
+              f"{', '.join(r.name for r in bundled_failed)}")
+        return 1
+
+    locked = sum(1 for r in records if r.state is PluginState.LOCKED)
+    print(f"OK — {len(records)} plugin record(s), {locked} locked, "
+          f"0 bundled failure(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/integration/http/test_enable_tracking.py
+++ b/tests/integration/http/test_enable_tracking.py
@@ -163,11 +163,15 @@ class TestEnableTrackingEndpoint:
         assert resp.status_code == 200
         assert resp.json()["tracking_enabled"] is False
 
-    def test_enable_tracking_unsupported_format_returns_400(
+    def test_enable_tracking_geojson_uses_file_blob_cdc(
         self, app_client, tmp_path
     ) -> None:
+        # Since v1.6.1 (#157) GeoJSON is trackable: enable_tracking routes
+        # it to the ``duckdb_diff`` file-blob CDC engine instead of
+        # rejecting it. Previously this asserted a 400
+        # ``tracking_unsupported_format`` — that contract changed when the
+        # DuckDB-diff engine was wired through the endpoint.
         client, tmp = app_client
-        # GeoJSON file uploaded via the upload endpoint
         geojson_path = tmp / "x.geojson"
         geojson_path.write_text(
             json.dumps(
@@ -191,13 +195,10 @@ class TestEnableTrackingEndpoint:
         ds = up.json()
 
         resp = client.post(f"/datasets/{ds['id']}/enable_tracking")
-        assert resp.status_code == 400
+        assert resp.status_code == 200, resp.text
         body = resp.json()
-        # The global error handler now passes through structured detail
-        # ``HTTPException(detail={"error": {"code": "...", "message": ...}})``
-        # so the contract is: top-level ``error.code`` is the stable
-        # machine-readable token clients dispatch on.
-        assert body["error"]["code"] == "tracking_unsupported_format", body
+        assert body["tracking_enabled"] is True
+        assert body["layers_tracked"], body
 
     def test_enable_tracking_404_unknown_dataset(self, app_client) -> None:
         client, _ = app_client

--- a/tests/integration/test_etl_cascade.py
+++ b/tests/integration/test_etl_cascade.py
@@ -1,0 +1,189 @@
+"""Integration test — the ETL loop, end to end and bounded (issue #188).
+
+Exercises the full plugin-ETL chain on the real primitives:
+
+    source.fetch()  ──▶  transform  ──▶  sink.write()        (E → T → L)
+         ▲                                     │
+         └──────── source.changed / cascade ◀──┘             (L → CDC → re-run)
+
+and proves the CDC cascade is bounded by ``MAX_CASCADE_DEPTH`` — a sink
+write that re-triggers the pipeline terminates instead of looping.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from core.plugin_model import (
+    AccessProtocol,
+    AccessSpec,
+    FetchMode,
+    Payload,
+    SourceResult,
+    WriteReport,
+    WriteSpec,
+)
+from core.sources import DeclarativeSink, DeclarativeSource, ProtocolRegistry, SourceEntryRef
+from core.models import ChangeRecord, Trigger, TriggerEvent, TriggerType
+from rules.trigger_evaluator import (
+    MAX_CASCADE_DEPTH,
+    CascadeDepthExceeded,
+    TriggerEvaluator,
+)
+
+
+# --------------------------------------------------------------------------
+# In-memory protocol adapter — both Fetcher and Writer
+# --------------------------------------------------------------------------
+
+
+class MemoryAdapter:
+    """A DB protocol adapter backed by an in-memory store."""
+
+    protocol = AccessProtocol.DB
+
+    def __init__(self) -> None:
+        self.tables: dict[str, list[dict]] = {
+            "parcels": [{"id": 1, "v": 10}, {"id": 2, "v": 20}],
+        }
+
+    def fetch(self, access, *, extent=None, mode=FetchMode.MATERIALIZE):
+        rows = list(self.tables[access.params["table"]])
+        return SourceResult(payload=Payload.TABLE, mode=mode, data=rows)
+
+    def write(self, result, spec):
+        self.tables[spec.destination] = list(result.data)
+        return WriteReport(
+            destination=spec.destination,
+            rows_written=len(result.data),
+            created=True,
+        )
+
+
+class ParcelsSource(DeclarativeSource):
+    name = "parcels"
+    domain = None  # not exercised here
+    payload = Payload.TABLE
+    jurisdiction = "FR"
+
+    def entries(self):
+        return [
+            SourceEntryRef(
+                id="parcels",
+                name="Parcels",
+                access=AccessSpec(
+                    protocol=AccessProtocol.DB, endpoint="mem://", params={"table": "parcels"}
+                ),
+            )
+        ]
+
+
+class AnalyseSink(DeclarativeSink):
+    name = "analyse"
+
+
+# --------------------------------------------------------------------------
+# E → T → L forward path
+# --------------------------------------------------------------------------
+
+
+def test_etl_forward_path_source_transform_sink() -> None:
+    adapter = MemoryAdapter()
+    registry = ProtocolRegistry()
+    registry.register(adapter)
+
+    source = ParcelsSource(registry=registry)
+    sink = AnalyseSink(registry=registry)
+
+    # E — extract
+    extracted = source.fetch("parcels")
+    assert [r["v"] for r in extracted.data] == [10, 20]
+
+    # T — transform (the capability stage: double every value)
+    transformed = SourceResult(
+        payload=Payload.TABLE,
+        data=[{**row, "v": row["v"] * 2} for row in extracted.data],
+    )
+
+    # L — load
+    report = sink.write(
+        transformed, WriteSpec(protocol=AccessProtocol.DB, destination="parcels_doubled")
+    )
+    assert report.rows_written == 2
+    assert report.created is True
+    assert [r["v"] for r in adapter.tables["parcels_doubled"]] == [20, 40]
+
+
+# --------------------------------------------------------------------------
+# L → CDC → re-run, bounded by MAX_CASCADE_DEPTH
+# --------------------------------------------------------------------------
+
+
+def _source_changed_trigger() -> Trigger:
+    # Unscoped SOURCE_CHANGED with no last_revision — fires on every new
+    # revision, i.e. the worst case: an unbounded re-run loop.
+    return Trigger(
+        id=uuid4(),
+        name="rerun-on-source-change",
+        event=TriggerEvent.MANUAL,
+        trigger_type=TriggerType.SOURCE_CHANGED,
+        conditions={},
+        enabled=True,
+    )
+
+
+def _source_changed_record(revision: str) -> ChangeRecord:
+    return ChangeRecord(
+        table_name="_external_source",
+        operation="INSERT",
+        new_values={"source": "parcels://parcels", "revision": revision},
+        feature_id="parcels",
+    )
+
+
+def test_etl_cdc_cascade_terminates() -> None:
+    """A sink write that re-fires the pipeline must stop, not loop forever."""
+    evaluator = TriggerEvaluator()
+    trigger = _source_changed_trigger()
+
+    runs = 0
+    depth = 1
+    while True:
+        try:
+            fired = evaluator.evaluate(
+                _source_changed_record(revision=f"r{depth}"), [trigger], depth=depth
+            )
+        except CascadeDepthExceeded:
+            break
+        runs += 1
+        if not fired[0].matched:
+            break
+        # Each re-run writes again -> a fresh revision -> a deeper cascade.
+        depth += 1
+
+    # Neither cut off after the first run, nor looped unbounded.
+    assert runs > 1, "cascade stopped too early"
+    assert runs <= MAX_CASCADE_DEPTH, "cascade exceeded the depth guard"
+
+
+def test_cascade_within_limit_completes() -> None:
+    """A chain shorter than the guard runs every step without raising."""
+    evaluator = TriggerEvaluator()
+    trigger = _source_changed_trigger()
+    for depth in range(1, MAX_CASCADE_DEPTH + 1):
+        fired = evaluator.evaluate(
+            _source_changed_record(revision=f"r{depth}"), [trigger], depth=depth
+        )
+        assert fired[0].matched is True
+
+
+def test_cascade_beyond_limit_raises() -> None:
+    evaluator = TriggerEvaluator()
+    with pytest.raises(CascadeDepthExceeded):
+        evaluator.evaluate(
+            _source_changed_record(revision="rX"),
+            [_source_changed_trigger()],
+            depth=MAX_CASCADE_DEPTH + 1,
+        )

--- a/tests/unit/test_catalog_source_bridge.py
+++ b/tests/unit/test_catalog_source_bridge.py
@@ -1,0 +1,117 @@
+"""Unit tests for the CatalogProvider → DataSource bridge (issue #179)."""
+
+from __future__ import annotations
+
+import pytest
+
+from catalog.models import CatalogDomain, CatalogEntry
+from catalog.providers.base import CatalogProvider
+from catalog.registry import PROVIDERS, register_provider
+from catalog.source_bridge import CatalogProviderSource, bridge_catalog_providers
+from core.plugin_model import Payload, SourceDomain
+from core.sources import DataSource, ProtocolNotSupported
+
+
+class FakeProvider(CatalogProvider):
+    """In-memory catalog provider with two entries."""
+
+    name = "fake-ign"
+    domain = CatalogDomain.OPENDATA
+    description = "fake provider for tests"
+
+    def __init__(self) -> None:
+        self._entries = {
+            f"opendata:fake-ign:{eid}": CatalogEntry(
+                id=f"opendata:fake-ign:{eid}",
+                domain=CatalogDomain.OPENDATA,
+                provider="fake-ign",
+                name=label,
+            )
+            for eid, label in [("bdtopo", "BD TOPO"), ("rpg", "RPG")]
+        }
+
+    def list_entries(self, search=None, tags=None, limit=50, offset=0):
+        items = list(self._entries.values())
+        if search:
+            q = search.lower()
+            items = [e for e in items if q in e.name.lower()]
+        return items[offset : offset + limit]
+
+    def get_entry(self, entry_id):
+        return self._entries.get(entry_id)
+
+
+@pytest.fixture
+def source() -> CatalogProviderSource:
+    return CatalogProviderSource(FakeProvider())
+
+
+@pytest.fixture
+def _clean_registry():
+    snapshot = dict(PROVIDERS)
+    yield
+    PROVIDERS.clear()
+    PROVIDERS.update(snapshot)
+
+
+# --------------------------------------------------------------------------
+# Contract conformance
+# --------------------------------------------------------------------------
+
+
+def test_bridge_satisfies_datasource_protocol(source: CatalogProviderSource) -> None:
+    assert isinstance(source, DataSource)
+
+
+def test_bridge_maps_axes(source: CatalogProviderSource) -> None:
+    assert source.name == "fake-ign"
+    assert source.domain is SourceDomain.BASE       # legacy domains stay coarse
+    assert source.payload is Payload.VECTOR         # OPENDATA → vector
+    assert source.jurisdiction == "*"
+
+
+def test_basemap_provider_maps_to_tiles() -> None:
+    class BasemapProvider(FakeProvider):
+        name = "fake-basemap"
+        domain = CatalogDomain.BASEMAP
+
+    assert CatalogProviderSource(BasemapProvider()).payload is Payload.TILES
+
+
+# --------------------------------------------------------------------------
+# Discovery delegates; ingestion is refused
+# --------------------------------------------------------------------------
+
+
+def test_catalog_delegates_to_provider(source: CatalogProviderSource) -> None:
+    assert len(source.catalog()) == 2
+    found = source.catalog(search="topo")
+    assert [e.name for e in found] == ["BD TOPO"]
+
+
+def test_fetch_is_refused(source: CatalogProviderSource) -> None:
+    with pytest.raises(ProtocolNotSupported, match="discovery-only"):
+        source.fetch("opendata:fake-ign:bdtopo")
+
+
+def test_schema_validates_entry(source: CatalogProviderSource) -> None:
+    assert source.schema("opendata:fake-ign:bdtopo") == {}
+    with pytest.raises(KeyError, match="unknown entry"):
+        source.schema("opendata:fake-ign:ghost")
+
+
+def test_revision_is_none(source: CatalogProviderSource) -> None:
+    assert source.revision("opendata:fake-ign:bdtopo") is None
+
+
+# --------------------------------------------------------------------------
+# bridge_catalog_providers
+# --------------------------------------------------------------------------
+
+
+def test_bridge_catalog_providers_wraps_registered(_clean_registry) -> None:
+    register_provider(FakeProvider())
+    bridged = bridge_catalog_providers()
+    names = {s.name for s in bridged}
+    assert "fake-ign" in names
+    assert all(isinstance(s, DataSource) for s in bridged)

--- a/tests/unit/test_file_blob_cdc.py
+++ b/tests/unit/test_file_blob_cdc.py
@@ -13,9 +13,7 @@ Covers:
 """
 from __future__ import annotations
 
-import json
 import os
-import time
 from pathlib import Path
 
 import geopandas as gpd
@@ -26,7 +24,6 @@ from core.models import ChangeOperation
 from persistence.file_blob_cdc import (
     SNAPSHOT_SUFFIX,
     FileBlobChangeDetector,
-    FileBlobSnapshot,
 )
 
 

--- a/tests/unit/test_marketplace_router.py
+++ b/tests/unit/test_marketplace_router.py
@@ -101,21 +101,71 @@ def client():
 
 
 class TestListPlugins:
+    """GET /marketplace/plugins — now sourced from the unified PluginHub (#181)."""
+
+    @staticmethod
+    def _hub_with(records):
+        from types import SimpleNamespace
+
+        from core.plugin_hub import PluginHub
+
+        return patch.object(
+            PluginHub, "get", classmethod(lambda cls: SimpleNamespace(records=records))
+        )
+
+    @staticmethod
+    def _record(name, dist, *, tier="community", trust="community", state="active",
+                detail=""):
+        from core.plugin_model import (
+            PluginKind,
+            PluginRecord,
+            PluginState,
+            Tier,
+            Trust,
+        )
+        from types import SimpleNamespace
+
+        return PluginRecord(
+            name=name,
+            kind=PluginKind.CAPABILITY,
+            tier_required=Tier(tier),
+            trust=Trust(trust),
+            state=PluginState(state),
+            detail=detail,
+            entry_point=SimpleNamespace(dist=SimpleNamespace(name=dist)),
+        )
+
     def test_empty(self, client):
-        with patch("capabilities.registry.list_plugins", return_value=[]):
+        with self._hub_with([]):
             resp = client.get("/marketplace/plugins")
         assert resp.status_code == 200
         assert resp.json() == []
 
     def test_with_plugins(self, client):
-        plugins = [{"name": "ftth", "module": "gispulse_cap_ftth.register"}]
-        with patch("capabilities.registry.list_plugins", return_value=plugins):
+        rec = self._record("ftth", "gispulse-cap-ftth", tier="pro", trust="verified")
+        with self._hub_with([rec]):
             resp = client.get("/marketplace/plugins")
         assert resp.status_code == 200
-        assert len(resp.json()) == 1
         data = resp.json()[0]
         assert data["id"] == "gispulse-cap-ftth"
+        assert data["kind"] == "capability"
+        assert data["tier"] == "pro"
+        assert data["trust"] == "verified"
         assert data["enabled"] is True
+        assert data["locked"] is False
+
+    def test_locked_plugin_is_flagged(self, client):
+        rec = self._record(
+            "ftth", "gispulse-cap-ftth", tier="pro", state="locked",
+            detail="requires the 'pro' tier",
+        )
+        with self._hub_with([rec]):
+            resp = client.get("/marketplace/plugins")
+        data = resp.json()[0]
+        assert data["state"] == "locked"
+        assert data["locked"] is True
+        assert data["enabled"] is False
+        assert "pro" in data["detail"]
 
 
 class TestGetPluginDetails:

--- a/tests/unit/test_plugin_discovery.py
+++ b/tests/unit/test_plugin_discovery.py
@@ -13,66 +13,84 @@ import pytest
 
 
 class TestDiscoverPlugins:
-    """Test capabilities.registry._discover_plugins."""
+    """capabilities.registry._discover_plugins — hub-mediated since #180.
+
+    Discovery is owned by core.plugin_hub.PluginHub; these tests patch
+    the hub's entry-point scan and assert _discover_plugins invokes each
+    ACTIVE capability record's register() callable.
+    """
+
+    @staticmethod
+    def _run(eps):
+        """Reset the hub, patch its entry-point scan, run _discover_plugins."""
+        from capabilities.registry import _discover_plugins
+        from core.plugin_hub import PluginHub
+
+        scan = eps if callable(eps) else (
+            lambda group: eps if group == "gispulse.capabilities" else []
+        )
+        PluginHub.reset()
+        try:
+            with patch("core.plugin_hub.entry_points", scan):
+                return _discover_plugins()
+        finally:
+            PluginHub.reset()
 
     def test_discover_no_plugins(self):
         """When no entry-points exist, discovery returns empty list."""
-        from capabilities.registry import _discover_plugins
-
-        with patch("importlib.metadata.entry_points", return_value=[]):
-            result = _discover_plugins()
-        assert result == []
+        assert self._run([]) == []
 
     def test_discover_loads_plugin(self):
-        """Valid entry-point is loaded and called."""
-        from capabilities.registry import _discover_plugins
-
+        """Valid entry-point is loaded and its register() is called."""
         ep = MagicMock()
         ep.name = "test_plugin"
         ep.value = "gispulse_cap_test:register"
         register_fn = MagicMock()
         ep.load.return_value = register_fn
 
-        with patch("importlib.metadata.entry_points", return_value=[ep]):
-            result = _discover_plugins()
+        result = self._run([ep])
 
         register_fn.assert_called_once()
-        assert len(result) == 1
-        assert result[0]["name"] == "test_plugin"
-        assert result[0]["status"] == "ok"
+        assert result == [
+            {"name": "test_plugin", "module": "gispulse_cap_test:register", "status": "ok"}
+        ]
 
-    def test_discover_handles_load_failure(self):
-        """If a plugin's register() raises, discovery logs warning and continues."""
-        from capabilities.registry import _discover_plugins
-
+    def test_discover_handles_register_failure(self):
+        """If a plugin's register() raises, discovery reports it and continues."""
         ep = MagicMock()
         ep.name = "bad_plugin"
         ep.value = "gispulse_cap_bad:register"
         ep.load.return_value = MagicMock(side_effect=ImportError("missing dep"))
 
-        with patch("importlib.metadata.entry_points", return_value=[ep]):
-            result = _discover_plugins()
+        result = self._run([ep])
 
         assert len(result) == 1
         assert result[0]["name"] == "bad_plugin"
         assert "error" in result[0]["status"]
 
+    def test_discover_handles_import_failure(self):
+        """If the plugin module fails to import, the hub marks the record
+        FAILED and _discover_plugins surfaces it as an error."""
+        ep = MagicMock()
+        ep.name = "broken_import"
+        ep.value = "gispulse_cap_broken:register"
+        ep.load.side_effect = ImportError("no module named gispulse_cap_broken")
+
+        result = self._run([ep])
+
+        assert len(result) == 1
+        assert "error" in result[0]["status"]
+
     def test_discover_handles_importlib_failure(self):
         """If importlib.metadata itself fails, discovery returns empty."""
-        from capabilities.registry import _discover_plugins
 
-        with patch(
-            "importlib.metadata.entry_points",
-            side_effect=Exception("broken"),
-        ):
-            result = _discover_plugins()
+        def boom(group):
+            raise RuntimeError("broken")
 
-        assert result == []
+        assert self._run(boom) == []
 
     def test_discover_multiple_plugins(self):
-        """Multiple entry-points are all loaded."""
-        from capabilities.registry import _discover_plugins
-
+        """Multiple entry-points are all loaded and registered."""
         eps = []
         for name in ("alpha", "beta", "gamma"):
             ep = MagicMock()
@@ -81,8 +99,7 @@ class TestDiscoverPlugins:
             ep.load.return_value = MagicMock()
             eps.append(ep)
 
-        with patch("importlib.metadata.entry_points", return_value=eps):
-            result = _discover_plugins()
+        result = self._run(eps)
 
         assert len(result) == 3
         assert all(r["status"] == "ok" for r in result)

--- a/tests/unit/test_plugin_hub_gate.py
+++ b/tests/unit/test_plugin_hub_gate.py
@@ -1,0 +1,212 @@
+"""Unit tests for the PluginHub tier/trust activation gate (issue #182)."""
+
+from __future__ import annotations
+
+import pytest
+
+from core import plugin_hub
+from core.plugin_contracts import LicenceState
+from core.plugin_hub import PluginHub
+from core.plugin_model import (
+    Origin,
+    PluginKind,
+    PluginRecord,
+    PluginState,
+    Tier,
+    Trust,
+)
+
+
+class FakeDist:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class FakeEP:
+    def __init__(self, name: str, dist: str | None = None, loader=None) -> None:
+        self.name = name
+        self.value = f"{name}:register"
+        self.dist = FakeDist(dist) if dist else None
+        self._loader = loader or (lambda: object())
+
+    def load(self):
+        return self._loader()
+
+
+class FakeLicence:
+    name = "fake"
+
+    def __init__(self, tier: str) -> None:
+        self._tier = tier
+
+    def current(self) -> LicenceState:
+        return LicenceState(org_id=None, tier=self._tier, valid=True)
+
+
+@pytest.fixture(autouse=True)
+def _reset_hub():
+    PluginHub.reset()
+    yield
+    PluginHub.reset()
+
+
+def _record(name="x", kind=PluginKind.CAPABILITY, **kw) -> PluginRecord:
+    return PluginRecord(name=name, kind=kind, **kw)
+
+
+# --------------------------------------------------------------------------
+# _resolve — origin / trust / tier from the curated registry
+# --------------------------------------------------------------------------
+
+
+def test_resolve_external_plugin_from_registry(monkeypatch) -> None:
+    monkeypatch.setattr(
+        plugin_hub,
+        "_curated_registry",
+        lambda: {"gispulse-cap-ftth": {"tier": Tier.PRO, "trust": Trust.VERIFIED}},
+    )
+    hub = PluginHub()
+    rec = _record(entry_point=FakeEP("ftth", dist="gispulse-cap-ftth"))
+    hub._resolve(rec)
+    assert rec.origin is Origin.EXTERNAL
+    assert rec.trust is Trust.VERIFIED
+    assert rec.tier_required is Tier.PRO
+
+
+def test_resolve_first_party_distribution(monkeypatch) -> None:
+    monkeypatch.setattr(plugin_hub, "_curated_registry", dict)
+    hub = PluginHub()
+    rec = _record("admin", PluginKind.EXTENSION, entry_point=FakeEP("admin", dist="gispulse-enterprise"))
+    hub._resolve(rec)
+    assert rec.origin is Origin.INTERNAL
+    assert rec.trust is Trust.FIRST_PARTY
+
+
+def test_resolve_unknown_plugin_keeps_community_defaults(monkeypatch) -> None:
+    monkeypatch.setattr(plugin_hub, "_curated_registry", dict)
+    hub = PluginHub()
+    rec = _record(entry_point=FakeEP("rando", dist="gispulse-cap-rando"))
+    hub._resolve(rec)
+    assert rec.trust is Trust.COMMUNITY
+    assert rec.tier_required is Tier.COMMUNITY
+
+
+# --------------------------------------------------------------------------
+# _gate — tier gate
+# --------------------------------------------------------------------------
+
+
+def test_gate_locks_pro_plugin_under_community_licence() -> None:
+    hub = PluginHub()
+    hub._licence_tier = Tier.COMMUNITY
+    rec = _record(tier_required=Tier.PRO)
+    assert hub._gate(rec) is False
+    assert "pro" in rec.detail
+
+
+def test_gate_allows_when_licence_tier_sufficient() -> None:
+    hub = PluginHub()
+    hub._licence_tier = Tier.ENTERPRISE
+    assert hub._gate(_record(tier_required=Tier.PRO)) is True
+
+
+def test_gate_allows_community_plugin_on_community_licence() -> None:
+    hub = PluginHub()
+    hub._licence_tier = Tier.COMMUNITY
+    assert hub._gate(_record(tier_required=Tier.COMMUNITY)) is True
+
+
+# --------------------------------------------------------------------------
+# _gate — trust gate (GISPULSE_PLUGINS_ALLOW_UNVERIFIED)
+# --------------------------------------------------------------------------
+
+
+def test_gate_allows_unverified_by_default(monkeypatch) -> None:
+    monkeypatch.delenv("GISPULSE_PLUGINS_ALLOW_UNVERIFIED", raising=False)
+    hub = PluginHub()
+    hub._licence_tier = Tier.COMMUNITY
+    assert hub._gate(_record(kind=PluginKind.SOURCE, trust=Trust.COMMUNITY)) is True
+
+
+def test_gate_blocks_unverified_when_disabled(monkeypatch) -> None:
+    monkeypatch.setenv("GISPULSE_PLUGINS_ALLOW_UNVERIFIED", "false")
+    hub = PluginHub()
+    hub._licence_tier = Tier.COMMUNITY
+    rec = _record(kind=PluginKind.SOURCE, trust=Trust.COMMUNITY)
+    assert hub._gate(rec) is False
+    assert "GISPULSE_PLUGINS_ALLOW_UNVERIFIED" in rec.detail
+
+
+def test_gate_keeps_verified_plugin_when_unverified_disabled(monkeypatch) -> None:
+    monkeypatch.setenv("GISPULSE_PLUGINS_ALLOW_UNVERIFIED", "false")
+    hub = PluginHub()
+    hub._licence_tier = Tier.COMMUNITY
+    assert hub._gate(_record(kind=PluginKind.SOURCE, trust=Trust.VERIFIED)) is True
+
+
+# --------------------------------------------------------------------------
+# Integration — a pro plugin is LOCKED, its code never loaded
+# --------------------------------------------------------------------------
+
+
+def test_discover_locks_pro_plugin_under_community(monkeypatch) -> None:
+    monkeypatch.setattr(
+        plugin_hub,
+        "_curated_registry",
+        lambda: {"gispulse-cap-ftth": {"tier": Tier.PRO, "trust": Trust.VERIFIED}},
+    )
+    loaded: list[str] = []
+    ep = FakeEP("ftth", dist="gispulse-cap-ftth", loader=lambda: loaded.append("x"))
+    monkeypatch.setattr(
+        plugin_hub,
+        "entry_points",
+        lambda group: [ep] if group == "gispulse.capabilities" else [],
+    )
+    hub = PluginHub()
+    hub.licence_provider = FakeLicence("community")
+    hub._discover_records()
+
+    rec = hub.records[0]
+    assert rec.state is PluginState.LOCKED
+    assert rec.tier_required is Tier.PRO
+    assert rec.obj is None
+    assert loaded == []  # gate refused before the entry-point was loaded
+
+
+def test_discover_activates_pro_plugin_under_enterprise(monkeypatch) -> None:
+    monkeypatch.setattr(
+        plugin_hub,
+        "_curated_registry",
+        lambda: {"gispulse-cap-ftth": {"tier": Tier.PRO, "trust": Trust.VERIFIED}},
+    )
+    sentinel = object()
+    ep = FakeEP("ftth", dist="gispulse-cap-ftth", loader=lambda: sentinel)
+    monkeypatch.setattr(
+        plugin_hub,
+        "entry_points",
+        lambda group: [ep] if group == "gispulse.capabilities" else [],
+    )
+    hub = PluginHub()
+    hub.licence_provider = FakeLicence("enterprise")
+    hub._discover_records()
+
+    rec = hub.records[0]
+    assert rec.state is PluginState.ACTIVE
+    assert rec.obj is sentinel
+
+
+def test_protocol_mismatch_warns_but_still_activates(monkeypatch) -> None:
+    class Obj:
+        requires_protocol = ">=99.0"  # unsatisfiable — warn-only, not a gate
+
+    ep = FakeEP("x", loader=Obj)
+    monkeypatch.setattr(plugin_hub, "_curated_registry", dict)
+    monkeypatch.setattr(
+        plugin_hub,
+        "entry_points",
+        lambda group: [ep] if group == "gispulse.protocols" else [],
+    )
+    hub = PluginHub()
+    hub.licence_provider = FakeLicence("community")
+    hub._discover_records()
+    assert hub.records[0].state is PluginState.ACTIVE

--- a/tests/unit/test_plugin_hub_records.py
+++ b/tests/unit/test_plugin_hub_records.py
@@ -1,0 +1,154 @@
+"""Unit tests for the PluginHub unified inventory (issue #177)."""
+
+from __future__ import annotations
+
+import pytest
+
+from core import plugin_hub
+from core.plugin_hub import PluginHub
+from core.plugin_model import PluginKind, PluginState
+
+
+class FakeEP:
+    """Minimal stand-in for ``importlib.metadata.EntryPoint``."""
+
+    def __init__(self, name: str, loader) -> None:
+        self.name = name
+        self.value = f"pkg_{name}:obj"
+        self._loader = loader
+
+    def load(self):
+        return self._loader()
+
+
+def _patch_entry_points(monkeypatch, groups: dict[str, list]) -> None:
+    """Make ``plugin_hub.entry_points`` resolve from a fixed group map."""
+    monkeypatch.setattr(
+        plugin_hub, "entry_points", lambda group: groups.get(group, [])
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_hub():
+    PluginHub.reset()
+    yield
+    PluginHub.reset()
+
+
+# --------------------------------------------------------------------------
+# _discover_records — coverage of the 11 groups
+# --------------------------------------------------------------------------
+
+
+def test_inventory_maps_each_group_to_its_kind(monkeypatch) -> None:
+    _patch_entry_points(
+        monkeypatch,
+        {
+            "gispulse.routers": [FakeEP("admin", object)],
+            "gispulse.mcp_tools": [FakeEP("permis", object)],
+            "gispulse.capabilities": [FakeEP("h3", lambda: (lambda: None))],
+            "gispulse.data_sources": [FakeEP("cadastre", object)],
+            "gispulse.data_sinks": [FakeEP("postgis", object)],
+            "gispulse.protocols": [FakeEP("wfs", object)],
+        },
+    )
+    hub = PluginHub()
+    hub._discover_records()
+
+    by_name = {r.name: r for r in hub.records}
+    assert by_name["admin"].kind is PluginKind.EXTENSION
+    assert by_name["permis"].kind is PluginKind.EXTENSION  # mcp_tools collapse too
+    assert by_name["h3"].kind is PluginKind.CAPABILITY
+    assert by_name["cadastre"].kind is PluginKind.SOURCE
+    assert by_name["postgis"].kind is PluginKind.SINK
+    assert by_name["wfs"].kind is PluginKind.PROTOCOL
+
+
+def test_inventory_empty_when_no_entry_points(monkeypatch) -> None:
+    _patch_entry_points(monkeypatch, {})
+    hub = PluginHub()
+    hub._discover_records()
+    assert hub.records == []
+
+
+# --------------------------------------------------------------------------
+# Lifecycle state — activate / fail
+# --------------------------------------------------------------------------
+
+
+def test_loadable_entry_point_becomes_active(monkeypatch) -> None:
+    sentinel = object()
+    _patch_entry_points(
+        monkeypatch, {"gispulse.data_sources": [FakeEP("ok", lambda: sentinel)]}
+    )
+    hub = PluginHub()
+    hub._discover_records()
+
+    rec = hub.records[0]
+    assert rec.state is PluginState.ACTIVE
+    assert rec.obj is sentinel
+    assert rec.detail == ""
+    assert rec.available is True
+
+
+def test_failing_entry_point_is_isolated_as_failed(monkeypatch) -> None:
+    def boom():
+        raise ImportError("missing native dep")
+
+    _patch_entry_points(
+        monkeypatch,
+        {
+            "gispulse.capabilities": [
+                FakeEP("good", object),
+                FakeEP("broken", boom),
+            ]
+        },
+    )
+    hub = PluginHub()
+    hub._discover_records()
+
+    states = {r.name: r for r in hub.records}
+    assert states["good"].state is PluginState.ACTIVE
+    assert states["broken"].state is PluginState.FAILED
+    assert "missing native dep" in states["broken"].detail
+    assert states["broken"].obj is None  # a bad plugin never crashes discovery
+
+
+# --------------------------------------------------------------------------
+# records_by_kind helper
+# --------------------------------------------------------------------------
+
+
+def test_records_by_kind_filters(monkeypatch) -> None:
+    _patch_entry_points(
+        monkeypatch,
+        {
+            "gispulse.data_sources": [FakeEP("a", object), FakeEP("b", object)],
+            "gispulse.routers": [FakeEP("admin", object)],
+        },
+    )
+    hub = PluginHub()
+    hub._discover_records()
+
+    sources = hub.records_by_kind(PluginKind.SOURCE)
+    assert sorted(r.name for r in sources) == ["a", "b"]
+    assert len(hub.records_by_kind(PluginKind.EXTENSION)) == 1
+    assert hub.records_by_kind(PluginKind.SINK) == []
+
+
+# --------------------------------------------------------------------------
+# Integration through the singleton + reset
+# --------------------------------------------------------------------------
+
+
+def test_get_runs_discovery_and_reset_clears_records(monkeypatch) -> None:
+    _patch_entry_points(
+        monkeypatch, {"gispulse.protocols": [FakeEP("stac", object)]}
+    )
+    hub = PluginHub.get()
+    assert [r.name for r in hub.records] == ["stac"]
+
+    PluginHub.reset()
+    assert PluginHub._instance is None
+    hub2 = PluginHub.get()
+    assert hub2 is not hub

--- a/tests/unit/test_plugin_model.py
+++ b/tests/unit/test_plugin_model.py
@@ -1,0 +1,201 @@
+"""Unit tests for the unified plugin model vocabulary (issue #176)."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from core.plugin_model import (
+    ENTRYPOINT_GROUPS,
+    PROTOCOL_VERSION,
+    AccessProtocol,
+    AccessSpec,
+    FetchMode,
+    Origin,
+    Payload,
+    PluginKind,
+    PluginManifest,
+    PluginRecord,
+    PluginState,
+    RuleClause,
+    SourceDomain,
+    SourceResult,
+    Tier,
+    Trust,
+    WriteMode,
+    WriteReport,
+    WriteSpec,
+    tier_satisfies,
+)
+
+
+# --------------------------------------------------------------------------
+# Enums
+# --------------------------------------------------------------------------
+
+
+def test_protocol_version_is_shared_with_contracts() -> None:
+    from core import plugin_contracts
+
+    assert plugin_contracts.PROTOCOL_VERSION is PROTOCOL_VERSION
+
+
+@pytest.mark.parametrize(
+    ("enum", "size"),
+    [
+        (PluginKind, 5),
+        (Origin, 2),
+        (Trust, 3),
+        (PluginState, 4),
+        (Tier, 4),
+        (SourceDomain, 9),
+        (Payload, 5),
+        (AccessProtocol, 15),
+        (FetchMode, 2),
+        (WriteMode, 3),
+    ],
+)
+def test_enum_cardinality(enum: type, size: int) -> None:
+    assert len(list(enum)) == size
+
+
+def test_enums_are_str_serializable() -> None:
+    # str-Enum members compare equal to their value — JSON / API friendly.
+    assert PluginKind.SOURCE == "source"
+    assert SourceDomain.REGLEMENTAIRE.value == "reglementaire"
+    assert AccessProtocol.OGC_FEATURES.value == "ogc-features"
+
+
+def test_entrypoint_groups_cover_single_group_kinds() -> None:
+    # EXTENSION spans nine sub-groups and is intentionally absent.
+    assert set(ENTRYPOINT_GROUPS) == {
+        PluginKind.SOURCE,
+        PluginKind.CAPABILITY,
+        PluginKind.SINK,
+        PluginKind.PROTOCOL,
+    }
+    assert ENTRYPOINT_GROUPS[PluginKind.SOURCE] == "gispulse.data_sources"
+    assert PluginKind.EXTENSION not in ENTRYPOINT_GROUPS
+
+
+# --------------------------------------------------------------------------
+# tier_satisfies
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("current", "required", "ok"),
+    [
+        (Tier.COMMUNITY, Tier.COMMUNITY, True),
+        (Tier.COMMUNITY, Tier.PRO, False),
+        (Tier.PRO, Tier.COMMUNITY, True),
+        (Tier.PRO, Tier.PRO, True),
+        (Tier.PRO, Tier.TEAM, False),
+        (Tier.ENTERPRISE, Tier.COMMUNITY, True),
+        (Tier.ENTERPRISE, Tier.ENTERPRISE, True),
+        (Tier.TEAM, Tier.ENTERPRISE, False),
+    ],
+)
+def test_tier_satisfies(current: Tier, required: Tier, ok: bool) -> None:
+    assert tier_satisfies(current, required) is ok
+
+
+# --------------------------------------------------------------------------
+# Dataclasses
+# --------------------------------------------------------------------------
+
+
+def test_manifest_is_frozen() -> None:
+    m = PluginManifest(name="cadastre", kind=PluginKind.SOURCE)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        m.name = "other"  # type: ignore[misc]
+
+
+def test_manifest_source_axes() -> None:
+    m = PluginManifest(
+        name="urbanisme",
+        kind=PluginKind.SOURCE,
+        origin=Origin.EXTERNAL,
+        domain=SourceDomain.REGLEMENTAIRE,
+        payload=Payload.VECTOR,
+        jurisdiction="FR",
+    )
+    assert m.domain is SourceDomain.REGLEMENTAIRE
+    assert m.jurisdiction == "FR"
+    assert m.tier is None  # external plugins don't grant themselves a tier
+
+
+def test_access_spec_defaults() -> None:
+    spec = AccessSpec(protocol=AccessProtocol.WFS, endpoint="https://x/wfs")
+    assert spec.params == {} and spec.format is None and spec.auth is None
+
+
+def test_source_result_reference_mode() -> None:
+    r = SourceResult(
+        payload=Payload.RASTER,
+        mode=FetchMode.REFERENCE,
+        reference="https://x/dem.tif",
+        crs="EPSG:2154",
+    )
+    assert r.data is None
+    assert r.reference.endswith(".tif")
+    assert r.mode is FetchMode.REFERENCE
+
+
+def test_write_spec_and_report() -> None:
+    spec = WriteSpec(protocol=AccessProtocol.DB, destination="postgis://analyse.t")
+    assert spec.mode is WriteMode.UPSERT
+    report = WriteReport(destination=spec.destination, rows_written=42, created=True)
+    assert report.rows_written == 42 and report.rows_failed == 0
+
+
+def test_rule_clause_is_jurisdiction_agnostic() -> None:
+    clause = RuleClause(
+        zone_code="UB",
+        jurisdiction="FR",
+        constraints={"emprise_max": 0.4, "hauteur_max": 12},
+        source_doc="reglement_UB.pdf#p14",
+    )
+    assert clause.constraints["hauteur_max"] == 12
+    assert clause.jurisdiction == "FR"
+
+
+# --------------------------------------------------------------------------
+# PluginRecord
+# --------------------------------------------------------------------------
+
+
+def test_plugin_record_defaults_and_availability() -> None:
+    rec = PluginRecord(name="h3_aggregate", kind=PluginKind.CAPABILITY)
+    assert rec.state is PluginState.DISCOVERED
+    assert rec.tier_required is Tier.COMMUNITY
+    assert rec.available is False
+
+    rec.state = PluginState.ACTIVE
+    assert rec.available is True
+
+
+def test_plugin_record_as_dict_is_json_safe() -> None:
+    rec = PluginRecord(
+        name="ftth_coverage",
+        kind=PluginKind.CAPABILITY,
+        origin=Origin.EXTERNAL,
+        trust=Trust.VERIFIED,
+        tier_required=Tier.PRO,
+        state=PluginState.LOCKED,
+        detail="requiert le palier 'pro'",
+        entry_point=object(),  # not JSON-safe — must be dropped
+        obj=object(),
+    )
+    d = rec.as_dict()
+    assert d == {
+        "name": "ftth_coverage",
+        "kind": "capability",
+        "origin": "external",
+        "trust": "verified",
+        "tier_required": "pro",
+        "state": "locked",
+        "detail": "requiert le palier 'pro'",
+    }
+    assert "entry_point" not in d and "obj" not in d

--- a/tests/unit/test_plugin_sdk_exports.py
+++ b/tests/unit/test_plugin_sdk_exports.py
@@ -1,0 +1,107 @@
+"""SDK surface + plugin-migration tests (issue #183)."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[2]
+_PLUGIN_PYPROJECTS = sorted((_REPO / "plugins").glob("*/pyproject.toml"))
+_PLUGIN_SOURCES = sorted((_REPO / "plugins").glob("*/gispulse_cap_*/*.py"))
+_TEMPLATE = _REPO / "examples" / "plugin-template"
+
+
+# --------------------------------------------------------------------------
+# gispulse.plugins.api — the single public surface
+# --------------------------------------------------------------------------
+
+
+def test_api_exports_manifest_and_contracts() -> None:
+    from gispulse.plugins import api
+
+    for symbol in (
+        "Capability",
+        "register_capability",
+        "PluginHostContext",
+        "PluginManifest",
+        "DataSource",
+        "RegulatorySource",
+        "DataSink",
+        "Fetcher",
+        "Writer",
+        "SourceResult",
+        "AccessSpec",
+        "RuleClause",
+    ):
+        assert symbol in api.__all__, f"{symbol} missing from api.__all__"
+        assert hasattr(api, symbol), f"{symbol} not importable from api"
+
+
+def test_api_symbols_are_the_core_objects() -> None:
+    from core.plugin_model import PluginManifest, SourceResult
+    from core.sources import DataSource
+    from gispulse.plugins import api
+
+    assert api.PluginManifest is PluginManifest
+    assert api.SourceResult is SourceResult
+    assert api.DataSource is DataSource
+
+
+# --------------------------------------------------------------------------
+# Migration — no plugin imports the internal layout directly
+# --------------------------------------------------------------------------
+
+
+def test_plugins_dir_is_present() -> None:
+    assert _PLUGIN_SOURCES, "no plugin sources found — repo layout changed?"
+
+
+@pytest.mark.parametrize("source", _PLUGIN_SOURCES, ids=lambda p: p.parent.name)
+def test_plugin_does_not_import_internal_layout(source: Path) -> None:
+    # Forbid importing the top-level ``capabilities`` package directly;
+    # an intra-package ``from gispulse_cap_x import capabilities`` is fine.
+    for raw in source.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        assert not line.startswith(("from capabilities.", "from capabilities import")), (
+            f"{source} still imports the internal capabilities.* layout — "
+            f"migrate to gispulse.plugins.api ({line!r})"
+        )
+        assert not line.startswith(("import capabilities ", "import capabilities.")), (
+            f"{source} still imports the internal capabilities package ({line!r})"
+        )
+        assert line != "import capabilities", (
+            f"{source} still imports the internal capabilities package"
+        )
+
+
+def test_template_uses_the_sdk() -> None:
+    caps = (_TEMPLATE / "gispulse_cap_example" / "capabilities.py").read_text("utf-8")
+    assert "from gispulse.plugins.api import" in caps
+    assert "from capabilities" not in caps
+
+
+# --------------------------------------------------------------------------
+# Manifest — [tool.gispulse.plugin] in every plugin pyproject
+# --------------------------------------------------------------------------
+
+
+def test_plugin_pyprojects_present() -> None:
+    assert len(_PLUGIN_PYPROJECTS) == 6
+
+
+@pytest.mark.parametrize(
+    "pyproject",
+    [*_PLUGIN_PYPROJECTS, _TEMPLATE / "pyproject.toml"],
+    ids=lambda p: p.parent.name,
+)
+def test_pyproject_declares_manifest_and_gispulse_dep(pyproject: Path) -> None:
+    data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    manifest = data.get("tool", {}).get("gispulse", {}).get("plugin")
+    assert manifest is not None, f"{pyproject} missing [tool.gispulse.plugin]"
+    assert manifest.get("protocol"), "manifest must declare a protocol specifier"
+    assert manifest.get("kind") == "capability"
+
+    deps = " ".join(data.get("project", {}).get("dependencies", []))
+    assert "gispulse" in deps, f"{pyproject} must depend on gispulse"

--- a/tests/unit/test_plugin_sdk_exports.py
+++ b/tests/unit/test_plugin_sdk_exports.py
@@ -88,7 +88,11 @@ def test_template_uses_the_sdk() -> None:
 
 
 def test_plugin_pyprojects_present() -> None:
-    assert len(_PLUGIN_PYPROJECTS) == 6
+    # 6 gispulse-cap-* plugins, plus any gispulse-src-* pilots (#184).
+    assert len(_PLUGIN_PYPROJECTS) >= 6
+
+
+_VALID_KINDS = {"capability", "source", "sink", "protocol"}
 
 
 @pytest.mark.parametrize(
@@ -101,7 +105,9 @@ def test_pyproject_declares_manifest_and_gispulse_dep(pyproject: Path) -> None:
     manifest = data.get("tool", {}).get("gispulse", {}).get("plugin")
     assert manifest is not None, f"{pyproject} missing [tool.gispulse.plugin]"
     assert manifest.get("protocol"), "manifest must declare a protocol specifier"
-    assert manifest.get("kind") == "capability"
+    assert manifest.get("kind") in _VALID_KINDS, (
+        f"{pyproject}: kind must be one of {sorted(_VALID_KINDS)}"
+    )
 
     deps = " ".join(data.get("project", {}).get("dependencies", []))
     assert "gispulse" in deps, f"{pyproject} must depend on gispulse"

--- a/tests/unit/test_plugin_sdk_exports.py
+++ b/tests/unit/test_plugin_sdk_exports.py
@@ -2,10 +2,18 @@
 
 from __future__ import annotations
 
-import tomllib
 from pathlib import Path
 
 import pytest
+
+# tomllib is stdlib on Python 3.11+; fall back to tomli on 3.10.
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10
+    try:
+        import tomli as tomllib
+    except ModuleNotFoundError:
+        tomllib = None  # type: ignore[assignment]
 
 _REPO = Path(__file__).resolve().parents[2]
 _PLUGIN_PYPROJECTS = sorted((_REPO / "plugins").glob("*/pyproject.toml"))
@@ -95,6 +103,7 @@ def test_plugin_pyprojects_present() -> None:
 _VALID_KINDS = {"capability", "source", "sink", "protocol"}
 
 
+@pytest.mark.skipif(tomllib is None, reason="needs tomllib (py3.11+) or tomli")
 @pytest.mark.parametrize(
     "pyproject",
     [*_PLUGIN_PYPROJECTS, _TEMPLATE / "pyproject.toml"],

--- a/tests/unit/test_source_watcher.py
+++ b/tests/unit/test_source_watcher.py
@@ -1,0 +1,169 @@
+"""Unit tests for SourceWatcherRegistry (issue #187)."""
+
+from __future__ import annotations
+
+import pytest
+
+from persistence.source_watcher import (
+    SourceWatcherRegistry,
+    interval_from_frequency,
+)
+
+
+class FakeSource:
+    """A DataSource stub with a mutable revision token."""
+
+    def __init__(self, name: str, revision: str | None) -> None:
+        self.name = name
+        self._revision = revision
+        self.calls = 0
+
+    def revision(self, entry_id: str) -> str | None:
+        self.calls += 1
+        return self._revision
+
+
+class BrokenSource:
+    name = "broken"
+
+    def revision(self, entry_id: str) -> str | None:
+        raise ConnectionError("upstream unreachable")
+
+
+class FakeHub:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict]] = []
+
+    def broadcast(self, event_type: str, data=None) -> None:
+        self.events.append((event_type, data))
+
+
+# --------------------------------------------------------------------------
+# interval_from_frequency
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("freq", "expected"),
+    [
+        ("quotidien", 3600.0),
+        ("ANNUEL", 24 * 3600.0),
+        ("pluriannuel", 24 * 3600.0),
+        (None, 6 * 3600.0),
+        ("inconnu", 6 * 3600.0),
+    ],
+)
+def test_interval_from_frequency(freq, expected) -> None:
+    assert interval_from_frequency(freq) == expected
+
+
+# --------------------------------------------------------------------------
+# register
+# --------------------------------------------------------------------------
+
+
+def test_register_captures_baseline_and_returns_key() -> None:
+    reg = SourceWatcherRegistry()
+    key = reg.register(FakeSource("cadastre", "2026-01"), "parcelles", interval_s=3600)
+    assert key == "cadastre:parcelles"
+    assert reg.list_watched() == ["cadastre:parcelles"]
+
+
+def test_register_rejects_sub_minute_interval() -> None:
+    reg = SourceWatcherRegistry()
+    with pytest.raises(ValueError, match=">= 60"):
+        reg.register(FakeSource("x", "r1"), "e", interval_s=5)
+
+
+def test_register_uses_frequency_when_no_interval() -> None:
+    reg = SourceWatcherRegistry()
+    reg.register(FakeSource("x", "r1"), "e", frequency="quotidien")
+    assert reg.list_watched() == ["x:e"]
+
+
+def test_unregister() -> None:
+    reg = SourceWatcherRegistry()
+    reg.register(FakeSource("x", "r1"), "e", interval_s=3600)
+    reg.unregister("x:e")
+    assert reg.list_watched() == []
+
+
+# --------------------------------------------------------------------------
+# poll — change detection + event emission
+# --------------------------------------------------------------------------
+
+
+def test_poll_no_change_emits_nothing() -> None:
+    hub = FakeHub()
+    reg = SourceWatcherRegistry(event_hub=hub)
+    reg.register(FakeSource("cadastre", "2026-01"), "parcelles", interval_s=3600)
+    assert reg.poll() == []
+    assert hub.events == []
+
+
+def test_poll_detects_new_millesime_and_broadcasts() -> None:
+    hub = FakeHub()
+    reg = SourceWatcherRegistry(event_hub=hub)
+    source = FakeSource("cadastre", "2026-01")
+    reg.register(source, "parcelles", interval_s=3600)
+
+    # A new millésime is published upstream.
+    source._revision = "2026-02"
+    changes = reg.poll()
+
+    assert len(changes) == 1
+    change = changes[0]
+    assert change["source"] == "cadastre://parcelles"
+    assert change["revision"] == "2026-02"
+    assert change["previous"] == "2026-01"
+
+    assert hub.events == [("source.changed", change)]
+
+
+def test_poll_is_idempotent_after_a_change() -> None:
+    hub = FakeHub()
+    reg = SourceWatcherRegistry(event_hub=hub)
+    source = FakeSource("bdtopo", "v1")
+    reg.register(source, "batiments", interval_s=3600)
+
+    source._revision = "v2"
+    assert len(reg.poll()) == 1   # change detected once
+    assert reg.poll() == []        # same revision — no re-fire
+    assert len(hub.events) == 1
+
+
+def test_poll_isolates_a_failing_source() -> None:
+    hub = FakeHub()
+    reg = SourceWatcherRegistry(event_hub=hub)
+    reg._entries["broken:e"] = reg._entries.get("broken:e") or _broken_entry()
+    ok = FakeSource("ok", "r1")
+    reg.register(ok, "e", interval_s=3600)
+
+    ok._revision = "r2"
+    changes = reg.poll()  # broken source raises, ok source still detected
+
+    assert [c["source"] for c in changes] == ["ok://e"]
+
+
+def _broken_entry():
+    from persistence.source_watcher import _WatchEntry
+
+    return _WatchEntry(source=BrokenSource(), entry_id="e", interval_s=3600.0,
+                       last_revision="r0")
+
+
+# --------------------------------------------------------------------------
+# daemon lifecycle
+# --------------------------------------------------------------------------
+
+
+def test_daemon_start_stop() -> None:
+    reg = SourceWatcherRegistry()
+    reg.register(FakeSource("x", "r1"), "e", interval_s=3600)
+    assert reg.is_running() is False
+    reg.start(tick_s=3600)
+    try:
+        assert reg.is_running() is True
+    finally:
+        reg.stop()
+    assert reg.is_running() is False

--- a/tests/unit/test_sources.py
+++ b/tests/unit/test_sources.py
@@ -1,0 +1,210 @@
+"""Unit tests for the ETL plugin contracts and protocol registry (issue #178)."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.plugin_model import (
+    AccessProtocol,
+    AccessSpec,
+    FetchMode,
+    Payload,
+    SourceDomain,
+    SourceResult,
+    WriteReport,
+    WriteSpec,
+)
+from core.sources import (
+    PROTOCOLS,
+    DataSink,
+    DataSource,
+    DeclarativeSink,
+    DeclarativeSource,
+    Fetcher,
+    ProtocolNotSupported,
+    ProtocolRegistry,
+    SourceEntryRef,
+    Writer,
+)
+
+
+# --------------------------------------------------------------------------
+# Test doubles
+# --------------------------------------------------------------------------
+
+
+class FakeWFS:
+    """Fetcher-only adapter."""
+
+    protocol = AccessProtocol.WFS
+
+    def fetch(self, access, *, extent=None, mode=FetchMode.MATERIALIZE):
+        return SourceResult(payload=Payload.VECTOR, mode=mode, data=f"rows@{access.endpoint}")
+
+
+class FakeDB:
+    """Adapter that both reads and writes."""
+
+    protocol = AccessProtocol.DB
+
+    def fetch(self, access, *, extent=None, mode=FetchMode.MATERIALIZE):
+        return SourceResult(payload=Payload.TABLE, data="table")
+
+    def write(self, result, spec):
+        return WriteReport(destination=spec.destination, rows_written=3, created=True)
+
+
+class NoProtocol:
+    def fetch(self, access, *, extent=None, mode=FetchMode.MATERIALIZE):  # noqa: ARG002
+        return SourceResult(payload=Payload.VECTOR)
+
+
+class NotAnAdapter:
+    protocol = AccessProtocol.WMS
+
+
+class FakeCadastre(DeclarativeSource):
+    name = "cadastre"
+    domain = SourceDomain.FONCIER
+    payload = Payload.VECTOR
+    jurisdiction = "FR"
+
+    def entries(self):
+        return [
+            SourceEntryRef(
+                id="parcelles",
+                name="Parcelles cadastrales",
+                access=AccessSpec(protocol=AccessProtocol.WFS, endpoint="https://ign/wfs"),
+                revision_token="2026-01",
+            ),
+        ]
+
+
+class FakePostgisSink(DeclarativeSink):
+    name = "postgis"
+
+
+@pytest.fixture
+def registry() -> ProtocolRegistry:
+    reg = ProtocolRegistry()
+    reg.register(FakeWFS())
+    reg.register(FakeDB())
+    return reg
+
+
+# --------------------------------------------------------------------------
+# ProtocolRegistry
+# --------------------------------------------------------------------------
+
+
+def test_register_files_adapter_under_its_roles(registry: ProtocolRegistry) -> None:
+    assert isinstance(registry.get_fetcher(AccessProtocol.WFS), FakeWFS)
+    assert isinstance(registry.get_fetcher(AccessProtocol.DB), FakeDB)
+    assert isinstance(registry.get_writer(AccessProtocol.DB), FakeDB)
+
+
+def test_fetcher_only_adapter_has_no_writer(registry: ProtocolRegistry) -> None:
+    with pytest.raises(ProtocolNotSupported, match="no writer"):
+        registry.get_writer(AccessProtocol.WFS)
+
+
+def test_missing_protocol_raises(registry: ProtocolRegistry) -> None:
+    with pytest.raises(ProtocolNotSupported, match="no fetcher"):
+        registry.get_fetcher(AccessProtocol.STAC)
+
+
+def test_register_rejects_adapter_without_protocol() -> None:
+    with pytest.raises(ValueError, match="must declare a 'protocol"):
+        ProtocolRegistry().register(NoProtocol())
+
+
+def test_register_rejects_non_adapter() -> None:
+    with pytest.raises(TypeError, match="neither a Fetcher nor a Writer"):
+        ProtocolRegistry().register(NotAnAdapter())
+
+
+def test_register_rejects_duplicate_without_override() -> None:
+    reg = ProtocolRegistry()
+    reg.register(FakeWFS())
+    with pytest.raises(ValueError, match="already registered"):
+        reg.register(FakeWFS())
+    reg.register(FakeWFS(), override=True)  # explicit override is fine
+
+
+def test_dispatch_fetch_resolves_and_runs(registry: ProtocolRegistry) -> None:
+    access = AccessSpec(protocol=AccessProtocol.WFS, endpoint="https://ign/wfs")
+    result = registry.dispatch_fetch(access, mode=FetchMode.REFERENCE)
+    assert result.data == "rows@https://ign/wfs"
+    assert result.mode is FetchMode.REFERENCE
+
+
+def test_dispatch_write_resolves_and_runs(registry: ProtocolRegistry) -> None:
+    spec = WriteSpec(protocol=AccessProtocol.DB, destination="postgis://analyse.t")
+    report = registry.dispatch_write(SourceResult(payload=Payload.TABLE), spec)
+    assert report.rows_written == 3 and report.created is True
+
+
+def test_module_level_registry_is_shared() -> None:
+    assert isinstance(PROTOCOLS, ProtocolRegistry)
+
+
+# --------------------------------------------------------------------------
+# Structural Protocol conformance
+# --------------------------------------------------------------------------
+
+
+def test_runtime_checkable_roles() -> None:
+    assert isinstance(FakeWFS(), Fetcher)
+    assert not isinstance(FakeWFS(), Writer)
+    assert isinstance(FakeDB(), Fetcher)
+    assert isinstance(FakeDB(), Writer)
+    assert isinstance(FakeCadastre(), DataSource)
+    assert isinstance(FakePostgisSink(), DataSink)
+
+
+# --------------------------------------------------------------------------
+# DeclarativeSource — fetch() delegates, zero network code
+# --------------------------------------------------------------------------
+
+
+def test_declarative_source_fetch_delegates(registry: ProtocolRegistry) -> None:
+    src = FakeCadastre(registry=registry)
+    result = src.fetch("parcelles")
+    assert result.payload is Payload.VECTOR
+    assert result.data == "rows@https://ign/wfs"
+
+
+def test_declarative_source_revision_returns_token(registry: ProtocolRegistry) -> None:
+    assert FakeCadastre(registry=registry).revision("parcelles") == "2026-01"
+
+
+def test_declarative_source_unknown_entry_raises(registry: ProtocolRegistry) -> None:
+    with pytest.raises(KeyError, match="unknown entry 'ghost'"):
+        FakeCadastre(registry=registry).fetch("ghost")
+
+
+def test_declarative_source_catalog_search(registry: ProtocolRegistry) -> None:
+    src = FakeCadastre(registry=registry)
+    assert len(src.catalog()) == 1
+    assert len(src.catalog(search="parcel")) == 1
+    assert src.catalog(search="zzz") == []
+
+
+def test_declarative_source_schema_validates_id(registry: ProtocolRegistry) -> None:
+    src = FakeCadastre(registry=registry)
+    assert src.schema("parcelles") == {}
+    with pytest.raises(KeyError):
+        src.schema("ghost")
+
+
+# --------------------------------------------------------------------------
+# DeclarativeSink — write() delegates
+# --------------------------------------------------------------------------
+
+
+def test_declarative_sink_write_delegates(registry: ProtocolRegistry) -> None:
+    sink = FakePostgisSink(registry=registry)
+    spec = WriteSpec(protocol=AccessProtocol.DB, destination="postgis://analyse.dvf")
+    report = sink.write(SourceResult(payload=Payload.TABLE), spec)
+    assert report.destination == "postgis://analyse.dvf"
+    assert report.rows_written == 3

--- a/tests/unit/test_src_cadastre.py
+++ b/tests/unit/test_src_cadastre.py
@@ -1,0 +1,100 @@
+"""Unit tests for the gispulse-src-cadastre pilot plugin (issue #184)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_PKG = Path(__file__).resolve().parents[2] / "plugins" / "gispulse-src-cadastre"
+if str(_PKG) not in sys.path:
+    sys.path.insert(0, str(_PKG))
+
+from gispulse_src_cadastre.source import CadastreSource  # noqa: E402
+
+from core.plugin_model import AccessProtocol, FetchMode, Payload, SourceDomain, SourceResult  # noqa: E402
+from core.sources import DataSource, ProtocolRegistry  # noqa: E402
+
+
+class FakeWFS:
+    """Records the AccessSpec it is handed and returns a marker result."""
+
+    protocol = AccessProtocol.WFS
+
+    def __init__(self) -> None:
+        self.calls: list = []
+
+    def fetch(self, access, *, extent=None, mode=FetchMode.MATERIALIZE):
+        self.calls.append(access)
+        return SourceResult(payload=Payload.VECTOR, mode=mode, data=access.params["typename"])
+
+
+@pytest.fixture
+def source() -> CadastreSource:
+    reg = ProtocolRegistry()
+    reg.register(FakeWFS())
+    return CadastreSource(registry=reg)
+
+
+# --------------------------------------------------------------------------
+# Contract conformance + declared axes
+# --------------------------------------------------------------------------
+
+
+def test_cadastre_is_a_datasource(source: CadastreSource) -> None:
+    assert isinstance(source, DataSource)
+    assert source.name == "cadastre"
+    assert source.domain is SourceDomain.FONCIER
+    assert source.payload is Payload.VECTOR
+    assert source.jurisdiction == "FR"
+
+
+def test_catalog_lists_three_entries(source: CadastreSource) -> None:
+    ids = {e.id for e in source.catalog()}
+    assert ids == {"parcelles", "communes", "batiments"}
+
+
+def test_catalog_search(source: CadastreSource) -> None:
+    found = source.catalog(search="parcel")
+    assert [e.id for e in found] == ["parcelles"]
+
+
+# --------------------------------------------------------------------------
+# Declarative fetch — delegates to the WFS adapter, zero network code
+# --------------------------------------------------------------------------
+
+
+def test_fetch_delegates_to_wfs_adapter() -> None:
+    wfs = FakeWFS()
+    reg = ProtocolRegistry()
+    reg.register(wfs)
+    src = CadastreSource(registry=reg)
+
+    result = src.fetch("parcelles")
+
+    assert result.payload is Payload.VECTOR
+    assert "PARCELLAIRE_EXPRESS:parcelle" in result.data
+    assert len(wfs.calls) == 1
+    assert wfs.calls[0].protocol is AccessProtocol.WFS
+
+
+def test_fetch_unknown_entry_raises(source: CadastreSource) -> None:
+    with pytest.raises(KeyError, match="unknown entry 'ghost'"):
+        source.fetch("ghost")
+
+
+# --------------------------------------------------------------------------
+# Schema + revision
+# --------------------------------------------------------------------------
+
+
+def test_schema_per_layer(source: CadastreSource) -> None:
+    assert "contenance" in source.schema("parcelles")
+    assert "code_insee" in source.schema("communes")
+    assert source.schema("batiments")["geometry"] == "geometry"
+
+
+def test_revision_exposes_millesime(source: CadastreSource) -> None:
+    # A freshness token the source watcher (issue #187) can poll.
+    assert source.revision("parcelles") == "2026-01"

--- a/tests/unit/test_trigger_source_changed.py
+++ b/tests/unit/test_trigger_source_changed.py
@@ -1,0 +1,103 @@
+"""Tests for the SOURCE_CHANGED trigger type (issue #186)."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from core.models import ChangeRecord, Trigger, TriggerEvent, TriggerType
+from rules.trigger_evaluator import TriggerEvaluator
+
+
+def _record(new_values: dict) -> ChangeRecord:
+    return ChangeRecord(
+        table_name="_external_source",
+        operation="INSERT",
+        new_values=new_values,
+        feature_id="src",
+    )
+
+
+def _trigger(conditions: dict) -> Trigger:
+    return Trigger(
+        id=uuid4(),
+        name="src-watch",
+        event=TriggerEvent.MANUAL,
+        trigger_type=TriggerType.SOURCE_CHANGED,
+        conditions=conditions,
+        enabled=True,
+    )
+
+
+def _fires(new_values: dict, conditions: dict) -> bool:
+    fired = TriggerEvaluator().evaluate(_record(new_values), [_trigger(conditions)])
+    return fired[0].matched
+
+
+# --------------------------------------------------------------------------
+# The enum value exists and dispatches
+# --------------------------------------------------------------------------
+
+
+def test_trigger_type_value() -> None:
+    assert TriggerType.SOURCE_CHANGED.value == "source_changed"
+
+
+# --------------------------------------------------------------------------
+# Revision comparison
+# --------------------------------------------------------------------------
+
+
+def test_fires_when_revision_changed() -> None:
+    assert _fires(
+        {"source": "cadastre://parcelles", "revision": "2026-02"},
+        {"source": "cadastre://parcelles", "last_revision": "2026-01"},
+    )
+
+
+def test_no_fire_when_revision_unchanged() -> None:
+    assert not _fires(
+        {"source": "cadastre://parcelles", "revision": "2026-01"},
+        {"source": "cadastre://parcelles", "last_revision": "2026-01"},
+    )
+
+
+def test_fires_on_first_observation_without_last_revision() -> None:
+    # No last_revision recorded yet — the first poll always fires.
+    assert _fires(
+        {"source": "cadastre://parcelles", "revision": "2026-01"},
+        {"source": "cadastre://parcelles"},
+    )
+
+
+def test_no_fire_when_event_has_no_revision() -> None:
+    assert not _fires(
+        {"source": "cadastre://parcelles"},
+        {"source": "cadastre://parcelles", "last_revision": "2026-01"},
+    )
+
+
+# --------------------------------------------------------------------------
+# Source matching
+# --------------------------------------------------------------------------
+
+
+def test_no_fire_when_source_mismatch() -> None:
+    assert not _fires(
+        {"source": "osm://poi", "revision": "r2"},
+        {"source": "cadastre://parcelles", "last_revision": "r1"},
+    )
+
+
+def test_fires_when_source_matches_and_revision_new() -> None:
+    assert _fires(
+        {"source": "bdtopo://batiments", "revision": "v3"},
+        {"source": "bdtopo://batiments", "last_revision": "v2"},
+    )
+
+
+def test_unscoped_trigger_fires_for_any_source() -> None:
+    # No 'source' in the trigger conditions — watches every source.
+    assert _fires(
+        {"source": "anything://x", "revision": "new"},
+        {"last_revision": "old"},
+    )


### PR DESCRIPTION
## Epic #175 — Modèle de plugins unifié → plateforme ETL

Refonte du système de plugins GISPulse en **plateforme ETL event-driven** sur un runtime unique. Implémente les 13 issues #176–#188 de l'epic #175.

Design complet : brainstorm projet `brainstorm_plugin_etl_unified_2026_05_16`.

### Modèle livré — graphe ETL

```
SOURCE (Extract) → CAPABILITY* (Transform) → SINK (Load)
```

5 `kind` de plugins, un seul `PluginHub`, cycle `discover → resolve → gate → activate`.

### Issues

| # | Livré |
|---|---|
| #176 | `core/plugin_model.py` — enums + dataclasses du modèle |
| #177 | `PluginHub` — inventaire unifié sur 11 groupes d'entry-points |
| #178 | `core/sources.py` — contrats `DataSource`/`RegulatorySource`/`DataSink` + `ProtocolRegistry` |
| #179 | bridge `CatalogProvider` → `DataSource` |
| #180 | `capabilities/registry` consomme le hub (fin du double discovery) |
| #181 | `registry.json` v3 + `/marketplace/plugins` sourcé du hub (état `locked`) |
| #182 | gate de tier/trust au chargement + `GISPULSE_PLUGINS_ALLOW_UNVERIFIED` |
| #183 | SDK : manifeste + migration des 6 plugins vers `gispulse.plugins.api` |
| #184 | package pilote `gispulse-src-cadastre` (`DeclarativeSource`) |
| #185 | job CI `plugins` : install réelle + `scripts/check_plugins.py` |
| #186 | `trigger_type = SOURCE_CHANGED` dans `TriggerEvaluator` |
| #187 | `SourceWatcherRegistry` — poll de fraîcheur des sources externes |
| #188 | test d'intégration cascade ETL bornée par `MAX_CASCADE_DEPTH` |

### Notes

- **Branche d'intégration** : un diamant de dépendances (#185 dépendait de deux chaînes disjointes) a été résolu par cette branche fusionnant les 9 branches features. Chaque issue garde son commit dédié.
- **220 tests** verts ; `ruff check .` propre (4 erreurs lint pré-existantes hors epic nettoyées dans un commit `chore` séparé).
- **Périmètres reportés** (notés dans les commits) : absorption réelle des fetchers WFS/APICarto (#178) · recâblage `catalog.registry` (#179) · vagues 2-3 des packages pilotes (#184) · mot-clé `on: source_changed:` du config-loader (#186).

Closes #176 #177 #178 #179 #180 #181 #182 #183 #184 #185 #186 #187 #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)
