### PR TITLE
[v1.7.0] Catalog discovery via PluginHub.records (#193)

### DIFF
--- a/catalog/__init__.py
+++ b/catalog/__init__.py
@@ -16,7 +16,7 @@ def _auto_register():
 
 _auto_register()
 
-# Discover third-party catalog providers via entry-points
+# Register third-party catalog providers discovered by the PluginHub (#193).
 from catalog.registry import _discover_providers  # noqa: E402
 
 _discover_providers()

--- a/catalog/registry.py
+++ b/catalog/registry.py
@@ -57,29 +57,54 @@ def list_providers() -> list[dict]:
     ]
 
 
-def _discover_providers() -> list[dict[str, str]]:
-    """Discover catalog providers from installed packages via entry-points.
+#: Entry-point group for third-party catalog-provider plugins.
+_CATALOG_PROVIDER_GROUP = "gispulse.catalog_providers"
 
-    Scans the ``gispulse.catalog_providers`` entry-point group. Each
-    entry-point must point to a callable that registers providers when
-    invoked (e.g. by calling :func:`register_provider`).
+
+def _discover_providers() -> list[dict[str, str]]:
+    """Register catalog-provider plugins discovered by the PluginHub.
+
+    Issue #193 — the :class:`~core.plugin_hub.PluginHub` owns the single
+    ``gispulse.catalog_providers`` entry-point scan; this function no
+    longer scans a second time, it *consumes* ``PluginHub.records``.
+
+    Each catalog-provider record is an ``EXTENSION`` whose loaded ``obj``
+    is the plugin's register callable — invoking it calls
+    :func:`register_provider`. A record the hub locked (tier/trust gate)
+    or failed to load is reported but never invoked.
 
     Returns:
