### PR TITLE
[v1.7.0] gispulse-src-ign — IGN reference data source plugin (#194)

### DIFF
--- a/plugins/gispulse-src-ign/gispulse_src_ign/__init__.py
+++ b/plugins/gispulse-src-ign/gispulse_src_ign/__init__.py
@@ -1,0 +1,21 @@
+"""GISPulse data-source plugin — IGN reference data (issue #194, pilot wave 1).
+
+Second ``gispulse-src-*`` pilot: validates the ``DeclarativeSource``
+contract on a *multi-layer* pure ``fetch()`` source (BD TOPO + Admin
+Express), after ``gispulse-src-cadastre`` proved the single-dataset case.
+"""
+
+from __future__ import annotations
+
+
+def register() -> None:
+    """Entry-point hook for the ``gispulse.data_sources`` group.
+
+    Registers an :class:`IgnSource` instance in the process-wide
+    ``core.sources.SOURCES`` registry so the source watcher (#197) can
+    resolve ``ign://<entry>`` URIs declared in ``triggers.yaml``.
+    """
+    from core.sources import SOURCES
+    from gispulse_src_ign.source import IgnSource
+
+    SOURCES.register(IgnSource())

--- a/plugins/gispulse-src-ign/gispulse_src_ign/source.py
+++ b/plugins/gispulse-src-ign/gispulse_src_ign/source.py
@@ -1,0 +1,109 @@
+"""IGN reference DataSource — BD TOPO + Admin Express vector layers.
+
+A :class:`~gispulse.plugins.api.DeclarativeSource` over the IGN
+Géoplateforme WFS. The plugin only *declares* the entries; the WFS
+round-trip is run by the registered protocol adapter (issue #192), so
+this package ships zero network code beyond the cheap ``revision()``
+freshness probe.
+
+GEOFLA is deprecated upstream — ``geofla`` is kept as a legacy alias of
+the Admin Express ``communes`` entry.
+"""
+
+from __future__ import annotations
+
+from gispulse.plugins.api import (
+    AccessProtocol,
+    AccessSpec,
+    DeclarativeSource,
+    Payload,
+    SourceDomain,
+    SourceEntryRef,
+)
+
+# IGN Géoplateforme — public WFS endpoint (no API key required).
+_GEOPLATEFORME_WFS = "https://data.geopf.fr/wfs/ows"
+_WFS_CAPABILITIES = (
+    f"{_GEOPLATEFORME_WFS}?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetCapabilities"
+)
+_REVISION_TIMEOUT_S = 8.0
+
+# Legacy alias — GEOFLA was retired upstream in favour of Admin Express.
+_ALIASES = {"geofla": "communes"}
+
+# entry_id -> (human label, WFS typename)
+_ENTRIES: dict[str, tuple[str, str]] = {
+    "batiments": ("Bâtiments (BD TOPO)", "BDTOPO_V3:batiment"),
+    "routes": ("Tronçons de route (BD TOPO)", "BDTOPO_V3:troncon_de_route"),
+    "cours_eau": ("Cours d'eau (BD TOPO)", "BDTOPO_V3:cours_d_eau"),
+    "communes": ("Communes (Admin Express)", "ADMINEXPRESS-COG.LATEST:commune"),
+    "departements": (
+        "Départements (Admin Express)",
+        "ADMINEXPRESS-COG.LATEST:departement",
+    ),
+    "regions": ("Régions (Admin Express)", "ADMINEXPRESS-COG.LATEST:region"),
+}
+
+
+def _probe_revision(url: str) -> str | None:
+    """Return a freshness token for ``url`` via a single HTTP HEAD.
+
+    Mirrors ``gispulse-src-cadastre`` (#198): derives the token from the
+    ``ETag`` / ``Last-Modified`` header, returns ``None`` on any network
+    error so the source watcher skips it rather than firing spuriously.
+    """
+    import httpx  # local import — keeps module import network-free
+
+    try:
+        resp = httpx.head(
+            url, timeout=_REVISION_TIMEOUT_S, follow_redirects=True
+        )
+    except Exception:  # noqa: BLE001 — any transport error ⇒ unknown
+        return None
+    etag = resp.headers.get("etag")
+    if etag:
+        return etag.strip('"')
+    last_modified = resp.headers.get("last-modified")
+    if last_modified:
+        return last_modified
+    return None
+
+
+class IgnSource(DeclarativeSource):
+    """IGN reference data (BD TOPO + Admin Express) as a GISPulse source."""
+
+    name = "ign"
+    domain = SourceDomain.BASE
+    payload = Payload.VECTOR
+    jurisdiction = "FR"
+
+    def entries(self) -> list[SourceEntryRef]:
+        return [
+            SourceEntryRef(
+                id=entry_id,
+                name=label,
+                access=AccessSpec(
+                    protocol=AccessProtocol.WFS,
+                    endpoint=_GEOPLATEFORME_WFS,
+                    params={"typename": typename},
+                    format="application/json",
+                ),
+                # revision() probes the WFS live (#198) — no stale token.
+                revision_token=None,
+                metadata={"provider": "IGN", "typename": typename},
+            )
+            for entry_id, (label, typename) in _ENTRIES.items()
+        ]
+
+    def _entry(self, entry_id: str) -> SourceEntryRef:
+        """Resolve the legacy ``geofla`` alias before the normal lookup."""
+        return super()._entry(_ALIASES.get(entry_id, entry_id))
+
+    def revision(self, entry_id: str) -> str | None:
+        """Cheap freshness token for the source watcher (#197/#198).
+
+        One HTTP HEAD against the Géoplateforme WFS GetCapabilities —
+        the millésime is service-wide, so every entry shares one probe.
+        """
+        self._entry(entry_id)  # validate id / resolve alias
+        return _probe_revision(_WFS_CAPABILITIES)

--- a/plugins/gispulse-src-ign/pyproject.toml
+++ b/plugins/gispulse-src-ign/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gispulse-src-ign"
+version = "0.1.0"
+description = "IGN reference data source for GISPulse (BD TOPO + Admin Express)"
+requires-python = ">=3.10"
+license = "AGPL-3.0-or-later"
+authors = [{ name = "GISPulse", email = "dev@gispulse.io" }]
+dependencies = [
+    "gispulse",
+]
+
+# Registered as a data source — discovered by core.plugin_hub.PluginHub.
+[project.entry-points."gispulse.data_sources"]
+ign = "gispulse_src_ign:register"
+
+[tool.gispulse.plugin]
+kind = "source"
+protocol = ">=1.0,<2.0"
+domain = "base"
+jurisdiction = "FR"
+display_name = "IGN (BD TOPO + Admin Express)"

--- a/tests/unit/test_src_ign.py
+++ b/tests/unit/test_src_ign.py
@@ -1,0 +1,144 @@
+"""Unit tests for the gispulse-src-ign pilot plugin (issue #194)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_PKG = Path(__file__).resolve().parents[2] / "plugins" / "gispulse-src-ign"
+if str(_PKG) not in sys.path:
+    sys.path.insert(0, str(_PKG))
+
+from gispulse_src_ign.source import IgnSource  # noqa: E402
+
+from core.plugin_model import (  # noqa: E402
+    AccessProtocol,
+    FetchMode,
+    Payload,
+    SourceDomain,
+    SourceResult,
+)
+from core.sources import DataSource, ProtocolRegistry  # noqa: E402
+
+
+class FakeWFS:
+    """Fetcher that echoes the typename it is handed."""
+
+    protocol = AccessProtocol.WFS
+
+    def __init__(self) -> None:
+        self.calls: list = []
+
+    def fetch(self, access, *, extent=None, mode=FetchMode.MATERIALIZE):
+        self.calls.append(access)
+        return SourceResult(
+            payload=Payload.VECTOR, mode=mode, data=access.params["typename"]
+        )
+
+
+@pytest.fixture
+def source() -> IgnSource:
+    reg = ProtocolRegistry()
+    reg.register(FakeWFS())
+    return IgnSource(registry=reg)
+
+
+class _FakeResponse:
+    def __init__(self, headers: dict[str, str]) -> None:
+        self.headers = headers
+
+
+# --------------------------------------------------------------------------
+# Contract conformance
+# --------------------------------------------------------------------------
+
+
+def test_ign_is_a_datasource(source: IgnSource) -> None:
+    assert isinstance(source, DataSource)
+    assert source.name == "ign"
+    assert source.domain is SourceDomain.BASE
+    assert source.payload is Payload.VECTOR
+    assert source.jurisdiction == "FR"
+
+
+def test_catalog_lists_six_entries(source: IgnSource) -> None:
+    ids = {e.id for e in source.catalog()}
+    assert ids == {
+        "batiments",
+        "routes",
+        "cours_eau",
+        "communes",
+        "departements",
+        "regions",
+    }
+
+
+def test_catalog_search(source: IgnSource) -> None:
+    found = source.catalog(search="commune")
+    assert [e.id for e in found] == ["communes"]
+
+
+# --------------------------------------------------------------------------
+# Declarative multi-layer fetch — delegates to the WFS adapter
+# --------------------------------------------------------------------------
+
+
+def test_fetch_delegates_per_layer(source: IgnSource) -> None:
+    assert "BDTOPO_V3:batiment" in source.fetch("batiments").data
+    assert "ADMINEXPRESS-COG.LATEST:region" in source.fetch("regions").data
+
+
+def test_fetch_unknown_entry_raises(source: IgnSource) -> None:
+    with pytest.raises(KeyError, match="unknown entry 'ghost'"):
+        source.fetch("ghost")
+
+
+# --------------------------------------------------------------------------
+# GEOFLA legacy alias
+# --------------------------------------------------------------------------
+
+
+def test_geofla_alias_resolves_to_communes(source: IgnSource) -> None:
+    """The retired GEOFLA name still resolves — to Admin Express communes."""
+    result = source.fetch("geofla")
+    assert "ADMINEXPRESS-COG.LATEST:commune" in result.data
+
+
+def test_geofla_alias_not_advertised_in_catalog(source: IgnSource) -> None:
+    """The alias works but is not surfaced as a first-class entry."""
+    assert "geofla" not in {e.id for e in source.catalog()}
+
+
+# --------------------------------------------------------------------------
+# revision() — cheap WFS freshness probe
+# --------------------------------------------------------------------------
+
+
+def test_revision_uses_wfs_etag(
+    source: IgnSource, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "httpx.head", lambda *_a, **_kw: _FakeResponse({"etag": '"ign-2026-04"'})
+    )
+    assert source.revision("communes") == "ign-2026-04"
+
+
+def test_revision_resolves_alias(
+    source: IgnSource, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "httpx.head", lambda *_a, **_kw: _FakeResponse({"etag": "x"})
+    )
+    assert source.revision("geofla") == "x"  # alias must not raise
+
+
+def test_revision_none_on_network_error(
+    source: IgnSource, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def boom(*_a, **_kw):
+        raise RuntimeError("unreachable")
+
+    monkeypatch.setattr("httpx.head", boom)
+    assert source.revision("batiments") is None


### PR DESCRIPTION
Sprint v1.7.0 — vague ETL. Deuxième plugin pilote `gispulse-src-*`.

## Livré
- `gispulse-src-ign` — `DeclarativeSource` sur la WFS Géoplateforme IGN, 6 couches vecteur : **BD TOPO** (bâtiments, routes, cours d'eau) + **Admin Express** (communes, départements, régions).
- Valide le contrat `DataSource` sur du `fetch()` pur **multi-couches** (après `gispulse-src-cadastre` qui validait le cas mono-dataset).
- `revision()` réel (HTTP HEAD WFS GetCapabilities, comme #198).
- Alias legacy `geofla` → Admin Express `communes` (GEOFLA déprécié upstream).
- Auto-découvert par le job CI `plugins` (`plugins/*/`).

## Tests
+10 (`test_src_ign`) : contrat DataSource, catalog 6 entrées, fetch multi-couches, alias geofla, revision.

## Hors scope
**RGE ALTI** (raster) reporté — il faut un adapter de protocole raster que le `FetcherRegistry` n'a pas encore.

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)