### PR TITLE
[v1.7.0] STAC + REST fetchers — complete the ProtocolRegistry absorption (#192)

### DIFF
--- a/gispulse/adapters/__init__.py
+++ b/gispulse/adapters/__init__.py
@@ -2,6 +2,11 @@
 
 from . import http  # noqa: F401
 
+# Side-effect imports — the core transport fetchers self-register in
+# core.sources.PROTOCOLS (issue #192), so DeclarativeSource.fetch() always
+# has a WFS / OGC API Features / STAC / REST adapter to dispatch to.
+from gispulse.adapters import ogc, rest, stac  # noqa: F401
+
 # MCP facade — available only when fastmcp is installed and compatible
 try:
     from gispulse.adapters.mcp import mcp as mcp_server  # noqa: F401

--- a/gispulse/adapters/rest/__init__.py
+++ b/gispulse/adapters/rest/__init__.py
@@ -1,0 +1,13 @@
+"""REST service adapter — generic GeoJSON-over-HTTP fetcher.
+
+Importing this package self-registers the core REST GeoJSON transport
+adapter in :data:`core.sources.PROTOCOLS` (issue #192), so the ETL fetch
+path has a real ``rest-api`` fetcher to dispatch to.
+"""
+
+from __future__ import annotations
+
+# Side-effect import: RestGeoJsonFetcher registers itself on import.
+from gispulse.adapters.rest import rest_fetcher  # noqa: F401
+
+__all__ = ["rest_fetcher"]

--- a/gispulse/adapters/rest/rest_fetcher.py
+++ b/gispulse/adapters/rest/rest_fetcher.py
@@ -1,0 +1,173 @@
+"""REST GeoJSON fetcher — generic GeoJSON-over-HTTP in the ProtocolRegistry.
+
+Issue #192. Completes the absorption of the core transport clients into
+:data:`core.sources.PROTOCOLS`: this module registers a fetcher under
+:attr:`~core.plugin_model.AccessProtocol.REST_API` for any endpoint that
+answers a GeoJSON ``FeatureCollection``.
+
+The canonical consumer is IGN **API Carto** (``apicarto.ign.fr``) — a
+geometry-filtered GeoJSON REST API — but the fetcher is endpoint-agnostic:
+the :class:`~core.plugin_model.AccessSpec` carries the literal query
+parameters, and an optional ``geom_param`` names the field that receives
+the fetch ``extent`` as a GeoJSON polygon.
+
+Importing this module self-registers the fetcher in the process-wide
+:data:`core.sources.PROTOCOLS` registry (idempotent).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from urllib.parse import urlencode
+
+from core.logging import get_logger
+from core.plugin_model import (
+    AccessProtocol,
+    AccessSpec,
+    FetchMode,
+    Payload,
+    SourceResult,
+)
+
+log = get_logger(__name__)
+
+#: GeoJSON (RFC 7946) coordinates are always WGS84.
+_GEOJSON_CRS = "EPSG:4326"
+_DEFAULT_TIMEOUT_S = 20.0
+#: AccessSpec.params keys the fetcher consumes itself — every *other* key
+#: is forwarded verbatim as an HTTP query parameter.
+_RESERVED_PARAMS = frozenset({"geom_param", "timeout"})
+
+
+def _bbox_from_extent(extent: Any) -> tuple[float, float, float, float] | None:
+    """Coerce a fetch ``extent`` into a 4-tuple bbox, or ``None``."""
+    if extent is None:
+        return None
+    try:
+        coords = tuple(float(c) for c in extent)
+    except (TypeError, ValueError):
+        return None
+    if len(coords) != 4:
+        return None
+    return coords  # type: ignore[return-value]
+
+
+def _bbox_polygon(bbox: tuple[float, float, float, float]) -> dict[str, Any]:
+    """Return a closed GeoJSON Polygon for ``bbox`` (minx, miny, maxx, maxy)."""
+    minx, miny, maxx, maxy = bbox
+    return {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [minx, miny],
+                [maxx, miny],
+                [maxx, maxy],
+                [minx, maxy],
+                [minx, miny],
+            ]
+        ],
+    }
+
+
+def _get_geojson(url: str, timeout: float) -> dict[str, Any]:
+    """GET ``url`` and return the parsed JSON body."""
+    import httpx
+
+    resp = httpx.get(
+        url,
+        timeout=timeout,
+        follow_redirects=True,
+        headers={"Accept": "application/geo+json, application/json"},
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+class RestGeoJsonFetcher:
+    """:class:`~core.sources.Fetcher` for ``AccessProtocol.REST_API``.
+
+    Reads a GeoJSON ``FeatureCollection`` from an HTTP endpoint. The
+    :class:`AccessSpec` carries the URL as ``endpoint`` and, in ``params``:
+
+    - ``geom_param`` — *(optional)* name of the query field that receives
+      the fetch ``extent`` as a GeoJSON polygon (API Carto uses ``geom``)
+    - ``timeout`` — HTTP timeout in seconds *(default: 20)*
+    - every other key — forwarded verbatim as an HTTP query parameter
+    """
+
+    protocol = AccessProtocol.REST_API
+
+    def fetch(
+        self,
+        access: AccessSpec,
+        *,
+        extent: Any | None = None,
+        mode: FetchMode = FetchMode.MATERIALIZE,
+    ) -> SourceResult:
+        import geopandas as gpd
+
+        params = dict(access.params or {})
+        timeout = float(params.get("timeout", _DEFAULT_TIMEOUT_S))
+        geom_param = params.get("geom_param")
+        query: dict[str, Any] = {
+            k: v for k, v in params.items() if k not in _RESERVED_PARAMS
+        }
+        bbox = _bbox_from_extent(extent)
+        if geom_param and bbox is not None:
+            query[str(geom_param)] = json.dumps(
+                _bbox_polygon(bbox), separators=(",", ":")
+            )
+        url = access.endpoint
+        if query:
+            sep = "&" if "?" in url else "?"
+            url = f"{url}{sep}{urlencode(query)}"
+
+        payload = _get_geojson(url, timeout)
+        if payload.get("type") != "FeatureCollection":
+            raise ValueError(
+                f"REST endpoint did not return a GeoJSON FeatureCollection "
+                f"(got type={payload.get('type')!r}): {access.endpoint}"
+            )
+        features = payload.get("features") or []
+        if features:
+            gdf = gpd.GeoDataFrame.from_features(features, crs=_GEOJSON_CRS)
+        else:
+            gdf = gpd.GeoDataFrame(geometry=[], crs=_GEOJSON_CRS)
+        log.info(
+            "rest_geojson_fetch",
+            endpoint=access.endpoint,
+            features=len(gdf),
+        )
+        return SourceResult(
+            payload=Payload.VECTOR,
+            mode=mode,
+            data=gdf,
+            crs=_GEOJSON_CRS,
+            metadata={"endpoint": access.endpoint, "feature_count": len(gdf)},
+        )
+
+
+def _register(registry: Any, fetcher: Any, protocol: AccessProtocol) -> None:
+    """Register ``fetcher`` under ``protocol`` — idempotent."""
+    from core.sources import PROTOCOLS, ProtocolNotSupported
+
+    target = registry if registry is not None else PROTOCOLS
+    try:
+        target.get_fetcher(protocol)
+        return  # already registered
+    except ProtocolNotSupported:
+        pass
+    target.register(fetcher)
+
+
+def register_rest_geojson_fetcher(registry: Any | None = None) -> None:
+    """Register a :class:`RestGeoJsonFetcher` (default registry: ``PROTOCOLS``)."""
+    _register(registry, RestGeoJsonFetcher(), AccessProtocol.REST_API)
+
+
+# Importing this module wires the fetcher into the global registry.
+register_rest_geojson_fetcher()
+
+
+__all__ = ["RestGeoJsonFetcher", "register_rest_geojson_fetcher"]

--- a/gispulse/adapters/stac/__init__.py
+++ b/gispulse/adapters/stac/__init__.py
@@ -1,0 +1,13 @@
+"""STAC service adapter — SpatioTemporal Asset Catalog fetcher.
+
+Importing this package self-registers the core STAC transport adapter
+in :data:`core.sources.PROTOCOLS` (issue #192), so the ETL fetch path
+has a real STAC fetcher to dispatch to.
+"""
+
+from __future__ import annotations
+
+# Side-effect import: StacFetcher registers itself in PROTOCOLS on import.
+from gispulse.adapters.stac import stac_fetcher  # noqa: F401
+
+__all__ = ["stac_fetcher"]

--- a/gispulse/adapters/stac/stac_fetcher.py
+++ b/gispulse/adapters/stac/stac_fetcher.py
@@ -1,0 +1,177 @@
+"""STAC fetcher — SpatioTemporal Asset Catalog in the ProtocolRegistry (#192).
+
+PR #189 delivered the :class:`~core.sources.ProtocolRegistry` /
+:class:`~core.sources.Fetcher` contract; #209 absorbed the WFS / OGC API
+Features clients. This module completes issue #192 by wrapping the
+existing :class:`catalog.providers.stac_client.STACClient` as a
+:class:`~core.sources.Fetcher` registered under
+:attr:`~core.plugin_model.AccessProtocol.STAC`.
+
+A STAC search resolves to *asset references* — COG / imagery hrefs —
+never a materialised raster. The returned
+:class:`~core.plugin_model.SourceResult` is therefore always
+:attr:`~core.plugin_model.FetchMode.REFERENCE`, regardless of the
+requested mode; downloading a scene is an explicit downstream step.
+
+Importing this module self-registers the fetcher in the process-wide
+:data:`core.sources.PROTOCOLS` registry (idempotent).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.logging import get_logger
+from core.plugin_model import (
+    AccessProtocol,
+    AccessSpec,
+    FetchMode,
+    Payload,
+    SourceResult,
+)
+
+log = get_logger(__name__)
+
+#: STAC search needs a bbox — fall back to the whole world when the fetch
+#: carries no extent.
+_DEFAULT_BBOX: list[float] = [-180.0, -90.0, 180.0, 90.0]
+#: STAC open datetime interval — matches any date.
+_DEFAULT_DATETIME = "../.."
+
+
+def _bbox_from_extent(extent: Any) -> list[float] | None:
+    """Coerce a fetch ``extent`` into a ``[minx, miny, maxx, maxy]`` list."""
+    if extent is None:
+        return None
+    try:
+        coords = [float(c) for c in extent]
+    except (TypeError, ValueError):
+        return None
+    return coords if len(coords) == 4 else None
+
+
+def _collections_from_params(params: dict[str, Any]) -> list[str]:
+    """Resolve the STAC collection ids declared on an :class:`AccessSpec`.
+
+    Accepts ``collections`` (str or list) or the singular ``collection``.
+
+    Raises:
+        ValueError: when neither key is declared.
+    """
+    raw = params.get("collections")
+    if isinstance(raw, str):
+        return [raw]
+    if isinstance(raw, (list, tuple)) and raw:
+        return [str(c) for c in raw]
+    single = params.get("collection")
+    if single:
+        return [str(single)]
+    raise ValueError(
+        "STAC AccessSpec.params must declare a 'collection' (id) or "
+        "'collections' (list of ids)"
+    )
+
+
+def _asset_href(item: dict, preferred: str | None) -> str | None:
+    """Pick an asset href from a STAC item — ``preferred`` key, else first."""
+    assets = item.get("assets") or {}
+    if not assets:
+        return None
+    if preferred and preferred in assets:
+        return assets[preferred].get("href")
+    first = next(iter(assets.values()))
+    return first.get("href")
+
+
+class StacFetcher:
+    """:class:`~core.sources.Fetcher` for ``AccessProtocol.STAC``.
+
+    Wraps :class:`catalog.providers.stac_client.STACClient`. The
+    :class:`AccessSpec` carries the catalog URL as ``endpoint`` and the
+    search in ``params``:
+
+    - ``collection`` / ``collections`` — STAC collection id(s) *(required)*
+    - ``datetime`` — ISO-8601 instant or interval *(default: any date)*
+    - ``limit`` — max items returned *(default: 10)*
+    - ``query`` — optional CQL2 property-filter dict
+    - ``asset`` — preferred asset key for the reference href
+    - ``timeout`` — HTTP timeout in seconds *(default: 30)*
+
+    The fetch ``extent`` is used as the search bbox (EPSG:4326).
+    """
+
+    protocol = AccessProtocol.STAC
+
+    def fetch(
+        self,
+        access: AccessSpec,
+        *,
+        extent: Any | None = None,
+        mode: FetchMode = FetchMode.MATERIALIZE,
+    ) -> SourceResult:
+        from catalog.providers.stac_client import STACClient
+
+        params = dict(access.params or {})
+        collections = _collections_from_params(params)
+        bbox = (
+            _bbox_from_extent(extent)
+            or _bbox_from_extent(params.get("bbox"))
+            or _DEFAULT_BBOX
+        )
+        client = STACClient(access.endpoint, timeout=int(params.get("timeout", 30)))
+        items = client.search(
+            bbox=bbox,
+            datetime=str(params.get("datetime", _DEFAULT_DATETIME)),
+            collections=collections,
+            limit=int(params.get("limit", 10)),
+            query=params.get("query"),
+        )
+        preferred = params.get("asset")
+        hrefs = [h for h in (_asset_href(it, preferred) for it in items) if h]
+        log.info(
+            "stac_fetch",
+            endpoint=access.endpoint,
+            collections=collections,
+            items=len(items),
+            assets=len(hrefs),
+        )
+        return SourceResult(
+            payload=Payload.RASTER,
+            # A STAC search yields asset references, never a materialised
+            # raster — the result is REFERENCE whatever the caller asked.
+            mode=FetchMode.REFERENCE,
+            reference=hrefs[0] if hrefs else None,
+            extent=tuple(bbox),  # type: ignore[arg-type]
+            metadata={
+                "catalog": access.endpoint,
+                "collections": collections,
+                "item_count": len(items),
+                "asset_hrefs": hrefs,
+                "requested_mode": mode.value,
+            },
+        )
+
+
+def _register(registry: Any, fetcher: Any, protocol: AccessProtocol) -> None:
+    """Register ``fetcher`` under ``protocol`` — idempotent."""
+    from core.sources import PROTOCOLS, ProtocolNotSupported
+
+    target = registry if registry is not None else PROTOCOLS
+    try:
+        target.get_fetcher(protocol)
+        return  # already registered
+    except ProtocolNotSupported:
+        pass
+    target.register(fetcher)
+
+
+def register_stac_fetcher(registry: Any | None = None) -> None:
+    """Register a :class:`StacFetcher` (default registry: ``PROTOCOLS``)."""
+    _register(registry, StacFetcher(), AccessProtocol.STAC)
+
+
+# Importing this module wires the fetcher into the global registry.
+register_stac_fetcher()
+
+
+__all__ = ["StacFetcher", "register_stac_fetcher"]

--- a/tests/unit/test_rest_fetcher.py
+++ b/tests/unit/test_rest_fetcher.py
@@ -1,0 +1,225 @@
+"""Tests for the REST GeoJSON fetcher in the ProtocolRegistry (#192)."""
+
+from __future__ import annotations
+
+import json
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+
+from core.plugin_model import AccessProtocol, AccessSpec, FetchMode, Payload
+from core.sources import ProtocolNotSupported, ProtocolRegistry
+from gispulse.adapters.rest.rest_fetcher import (
+    RestGeoJsonFetcher,
+    _bbox_from_extent,
+    _bbox_polygon,
+    register_rest_geojson_fetcher,
+)
+
+
+def _feature_collection(n: int) -> dict:
+    return {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "geometry": {"type": "Point", "coordinates": [float(i), float(i)]},
+                "properties": {"id": f"f{i}"},
+            }
+            for i in range(n)
+        ],
+    }
+
+
+@pytest.fixture
+def mock_get(monkeypatch: pytest.MonkeyPatch) -> list:
+    """Patch _get_geojson; return the list of (url, timeout) calls."""
+    calls: list = []
+
+    def fake(url: str, timeout: float) -> dict:
+        calls.append({"url": url, "timeout": timeout})
+        return _feature_collection(3)
+
+    monkeypatch.setattr(
+        "gispulse.adapters.rest.rest_fetcher._get_geojson", fake
+    )
+    return calls
+
+
+def _query_of(url: str) -> dict:
+    """Return the parsed query string of ``url`` as a flat dict."""
+    return {k: v[0] for k, v in parse_qs(urlsplit(url).query).items()}
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def test_bbox_from_extent_valid() -> None:
+    assert _bbox_from_extent((1, 2, 3, 4)) == (1.0, 2.0, 3.0, 4.0)
+
+
+@pytest.mark.parametrize("bad", [None, (1, 2, 3), (1, 2, 3, 4, 5), "nope", 42])
+def test_bbox_from_extent_rejects_non_bbox(bad: object) -> None:
+    assert _bbox_from_extent(bad) is None
+
+
+def test_bbox_polygon_is_closed_ring() -> None:
+    poly = _bbox_polygon((0.0, 0.0, 10.0, 20.0))
+    assert poly["type"] == "Polygon"
+    ring = poly["coordinates"][0]
+    assert ring[0] == ring[-1] == [0.0, 0.0]
+    assert len(ring) == 5
+
+
+# ---------------------------------------------------------------------------
+# RestGeoJsonFetcher.fetch
+# ---------------------------------------------------------------------------
+
+
+def test_fetcher_declares_rest_protocol() -> None:
+    assert RestGeoJsonFetcher.protocol is AccessProtocol.REST_API
+
+
+def test_fetch_returns_vector_source_result(mock_get: list) -> None:
+    access = AccessSpec(
+        protocol=AccessProtocol.REST_API,
+        endpoint="https://apicarto.example.org/api/cadastre/parcelle",
+        params={},
+    )
+    result = RestGeoJsonFetcher().fetch(access)
+
+    assert result.payload is Payload.VECTOR
+    assert len(result.data) == 3
+    assert result.crs == "EPSG:4326"
+    assert result.metadata["feature_count"] == 3
+
+
+def test_geom_param_injects_bbox_polygon(mock_get: list) -> None:
+    access = AccessSpec(
+        protocol=AccessProtocol.REST_API,
+        endpoint="https://apicarto.example.org/api/cadastre/parcelle",
+        params={"geom_param": "geom"},
+    )
+    RestGeoJsonFetcher().fetch(access, extent=(0, 0, 10, 10))
+
+    query = _query_of(mock_get[0]["url"])
+    assert "geom" in query
+    geom = json.loads(query["geom"])
+    assert geom["type"] == "Polygon"
+
+
+def test_no_geom_param_means_no_geometry_query(mock_get: list) -> None:
+    access = AccessSpec(
+        protocol=AccessProtocol.REST_API,
+        endpoint="https://apicarto.example.org/api/cadastre/parcelle",
+        params={},
+    )
+    RestGeoJsonFetcher().fetch(access, extent=(0, 0, 10, 10))
+    assert urlsplit(mock_get[0]["url"]).query == ""
+
+
+def test_vendor_params_forwarded_verbatim(mock_get: list) -> None:
+    access = AccessSpec(
+        protocol=AccessProtocol.REST_API,
+        endpoint="https://apicarto.example.org/api/cadastre/parcelle",
+        params={"code_insee": "44109", "_limit": 50, "timeout": 5},
+    )
+    RestGeoJsonFetcher().fetch(access)
+
+    query = _query_of(mock_get[0]["url"])
+    assert query["code_insee"] == "44109"
+    assert query["_limit"] == "50"
+    # 'timeout' is a reserved key — consumed, not forwarded.
+    assert "timeout" not in query
+    assert mock_get[0]["timeout"] == 5.0
+
+
+def test_endpoint_with_existing_query_appends_with_ampersand(
+    mock_get: list,
+) -> None:
+    access = AccessSpec(
+        protocol=AccessProtocol.REST_API,
+        endpoint="https://apicarto.example.org/api/parcelle?source=bdparcellaire",
+        params={"code_insee": "44109"},
+    )
+    RestGeoJsonFetcher().fetch(access)
+    query = _query_of(mock_get[0]["url"])
+    assert query == {"source": "bdparcellaire", "code_insee": "44109"}
+
+
+def test_non_featurecollection_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "gispulse.adapters.rest.rest_fetcher._get_geojson",
+        lambda url, timeout: {"type": "Feature", "geometry": None},
+    )
+    access = AccessSpec(
+        protocol=AccessProtocol.REST_API,
+        endpoint="https://apicarto.example.org/api/parcelle",
+        params={},
+    )
+    with pytest.raises(ValueError, match="FeatureCollection"):
+        RestGeoJsonFetcher().fetch(access)
+
+
+def test_empty_featurecollection_yields_empty_gdf(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "gispulse.adapters.rest.rest_fetcher._get_geojson",
+        lambda url, timeout: {"type": "FeatureCollection", "features": []},
+    )
+    access = AccessSpec(
+        protocol=AccessProtocol.REST_API,
+        endpoint="https://apicarto.example.org/api/parcelle",
+        params={},
+    )
+    result = RestGeoJsonFetcher().fetch(access)
+    assert result.payload is Payload.VECTOR
+    assert len(result.data) == 0
+    assert result.metadata["feature_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Registration + dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_register_rest_fetcher_into_fresh_registry() -> None:
+    reg = ProtocolRegistry()
+    with pytest.raises(ProtocolNotSupported):
+        reg.get_fetcher(AccessProtocol.REST_API)
+
+    register_rest_geojson_fetcher(reg)
+    assert isinstance(reg.get_fetcher(AccessProtocol.REST_API), RestGeoJsonFetcher)
+
+
+def test_register_rest_fetcher_is_idempotent() -> None:
+    reg = ProtocolRegistry()
+    register_rest_geojson_fetcher(reg)
+    register_rest_geojson_fetcher(reg)  # second call must not raise
+    assert isinstance(reg.get_fetcher(AccessProtocol.REST_API), RestGeoJsonFetcher)
+
+
+def test_rest_fetcher_self_registered_in_global_protocols() -> None:
+    """Importing the module wired the fetcher into the shared registry."""
+    from core.sources import PROTOCOLS
+
+    assert isinstance(
+        PROTOCOLS.get_fetcher(AccessProtocol.REST_API), RestGeoJsonFetcher
+    )
+
+
+def test_dispatch_fetch_routes_to_rest_fetcher(mock_get: list) -> None:
+    """End-to-end: a REST AccessSpec dispatches through the registry."""
+    reg = ProtocolRegistry()
+    register_rest_geojson_fetcher(reg)
+    access = AccessSpec(
+        protocol=AccessProtocol.REST_API,
+        endpoint="https://apicarto.ign.fr/api/cadastre/parcelle",
+        params={"code_insee": "44109"},
+    )
+    result = reg.dispatch_fetch(access, mode=FetchMode.MATERIALIZE)
+    assert result.payload is Payload.VECTOR
+    assert len(mock_get) == 1

--- a/tests/unit/test_stac_fetcher.py
+++ b/tests/unit/test_stac_fetcher.py
@@ -1,0 +1,212 @@
+"""Tests for the STAC fetcher absorbed into the ProtocolRegistry (#192)."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.plugin_model import AccessProtocol, AccessSpec, FetchMode, Payload
+from core.sources import ProtocolNotSupported, ProtocolRegistry
+from gispulse.adapters.stac.stac_fetcher import (
+    StacFetcher,
+    _bbox_from_extent,
+    register_stac_fetcher,
+)
+
+_ITEMS = [
+    {
+        "id": "scene-1",
+        "assets": {
+            "B04": {"href": "https://stac.example.org/scene-1/B04.tif"},
+            "visual": {"href": "https://stac.example.org/scene-1/visual.tif"},
+        },
+    },
+    {
+        "id": "scene-2",
+        "assets": {"B04": {"href": "https://stac.example.org/scene-2/B04.tif"}},
+    },
+]
+
+
+@pytest.fixture
+def mock_stac(monkeypatch: pytest.MonkeyPatch) -> list:
+    """Patch STACClient; return [init_kwargs, search_kwargs] call records."""
+    calls: list = []
+
+    class _FakeClient:
+        def __init__(self, url: str, timeout: int = 30) -> None:
+            calls.append({"url": url, "timeout": timeout})
+
+        def search(self, *, bbox, datetime, collections, limit=10, query=None):
+            calls.append(
+                {
+                    "bbox": bbox,
+                    "datetime": datetime,
+                    "collections": collections,
+                    "limit": limit,
+                    "query": query,
+                }
+            )
+            return list(_ITEMS)
+
+    monkeypatch.setattr(
+        "catalog.providers.stac_client.STACClient", _FakeClient
+    )
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# _bbox_from_extent
+# ---------------------------------------------------------------------------
+
+
+def test_bbox_from_extent_valid() -> None:
+    assert _bbox_from_extent((1, 2, 3, 4)) == [1.0, 2.0, 3.0, 4.0]
+
+
+@pytest.mark.parametrize("bad", [None, (1, 2, 3), (1, 2, 3, 4, 5), "nope", 42])
+def test_bbox_from_extent_rejects_non_bbox(bad: object) -> None:
+    assert _bbox_from_extent(bad) is None
+
+
+# ---------------------------------------------------------------------------
+# StacFetcher.fetch
+# ---------------------------------------------------------------------------
+
+
+def test_fetcher_declares_stac_protocol() -> None:
+    assert StacFetcher.protocol is AccessProtocol.STAC
+
+
+def test_fetch_returns_reference_result(mock_stac: list) -> None:
+    access = AccessSpec(
+        protocol=AccessProtocol.STAC,
+        endpoint="https://stac.example.org/v1",
+        params={"collection": "sentinel-2-l2a"},
+    )
+    result = StacFetcher().fetch(access)
+
+    assert result.payload is Payload.RASTER
+    # A STAC search resolves to references — never a materialised raster.
+    assert result.mode is FetchMode.REFERENCE
+    assert result.reference == "https://stac.example.org/scene-1/B04.tif"
+    assert result.metadata["item_count"] == 2
+    assert len(result.metadata["asset_hrefs"]) == 2
+
+
+def test_fetch_records_requested_mode(mock_stac: list) -> None:
+    access = AccessSpec(
+        protocol=AccessProtocol.STAC,
+        endpoint="https://stac.example.org/v1",
+        params={"collection": "sentinel-2-l2a"},
+    )
+    result = StacFetcher().fetch(access, mode=FetchMode.MATERIALIZE)
+    # The result stays REFERENCE, but the caller's intent is kept visible.
+    assert result.mode is FetchMode.REFERENCE
+    assert result.metadata["requested_mode"] == "materialize"
+
+
+def test_fetch_without_collection_raises() -> None:
+    access = AccessSpec(
+        protocol=AccessProtocol.STAC,
+        endpoint="https://stac.example.org/v1",
+        params={},
+    )
+    with pytest.raises(ValueError, match="must declare a 'collection'"):
+        StacFetcher().fetch(access)
+
+
+def test_collections_list_is_forwarded(mock_stac: list) -> None:
+    access = AccessSpec(
+        protocol=AccessProtocol.STAC,
+        endpoint="https://stac.example.org/v1",
+        params={"collections": ["landsat-c2-l2", "sentinel-2-l2a"]},
+    )
+    StacFetcher().fetch(access)
+    assert mock_stac[1]["collections"] == ["landsat-c2-l2", "sentinel-2-l2a"]
+
+
+def test_preferred_asset_selects_href(mock_stac: list) -> None:
+    access = AccessSpec(
+        protocol=AccessProtocol.STAC,
+        endpoint="https://stac.example.org/v1",
+        params={"collection": "sentinel-2-l2a", "asset": "visual"},
+    )
+    result = StacFetcher().fetch(access)
+    # scene-1 has 'visual'; scene-2 has only 'B04' — it falls back.
+    assert result.reference == "https://stac.example.org/scene-1/visual.tif"
+    assert result.metadata["asset_hrefs"] == [
+        "https://stac.example.org/scene-1/visual.tif",
+        "https://stac.example.org/scene-2/B04.tif",
+    ]
+
+
+def test_extent_becomes_search_bbox(mock_stac: list) -> None:
+    access = AccessSpec(
+        protocol=AccessProtocol.STAC,
+        endpoint="https://stac.example.org/v1",
+        params={"collection": "sentinel-2-l2a"},
+    )
+    StacFetcher().fetch(access, extent=(0, 0, 10, 10))
+    assert mock_stac[1]["bbox"] == [0.0, 0.0, 10.0, 10.0]
+
+
+def test_default_world_bbox_without_extent(mock_stac: list) -> None:
+    access = AccessSpec(
+        protocol=AccessProtocol.STAC,
+        endpoint="https://stac.example.org/v1",
+        params={"collection": "sentinel-2-l2a"},
+    )
+    StacFetcher().fetch(access)
+    assert mock_stac[1]["bbox"] == [-180.0, -90.0, 180.0, 90.0]
+
+
+def test_timeout_param_reaches_client(mock_stac: list) -> None:
+    access = AccessSpec(
+        protocol=AccessProtocol.STAC,
+        endpoint="https://stac.example.org/v1",
+        params={"collection": "sentinel-2-l2a", "timeout": 8},
+    )
+    StacFetcher().fetch(access)
+    assert mock_stac[0]["timeout"] == 8
+
+
+# ---------------------------------------------------------------------------
+# Registration + dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_register_stac_fetcher_into_fresh_registry() -> None:
+    reg = ProtocolRegistry()
+    with pytest.raises(ProtocolNotSupported):
+        reg.get_fetcher(AccessProtocol.STAC)
+
+    register_stac_fetcher(reg)
+    assert isinstance(reg.get_fetcher(AccessProtocol.STAC), StacFetcher)
+
+
+def test_register_stac_fetcher_is_idempotent() -> None:
+    reg = ProtocolRegistry()
+    register_stac_fetcher(reg)
+    register_stac_fetcher(reg)  # second call must not raise on a taken slot
+    assert isinstance(reg.get_fetcher(AccessProtocol.STAC), StacFetcher)
+
+
+def test_stac_fetcher_self_registered_in_global_protocols() -> None:
+    """Importing the module wired the fetcher into the shared registry."""
+    from core.sources import PROTOCOLS
+
+    assert isinstance(PROTOCOLS.get_fetcher(AccessProtocol.STAC), StacFetcher)
+
+
+def test_dispatch_fetch_routes_to_stac_fetcher(mock_stac: list) -> None:
+    """End-to-end: a STAC AccessSpec dispatches through the registry."""
+    reg = ProtocolRegistry()
+    register_stac_fetcher(reg)
+    access = AccessSpec(
+        protocol=AccessProtocol.STAC,
+        endpoint="https://earth-search.aws.element84.com/v1",
+        params={"collection": "sentinel-2-l2a"},
+    )
+    result = reg.dispatch_fetch(access, mode=FetchMode.MATERIALIZE)
+    assert result.payload is Payload.RASTER
+    assert len(mock_stac) == 2  # one __init__, one search


### PR DESCRIPTION
Completes **#192** — the reliquat after #209 (which absorbed WFS + OGC API Features).

## What
- **`StacFetcher`** (`AccessProtocol.STAC`) — wraps the catalog `STACClient`. A STAC search resolves to asset references (COG hrefs); the `SourceResult` mode is `REFERENCE` regardless of the requested mode.
- **`RestGeoJsonFetcher`** (`AccessProtocol.REST_API`) — reads a GeoJSON `FeatureCollection` from any HTTP endpoint. An optional `geom_param` injects the fetch `extent` as a GeoJSON polygon; IGN **API Carto** is the canonical consumer.
- `gispulse.adapters` now eagerly imports `ogc`/`rest`/`stac` so the four core fetchers register **deterministically** (previously WFS registered only incidentally via a catalog-router import).

## Acceptance (#192)
- ✅ `gispulse-src-cadastre` runs an end-to-end network `fetch()` via the registry (WFS, since #209).
- ✅ Per-`AccessProtocol` dispatch tests for STAC and REST.

## Tests
465 unit tests green locally (sources/plugin/catalog/fetcher slice). New: `test_stac_fetcher.py`, `test_rest_fetcher.py` — dispatch routing, registration idempotence, `extent`→bbox, vendor-param forwarding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)