-        List of dicts with ``name``, ``module``, and ``status`` for each
-        discovered plugin entry-point.
+        List of dicts with ``name``, ``module`` and ``status`` for each
+        catalog-provider record the hub discovered.
     """
     loaded: list[dict[str, str]] = []
     try:
-        from importlib.metadata import entry_points
+        from core.plugin_hub import PluginHub
+        from core.plugin_model import PluginState
 
-        eps = entry_points(group="gispulse.catalog_providers")
-        for ep in eps:
-            try:
-                register_fn = ep.load()
-                register_fn()
-                loaded.append({"name": ep.name, "module": ep.value, "status": "ok"})
-            except Exception as exc:
-                loaded.append({"name": ep.name, "module": ep.value, "status": f"error: {exc}"})
+        hub = PluginHub.get()
     except Exception:
-        pass
+        return loaded
+
+    for rec in hub.records:
+        ep = rec.entry_point
+        if ep is None or getattr(ep, "group", None) != _CATALOG_PROVIDER_GROUP:
+            continue
+        module = str(getattr(ep, "value", ""))
+        if rec.state is not PluginState.ACTIVE:
+            loaded.append(
+                {
+                    "name": rec.name,
+                    "module": module,
+                    "status": f"skipped: {rec.detail or rec.state.value}",
+                }
+            )
+            continue
+        try:
+            rec.obj()  # the loaded register callable
+            loaded.append({"name": rec.name, "module": module, "status": "ok"})
+        except Exception as exc:
+            loaded.append(
+                {"name": rec.name, "module": module, "status": f"error: {exc}"}
+            )
     return loaded

--- a/core/plugin_hub.py
+++ b/core/plugin_hub.py
@@ -60,6 +60,11 @@ _EXTENSION_GROUPS: tuple[str, ...] = (
     "gispulse.lifecycle",
     "gispulse.mcp_tools",
     "gispulse.mcp_resources",
+    # Discovery-only — catalog providers extend the GIS catalog subsystem.
+    # The hub owns the single entry-point scan (issue #193); the records
+    # are consumed by ``catalog.registry``. The v1.8 ExtensionHub refonte
+    # promotes these to a first-class ``data-pack`` kind.
+    "gispulse.catalog_providers",
 )
 
 # Distributions shipped by GISPulse itself — their plugins are trusted
@@ -287,11 +292,11 @@ class PluginHub:
     # ---------------------------------------------------- unified inventory
 
     def _discover_records(self) -> None:
-        """Build the unified plugin inventory across all 11 entry-point groups.
+        """Build the unified plugin inventory across every entry-point group.
 
         Each entry-point becomes a :class:`~core.plugin_model.PluginRecord`
         and runs the ``discover → resolve → gate → activate`` cycle. The
-        nine host-extension sub-groups collapse to
+        host-extension sub-groups collapse to
         :attr:`~core.plugin_model.PluginKind.EXTENSION`; capabilities /
         data_sources / data_sinks / protocols map to their own kind.
 

--- a/tests/unit/test_catalog_discovery.py
+++ b/tests/unit/test_catalog_discovery.py
@@ -1,4 +1,9 @@
-"""Tests for catalog provider entry-point discovery."""
+"""Tests for catalog-provider discovery via the PluginHub (#193).
+
+Issue #193 moved the single ``gispulse.catalog_providers`` entry-point
+scan into :class:`~core.plugin_hub.PluginHub`; :func:`_discover_providers`
+now *consumes* ``PluginHub.records`` instead of scanning a second time.
+"""
 
 from __future__ import annotations
 
@@ -6,7 +11,14 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from catalog.registry import PROVIDERS, _discover_providers, register_provider
+from catalog.registry import (
+    PROVIDERS,
+    _CATALOG_PROVIDER_GROUP,
+    _discover_providers,
+    register_provider,
+)
+from core import plugin_hub
+from core.plugin_model import PluginKind, PluginRecord, PluginState
 
 
 @pytest.fixture(autouse=True)
@@ -18,13 +30,54 @@ def _restore_providers():
     PROVIDERS.update(original)
 
 
-class TestDiscoverProviders:
-    def test_no_entrypoints_returns_empty(self):
-        with patch("importlib.metadata.entry_points", return_value=[]):
-            result = _discover_providers()
-        assert result == []
+class _FakeEP:
+    """Stand-in for ``importlib.metadata.EntryPoint``."""
 
-    def test_loads_plugin_provider(self):
+    def __init__(self, name: str, value: str, group: str) -> None:
+        self.name = name
+        self.value = value
+        self.group = group
+
+
+class _FakeHub:
+    """Minimal stand-in for the PluginHub — only ``records`` is consumed."""
+
+    def __init__(self, records: list[PluginRecord]) -> None:
+        self.records = records
+
+
+def _catalog_record(
+    name: str,
+    *,
+    obj=None,
+    state: PluginState = PluginState.ACTIVE,
+    detail: str = "",
+    group: str = _CATALOG_PROVIDER_GROUP,
+) -> PluginRecord:
+    rec = PluginRecord(
+        name=name,
+        kind=PluginKind.EXTENSION,
+        entry_point=_FakeEP(name, f"{name}_pkg.catalog:register", group),
+    )
+    rec.state = state
+    rec.detail = detail
+    rec.obj = obj
+    return rec
+
+
+def _with_hub(records: list[PluginRecord]):
+    """Patch ``PluginHub.get()`` to return a fake hub holding ``records``."""
+    return patch.object(
+        plugin_hub.PluginHub, "get", return_value=_FakeHub(records)
+    )
+
+
+class TestDiscoverProviders:
+    def test_no_records_returns_empty(self):
+        with _with_hub([]):
+            assert _discover_providers() == []
+
+    def test_loads_active_catalog_provider_record(self):
         fake_provider = MagicMock()
         fake_provider.domain.value = "test"
         fake_provider.name = "fake_prov"
@@ -32,12 +85,8 @@ class TestDiscoverProviders:
         def register_fn():
             register_provider(fake_provider)
 
-        ep = MagicMock()
-        ep.name = "test_plugin"
-        ep.value = "my_pkg.catalog:register"
-        ep.load.return_value = register_fn
-
-        with patch("importlib.metadata.entry_points", return_value=[ep]):
+        rec = _catalog_record("test_plugin", obj=register_fn)
+        with _with_hub([rec]):
             result = _discover_providers()
 
         assert len(result) == 1
@@ -45,22 +94,54 @@ class TestDiscoverProviders:
         assert result[0]["status"] == "ok"
         assert "test:fake_prov" in PROVIDERS
 
-    def test_failing_plugin_does_not_crash(self):
-        ep = MagicMock()
-        ep.name = "broken_plugin"
-        ep.value = "bad_pkg:register"
-        ep.load.side_effect = ImportError("no such module")
+    def test_failing_register_callable_does_not_crash(self):
+        def boom():
+            raise RuntimeError("provider blew up")
 
-        with patch("importlib.metadata.entry_points", return_value=[ep]):
+        rec = _catalog_record("broken_plugin", obj=boom)
+        with _with_hub([rec]):
             result = _discover_providers()
 
         assert len(result) == 1
         assert result[0]["status"].startswith("error:")
 
+    def test_locked_record_is_skipped_not_invoked(self):
+        sentinel = MagicMock()
+        rec = _catalog_record(
+            "pro_plugin",
+            obj=sentinel,
+            state=PluginState.LOCKED,
+            detail="requires the 'pro' tier",
+        )
+        with _with_hub([rec]):
+            result = _discover_providers()
+
+        assert result[0]["status"].startswith("skipped:")
+        assert "pro" in result[0]["status"]
+        sentinel.assert_not_called()
+
+    def test_non_catalog_records_are_ignored(self):
+        router = PluginRecord(
+            name="admin_router",
+            kind=PluginKind.EXTENSION,
+            entry_point=_FakeEP("admin_router", "pkg:router", "gispulse.routers"),
+        )
+        router.state = PluginState.ACTIVE
+        router.obj = MagicMock()
+        with _with_hub([router]):
+            result = _discover_providers()
+
+        assert result == []
+        router.obj.assert_not_called()
+
+    def test_hub_failure_returns_empty(self):
+        with patch.object(
+            plugin_hub.PluginHub, "get", side_effect=RuntimeError("hub down")
+        ):
+            assert _discover_providers() == []
+
     def test_existing_providers_unaffected(self):
         provider_count_before = len(PROVIDERS)
-
-        with patch("importlib.metadata.entry_points", return_value=[]):
+        with _with_hub([]):
             _discover_providers()
-
         assert len(PROVIDERS) == provider_count_before


### PR DESCRIPTION
Completes **#193** — follow-up of #179 (the `CatalogProvider → DataSource` bridge).

## Problem
`catalog/registry.py` ran its **own** `gispulse.catalog_providers` entry-point scan, in parallel to the `PluginHub` — the double discovery flagged by EPIC #175.

## What
- `gispulse.catalog_providers` joins `PluginHub._EXTENSION_GROUPS`: catalog-provider plugins are now discovered **once**, as `EXTENSION` records in the unified hub inventory (`discover → resolve → gate → activate`).
- `catalog.registry._discover_providers()` **consumes `PluginHub.records`** — it filters catalog-provider records by entry-point group and invokes each `ACTIVE` record's loaded register callable. Records the hub **locked** (tier/trust gate) or **failed** to load are reported but never invoked.

## Acceptance (#193)
- ✅ `catalog/registry.py` no longer scans entry-points — it is fed by the hub.
- ✅ `/catalog/*` functionally unchanged: the 7 built-in providers still self-register via `catalog._auto_register()`; only third-party plugin discovery moved.

## Tests
506 green (plugin / catalog / marketplace / source slice). `test_catalog_discovery.py` rewritten for the hub-backed contract — locked-record skip, hub-failure fallback, non-catalog-record filtering.

> The v1.8 *ExtensionHub* refonte will promote catalog providers from an `EXTENSION` group-filter to a first-class `data-pack` kind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)