### PR TITLE
[v1.7.0] source_changed triggers — config syntax + cadastre revision() + watcher wiring

### DIFF
--- a/core/sources.py
+++ b/core/sources.py
@@ -308,6 +308,50 @@ class DeclarativeSource(ABC):
         return self._entry(entry_id).revision_token
 
 
+class SourceRegistry:
+    """Process-wide registry of activated :class:`DataSource` instances.
+
+    Keyed by ``DataSource.name``. Populated by the ``register()`` hook of
+    each ``gispulse.data_sources`` plugin. The source watcher (issue
+    #197) resolves a ``<source>://<entry>`` URI from ``triggers.yaml``
+    against this registry to find the live source object to poll.
+    """
+
+    def __init__(self) -> None:
+        self._sources: dict[str, Any] = {}
+
+    def register(self, source: Any) -> None:
+        """Record ``source`` under its ``name`` (last registration wins)."""
+        name = getattr(source, "name", None)
+        if not name:
+            raise ValueError(
+                "a DataSource must declare a non-empty 'name' to be registered"
+            )
+        self._sources[name] = source
+
+    def get(self, name: str) -> Any:
+        """Return the source registered as ``name`` or raise ``KeyError``."""
+        try:
+            return self._sources[name]
+        except KeyError:
+            raise KeyError(
+                f"no data source named {name!r} is registered "
+                f"(available: {', '.join(self.names()) or 'none'})"
+            ) from None
+
+    def names(self) -> list[str]:
+        return sorted(self._sources)
+
+    def clear(self) -> None:
+        """Drop every registration — used by tests for isolation."""
+        self._sources.clear()
+
+
+# Process-wide source registry. Populated by ``gispulse.data_sources``
+# plugin ``register()`` hooks; read by the source watcher (#197).
+SOURCES = SourceRegistry()
+
+
 class DeclarativeSink(ABC):
     """Base for sinks that delegate writing to a registered :class:`Writer`."""
 
@@ -332,4 +376,6 @@ __all__ = [
     "DataSink",
     "DeclarativeSource",
     "DeclarativeSink",
+    "SourceRegistry",
+    "SOURCES",
 ]

--- a/gispulse/cli_triggers_watch.py
+++ b/gispulse/cli_triggers_watch.py
@@ -290,6 +290,29 @@ def _maybe_reload(
     )
 
 
+def _start_source_watcher(runtime: "HeadlessRuntime") -> Any:
+    """Build + start the external-source watcher for ``runtime`` (#197).
+
+    Returns the running :class:`SourceWatcherRegistry`, or ``None`` when
+    the config declares no ``source_changed`` trigger (or the build
+    fails — a broken source watcher must never abort the DML daemon).
+    """
+    from gispulse.runtime.source_watch import build_source_watcher
+
+    try:
+        watcher = build_source_watcher(
+            runtime.triggers, runtime.action_dispatcher
+        )
+    except Exception as exc:  # noqa: BLE001 — never abort the DML loop
+        emit_json("source_watcher_build_failed", error=str(exc))
+        return None
+    if watcher is None:
+        return None
+    watcher.start()
+    emit_json("source_watcher_started", watched=watcher.list_watched())
+    return watcher
+
+
 # ---------------------------------------------------------------------------
 # The loop itself
 # ---------------------------------------------------------------------------
@@ -367,6 +390,12 @@ def run_watch_loop(
         triggers=len(initial_runtime.triggers),
     )
 
+    # Source watcher (#197) — polls external data sources declared with
+    # ``on: {source_changed: ...}`` on its own slow daemon thread. ``None``
+    # when the config has no source trigger. Rebuilt on each runtime swap.
+    source_watcher = _start_source_watcher(initial_runtime)
+    watched_runtime: "HeadlessRuntime" = initial_runtime
+
     try:
         while not stop_event.is_set():
             tick_count += 1
