### PR TITLE
[v1.7.0] OGC fetchers — WFS + OGC API Features dispatch via the ProtocolRegistry (#192)

### DIFF
--- a/gispulse/adapters/ogc/__init__.py
+++ b/gispulse/adapters/ogc/__init__.py
@@ -1,0 +1,13 @@
+"""OGC service adapters — WFS / OGC API Features clients and fetchers.
+
+Importing this package self-registers the core OGC transport adapters
+in :data:`core.sources.PROTOCOLS` (issue #192), so the ETL fetch path
+has a real WFS fetcher to dispatch to.
+"""
+
+from __future__ import annotations
+
+# Side-effect import: WfsFetcher registers itself in PROTOCOLS on import.
+from gispulse.adapters.ogc import wfs_fetcher  # noqa: F401
+
+__all__ = ["wfs_fetcher"]

--- a/gispulse/adapters/ogc/wfs_fetcher.py
+++ b/gispulse/adapters/ogc/wfs_fetcher.py
@@ -1,0 +1,140 @@
+"""WFS Fetcher — absorbs ``wfs_client`` into the ProtocolRegistry (issue #192).
+
+PR #189 delivered the :class:`~core.sources.ProtocolRegistry` /
+:class:`~core.sources.Fetcher` contract, but no real transport adapter
+was registered — so a :class:`~core.sources.DeclarativeSource` had
+nothing to dispatch ``fetch()`` to. This module wraps the existing
+paginating WFS client (:func:`gispulse.adapters.ogc.wfs_client.fetch_wfs`)
+as a :class:`~core.sources.Fetcher` and registers it under
+:attr:`~core.plugin_model.AccessProtocol.WFS`.
+
+Importing this module self-registers the fetcher in the process-wide
+:data:`core.sources.PROTOCOLS` registry (idempotent), so
+``gispulse-src-cadastre`` and the like resolve a real WFS round-trip.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.logging import get_logger
+from core.plugin_model import (
+    AccessProtocol,
+    AccessSpec,
+    FetchMode,
+    Payload,
+    SourceResult,
+)
+
+log = get_logger(__name__)
+
+# AccessSpec.params keys the fetcher consumes itself. Every *other* key
+# is forwarded verbatim to the WFS request as a vendor parameter.
+_RESERVED_PARAMS = frozenset(
+    {"typename", "typenames", "layer", "version", "crs", "max_features", "cql_filter"}
+)
+
+
+def _bbox_from_extent(
+    extent: Any,
+) -> tuple[float, float, float, float] | None:
+    """Coerce a fetch ``extent`` into a 4-tuple bbox, or ``None``."""
+    if extent is None:
+        return None
+    try:
+        coords = tuple(float(c) for c in extent)
+    except (TypeError, ValueError):
+        return None
+    if len(coords) != 4:
+        return None
+    return coords  # type: ignore[return-value]
+
+
+class WfsFetcher:
+    """:class:`~core.sources.Fetcher` for ``AccessProtocol.WFS``.
+
+    Translates an :class:`~core.plugin_model.AccessSpec` into the
+    ``OGCSourceConfig`` the legacy paginating client expects, runs the
+    request, and wraps the resulting GeoDataFrame in a
+    :class:`~core.plugin_model.SourceResult`.
+    """
+
+    protocol = AccessProtocol.WFS
+
+    def fetch(
+        self,
+        access: AccessSpec,
+        *,
+        extent: Any | None = None,
+        mode: FetchMode = FetchMode.MATERIALIZE,
+    ) -> SourceResult:
+        from core.models import OGCSourceConfig
+        from gispulse.adapters.ogc.wfs_client import fetch_wfs
+
+        params = dict(access.params or {})
+        layer = (
+            params.get("typename")
+            or params.get("typenames")
+            or params.get("layer")
+        )
+        if not layer:
+            raise ValueError(
+                "WFS AccessSpec.params must declare a 'typename' "
+                "(the WFS layer / featureType to request)"
+            )
+
+        crs = str(params.get("crs", "EPSG:4326"))
+        vendor = {k: v for k, v in params.items() if k not in _RESERVED_PARAMS}
+        cfg = OGCSourceConfig(
+            source_type="wfs",
+            url=access.endpoint,
+            layer_name=str(layer),
+            version=str(params.get("version", "2.0.0")),
+            crs=crs,
+            auth=None,
+            max_features=params.get("max_features"),
+            params=vendor,
+        )
+
+        gdf = fetch_wfs(
+            cfg,
+            bbox=_bbox_from_extent(extent),
+            cql_filter=params.get("cql_filter"),
+        )
+        log.info(
+            "wfs_fetch",
+            endpoint=access.endpoint,
+            layer=str(layer),
+            features=len(gdf),
+        )
+        return SourceResult(
+            payload=Payload.VECTOR,
+            mode=mode,
+            data=gdf,
+            crs=crs,
+            metadata={"layer": str(layer), "feature_count": len(gdf)},
+        )
+
+
+def register_wfs_fetcher(registry: Any | None = None) -> None:
+    """Register a :class:`WfsFetcher` in ``registry`` (default: PROTOCOLS).
+
+    Idempotent — a second call is a no-op rather than a duplicate-slot
+    error, so importing this module repeatedly is safe.
+    """
+    from core.sources import PROTOCOLS, ProtocolNotSupported
+
+    target = registry if registry is not None else PROTOCOLS
+    try:
+        target.get_fetcher(AccessProtocol.WFS)
+        return  # already registered
+    except ProtocolNotSupported:
+        pass
+    target.register(WfsFetcher())
+
+
+# Importing this module wires the fetcher into the global registry.
+register_wfs_fetcher()
+
+
+__all__ = ["WfsFetcher", "register_wfs_fetcher"]

--- a/gispulse/adapters/ogc/wfs_fetcher.py
+++ b/gispulse/adapters/ogc/wfs_fetcher.py
@@ -1,16 +1,18 @@
-"""WFS Fetcher — absorbs ``wfs_client`` into the ProtocolRegistry (issue #192).
+"""OGC fetchers — WFS + OGC API Features in the ProtocolRegistry (issue #192).
 
 PR #189 delivered the :class:`~core.sources.ProtocolRegistry` /
 :class:`~core.sources.Fetcher` contract, but no real transport adapter
 was registered — so a :class:`~core.sources.DeclarativeSource` had
 nothing to dispatch ``fetch()`` to. This module wraps the existing
-paginating WFS client (:func:`gispulse.adapters.ogc.wfs_client.fetch_wfs`)
-as a :class:`~core.sources.Fetcher` and registers it under
-:attr:`~core.plugin_model.AccessProtocol.WFS`.
+paginating OGC clients
+(:func:`gispulse.adapters.ogc.wfs_client.fetch_wfs` and
+:func:`~gispulse.adapters.ogc.wfs_client.fetch_ogc_api_features`) as
+:class:`~core.sources.Fetcher` adapters and registers them under
+:attr:`~core.plugin_model.AccessProtocol.WFS` and
+:attr:`~core.plugin_model.AccessProtocol.OGC_FEATURES`.
 
-Importing this module self-registers the fetcher in the process-wide
-:data:`core.sources.PROTOCOLS` registry (idempotent), so
-``gispulse-src-cadastre`` and the like resolve a real WFS round-trip.
+Importing this module self-registers both fetchers in the process-wide
+:data:`core.sources.PROTOCOLS` registry (idempotent).
 """
 
 from __future__ import annotations
@@ -28,10 +30,19 @@ from core.plugin_model import (
 
 log = get_logger(__name__)
 
-# AccessSpec.params keys the fetcher consumes itself. Every *other* key
-# is forwarded verbatim to the WFS request as a vendor parameter.
+# AccessSpec.params keys the fetchers consume themselves. Every *other*
+# key is forwarded verbatim to the OGC request as a vendor parameter.
 _RESERVED_PARAMS = frozenset(
-    {"typename", "typenames", "layer", "version", "crs", "max_features", "cql_filter"}
+    {
+        "typename",
+        "typenames",
+        "layer",
+        "collection",
+        "version",
+        "crs",
+        "max_features",
+        "cql_filter",
+    }
 )
 
 
@@ -50,14 +61,45 @@ def _bbox_from_extent(
     return coords  # type: ignore[return-value]
 
 
-class WfsFetcher:
-    """:class:`~core.sources.Fetcher` for ``AccessProtocol.WFS``.
+def _ogc_config_from_access(access: AccessSpec, *, source_type: str):
+    """Translate an :class:`AccessSpec` into an ``OGCSourceConfig``.
 
-    Translates an :class:`~core.plugin_model.AccessSpec` into the
-    ``OGCSourceConfig`` the legacy paginating client expects, runs the
-    request, and wraps the resulting GeoDataFrame in a
-    :class:`~core.plugin_model.SourceResult`.
+    Returns ``(cfg, params)`` — ``params`` is the parsed ``AccessSpec``
+    param dict so a caller can still read protocol-specific keys
+    (e.g. WFS's ``cql_filter``). Raises :class:`ValueError` when no layer
+    / collection is declared.
     """
+    from core.models import OGCSourceConfig
+
+    params = dict(access.params or {})
+    layer = (
+        params.get("collection")
+        or params.get("typename")
+        or params.get("typenames")
+        or params.get("layer")
+    )
+    if not layer:
+        raise ValueError(
+            "OGC AccessSpec.params must declare a 'typename' (WFS layer) "
+            "or 'collection' (OGC API Features collection)"
+        )
+    crs = str(params.get("crs", "EPSG:4326"))
+    vendor = {k: v for k, v in params.items() if k not in _RESERVED_PARAMS}
+    cfg = OGCSourceConfig(
+        source_type=source_type,
+        url=access.endpoint,
+        layer_name=str(layer),
+        version=str(params.get("version", "2.0.0")),
+        crs=crs,
+        auth=None,
+        max_features=params.get("max_features"),
+        params=vendor,
+    )
+    return cfg, params
+
+
+class WfsFetcher:
+    """:class:`~core.sources.Fetcher` for ``AccessProtocol.WFS``."""
 
     protocol = AccessProtocol.WFS
 
@@ -68,34 +110,9 @@ class WfsFetcher:
         extent: Any | None = None,
         mode: FetchMode = FetchMode.MATERIALIZE,
     ) -> SourceResult:
-        from core.models import OGCSourceConfig
         from gispulse.adapters.ogc.wfs_client import fetch_wfs
 
-        params = dict(access.params or {})
-        layer = (
-            params.get("typename")
-            or params.get("typenames")
-            or params.get("layer")
-        )
-        if not layer:
-            raise ValueError(
-                "WFS AccessSpec.params must declare a 'typename' "
-                "(the WFS layer / featureType to request)"
-            )
-
-        crs = str(params.get("crs", "EPSG:4326"))
-        vendor = {k: v for k, v in params.items() if k not in _RESERVED_PARAMS}
-        cfg = OGCSourceConfig(
-            source_type="wfs",
-            url=access.endpoint,
-            layer_name=str(layer),
-            version=str(params.get("version", "2.0.0")),
-            crs=crs,
-            auth=None,
-            max_features=params.get("max_features"),
-            params=vendor,
-        )
-
+        cfg, params = _ogc_config_from_access(access, source_type="wfs")
         gdf = fetch_wfs(
             cfg,
             bbox=_bbox_from_extent(extent),
@@ -104,37 +121,93 @@ class WfsFetcher:
         log.info(
             "wfs_fetch",
             endpoint=access.endpoint,
-            layer=str(layer),
+            layer=cfg.layer_name,
             features=len(gdf),
         )
         return SourceResult(
             payload=Payload.VECTOR,
             mode=mode,
             data=gdf,
-            crs=crs,
-            metadata={"layer": str(layer), "feature_count": len(gdf)},
+            crs=cfg.crs,
+            metadata={"layer": cfg.layer_name, "feature_count": len(gdf)},
         )
 
 
-def register_wfs_fetcher(registry: Any | None = None) -> None:
-    """Register a :class:`WfsFetcher` in ``registry`` (default: PROTOCOLS).
+class OgcFeaturesFetcher:
+    """:class:`~core.sources.Fetcher` for ``AccessProtocol.OGC_FEATURES``.
 
-    Idempotent — a second call is a no-op rather than a duplicate-slot
-    error, so importing this module repeatedly is safe.
+    The modern OGC API - Features (GeoJSON, ``/collections/{id}/items``,
+    ``next``-link pagination). The entry's layer is the collection id —
+    declare it as ``collection`` (preferred) or ``typename``.
     """
+
+    protocol = AccessProtocol.OGC_FEATURES
+
+    def fetch(
+        self,
+        access: AccessSpec,
+        *,
+        extent: Any | None = None,
+        mode: FetchMode = FetchMode.MATERIALIZE,
+    ) -> SourceResult:
+        from gispulse.adapters.ogc.wfs_client import fetch_ogc_api_features
+
+        cfg, _params = _ogc_config_from_access(
+            access, source_type="ogc_api_features"
+        )
+        gdf = fetch_ogc_api_features(cfg, bbox=_bbox_from_extent(extent))
+        log.info(
+            "ogc_features_fetch",
+            endpoint=access.endpoint,
+            collection=cfg.layer_name,
+            features=len(gdf),
+        )
+        return SourceResult(
+            payload=Payload.VECTOR,
+            mode=mode,
+            data=gdf,
+            crs=cfg.crs,
+            metadata={"collection": cfg.layer_name, "feature_count": len(gdf)},
+        )
+
+
+def _register(registry: Any, fetcher: Any, protocol: AccessProtocol) -> None:
+    """Register ``fetcher`` under ``protocol`` — idempotent."""
     from core.sources import PROTOCOLS, ProtocolNotSupported
 
     target = registry if registry is not None else PROTOCOLS
     try:
-        target.get_fetcher(AccessProtocol.WFS)
+        target.get_fetcher(protocol)
         return  # already registered
     except ProtocolNotSupported:
         pass
-    target.register(WfsFetcher())
+    target.register(fetcher)
 
 
-# Importing this module wires the fetcher into the global registry.
-register_wfs_fetcher()
+def register_wfs_fetcher(registry: Any | None = None) -> None:
+    """Register a :class:`WfsFetcher` (default registry: PROTOCOLS)."""
+    _register(registry, WfsFetcher(), AccessProtocol.WFS)
 
 
-__all__ = ["WfsFetcher", "register_wfs_fetcher"]
+def register_ogc_features_fetcher(registry: Any | None = None) -> None:
+    """Register an :class:`OgcFeaturesFetcher` (default: PROTOCOLS)."""
+    _register(registry, OgcFeaturesFetcher(), AccessProtocol.OGC_FEATURES)
+
+
+def register_core_ogc_fetchers(registry: Any | None = None) -> None:
+    """Register every built-in OGC fetcher in ``registry``."""
+    register_wfs_fetcher(registry)
+    register_ogc_features_fetcher(registry)
+
+
+# Importing this module wires the fetchers into the global registry.
+register_core_ogc_fetchers()
+
+
+__all__ = [
+    "OgcFeaturesFetcher",
+    "WfsFetcher",
+    "register_core_ogc_fetchers",
+    "register_ogc_features_fetcher",
+    "register_wfs_fetcher",
+]

--- a/tests/unit/test_wfs_fetcher.py
+++ b/tests/unit/test_wfs_fetcher.py
@@ -158,3 +158,93 @@ def test_dispatch_fetch_routes_to_wfs_fetcher(mock_fetch_wfs: list) -> None:
     result = reg.dispatch_fetch(access, mode=FetchMode.MATERIALIZE)
     assert result.payload is Payload.VECTOR
     assert len(mock_fetch_wfs) == 1
+
+
+# ---------------------------------------------------------------------------
+# OgcFeaturesFetcher (#192)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_fetch_ogc(monkeypatch: pytest.MonkeyPatch) -> list:
+    """Patch wfs_client.fetch_ogc_api_features; return the recorded calls."""
+    calls: list = []
+
+    def fake(cfg, *, bbox=None, **_kw):
+        calls.append({"cfg": cfg, "bbox": bbox})
+        return _FakeGDF(4)
+
+    monkeypatch.setattr(
+        "gispulse.adapters.ogc.wfs_client.fetch_ogc_api_features", fake
+    )
+    return calls
+
+
+def test_ogc_features_fetcher_declares_protocol() -> None:
+    from gispulse.adapters.ogc.wfs_fetcher import OgcFeaturesFetcher
+
+    assert OgcFeaturesFetcher.protocol is AccessProtocol.OGC_FEATURES
+
+
+def test_ogc_features_fetch_returns_vector_result(mock_fetch_ogc: list) -> None:
+    from gispulse.adapters.ogc.wfs_fetcher import OgcFeaturesFetcher
+
+    access = AccessSpec(
+        protocol=AccessProtocol.OGC_FEATURES,
+        endpoint="https://features.example.org",
+        params={"collection": "buildings", "crs": "EPSG:4326"},
+    )
+    result = OgcFeaturesFetcher().fetch(access, extent=(0, 0, 5, 5))
+
+    assert result.payload is Payload.VECTOR
+    assert len(result.data) == 4
+    assert result.metadata["collection"] == "buildings"
+    assert mock_fetch_ogc[0]["cfg"].layer_name == "buildings"
+    assert mock_fetch_ogc[0]["bbox"] == (0.0, 0.0, 5.0, 5.0)
+
+
+def test_ogc_features_layer_falls_back_to_typename(mock_fetch_ogc: list) -> None:
+    from gispulse.adapters.ogc.wfs_fetcher import OgcFeaturesFetcher
+
+    access = AccessSpec(
+        protocol=AccessProtocol.OGC_FEATURES,
+        endpoint="https://features.example.org",
+        params={"typename": "parcels"},
+    )
+    OgcFeaturesFetcher().fetch(access)
+    assert mock_fetch_ogc[0]["cfg"].layer_name == "parcels"
+
+
+def test_ogc_features_without_layer_raises(mock_fetch_ogc: list) -> None:
+    from gispulse.adapters.ogc.wfs_fetcher import OgcFeaturesFetcher
+
+    access = AccessSpec(
+        protocol=AccessProtocol.OGC_FEATURES,
+        endpoint="https://features.example.org",
+        params={},
+    )
+    with pytest.raises(ValueError, match="must declare a 'typename'"):
+        OgcFeaturesFetcher().fetch(access)
+
+
+def test_register_core_ogc_fetchers_registers_both() -> None:
+    from gispulse.adapters.ogc.wfs_fetcher import (
+        OgcFeaturesFetcher,
+        register_core_ogc_fetchers,
+    )
+
+    reg = ProtocolRegistry()
+    register_core_ogc_fetchers(reg)
+    assert isinstance(reg.get_fetcher(AccessProtocol.WFS), WfsFetcher)
+    assert isinstance(
+        reg.get_fetcher(AccessProtocol.OGC_FEATURES), OgcFeaturesFetcher
+    )
+
+
+def test_ogc_features_fetcher_self_registered() -> None:
+    from core.sources import PROTOCOLS
+    from gispulse.adapters.ogc.wfs_fetcher import OgcFeaturesFetcher
+
+    assert isinstance(
+        PROTOCOLS.get_fetcher(AccessProtocol.OGC_FEATURES), OgcFeaturesFetcher
+    )

--- a/tests/unit/test_wfs_fetcher.py
+++ b/tests/unit/test_wfs_fetcher.py
@@ -1,0 +1,160 @@
+"""Tests for the WFS fetcher absorbed into the ProtocolRegistry (#192)."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.plugin_model import (
+    AccessProtocol,
+    AccessSpec,
+    FetchMode,
+    Payload,
+)
+from core.sources import ProtocolNotSupported, ProtocolRegistry
+from gispulse.adapters.ogc.wfs_fetcher import (
+    WfsFetcher,
+    _bbox_from_extent,
+    register_wfs_fetcher,
+)
+
+
+class _FakeGDF:
+    """Stand-in GeoDataFrame — the fetcher only calls len() on it."""
+
+    def __init__(self, n: int) -> None:
+        self._n = n
+
+    def __len__(self) -> int:
+        return self._n
+
+
+@pytest.fixture
+def mock_fetch_wfs(monkeypatch: pytest.MonkeyPatch) -> list:
+    """Patch wfs_client.fetch_wfs; return the list of (cfg, kwargs) calls."""
+    calls: list = []
+
+    def fake(cfg, *, bbox=None, cql_filter=None, **_kw):
+        calls.append({"cfg": cfg, "bbox": bbox, "cql_filter": cql_filter})
+        return _FakeGDF(7)
+
+    monkeypatch.setattr(
+        "gispulse.adapters.ogc.wfs_client.fetch_wfs", fake
+    )
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# _bbox_from_extent
+# ---------------------------------------------------------------------------
+
+
+def test_bbox_from_extent_valid() -> None:
+    assert _bbox_from_extent((1, 2, 3, 4)) == (1.0, 2.0, 3.0, 4.0)
+
+
+@pytest.mark.parametrize("bad", [None, (1, 2, 3), (1, 2, 3, 4, 5), "nope", 42])
+def test_bbox_from_extent_rejects_non_bbox(bad: object) -> None:
+    assert _bbox_from_extent(bad) is None
+
+
+# ---------------------------------------------------------------------------
+# WfsFetcher.fetch
+# ---------------------------------------------------------------------------
+
+
+def test_fetcher_declares_wfs_protocol() -> None:
+    assert WfsFetcher.protocol is AccessProtocol.WFS
+
+
+def test_fetch_returns_vector_source_result(mock_fetch_wfs: list) -> None:
+    access = AccessSpec(
+        protocol=AccessProtocol.WFS,
+        endpoint="https://data.geopf.fr/wfs/ows",
+        params={"typename": "CADASTRE:parcelle", "crs": "EPSG:2154"},
+    )
+    result = WfsFetcher().fetch(access)
+
+    assert result.payload is Payload.VECTOR
+    assert len(result.data) == 7
+    assert result.crs == "EPSG:2154"
+    assert result.metadata["feature_count"] == 7
+
+
+def test_fetch_maps_access_to_ogc_config(mock_fetch_wfs: list) -> None:
+    access = AccessSpec(
+        protocol=AccessProtocol.WFS,
+        endpoint="https://wfs.example.org/ows",
+        params={"typename": "ns:layer", "version": "1.1.0", "sortBy": "id"},
+    )
+    WfsFetcher().fetch(access, extent=(0, 0, 10, 10))
+
+    call = mock_fetch_wfs[0]
+    cfg = call["cfg"]
+    assert cfg.url == "https://wfs.example.org/ows"
+    assert cfg.layer_name == "ns:layer"
+    assert cfg.version == "1.1.0"
+    assert call["bbox"] == (0.0, 0.0, 10.0, 10.0)
+    # Non-reserved params are forwarded verbatim as vendor params.
+    assert cfg.params == {"sortBy": "id"}
+
+
+def test_fetch_without_typename_raises(mock_fetch_wfs: list) -> None:
+    access = AccessSpec(
+        protocol=AccessProtocol.WFS,
+        endpoint="https://wfs.example.org/ows",
+        params={},
+    )
+    with pytest.raises(ValueError, match="must declare a 'typename'"):
+        WfsFetcher().fetch(access)
+
+
+def test_fetch_forwards_cql_filter(mock_fetch_wfs: list) -> None:
+    access = AccessSpec(
+        protocol=AccessProtocol.WFS,
+        endpoint="https://wfs.example.org/ows",
+        params={"typename": "ns:layer", "cql_filter": "pop > 1000"},
+    )
+    WfsFetcher().fetch(access)
+    assert mock_fetch_wfs[0]["cql_filter"] == "pop > 1000"
+
+
+# ---------------------------------------------------------------------------
+# Registration + dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_register_wfs_fetcher_into_fresh_registry() -> None:
+    reg = ProtocolRegistry()
+    with pytest.raises(ProtocolNotSupported):
+        reg.get_fetcher(AccessProtocol.WFS)
+
+    register_wfs_fetcher(reg)
+    assert isinstance(reg.get_fetcher(AccessProtocol.WFS), WfsFetcher)
+
+
+def test_register_wfs_fetcher_is_idempotent() -> None:
+    reg = ProtocolRegistry()
+    register_wfs_fetcher(reg)
+    register_wfs_fetcher(reg)  # second call must not raise on a taken slot
+    assert isinstance(reg.get_fetcher(AccessProtocol.WFS), WfsFetcher)
+
+
+def test_wfs_fetcher_self_registered_in_global_protocols() -> None:
+    """Importing the module wired the fetcher into the shared registry."""
+    from core.sources import PROTOCOLS
+
+    assert isinstance(PROTOCOLS.get_fetcher(AccessProtocol.WFS), WfsFetcher)
+
+
+def test_dispatch_fetch_routes_to_wfs_fetcher(mock_fetch_wfs: list) -> None:
+    """End-to-end: a WFS AccessSpec dispatches through the registry."""
+    reg = ProtocolRegistry()
+    register_wfs_fetcher(reg)
+    access = AccessSpec(
+        protocol=AccessProtocol.WFS,
+        endpoint="https://data.geopf.fr/wfs/ows",
+        params={"typename": "CADASTRE:parcelle"},
+    )
+    result = reg.dispatch_fetch(access, mode=FetchMode.MATERIALIZE)
+    assert result.payload is Payload.VECTOR
+    assert len(mock_fetch_wfs) == 1


### PR DESCRIPTION
Sprint v1.7.0 — vague ETL. Premiers transport adapters réels branchés sur le `ProtocolRegistry`.

## Problème
PR #189 a livré le contrat `Fetcher`/`ProtocolRegistry` mais aucun fetcher réel n'était enregistré — `DeclarativeSource.fetch()` n'avait nulle part où dispatcher.

## Livré
- `WfsFetcher` (`AccessProtocol.WFS`) — wrappe `wfs_client.fetch_wfs`.
- `OgcFeaturesFetcher` (`AccessProtocol.OGC_FEATURES`) — wrappe `fetch_ogc_api_features` (GeoJSON, pagination `next`).
- Mapping `AccessSpec → OGCSourceConfig` factorisé (`_ogc_config_from_access`).
- Auto-enregistrement des deux dans `core.sources.PROTOCOLS` à l'import de `gispulse.adapters.ogc` (idempotent).
- `gispulse-src-cadastre` résout un vrai aller-retour WFS end-to-end via `dispatch_fetch`.

## Tests
+21 (`test_wfs_fetcher`). 160 tests verts (ogc/catalog/sources).

## Reste sur #192
Adapters **APICarto** et **STAC** non encore absorbés. #192 reste ouverte ; ce PR couvre WFS + OGC API Features.

Advances #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)
