### PR TITLE
[v1.7.0] Quick-wins — mcp launcher + dialect scanner + SSRF guard + flake fix

### DIFF
--- a/core/sources.py
+++ b/core/sources.py
@@ -150,7 +150,15 @@ class ProtocolRegistry:
         extent: Any | None = None,
         mode: FetchMode = FetchMode.MATERIALIZE,
     ) -> SourceResult:
-        """Resolve ``access.protocol`` to a fetcher and run it."""
+        """Resolve ``access.protocol`` to a fetcher and run it.
+
+        The endpoint is SSRF-checked first (issue #199): a declared
+        source — or a third-party plugin — must not steer a fetch at an
+        internal address. Non-HTTP endpoints (file paths) are left alone.
+        """
+        from core.ssrf import guard_outbound_url
+
+        guard_outbound_url(getattr(access, "endpoint", None))
         return self.get_fetcher(access.protocol).fetch(access, extent=extent, mode=mode)
 
     def dispatch_write(self, result: SourceResult, spec: WriteSpec) -> WriteReport:

--- a/core/ssrf.py
+++ b/core/ssrf.py
@@ -1,0 +1,118 @@
+"""SSRF guard — block outbound requests to private / internal addresses.
+
+Issue #199. The ETL ``FetcherRegistry`` (and any other outbound caller)
+must not let a declared source — or a third-party marketplace plugin —
+point a request at ``169.254.169.254``, ``localhost`` or an RFC1918
+host. The webhook client already had this protection (issue #451); this
+module is the shared, reusable form so the fetch path gets it too.
+
+A blocked deployment that *does* have legitimate internal sources opts
+back in with ``GISPULSE_FETCH_ALLOW_PRIVATE=1``.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+import socket
+from urllib.parse import urlparse
+
+from core.logging import get_logger
+
+log = get_logger(__name__)
+
+# Env opt-in: when truthy, private/internal addresses are allowed. For
+# deployments whose data sources legitimately live on an internal network.
+_ALLOW_PRIVATE_ENV = "GISPULSE_FETCH_ALLOW_PRIVATE"
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+class SSRFError(RuntimeError):
+    """Raised when a URL targets a blocked (private/internal) address."""
+
+
+def _allow_private_default() -> bool:
+    return os.environ.get(_ALLOW_PRIVATE_ENV, "").strip().lower() in _TRUTHY
+
+
+def resolve_all(hostname: str) -> list[str]:
+    """Return every IP (v4+v6) ``hostname`` resolves to.
+
+    On DNS failure returns ``[hostname]`` verbatim — :func:`is_blocked_address`
+    then refuses the unresolvable literal rather than letting it through.
+    """
+    try:
+        infos = socket.getaddrinfo(hostname, None)
+    except socket.gaierror:
+        return [hostname]
+    return list({info[4][0] for info in infos})
+
+
+def is_blocked_address(addr: str) -> bool:
+    """True if ``addr`` is private / loopback / link-local / reserved.
+
+    A non-IP string (DNS failed, leaving a hostname literal) is blocked —
+    failing closed is the safe default for an SSRF guard.
+    """
+    try:
+        ip = ipaddress.ip_address(addr)
+    except ValueError:
+        return True
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    )
+
+
+def guard_outbound_url(url: str | None, *, allow_private: bool | None = None) -> None:
+    """SSRF-check an outbound URL before a request is made.
+
+    A no-op for a non-``http(s)`` endpoint — a local file path or a
+    ``file://`` URI is not a network target and is left to the caller.
+    An ``http(s)`` URL whose host resolves to a blocked address raises
+    :class:`SSRFError`.
+
+    Args:
+        url:           The endpoint about to be requested.
+        allow_private: Override the ``GISPULSE_FETCH_ALLOW_PRIVATE`` env
+                       opt-in. ``None`` (default) reads the env.
+
+    Raises:
+        SSRFError: the URL resolves to a private / internal address.
+    """
+    if not url:
+        return
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        return  # not an HTTP target — nothing to SSRF-check
+
+    if allow_private is None:
+        allow_private = _allow_private_default()
+    if allow_private:
+        return
+
+    host = parsed.hostname
+    if not host:
+        raise SSRFError(f"URL {url!r} has no hostname")
+
+    for addr in resolve_all(host):
+        if is_blocked_address(addr):
+            log.warning("ssrf_blocked", host=host, address=addr)
+            raise SSRFError(
+                f"host {host!r} resolves to blocked address {addr!r} "
+                f"(private/loopback/link-local/reserved) — set "
+                f"{_ALLOW_PRIVATE_ENV}=1 to allow internal sources"
+            )
+
+
+__all__ = [
+    "SSRFError",
+    "guard_outbound_url",
+    "is_blocked_address",
+    "resolve_all",
+]

--- a/gispulse/cli.py
+++ b/gispulse/cli.py
@@ -1539,6 +1539,15 @@ from gispulse.cli_portal import cmd_portal  # noqa: E402
 app.command(name="portal")(cmd_portal)
 
 
+# ---------------------------------------------------------------------------
+# mcp — Model Context Protocol server for LLM agents (v1.7.0 #201)
+# ---------------------------------------------------------------------------
+
+from gispulse.cli_mcp import cmd_mcp  # noqa: E402
+
+app.command(name="mcp")(cmd_mcp)
+
+
 def main() -> None:
     from gispulse._pyogrio_warnings import silence_gispulse_extension_warnings
 

--- a/gispulse/cli_mcp.py
+++ b/gispulse/cli_mcp.py
@@ -1,0 +1,55 @@
+"""``gispulse mcp`` — run the GISPulse MCP server (issue #201).
+
+Exposes the GISPulse tool / resource surface to LLM agents over the
+Model Context Protocol. The transport is **stdio** — the shape Claude
+Desktop and Claude Code expect for a local server. Wire a client at it
+with, e.g. in ``.mcp.json``::
+
+    {
+      "mcpServers": {
+        "gispulse": { "command": "gispulse", "args": ["mcp"] }
+      }
+    }
+
+The MCP server module itself (``gispulse.adapters.mcp.server``) was
+delivered by PR #162 but had no launcher — this command is that missing
+launcher. Re-aligning the tool surface on the current product and an
+HTTP transport are tracked in the MCP epic (milestone v1.8.0).
+"""
+
+from __future__ import annotations
+
+import typer
+
+
+def cmd_mcp(
+    transport: str = typer.Option(
+        "stdio",
+        "--transport",
+        help="MCP transport. Only 'stdio' is supported in v1.7.0.",
+    ),
+) -> None:
+    """Run the GISPulse MCP server (stdio) for LLM agents."""
+    try:
+        from gispulse.adapters.mcp.server import create_mcp_server
+    except ImportError:
+        typer.echo(
+            "MCP support requires the 'mcp' extra. "
+            "Install it with: pip install 'gispulse[mcp]'",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    if transport != "stdio":
+        typer.echo(
+            f"unsupported transport {transport!r} — only 'stdio' is "
+            "available in v1.7.0 (HTTP transport is tracked in the MCP "
+            "epic, milestone v1.8.0)",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    server = create_mcp_server()
+    typer.echo("GISPulse MCP server — stdio transport, ready.", err=True)
+    # FastMCP's stdio transport blocks until the client disconnects.
+    server.run()

--- a/gispulse/runtime/config_loader.py
+++ b/gispulse/runtime/config_loader.py
@@ -54,10 +54,14 @@ from typing import TYPE_CHECKING, Any, Iterable, Literal
 import yaml  # type: ignore[import-untyped]
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from core.logging import get_logger
+
 if TYPE_CHECKING:  # pragma: no cover
     from core.graph import ActionDef
     from core.models import Trigger
 
+
+log = get_logger(__name__)
 
 CONFIG_VERSION = 1
 
@@ -625,7 +629,29 @@ def parse_config_text(
     except Exception as exc:  # ValidationError or others
         raise ConfigError(f"invalid config schema: {exc}") from exc
 
+    _warn_dialect_drift(config, source)
     return config
+
+
+def _warn_dialect_drift(config: GISPulseConfig, source: str) -> None:
+    """Emit a ``dialect_drift`` warning per PostGIS-only construct (#146).
+
+    ADR 0001 makes DuckDB-spatial the contract dialect. A ``run_sql`` /
+    ``predicate`` using a PostGIS-only construct loads fine but fails at
+    the first tick — so we surface it here, at config-load time, unless
+    the config pins ``engine: postgis`` (in which case the constructs
+    are legitimate and :func:`scan_for_dialect_drift` returns nothing).
+    """
+    from gispulse.runtime.dialect_scanner import scan_for_dialect_drift
+
+    for finding in scan_for_dialect_drift(config):
+        log.warning(
+            "dialect_drift",
+            source=source,
+            construct=finding.construct,
+            location=finding.location,
+            hint=finding.hint,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/gispulse/runtime/dialect_scanner.py
+++ b/gispulse/runtime/dialect_scanner.py
@@ -1,0 +1,129 @@
+"""Config-load-time scan for PostGIS-only SQL constructs (issue #146).
+
+ADR 0001 declares DuckDB-spatial the contract dialect for
+``triggers.yaml``. That declaration was documentary only: a user could
+write a PostGIS-only construct in a ``run_sql`` action or a ``predicate``
+and only discover it when the first tick blew up — often long after
+deployment.
+
+This module closes that gap with a *regex blocklist* scan (no SQL
+grammar parser — ADR 0001 rejects auto-transpilation, and false
+positives are silenced by declaring ``engine: postgis``, which is the
+correct answer anyway). It walks every ``run_sql`` expression and every
+``predicate`` and flags the known PostGIS-only constructs.
+
+The caller (config loader / CLI) emits a structured ``dialect_drift``
+warning per finding *unless* the config declares ``engine: postgis``.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from gispulse.runtime.config_loader import GISPulseConfig
+
+
+@dataclass(frozen=True)
+class DialectFinding:
+    """One PostGIS-only construct found in a config expression."""
+
+    construct: str       # human label of the offending pattern
+    location: str        # where it was found (trigger name + field)
+    snippet: str         # the verbatim expression it appeared in
+    hint: str            # how to make it portable
+
+    def message(self) -> str:
+        return (
+            f"{self.location}: PostGIS-only construct {self.construct} — "
+            f"{self.hint}"
+        )
+
+
+# Each entry: (label, regex, portability hint). The patterns are
+# deliberately loose — a blocklist, not a parser. ``engine: postgis``
+# silences every one of them at once.
+_RAW_PATTERNS: tuple[tuple[str, str, str], ...] = (
+    (
+        "ST_Transform/2 (2-arg form)",
+        r"\bST_Transform\s*\(\s*[^,()]+,\s*\d+\s*\)",
+        "DuckDB's ST_Transform needs explicit source+target CRS — use the "
+        "3-arg form ST_Transform(geom, 'EPSG:2154', 'EPSG:4326')",
+    ),
+    (
+        "geography() cast",
+        r"\bgeography\s*\(",
+        "geography is a PostGIS type; cast to a metric CRS and use planar "
+        "functions, or pin engine: postgis",
+    ),
+    (
+        "INTERSECTS() shorthand",
+        r"(?<!ST_)\bINTERSECTS\s*\(",
+        "use the portable ST_Intersects(a, b)",
+    ),
+    (
+        "&& bounding-box operator",
+        r"&&",
+        "the && GiST hint is PostGIS-only — DuckDB plans bbox joins itself",
+    ),
+    (
+        "::geometry / ::geography cast",
+        r"::\s*(?:geometry|geography)\b",
+        "the ::type cast is PostgreSQL syntax — drop it or pin engine: postgis",
+    ),
+)
+
+# Compile once, case-insensitive.
+_COMPILED: tuple[tuple[str, re.Pattern[str], str], ...] = tuple(
+    (label, re.compile(rx, re.IGNORECASE), hint)
+    for label, rx, hint in _RAW_PATTERNS
+)
+
+
+def scan_expression(expr: str, location: str) -> list[DialectFinding]:
+    """Return every PostGIS-only construct found in a single expression."""
+    if not expr:
+        return []
+    findings: list[DialectFinding] = []
+    for label, pattern, hint in _COMPILED:
+        if pattern.search(expr):
+            findings.append(
+                DialectFinding(
+                    construct=label, location=location, snippet=expr, hint=hint
+                )
+            )
+    return findings
+
+
+def scan_for_dialect_drift(config: "GISPulseConfig") -> list[DialectFinding]:
+    """Scan every ``run_sql`` expression and ``predicate`` in ``config``.
+
+    Returns an empty list when the config pins ``engine: postgis`` — the
+    constructs are legitimate there — or when nothing PostGIS-only is
+    found. The caller decides how to surface the findings.
+    """
+    if (config.engine or "").strip().lower() == "postgis":
+        return []
+
+    findings: list[DialectFinding] = []
+    for entry in config.triggers:
+        if entry.predicate:
+            findings.extend(
+                scan_expression(
+                    entry.predicate, f"trigger {entry.name!r} predicate"
+                )
+            )
+        for idx, action in enumerate(entry.actions):
+            if action.type == "run_sql" and action.expression:
+                findings.extend(
+                    scan_expression(
+                        action.expression,
+                        f"trigger {entry.name!r} run_sql action #{idx + 1}",
+                    )
+                )
+    return findings
+
+
+__all__ = ["DialectFinding", "scan_expression", "scan_for_dialect_drift"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ scheduling = ["croniter>=1.3,<7.0"]
 sso = ["PyJWT[crypto]>=2.8,<3.0", "httpx>=0.24,<1.0"]
 billing = ["stripe>=7.0,<16.0"]
 parquet = ["pyarrow>=14,<25"]
-dev = ["pytest>=9.0.3,<10.0", "pytest-cov>=4.0,<8.0", "pytest-asyncio>=1.0,<2.0", "ruff>=0.1,<1.0", "httpx>=0.24,<1.0", "pip-audit>=2.7,<3.0"]
+dev = ["pytest>=9.0.3,<10.0", "pytest-cov>=4.0,<8.0", "pytest-asyncio>=1.0,<2.0", "pytest-rerunfailures>=14.0,<16.0", "ruff>=0.1,<1.0", "httpx>=0.24,<1.0", "pip-audit>=2.7,<3.0"]
 all = ["gispulse[postgis,api,mcp,raster,network,classification,pointcloud,redis,s3,scheduling,sso,billing,parquet,dev]"]
 
 [project.urls]
@@ -115,4 +115,5 @@ testpaths = ["tests"]
 asyncio_mode = "auto"
 markers = [
     "asyncio: mark a test as an async coroutine",
+    "flaky: known file-lock race retried via pytest-rerunfailures (#191)",
 ]

--- a/tests/dsl/test_dialect_scanner.py
+++ b/tests/dsl/test_dialect_scanner.py
@@ -1,0 +1,124 @@
+"""Tests for the PostGIS dialect-drift scanner (issue #146)."""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from gispulse.runtime.config_loader import parse_config_text
+from gispulse.runtime.dialect_scanner import (
+    scan_expression,
+    scan_for_dialect_drift,
+)
+
+
+# ---------------------------------------------------------------------------
+# scan_expression — the five blocklisted patterns
+# ---------------------------------------------------------------------------
+
+
+def test_portable_sql_is_not_flagged() -> None:
+    """ST_Buffer with an explicit distance is portable DuckDB-spatial."""
+    assert scan_expression("UPDATE t SET g = ST_Buffer(geom, 100)", "x") == []
+
+
+def test_st_transform_2arg_flagged() -> None:
+    findings = scan_expression("SELECT ST_Transform(geom, 4326)", "x")
+    assert len(findings) == 1
+    assert "ST_Transform" in findings[0].construct
+
+
+def test_geography_cast_flagged() -> None:
+    findings = scan_expression("SELECT geography(geom)", "x")
+    assert any("geography" in f.construct for f in findings)
+
+
+def test_intersects_shorthand_flagged() -> None:
+    findings = scan_expression("WHERE INTERSECTS(a, b)", "x")
+    assert any("INTERSECTS" in f.construct for f in findings)
+
+
+def test_st_intersects_is_portable() -> None:
+    """The portable ST_Intersects must not trip the INTERSECTS rule."""
+    assert scan_expression("WHERE ST_Intersects(a, b)", "x") == []
+
+
+def test_bbox_operator_flagged() -> None:
+    findings = scan_expression("WHERE a.geom && b.geom", "x")
+    assert any("&&" in f.construct for f in findings)
+
+
+def test_type_cast_flagged() -> None:
+    geom = scan_expression("SELECT g::geometry", "x")
+    geog = scan_expression("SELECT g :: geography", "x")
+    assert geom and geog
+
+
+def test_multiple_constructs_all_reported() -> None:
+    findings = scan_expression(
+        "SELECT ST_Transform(geom, 2154), g::geometry", "x"
+    )
+    assert len(findings) == 2
+
+
+# ---------------------------------------------------------------------------
+# scan_for_dialect_drift — over a parsed config
+# ---------------------------------------------------------------------------
+
+
+def _config(engine_line: str = "", expression: str = "ST_Transform(geom, 4326)"):
+    text = textwrap.dedent(
+        f"""
+        version: 1
+        gpkg: ./unused.gpkg
+        {engine_line}
+        triggers:
+          - name: enrich
+            table: parcels
+            actions:
+              - type: run_sql
+                expression: "{expression}"
+        """
+    ).strip()
+    return parse_config_text(text, resolve_gpkg=False)
+
+
+def test_run_sql_drift_is_found() -> None:
+    findings = scan_for_dialect_drift(_config())
+    assert len(findings) == 1
+    assert "run_sql action" in findings[0].location
+
+
+def test_portable_run_sql_clean() -> None:
+    assert scan_for_dialect_drift(_config(expression="ST_Buffer(geom, 50)")) == []
+
+
+def test_engine_postgis_silences_the_scan() -> None:
+    """Pinning engine: postgis makes the constructs legitimate (#146)."""
+    cfg = _config(engine_line="engine: postgis")
+    assert scan_for_dialect_drift(cfg) == []
+
+
+def test_finding_message_is_actionable() -> None:
+    finding = scan_for_dialect_drift(_config())[0]
+    msg = finding.message()
+    assert "PostGIS-only" in msg and finding.hint in msg
+
+
+def test_loader_emits_dialect_drift_warning(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """parse_config_text logs a dialect_drift event for a drifting config."""
+    _config()  # parse_config_text runs _warn_dialect_drift
+    out = capsys.readouterr()
+    assert "dialect_drift" in (out.out + out.err)
+
+
+def test_loader_silent_for_portable_config(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """No dialect_drift noise for a portable config."""
+    _config(expression="ST_Buffer(geom, 50)")
+    out = capsys.readouterr()
+    assert "dialect_drift" not in (out.out + out.err)

--- a/tests/integration/http/test_lot2_v2_smoke.py
+++ b/tests/integration/http/test_lot2_v2_smoke.py
@@ -433,6 +433,13 @@ async def test_p01_ws_accepts_in_dev_default(tmp_data_dir: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
+# Known file-lock race (#191): the test reaches into a GPKG with raw
+# sqlite3 while the server still holds a pyogrio handle on it, so SQLite
+# occasionally reports "file is not a database" on CI (~50 % per matrix
+# leg). It is a test-harness race, not a product regression — the
+# ``_connect_with_retry`` helper already absorbs most of it; the rerun
+# marker covers the residual window.
+@pytest.mark.flaky(reruns=2, reruns_delay=1)
 @pytest.mark.asyncio
 async def test_p02_enable_tracking_full_lifecycle(tmp_data_dir: Path, tmp_path: Path) -> None:
     import websockets

--- a/tests/unit/test_cli_mcp.py
+++ b/tests/unit/test_cli_mcp.py
@@ -1,0 +1,46 @@
+"""Tests for ``gispulse mcp`` (issue #201)."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+from typer.testing import CliRunner
+
+from gispulse.cli import app
+
+runner = CliRunner()
+
+
+def test_mcp_rejects_non_stdio_transport() -> None:
+    """v1.7.0 ships stdio only — an HTTP request fails cleanly."""
+    result = runner.invoke(app, ["mcp", "--transport", "http"])
+    assert result.exit_code == 1
+    assert "only 'stdio'" in result.output
+
+
+def test_mcp_launches_stdio_server(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``gispulse mcp`` builds the server and runs its stdio transport."""
+    runs: list[bool] = []
+
+    class FakeServer:
+        def run(self) -> None:
+            runs.append(True)
+
+    import gispulse.adapters.mcp.server as srv
+
+    monkeypatch.setattr(srv, "create_mcp_server", lambda *a, **k: FakeServer())
+    result = runner.invoke(app, ["mcp"])
+
+    assert result.exit_code == 0
+    assert runs == [True]
+
+
+def test_mcp_reports_missing_extra(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A clear message when the optional 'mcp' extra is not installed."""
+    # Simulate the import failing inside cmd_mcp.
+    monkeypatch.setitem(sys.modules, "gispulse.adapters.mcp.server", None)
+    result = runner.invoke(app, ["mcp"])
+
+    assert result.exit_code == 1
+    assert "pip install 'gispulse[mcp]'" in result.output

--- a/tests/unit/test_sources.py
+++ b/tests/unit/test_sources.py
@@ -74,7 +74,7 @@ class FakeCadastre(DeclarativeSource):
             SourceEntryRef(
                 id="parcelles",
                 name="Parcelles cadastrales",
-                access=AccessSpec(protocol=AccessProtocol.WFS, endpoint="https://ign/wfs"),
+                access=AccessSpec(protocol=AccessProtocol.WFS, endpoint="https://93.184.216.34/wfs"),
                 revision_token="2026-01",
             ),
         ]
@@ -132,9 +132,9 @@ def test_register_rejects_duplicate_without_override() -> None:
 
 
 def test_dispatch_fetch_resolves_and_runs(registry: ProtocolRegistry) -> None:
-    access = AccessSpec(protocol=AccessProtocol.WFS, endpoint="https://ign/wfs")
+    access = AccessSpec(protocol=AccessProtocol.WFS, endpoint="https://93.184.216.34/wfs")
     result = registry.dispatch_fetch(access, mode=FetchMode.REFERENCE)
-    assert result.data == "rows@https://ign/wfs"
+    assert result.data == "rows@https://93.184.216.34/wfs"
     assert result.mode is FetchMode.REFERENCE
 
 
@@ -171,7 +171,7 @@ def test_declarative_source_fetch_delegates(registry: ProtocolRegistry) -> None:
     src = FakeCadastre(registry=registry)
     result = src.fetch("parcelles")
     assert result.payload is Payload.VECTOR
-    assert result.data == "rows@https://ign/wfs"
+    assert result.data == "rows@https://93.184.216.34/wfs"
 
 
 def test_declarative_source_revision_returns_token(registry: ProtocolRegistry) -> None:

--- a/tests/unit/test_ssrf.py
+++ b/tests/unit/test_ssrf.py
@@ -1,0 +1,122 @@
+"""Tests for the SSRF guard on outbound fetches (issue #199)."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.ssrf import SSRFError, guard_outbound_url, is_blocked_address
+
+
+# ---------------------------------------------------------------------------
+# is_blocked_address
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "addr",
+    ["10.0.0.1", "192.168.1.1", "127.0.0.1", "169.254.169.254", "::1", "not-an-ip"],
+)
+def test_blocked_addresses(addr: str) -> None:
+    assert is_blocked_address(addr) is True
+
+
+@pytest.mark.parametrize("addr", ["8.8.8.8", "1.1.1.1", "93.184.216.34"])
+def test_public_addresses_allowed(addr: str) -> None:
+    assert is_blocked_address(addr) is False
+
+
+# ---------------------------------------------------------------------------
+# guard_outbound_url — literal-IP URLs need no DNS
+# ---------------------------------------------------------------------------
+
+
+def test_guard_allows_public_ip() -> None:
+    guard_outbound_url("https://8.8.8.8/wfs")  # no raise
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://10.0.0.1/wfs",
+        "http://192.168.0.5/data",
+        "http://127.0.0.1:8000/",
+        "http://169.254.169.254/latest/meta-data/",  # cloud metadata
+    ],
+)
+def test_guard_blocks_internal_targets(url: str) -> None:
+    with pytest.raises(SSRFError, match="blocked address"):
+        guard_outbound_url(url)
+
+
+def test_guard_skips_non_http_endpoints() -> None:
+    """Local file paths / file:// URIs are not network targets."""
+    guard_outbound_url("/var/data/layer.gpkg")
+    guard_outbound_url("file:///var/data/layer.gpkg")
+    guard_outbound_url(None)
+    guard_outbound_url("")
+
+
+def test_guard_allows_private_with_explicit_flag() -> None:
+    guard_outbound_url("http://10.0.0.1/wfs", allow_private=True)  # no raise
+
+
+def test_guard_respects_env_optin(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GISPULSE_FETCH_ALLOW_PRIVATE", "1")
+    guard_outbound_url("http://10.0.0.1/wfs")  # no raise
+
+
+def test_guard_rejects_url_without_hostname() -> None:
+    with pytest.raises(SSRFError, match="no hostname"):
+        guard_outbound_url("http://")
+
+
+# ---------------------------------------------------------------------------
+# Integration — ProtocolRegistry.dispatch_fetch is guarded
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_fetch_blocks_private_endpoint() -> None:
+    from core.plugin_model import AccessProtocol, AccessSpec, FetchMode, Payload, SourceResult
+    from core.sources import ProtocolRegistry
+
+    called: list = []
+
+    class FakeWFS:
+        protocol = AccessProtocol.WFS
+
+        def fetch(self, access, *, extent=None, mode=FetchMode.MATERIALIZE):
+            called.append(access)
+            return SourceResult(payload=Payload.VECTOR, mode=mode, data=None)
+
+    reg = ProtocolRegistry()
+    reg.register(FakeWFS())
+    access = AccessSpec(
+        protocol=AccessProtocol.WFS,
+        endpoint="http://169.254.169.254/wfs",
+        params={},
+        format="application/json",
+    )
+    with pytest.raises(SSRFError):
+        reg.dispatch_fetch(access)
+    assert called == []  # fetcher never reached
+
+
+def test_dispatch_fetch_allows_public_endpoint() -> None:
+    from core.plugin_model import AccessProtocol, AccessSpec, FetchMode, Payload, SourceResult
+    from core.sources import ProtocolRegistry
+
+    class FakeWFS:
+        protocol = AccessProtocol.WFS
+
+        def fetch(self, access, *, extent=None, mode=FetchMode.MATERIALIZE):
+            return SourceResult(payload=Payload.VECTOR, mode=mode, data="ok")
+
+    reg = ProtocolRegistry()
+    reg.register(FakeWFS())
+    access = AccessSpec(
+        protocol=AccessProtocol.WFS,
+        endpoint="https://8.8.8.8/wfs",
+        params={},
+        format="application/json",
+    )
+    assert reg.dispatch_fetch(access).data == "ok"


### PR DESCRIPTION
Sprint v1.7.0 — vague quick-wins. 4 issues indépendantes, faible risque.

| # | Livré |
|---|---|
| #201 | `gispulse mcp` — lance le serveur MCP (stdio). Le serveur (PR #162) n'avait aucun launcher. |
| #146 | Scanner de dérive de dialecte — blocklist regex (ST_Transform/2, geography(), INTERSECTS(), `&&`, `::geometry`) ; warning `dialect_drift` au chargement sauf `engine: postgis`. |
| #199 | Guard SSRF sur `FetcherRegistry.dispatch_fetch` — `core.ssrf.guard_outbound_url` bloque RFC1918/loopback/link-local ; opt-in `GISPULSE_FETCH_ALLOW_PRIVATE`. |
| #191 | `test_p02` marqué `flaky(reruns=2)` + `pytest-rerunfailures` — race de lock fichier connue, pas une régression. |

## Tests
+20 SSRF · +14 dialect scanner · +3 mcp CLI. Non-régression sources/protocol verte (2 tests `test_sources` réalignés sur IP littérale car le guard SSRF fail-closed sur hostname non résolvable).

## Hors scope
#160 (bench perf) reporté — aucun dossier `bench/` n'existe : c'est une création de harness, pas un quick-win.

Closes #201 #146 #199 #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)