@@ -387,6 +416,16 @@ def run_watch_loop(
                 # unexpected exception here means a bug, not a transient
                 # — log loudly and fall through.
                 emit_json("watch_reload_unexpected_error", error=str(exc))
+
+            # A successful config reload swaps the runtime; rebuild the
+            # source watcher so it tracks the new trigger list / dispatcher
+            # (#197). ``watched_runtime`` holds a reference so the swapped
+            # runtime object identity stays stable for this comparison.
+            if snapshot.runtime is not watched_runtime:
+                if source_watcher is not None:
+                    source_watcher.stop()
+                source_watcher = _start_source_watcher(snapshot.runtime)
+                watched_runtime = snapshot.runtime
 
             # Snapshot the busy-retry counter before the tick so we can
             # diff after.
@@ -450,6 +489,11 @@ def run_watch_loop(
             if sleeper(poll_interval):
                 break
     finally:
+        if source_watcher is not None:
+            try:
+                source_watcher.stop()
+            except Exception as exc:
+                log.warning("source_watcher_stop_failed: %s", exc)
         try:
             snapshot.runtime.close()
         except Exception as exc:

--- a/gispulse/runtime/config_loader.py
+++ b/gispulse/runtime/config_loader.py
@@ -18,6 +18,15 @@ Schema (version 1, strict)::
             value: 2026-04-27
           - type: run_sql
             expression: "UPDATE parcels SET status='ok' WHERE fid=NEW.fid"
+      # A source-watched trigger (#195) — fires when an external data
+      # source publishes a new revision instead of on a local DML edit.
+      # It declares ``on: {source_changed: <uri>}`` and no ``table``.
+      - name: refresh_on_new_millesime
+        on:
+          source_changed: cadastre://parcelles
+          frequency: mensuel
+        actions:
+          - type: log_event
     security:
       webhook_allowlist:
         - example.com
@@ -163,13 +172,48 @@ class ActionConfigModel(BaseModel):
         return v
 
 
+class OnConfigModel(BaseModel):
+    """The ``on:`` discriminator for non-DML triggers (issue #195).
+
+    Today it carries a single key — ``source_changed`` — naming the
+    external source URI to watch (e.g. ``cadastre://parcelles``). A
+    trigger declaring ``on:`` is a *source-watched* trigger: it fires
+    when :class:`~persistence.source_watcher.SourceWatcherRegistry`
+    observes a new ``revision()`` token, not on a local DML edit. Such
+    a trigger therefore declares no ``table`` / ``when`` / ``predicate``.
+
+    ``frequency`` is an optional catalog-style label (``quotidien``,
+    ``mensuel``…) mapped to a poll interval by
+    :func:`persistence.source_watcher.interval_from_frequency`.
+    """
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    source_changed: str = Field(min_length=1, max_length=2048)
+    frequency: str | None = Field(default=None, max_length=64)
+
+
 class TriggerConfigModel(BaseModel):
-    """One trigger entry in the YAML config."""
+    """One trigger entry in the YAML config.
+
+    Two mutually-exclusive shapes:
+
+    - **DML trigger** (historical default) — declares a ``table`` and
+      fires on local change-log edits.
+    - **Source trigger** (#195) — declares ``on: {source_changed: <uri>}``
+      and fires on an external-source revision change. It declares no
+      ``table``.
+    """
 
     model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
 
     name: str = Field(min_length=1, max_length=120)
-    table: str = Field(min_length=1, max_length=120)
+    # Required for DML triggers, forbidden for source triggers — enforced
+    # by :meth:`_validate_trigger_mode`. Optional at the field level so a
+    # source trigger can omit it entirely.
+    table: str | None = Field(default=None, max_length=120)
+    # ``on:`` discriminator — when set, this is a source-watched trigger.
+    on: OnConfigModel | None = None
     # ESRI Attribute Rules vocabulary aliases (#125):
     # ``constraint`` ≡ ``validation`` (rule rejects/tags the row),
     # ``calculation`` ≡ ``trigger`` (rule writes derived attributes),
@@ -211,6 +255,35 @@ class TriggerConfigModel(BaseModel):
     predicate: str | None = None
     actions: list[ActionConfigModel] = Field(default_factory=list)
     enabled: bool = True
+
+    @model_validator(mode="after")
+    def _validate_trigger_mode(self) -> "TriggerConfigModel":
+        """Enforce the DML / source-trigger split (#195).
+
+        A source-watched trigger (``on:`` set) watches an external
+        source, not a GPKG layer — declaring a ``table`` or a
+        ``predicate`` on it is a config error. Conversely a DML trigger
+        must name the ``table`` it watches.
+        """
+        if self.on is not None:
+            if self.table is not None:
+                raise ValueError(
+                    f"trigger {self.name!r}: a source_changed trigger must "
+                    f"not declare a 'table' — it watches the external "
+                    f"source {self.on.source_changed!r}, not a layer"
+                )
+            if self.predicate is not None:
+                raise ValueError(
+                    f"trigger {self.name!r}: 'predicate' is not supported on "
+                    f"a source_changed trigger"
+                )
+        elif not self.table:
+            raise ValueError(
+                f"trigger {self.name!r}: a DML trigger requires a 'table' "
+                f"(or declare 'on: {{source_changed: <uri>}}' for a "
+                f"source-watched trigger)"
+            )
+        return self
 
     @field_validator("when")
     @classmethod
@@ -548,6 +621,32 @@ def load_config(
     )
 
 
+def _normalize_on_keys(raw: dict[str, Any]) -> None:
+    """Restore the trigger ``on:`` key mangled into ``True`` by YAML 1.1.
+
+    ``yaml.safe_load`` coerces the bare scalar ``on`` to the boolean
+    ``True`` per the YAML 1.1 boolean grammar (the "Norway problem").
+    The ``on:`` trigger discriminator (#195) therefore arrives as a
+    boolean dict key, which pydantic rejects (keys must be strings). We
+    move it back to the string ``"on"`` in place, before validation.
+
+    A trigger that somehow carries *both* a boolean ``on`` key and an
+    explicit string ``"on"`` key is a config error — we refuse rather
+    than silently picking one.
+    """
+    triggers = raw.get("triggers")
+    if not isinstance(triggers, list):
+        return
+    for entry in triggers:
+        if isinstance(entry, dict) and True in entry:
+            if "on" in entry:
+                raise ConfigError(
+                    "trigger declares the 'on:' key twice (once bare, once "
+                    "quoted) — keep a single 'on:'"
+                )
+            entry["on"] = entry.pop(True)
+
+
 def parse_config_text(
     text: str,
     *,
@@ -619,6 +718,10 @@ def parse_config_text(
             # ``GISPulseConfig`` requires a string here; fall back to a
             # placeholder so pydantic validates the rest of the doc.
             raw["gpkg"] = "<unbound>"
+
+    # YAML 1.1 coerces the bare trigger key ``on`` to boolean True;
+    # restore it to the string ``"on"`` so pydantic accepts it (#195).
+    _normalize_on_keys(raw)
 
     try:
         config = GISPulseConfig.model_validate(raw)
@@ -695,6 +798,34 @@ def to_triggers(config: GISPulseConfig) -> list["Trigger"]:
             actions.append(
                 ActionDef(action_type=type_map[ac.type], config=cfg),
             )
+
+        # Source-watched trigger (#195) — fires on an external-source
+        # revision change, not a local DML edit. It carries the watched
+        # source URI (and optional poll frequency) in ``conditions``;
+        # ``TriggerEvaluator._eval_source_changed`` reads ``source`` /
+        # ``last_revision`` from there.
+        if entry.on is not None:
+            source_conditions: dict[str, Any] = {
+                "yaml_name": entry.name,
+                "source": entry.on.source_changed,
+            }
+            if entry.on.frequency:
+                source_conditions["frequency"] = entry.on.frequency
+            triggers.append(
+                Trigger(
+                    name=entry.name,
+                    description=(
+                        f"Source watcher (source={entry.on.source_changed})"
+                    ),
+                    event=TriggerEvent.DATA_CHANGED,
+                    trigger_type=TriggerType.SOURCE_CHANGED,
+                    category=TriggerCategory.INTEGRATION,
+                    conditions=source_conditions,
+                    actions=actions,
+                    enabled=entry.enabled,
+                )
+            )
+            continue
 
         # Stash the user-friendly metadata on the trigger so log lines
         # and validate output can reference the YAML name. ``events`` is
@@ -776,7 +907,9 @@ def validate_against_gpkg(config: GISPulseConfig) -> list[str]:
         # (they show up in _gispulse_change_log too) but we don't
         # encourage that path. We just don't reject them.
         for entry in config.triggers:
-            if entry.table not in layers:
+            # Source-watched triggers (#195) reference an external source,
+            # not a GPKG layer — there is no table to check.
+            if entry.on is None and entry.table not in layers:
                 errors.append(
                     f"trigger {entry.name!r}: table {entry.table!r} not "
                     f"found in {gpkg_path.name} (available: "
@@ -810,6 +943,7 @@ __all__ = [
     "ActionConfigModel",
     "ConfigError",
     "GISPulseConfig",
+    "OnConfigModel",
     "RuntimeConfigModel",
     "SecurityConfigModel",
     "TriggerConfigModel",

--- a/gispulse/runtime/source_watch.py
+++ b/gispulse/runtime/source_watch.py
@@ -1,0 +1,196 @@
+"""Wire :class:`SourceWatcherRegistry` into the watch runtime (issue #197).
+
+PR #189 delivered :class:`~persistence.source_watcher.SourceWatcherRegistry`
+but nothing instantiated it — the external-source watcher was dead code.
+This module is the missing bridge between three pieces:
+
+- the ``source_changed`` triggers parsed from ``triggers.yaml`` (#195),
+- the live :class:`~core.sources.DataSource` objects registered by the
+  ``gispulse.data_sources`` plugins (resolved through
+  :data:`core.sources.SOURCES`),
+- the runtime :class:`~gispulse.adapters.esb.action_dispatcher.ActionDispatcher`
+  that runs the trigger's actions.
+
+Flow::
+
+    SourceWatcherRegistry.poll()        # revision() differs
+        └─▶ SourceChangeBridge.broadcast("source.changed", payload)
+                └─▶ match SOURCE_CHANGED triggers by source URI
+                        └─▶ ActionDispatcher.dispatch_all(trigger.actions)
+
+:func:`build_source_watcher` is called once by ``run_watch_loop`` after
+the runtime is built; the returned registry runs its own slow daemon
+thread (hours-scale poll), independent of the fast DML tick.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+from urllib.parse import urlparse
+
+from core.enums import TriggerType
+from core.logging import get_logger
+from persistence.source_watcher import SourceWatcherRegistry
+
+log = get_logger(__name__)
+
+# A resolver maps a ``<source>://<entry>`` URI to ``(DataSource, entry_id)``.
+SourceResolver = Callable[[str], "tuple[Any, str]"]
+
+
+def _is_source_trigger(trigger: Any) -> bool:
+    """True when ``trigger`` is a SOURCE_CHANGED trigger."""
+    return trigger.trigger_type == TriggerType.SOURCE_CHANGED
+
+
+def parse_source_uri(uri: str) -> tuple[str, str]:
+    """Split ``<source>://<entry>`` into ``(source_name, entry_id)``.
+
+    Example: ``cadastre://parcelles`` → ``("cadastre", "parcelles")``.
+
+    Raises:
+        ValueError: when the URI has no scheme or no entry component.
+    """
+    parsed = urlparse(uri)
+    name = parsed.scheme
+    entry = f"{parsed.netloc}{parsed.path}".strip("/")
+    if not name or not entry:
+        raise ValueError(
+            f"invalid source URI {uri!r} — expected '<source>://<entry>'"
+        )
+    return name, entry
+
+
+def resolve_via_registry(uri: str) -> tuple[Any, str]:
+    """Default resolver — look the source up in :data:`core.sources.SOURCES`."""
+    from core.sources import SOURCES
+
+    name, entry = parse_source_uri(uri)
+    return SOURCES.get(name), entry
+
+
+def _make_context(trigger: Any, data: dict[str, Any]) -> Any:
+    """Build the :class:`TriggerContext` an action handler expects.
+
+    A source-changed event has no DML row, so ``table`` / ``row_id`` are
+    empty and the source payload (source URI, new + previous revision)
+    travels in ``new_attrs`` for handlers that want to reference it.
+    """
+    from gispulse.core.dispatcher import EvalResult, TriggerContext
+
+    return TriggerContext(
+        trigger=trigger,
+        eval_result=EvalResult(matched=True),
+        table="",
+        operation="source_changed",
+        new_attrs=dict(data),
+    )
+
+
+class SourceChangeBridge:
+    """EventHub adapter turning a ``source.changed`` broadcast into dispatch.
+
+    Implements the ``broadcast(event_type, data)`` contract that
+    :class:`SourceWatcherRegistry` calls. On a ``source.changed`` event
+    it selects the SOURCE_CHANGED triggers whose configured ``source``
+    equals the event's source URI and dispatches their actions.
+
+    The registry only broadcasts on an *actual* revision change (it
+    diffs revisions internally), so matching here is a plain source-URI
+    equality check — no revision comparison is repeated.
+    """
+
+    def __init__(self, triggers: list[Any], dispatcher: Any) -> None:
+        self._triggers = [t for t in triggers if _is_source_trigger(t)]
+        self._dispatcher = dispatcher
+        self.fired = 0  # cumulative dispatched-trigger count (observability)
+
+    def broadcast(
+        self, event_type: str, data: dict[str, Any] | None = None
+    ) -> None:
+        if event_type != "source.changed" or not data:
+            return
+        event_source = data.get("source")
+        for trig in self._triggers:
+            if not trig.enabled:
+                continue
+            if trig.conditions.get("source") != event_source:
+                continue
+            try:
+                self._dispatcher.dispatch_all(
+                    trig.actions, _make_context(trig, data)
+                )
+            except Exception as exc:  # noqa: BLE001 — one trigger never blocks the rest
+                log.warning(
+                    "source_changed_dispatch_failed",
+                    trigger=trig.name,
+                    source=event_source,
+                    error=str(exc),
+                )
+                continue
+            self.fired += 1
+            log.info(
+                "source_changed_trigger_fired",
+                trigger=trig.name,
+                source=event_source,
+                revision=data.get("revision"),
+            )
+
+
+def build_source_watcher(
+    triggers: list[Any],
+    dispatcher: Any,
+    *,
+    resolver: SourceResolver = resolve_via_registry,
+) -> SourceWatcherRegistry | None:
+    """Build a :class:`SourceWatcherRegistry` wired to dispatch triggers.
+
+    Args:
+        triggers:   The full trigger list (DML + source); only the
+                    SOURCE_CHANGED ones are wired.
+        dispatcher: The runtime ``ActionDispatcher`` that runs actions.
+        resolver:   ``uri -> (DataSource, entry_id)``. Defaults to
+                    :func:`resolve_via_registry`; tests inject a fake.
+
+    Returns:
+        A ready (not-yet-started) registry, or ``None`` when the config
+        declares no source trigger. An unresolvable URI is logged and
+        skipped — one bad source never blocks the others.
+    """
+    source_triggers = [t for t in triggers if _is_source_trigger(t)]
+    if not source_triggers:
+        return None
+
+    bridge = SourceChangeBridge(triggers, dispatcher)
+    registry = SourceWatcherRegistry(event_hub=bridge)
+
+    for trig in source_triggers:
+        uri = trig.conditions.get("source")
+        if not uri:
+            log.warning("source_watch_missing_uri", trigger=trig.name)
+            continue
+        try:
+            source, entry_id = resolver(uri)
+        except (KeyError, ValueError) as exc:
+            log.warning("source_watch_unresolved", uri=uri, error=str(exc))
+            continue
+        try:
+            registry.register(
+                source,
+                entry_id,
+                frequency=trig.conditions.get("frequency"),
+            )
+        except Exception as exc:  # noqa: BLE001 — bad baseline revision, etc.
+            log.warning(
+                "source_watch_register_failed", uri=uri, error=str(exc)
+            )
+    return registry
+
+
+__all__ = [
+    "SourceChangeBridge",
+    "SourceResolver",
+    "build_source_watcher",
+    "parse_source_uri",
+    "resolve_via_registry",
+]

--- a/plugins/gispulse-src-cadastre/gispulse_src_cadastre/__init__.py
+++ b/plugins/gispulse-src-cadastre/gispulse_src_cadastre/__init__.py
@@ -10,8 +10,11 @@ from __future__ import annotations
 def register() -> None:
     """Entry-point hook for the ``gispulse.data_sources`` group.
 
-    Importing the module is enough — :class:`CadastreSource` is a plain
-    declarative class; the PluginHub records the source from this
-    callable.
+    Registers a :class:`CadastreSource` instance in the process-wide
+    ``core.sources.SOURCES`` registry so the source watcher (issue #197)
+    can resolve ``cadastre://<entry>`` URIs declared in ``triggers.yaml``.
     """
-    from gispulse_src_cadastre import source  # noqa: F401
+    from core.sources import SOURCES
+    from gispulse_src_cadastre.source import CadastreSource
+
+    SOURCES.register(CadastreSource())

--- a/plugins/gispulse-src-cadastre/gispulse_src_cadastre/source.py
+++ b/plugins/gispulse-src-cadastre/gispulse_src_cadastre/source.py
@@ -23,9 +23,38 @@ from gispulse.plugins.api import (
 _GEOPLATEFORME_WFS = "https://data.geopf.fr/wfs/ows"
 _LAYER_PREFIX = "CADASTRALPARCELS.PARCELLAIRE_EXPRESS"
 
-# Millésime token surfaced by revision() — drives the source watcher
-# (issue #187). Parcellaire Express is refreshed twice a year.
-_MILLESIME = "2026-01"
+# WFS GetCapabilities URL — the cheap freshness probe target for
+# revision() (issue #198). A HEAD against it reads the ETag /
+# Last-Modified header without downloading the document.
+_WFS_CAPABILITIES = (
+    f"{_GEOPLATEFORME_WFS}?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetCapabilities"
+)
+_REVISION_TIMEOUT_S = 8.0
+
+
+def _probe_revision(url: str) -> str | None:
+    """Return a freshness token for ``url`` via a single HTTP HEAD.
+
+    Derives the token from the ``ETag`` (preferred) or ``Last-Modified``
+    response header. Returns ``None`` — meaning "freshness unknown" — on
+    any network error or when the endpoint exposes neither header, so
+    the source watcher skips it rather than emitting a spurious change.
+    """
+    import httpx  # local import — keeps module import network-free
+
+    try:
+        resp = httpx.head(
+            url, timeout=_REVISION_TIMEOUT_S, follow_redirects=True
+        )
+    except Exception:  # noqa: BLE001 — any transport error ⇒ unknown
+        return None
+    etag = resp.headers.get("etag")
+    if etag:
+        return etag.strip('"')
+    last_modified = resp.headers.get("last-modified")
+    if last_modified:
+        return last_modified
+    return None
 
 
 class CadastreSource(DeclarativeSource):
@@ -54,9 +83,27 @@ class CadastreSource(DeclarativeSource):
                 params={"typename": f"{_LAYER_PREFIX}:{layer}"},
                 format="application/json",
             ),
-            revision_token=_MILLESIME,
+            # revision() probes the WFS live (issue #198); the declared
+            # token stays None so nothing hard-codes a stale millésime.
+            revision_token=None,
             metadata={"provider": "IGN", "dataset": "Parcellaire Express"},
         )
+
+    def revision(self, entry_id: str) -> str | None:
+        """Cheap freshness token for the source watcher (issue #187/#198).
+
+        Issues a single HTTP HEAD against the Géoplateforme WFS
+        GetCapabilities URL and derives the token from its ``ETag`` /
+        ``Last-Modified`` header — never a full ``fetch()``. The
+        Parcellaire Express millésime is dataset-wide, so every entry
+        shares one probe; ``entry_id`` is only validated here.
+
+        Returns ``None`` when the endpoint is unreachable or exposes no
+        freshness header — the watcher treats that as "unknown" and
+        skips it instead of emitting a spurious ``source.changed``.
+        """
+        self._entry(entry_id)  # validate the id
+        return _probe_revision(_WFS_CAPABILITIES)
 
     def schema(self, entry_id: str) -> dict:
         """Normalised attribute schema of a cadastre layer."""

--- a/tests/runtime/test_config_loader.py
+++ b/tests/runtime/test_config_loader.py
@@ -442,3 +442,162 @@ def test_when_dedupes_and_rejects_empty(tracked_gpkg: Path, tmp_path: Path) -> N
     )
     cfg = load_config(dup)
     assert cfg.triggers[0].when == ["INSERT", "UPDATE"]
+
+
+# ---------------------------------------------------------------------------
+# Source-watched triggers — `on: source_changed:` (#195)
+# ---------------------------------------------------------------------------
+
+
+def test_source_changed_trigger_loads(tracked_gpkg: Path, tmp_path: Path) -> None:
+    """A trigger declaring ``on: {source_changed: <uri>}`` parses cleanly."""
+    cfg_path = tmp_path / "src.yaml"
+    cfg_path.write_text(
+        textwrap.dedent(
+            f"""
+            version: 1
+            gpkg: {tracked_gpkg}
+            triggers:
+              - name: refresh_on_millesime
+                on:
+                  source_changed: cadastre://parcelles
+                  frequency: mensuel
+                actions:
+                  - type: log_event
+            """,
+        ).strip(),
+        encoding="utf-8",
+    )
+    cfg = load_config(cfg_path)
+    assert len(cfg.triggers) == 1
+    entry = cfg.triggers[0]
+    assert entry.table is None
+    assert entry.on is not None
+    assert entry.on.source_changed == "cadastre://parcelles"
+    assert entry.on.frequency == "mensuel"
+
+
+def test_source_changed_to_triggers_maps_source_changed_type(
+    tracked_gpkg: Path, tmp_path: Path
+) -> None:
+    """``to_triggers`` builds a SOURCE_CHANGED domain trigger."""
+    from core.enums import TriggerCategory, TriggerType
+
+    cfg_path = tmp_path / "src.yaml"
+    cfg_path.write_text(
+        textwrap.dedent(
+            f"""
+            version: 1
+            gpkg: {tracked_gpkg}
+            triggers:
+              - name: refresh
+                on:
+                  source_changed: cadastre://parcelles
+                actions:
+                  - type: log_event
+            """,
+        ).strip(),
+        encoding="utf-8",
+    )
+    triggers = to_triggers(load_config(cfg_path))
+    assert len(triggers) == 1
+    trig = triggers[0]
+    assert trig.trigger_type == TriggerType.SOURCE_CHANGED
+    assert trig.category == TriggerCategory.INTEGRATION
+    assert trig.conditions["source"] == "cadastre://parcelles"
+    assert "table" not in trig.conditions
+
+
+def test_source_changed_trigger_rejects_table(
+    tracked_gpkg: Path, tmp_path: Path
+) -> None:
+    """Declaring both ``on:`` and ``table`` is a config error."""
+    bad = tmp_path / "bad.yaml"
+    bad.write_text(
+        textwrap.dedent(
+            f"""
+            version: 1
+            gpkg: {tracked_gpkg}
+            triggers:
+              - name: confused
+                table: parcels
+                on:
+                  source_changed: cadastre://parcelles
+                actions: []
+            """,
+        ).strip(),
+        encoding="utf-8",
+    )
+    with pytest.raises(ConfigError, match="must not declare a 'table'"):
+        load_config(bad)
+
+
+def test_source_changed_trigger_rejects_predicate(
+    tracked_gpkg: Path, tmp_path: Path
+) -> None:
+    """A source trigger cannot carry a DML predicate."""
+    bad = tmp_path / "bad.yaml"
+    bad.write_text(
+        textwrap.dedent(
+            f"""
+            version: 1
+            gpkg: {tracked_gpkg}
+            triggers:
+              - name: confused
+                predicate: "status == 'x'"
+                on:
+                  source_changed: cadastre://parcelles
+                actions: []
+            """,
+        ).strip(),
+        encoding="utf-8",
+    )
+    with pytest.raises(ConfigError, match="'predicate' is not supported"):
+        load_config(bad)
+
+
+def test_dml_trigger_still_requires_table(
+    tracked_gpkg: Path, tmp_path: Path
+) -> None:
+    """A trigger without ``on:`` must still name a ``table``."""
+    bad = tmp_path / "bad.yaml"
+    bad.write_text(
+        textwrap.dedent(
+            f"""
+            version: 1
+            gpkg: {tracked_gpkg}
+            triggers:
+              - name: tableless
+                actions: []
+            """,
+        ).strip(),
+        encoding="utf-8",
+    )
+    with pytest.raises(ConfigError, match="requires a 'table'"):
+        load_config(bad)
+
+
+def test_source_changed_trigger_skips_gpkg_table_check(
+    tracked_gpkg: Path, tmp_path: Path
+) -> None:
+    """``validate_against_gpkg`` does not flag a source trigger's absent table."""
+    cfg_path = tmp_path / "mixed.yaml"
+    cfg_path.write_text(
+        textwrap.dedent(
+            f"""
+            version: 1
+            gpkg: {tracked_gpkg}
+            triggers:
+              - name: dml_one
+                table: parcels
+                actions: []
+              - name: src_one
+                on:
+                  source_changed: cadastre://parcelles
+                actions: []
+            """,
+        ).strip(),
+        encoding="utf-8",
+    )
+    errors = validate_against_gpkg(load_config(cfg_path))
+    assert errors == []

--- a/tests/runtime/test_source_watch.py
+++ b/tests/runtime/test_source_watch.py
@@ -1,0 +1,229 @@
+"""Tests for ``gispulse.runtime.source_watch`` — the #197 wiring.
+
+Covers the bridge that turns a ``SourceWatcherRegistry`` revision change
+into an ``ActionDispatcher`` dispatch, and the end-to-end builder that
+the watch loop calls.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from gispulse.runtime.source_watch import (
+    SourceChangeBridge,
+    build_source_watcher,
+    parse_source_uri,
+    resolve_via_registry,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fakes + helpers
+# ---------------------------------------------------------------------------
+
+
+class FakeSource:
+    """A DataSource whose revision() walks a predefined sequence."""
+
+    def __init__(self, name: str, revisions: list[str | None]) -> None:
+        self.name = name
+        self._revisions = list(revisions)
+        self.calls = 0
+
+    def revision(self, entry_id: str) -> str | None:
+        idx = min(self.calls, len(self._revisions) - 1)
+        self.calls += 1
+        return self._revisions[idx]
+
+
+class FakeDispatcher:
+    """Records every dispatch_all call."""
+
+    def __init__(self) -> None:
+        self.calls: list = []
+
+    def dispatch_all(self, actions: list, context) -> int:
+        self.calls.append((actions, context))
+        return len(actions)
+
+
+def _triggers(yaml_doc: str) -> list:
+    """Parse a full ``triggers.yaml`` document into domain Trigger objects."""
+    from gispulse.runtime.config_loader import parse_config_text, to_triggers
+
+    cfg = parse_config_text(textwrap.dedent(yaml_doc).strip(), resolve_gpkg=False)
+    return to_triggers(cfg)
+
+
+_ONE_SOURCE_TRIGGER = """
+    version: 1
+    gpkg: ./unused.gpkg
+    triggers:
+      - name: refresh
+        on:
+          source_changed: cadastre://parcelles
+        actions:
+          - type: log_event
+"""
+
+
+# ---------------------------------------------------------------------------
+# parse_source_uri
+# ---------------------------------------------------------------------------
+
+
+def test_parse_source_uri_valid() -> None:
+    assert parse_source_uri("cadastre://parcelles") == ("cadastre", "parcelles")
+
+
+def test_parse_source_uri_nested_entry() -> None:
+    assert parse_source_uri("ign://bdtopo/batiment") == ("ign", "bdtopo/batiment")
+
+
+@pytest.mark.parametrize("bad", ["", "parcelles", "://entry", "cadastre://"])
+def test_parse_source_uri_invalid(bad: str) -> None:
+    with pytest.raises(ValueError, match="invalid source URI"):
+        parse_source_uri(bad)
+
+
+# ---------------------------------------------------------------------------
+# resolve_via_registry
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_via_registry() -> None:
+    from core.sources import SOURCES
+
+    src = FakeSource("demo", ["r1"])
+    SOURCES.register(src)
+    try:
+        resolved, entry = resolve_via_registry("demo://things")
+        assert resolved is src
+        assert entry == "things"
+    finally:
+        SOURCES.clear()
+
+
+def test_resolve_via_registry_unknown_source() -> None:
+    from core.sources import SOURCES
+
+    SOURCES.clear()
+    with pytest.raises(KeyError, match="no data source named 'ghost'"):
+        resolve_via_registry("ghost://x")
+
+
+# ---------------------------------------------------------------------------
+# SourceChangeBridge
+# ---------------------------------------------------------------------------
+
+
+def test_bridge_dispatches_matching_trigger() -> None:
+    triggers = _triggers(_ONE_SOURCE_TRIGGER)
+    dispatcher = FakeDispatcher()
+    bridge = SourceChangeBridge(triggers, dispatcher)
+
+    bridge.broadcast(
+        "source.changed",
+        {"source": "cadastre://parcelles", "revision": "2026-07"},
+    )
+
+    assert bridge.fired == 1
+    assert len(dispatcher.calls) == 1
+    actions, ctx = dispatcher.calls[0]
+    assert ctx.operation == "source_changed"
+    assert ctx.new_attrs["revision"] == "2026-07"
+
+
+def test_bridge_ignores_non_matching_source() -> None:
+    bridge = SourceChangeBridge(_triggers(_ONE_SOURCE_TRIGGER), FakeDispatcher())
+    bridge.broadcast(
+        "source.changed", {"source": "ign://bdtopo", "revision": "x"}
+    )
+    assert bridge.fired == 0
+
+
+def test_bridge_ignores_non_source_event() -> None:
+    dispatcher = FakeDispatcher()
+    bridge = SourceChangeBridge(_triggers(_ONE_SOURCE_TRIGGER), dispatcher)
+    bridge.broadcast("dml.changed", {"source": "cadastre://parcelles"})
+    bridge.broadcast("source.changed", None)
+    assert bridge.fired == 0
+    assert dispatcher.calls == []
+
+
+def test_bridge_skips_disabled_trigger() -> None:
+    triggers = _triggers(_ONE_SOURCE_TRIGGER)
+    triggers[0].enabled = False
+    bridge = SourceChangeBridge(triggers, FakeDispatcher())
+    bridge.broadcast(
+        "source.changed", {"source": "cadastre://parcelles", "revision": "x"}
+    )
+    assert bridge.fired == 0
+
+
+# ---------------------------------------------------------------------------
+# build_source_watcher
+# ---------------------------------------------------------------------------
+
+
+def test_build_source_watcher_none_without_source_triggers() -> None:
+    """A DML-only config yields no source watcher."""
+    dml = _triggers(
+        """
+        version: 1
+        gpkg: ./unused.gpkg
+        triggers:
+          - name: dml_only
+            table: parcels
+            actions: []
+        """
+    )
+    assert build_source_watcher(dml, FakeDispatcher()) is None
+
+
+def test_build_source_watcher_registers_entry() -> None:
+    src = FakeSource("cadastre", ["baseline"])
+    watcher = build_source_watcher(
+        _triggers(_ONE_SOURCE_TRIGGER),
+        FakeDispatcher(),
+        resolver=lambda uri: (src, "parcelles"),
+    )
+    assert watcher is not None
+    assert watcher.list_watched() == ["cadastre:parcelles"]
+
+
+def test_build_source_watcher_skips_unresolved_uri() -> None:
+    def boom(uri: str):
+        raise KeyError("not registered")
+
+    watcher = build_source_watcher(
+        _triggers(_ONE_SOURCE_TRIGGER), FakeDispatcher(), resolver=boom
+    )
+    # Watcher is still built (a source trigger exists) but has no entry.
+    assert watcher is not None
+    assert watcher.list_watched() == []
+
+
+def test_source_watcher_poll_fires_trigger_end_to_end() -> None:
+    """The headline #197 path: a new revision dispatches the trigger."""
+    # Baseline revision captured at register() = 'r1'; next poll = 'r2'.
+    src = FakeSource("cadastre", ["r1", "r2"])
+    dispatcher = FakeDispatcher()
+    watcher = build_source_watcher(
+        _triggers(_ONE_SOURCE_TRIGGER),
+        dispatcher,
+        resolver=lambda uri: (src, "parcelles"),
+    )
+    assert watcher is not None
+
+    # First poll observes 'r2' ≠ baseline 'r1' → one source.changed.
+    changes = watcher.poll()
+    assert len(changes) == 1
+    assert changes[0]["revision"] == "r2"
+    assert len(dispatcher.calls) == 1  # trigger dispatched
+
+    # Second poll observes 'r2' again (sequence exhausted) → no change.
+    assert watcher.poll() == []
+    assert len(dispatcher.calls) == 1

--- a/tests/unit/test_src_cadastre.py
+++ b/tests/unit/test_src_cadastre.py
@@ -95,6 +95,64 @@ def test_schema_per_layer(source: CadastreSource) -> None:
     assert source.schema("batiments")["geometry"] == "geometry"
 
 
-def test_revision_exposes_millesime(source: CadastreSource) -> None:
-    # A freshness token the source watcher (issue #187) can poll.
-    assert source.revision("parcelles") == "2026-01"
+class _FakeResponse:
+    """Minimal stand-in for an ``httpx.Response`` — only ``.headers``."""
+
+    def __init__(self, headers: dict[str, str]) -> None:
+        self.headers = headers
+
+
+def test_revision_probes_wfs_and_uses_etag(
+    source: CadastreSource, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """revision() derives its token from the WFS ETag header (#198)."""
+    captured: list[str] = []
+
+    def fake_head(url, **_kw):
+        captured.append(url)
+        return _FakeResponse({"etag": '"millesime-2026-07"'})
+
+    monkeypatch.setattr("httpx.head", fake_head)
+    token = source.revision("parcelles")
+
+    assert token == "millesime-2026-07"  # quotes stripped
+    assert captured and "GetCapabilities" in captured[0]
+
+
+def test_revision_falls_back_to_last_modified(
+    source: CadastreSource, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "httpx.head",
+        lambda *_a, **_kw: _FakeResponse(
+            {"last-modified": "Wed, 01 Jul 2026 00:00:00 GMT"}
+        ),
+    )
+    assert source.revision("communes") == "Wed, 01 Jul 2026 00:00:00 GMT"
+
+
+def test_revision_returns_none_on_network_error(
+    source: CadastreSource, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unreachable endpoint yields None — the watcher skips it."""
+
+    def boom(*_a, **_kw):
+        raise RuntimeError("connection refused")
+
+    monkeypatch.setattr("httpx.head", boom)
+    assert source.revision("parcelles") is None
+
+
+def test_revision_returns_none_without_freshness_header(
+    source: CadastreSource, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("httpx.head", lambda *_a, **_kw: _FakeResponse({}))
+    assert source.revision("batiments") is None
+
+
+def test_revision_validates_entry_id(
+    source: CadastreSource, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("httpx.head", lambda *_a, **_kw: _FakeResponse({}))
+    with pytest.raises(KeyError, match="unknown entry 'ghost'"):
+        source.revision("ghost")


### PR DESCRIPTION
Sprint v1.7.0 — chemin critique « câbler la plateforme ETL ». Rend l'objectif du sprint réel : un trigger `source_changed` sur une vraie source WFS déclenche le dispatch d'actions.

## Issues

| # | Livré |
|---|---|
| #195 | Syntaxe `on: {source_changed: <uri>}` dans `triggers.yaml` — modèle polymorphe DML / source, contournement du « Norway problem » YAML |
| #198 | `CadastreSource.revision()` réel — HTTP HEAD sur la WFS GetCapabilities, ETag/Last-Modified ; `_MILLESIME` hardcodé supprimé |
| #197 | `SourceWatcherRegistry` câblé dans le runtime `watch` — `core.sources.SOURCES` registry, `SourceChangeBridge`, dispatch end-to-end |

## Notes
- Le `SourceWatcherRegistry` de PR #189 était orphelin (instancié nulle part) — pattern ESB-orphelin (#451/#458). Désormais `run_watch_loop` le build + start, rebuild au reload de config.
- Chemin end-to-end vérifié en test : `revision()` change → `source.changed` → `ActionDispatcher.dispatch_all`.
- 620 tests verts (runtime/rules/esb/sources), ruff clean.

## Hors scope (reste du sprint)
#192 FetcherRegistry · #193 catalog→hub · #146 dialect scanner · #160 bench · #191 flake · #199 SSRF · #194 src-ign · #201 mcp.

Closes #195 #197 #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)