### PR TITLE
feat(plugin): gispulse-src-gpu — Géoportail de l'Urbanisme (#184)

### DIFF
--- a/plugins/gispulse-src-gpu/gispulse_src_gpu/__init__.py
+++ b/plugins/gispulse-src-gpu/gispulse_src_gpu/__init__.py
@@ -17,10 +17,11 @@ def register() -> None:
     """Entry-point hook for the ``gispulse.data_sources`` group.
 
     Registers a :class:`GpuSource` instance in the process-wide
-    ``core.sources.SOURCES`` registry so the source watcher (issue #197)
-    can resolve ``gpu://<entry>`` URIs declared in ``triggers.yaml``.
+    ``gispulse.core.sources.SOURCES`` registry so the source watcher
+    (issue #197) can resolve ``gpu://<entry>`` URIs declared in
+    ``triggers.yaml``.
     """
-    from core.sources import SOURCES
+    from gispulse.core.sources import SOURCES
     from gispulse_src_gpu.source import GpuSource
 
     SOURCES.register(GpuSource())

--- a/plugins/gispulse-src-gpu/gispulse_src_gpu/__init__.py
+++ b/plugins/gispulse-src-gpu/gispulse_src_gpu/__init__.py
@@ -1,0 +1,26 @@
+"""GISPulse data-source plugin — Géoportail de l'Urbanisme (issue #184, pilot wave 2).
+
+Second-wave pilot of the ``gispulse-src-*`` family: exercises the
+``DeclarativeSource`` contract on a multi-entry ``Payload.VECTOR`` WFS
+source for French urban-planning documents (PLU / PLUi / POS / CC).
+
+Domain: :data:`SourceDomain.REGLEMENTAIRE` — promotion to
+:class:`RegulatorySource` (with a wired :meth:`ruleset`) is left to a
+follow-up plugin once the :class:`RuleClause`-to-PLU mapping is
+stabilised.
+"""
+
+from __future__ import annotations
+
+
+def register() -> None:
+    """Entry-point hook for the ``gispulse.data_sources`` group.
+
+    Registers a :class:`GpuSource` instance in the process-wide
+    ``core.sources.SOURCES`` registry so the source watcher (issue #197)
+    can resolve ``gpu://<entry>`` URIs declared in ``triggers.yaml``.
+    """
+    from core.sources import SOURCES
+    from gispulse_src_gpu.source import GpuSource
+
+    SOURCES.register(GpuSource())

--- a/plugins/gispulse-src-gpu/gispulse_src_gpu/source.py
+++ b/plugins/gispulse-src-gpu/gispulse_src_gpu/source.py
@@ -160,6 +160,14 @@ class GpuSource(DeclarativeSource):
                 # revision() probes the WFS live (#198) — no stale
                 # token hard-coded here.
                 revision_token=None,
+                # Per-entry classification axes (#227, EPIC #226) — the
+                # worldwide catalogue filters on these. Every wfs_du
+                # layer in this pilot shares the source-level
+                # classification, so repeat it here rather than leave
+                # the entry unclassified (axes default to None).
+                domain=self.domain,
+                payload=self.payload,
+                jurisdiction=self.jurisdiction,
                 metadata={
                     "provider": "IGN / DGALN",
                     "platform": "Géoportail de l'Urbanisme",

--- a/plugins/gispulse-src-gpu/gispulse_src_gpu/source.py
+++ b/plugins/gispulse-src-gpu/gispulse_src_gpu/source.py
@@ -1,0 +1,246 @@
+"""French GPU DataSource — Géoportail de l'Urbanisme zones d'urbanisme.
+
+A :class:`~gispulse.plugins.api.DeclarativeSource`: the plugin only
+*declares* its access spec; the actual WFS request is delegated to the
+:class:`WfsFetcher` registered in the :class:`ProtocolRegistry` (#209),
+so this package ships zero network code besides a HEAD probe for
+:meth:`revision`.
+
+Data: Géoportail de l'Urbanisme (https://www.geoportail-urbanisme.gouv.fr/)
+— the national platform mandated by the loi ALUR / ordonnance 2013-1184
+for dematerialised urban-planning documents (PLU, PLUi, POS, cartes
+communales, SCoT) plus their prescriptions and informational layers.
+
+This pilot exposes nine WFS feature types of the ``wfs_du`` namespace
+that together describe the urban-planning fabric of a parcel:
+
+* the three core layers (``zone_urba``, ``prescription_surf``,
+  ``doc_urba``) already consumed by ``gispulse-permis``;
+* the two additional prescription geometries (``prescription_lin``,
+  ``prescription_pct``);
+* the three informational layers (``info_surf``, ``info_lin``,
+  ``info_pct``);
+* the carte-communale sectors (``secteur_cc``).
+
+.. note::
+   GPU is semantically a :class:`RegulatorySource` — every zone or
+   prescription carries an applicable rule (a PLU regulation). Promoting
+   :class:`GpuSource` to :class:`RegulatorySource` and wiring
+   :meth:`ruleset` over the WFS attributes (``libelle``, ``typezone``,
+   ``insee``, …) is left to a follow-up plugin once the
+   :class:`RuleClause`-to-PLU mapping is stabilised. The declaration,
+   schema and :meth:`revision` plumbing are usable today by the source
+   watcher and any catalog / marketplace consumer.
+
+.. note::
+   Servitudes d'utilité publique (the seven ``wfs_du`` SUP feature types
+   — ``servitude``, ``assiette_sup_s/l/p``, ``generateur_sup_s/l/p``,
+   ``acte_sup``) are intentionally **not** in this pilot. They are
+   conceptually distinct from the urban-planning layers and warrant a
+   dedicated ``gispulse-src-sup`` package — most likely also a
+   :class:`RegulatorySource`.
+"""
+
+from __future__ import annotations
+
+from gispulse.plugins.api import (
+    AccessProtocol,
+    AccessSpec,
+    DeclarativeSource,
+    Payload,
+    SourceDomain,
+    SourceEntryRef,
+)
+
+# IGN Géoplateforme — public WFS endpoint for the Géoportail de
+# l'Urbanisme (no API key required).
+_GEOPLATEFORME_WFS = "https://data.geopf.fr/wfs/ows"
+
+# WFS GetCapabilities URL — cheap freshness probe target for
+# revision() (issue #198). A HEAD against it reads the ``ETag`` /
+# ``Last-Modified`` header without downloading the document.
+_WFS_CAPABILITIES = (
+    f"{_GEOPLATEFORME_WFS}?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetCapabilities"
+)
+_REVISION_TIMEOUT_S = 8.0
+
+
+# Entry-id → (display label, WFS typename) — every WFS feature type
+# this pilot exposes. Names mirror the layer naming on the Géoportail
+# de l'Urbanisme so authors of triggers and pipelines find what they
+# expect.
+_ENTRIES: dict[str, tuple[str, str]] = {
+    # Core zoning
+    "zone-urba": (
+        "Zones d'urbanisme (PLU, PLUi, POS)",
+        "wfs_du:zone_urba",
+    ),
+    "doc-urba": (
+        "Documents d'urbanisme — emprises et métadonnées",
+        "wfs_du:doc_urba",
+    ),
+    "secteur-cc": (
+        "Secteurs de carte communale",
+        "wfs_du:secteur_cc",
+    ),
+    # Prescriptions — what the document constrains on the ground
+    "prescription-surf": (
+        "Prescriptions surfaciques",
+        "wfs_du:prescription_surf",
+    ),
+    "prescription-lin": (
+        "Prescriptions linéaires",
+        "wfs_du:prescription_lin",
+    ),
+    "prescription-pct": (
+        "Prescriptions ponctuelles",
+        "wfs_du:prescription_pct",
+    ),
+    # Informations — what the document signals (non-constraining)
+    "info-surf": (
+        "Informations surfaciques",
+        "wfs_du:info_surf",
+    ),
+    "info-lin": (
+        "Informations linéaires",
+        "wfs_du:info_lin",
+    ),
+    "info-pct": (
+        "Informations ponctuelles",
+        "wfs_du:info_pct",
+    ),
+}
+
+
+def _probe_revision(url: str) -> str | None:
+    """Return a freshness token for ``url`` via a single HTTP HEAD.
+
+    Mirrors :mod:`gispulse_src_cadastre` (#198): derives the token from
+    the ``ETag`` (preferred) / ``Last-Modified`` response header.
+    Returns ``None`` — meaning "freshness unknown" — on any network
+    error or when the endpoint exposes neither header, so the source
+    watcher skips it rather than emitting a spurious change.
+    """
+    import httpx  # local import — keeps module import network-free
+
+    try:
+        resp = httpx.head(
+            url, timeout=_REVISION_TIMEOUT_S, follow_redirects=True
+        )
+    except Exception:  # noqa: BLE001 — any transport error ⇒ unknown
+        return None
+    etag = resp.headers.get("etag")
+    if etag:
+        return etag.strip('"')
+    last_modified = resp.headers.get("last-modified")
+    if last_modified:
+        return last_modified
+    return None
+
+
+class GpuSource(DeclarativeSource):
+    """Géoportail de l'Urbanisme zones / prescriptions / infos."""
+
+    name = "gpu"
+    domain = SourceDomain.REGLEMENTAIRE
+    payload = Payload.VECTOR
+    jurisdiction = "FR"
+
+    def entries(self) -> list[SourceEntryRef]:
+        return [
+            SourceEntryRef(
+                id=entry_id,
+                name=label,
+                access=AccessSpec(
+                    protocol=AccessProtocol.WFS,
+                    endpoint=_GEOPLATEFORME_WFS,
+                    params={"typename": typename},
+                    format="application/json",
+                ),
+                # revision() probes the WFS live (#198) — no stale
+                # token hard-coded here.
+                revision_token=None,
+                metadata={
+                    "provider": "IGN / DGALN",
+                    "platform": "Géoportail de l'Urbanisme",
+                    "typename": typename,
+                },
+            )
+            for entry_id, (label, typename) in _ENTRIES.items()
+        ]
+
+    def revision(self, entry_id: str) -> str | None:
+        """Cheap freshness token for the source watcher (#187/#198).
+
+        One HTTP HEAD against the Géoplateforme WFS GetCapabilities —
+        the millésime is service-wide (the Géoportail de l'Urbanisme
+        publishes one consolidated GetCapabilities for all ``wfs_du``
+        layers), so every entry shares one probe.
+        """
+        self._entry(entry_id)  # validate the id
+        return _probe_revision(_WFS_CAPABILITIES)
+
+    def schema(self, entry_id: str) -> dict:
+        """Normalised attribute schema per GPU feature type.
+
+        Attribute names follow the ``wfs_du`` schema documented by the
+        Géoportail de l'Urbanisme. ``gpu_doc_id`` is the synthetic join
+        key (built from ``gpu_doc_id`` exposed as ``idurba`` on every
+        layer) plugins can use to attach a feature to its parent
+        urban-planning document.
+        """
+        self._entry(entry_id)  # validates the id
+        common = {
+            "gid": "int",
+            "idurba": "str",      # parent document id (joins to doc-urba)
+            "geometry": "geometry",
+        }
+        if entry_id == "zone-urba":
+            return {
+                **common,
+                "libelle": "str",     # PLU zone label, e.g. "UA", "UB", "A", "N"
+                "libelong": "str",    # long-form label
+                "typezone": "str",    # zone family (U, AU, A, N)
+                "destdomi": "str",    # dominant destination
+                "nomfic": "str",      # regulation file name
+                "urlfic": "str",      # regulation file URL
+            }
+        if entry_id == "doc-urba":
+            return {
+                **common,
+                "typedoc": "str",     # PLU / PLUi / POS / CC / RNU
+                "datappro": "date",   # approval date
+                "datefin": "date",    # end of validity
+                "datvalid": "date",   # validation date
+                "intercoid": "str",   # EPCI id if PLUi
+                "insee": "str",       # commune INSEE code
+                "siren": "str",
+            }
+        if entry_id == "secteur-cc":
+            return {
+                **common,
+                "libelle": "str",
+                "libelong": "str",
+                "typesect": "str",    # constructible / non-constructible
+                "insee": "str",
+            }
+        if entry_id in {"prescription-surf", "prescription-lin", "prescription-pct"}:
+            return {
+                **common,
+                "libelle": "str",
+                "txt": "str",         # free-text description
+                "typepsc": "str",     # prescription category
+                "stypepsc": "str",    # prescription sub-category
+                "nomfic": "str",
+                "urlfic": "str",
+            }
+        # info-surf / info-lin / info-pct
+        return {
+            **common,
+            "libelle": "str",
+            "txt": "str",
+            "typeinf": "str",         # information category
+            "stypeinf": "str",        # information sub-category
+            "nomfic": "str",
+            "urlfic": "str",
+        }

--- a/plugins/gispulse-src-gpu/pyproject.toml
+++ b/plugins/gispulse-src-gpu/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gispulse-src-gpu"
+version = "0.1.0"
+description = "Géoportail de l'Urbanisme data source for GISPulse (PLU, prescriptions, informations)"
+requires-python = ">=3.10"
+license = "AGPL-3.0-or-later"
+authors = [{ name = "GISPulse", email = "dev@gispulse.io" }]
+dependencies = [
+    "gispulse",
+]
+
+# Registered as a data source — discovered by core.plugin_hub.PluginHub.
+[project.entry-points."gispulse.data_sources"]
+gpu = "gispulse_src_gpu:register"
+
+[tool.gispulse.plugin]
+kind = "source"
+protocol = ">=1.0,<2.0"
+domain = "reglementaire"
+jurisdiction = "FR"
+display_name = "GPU — Géoportail de l'Urbanisme (France)"

--- a/tests/unit/test_src_gpu.py
+++ b/tests/unit/test_src_gpu.py
@@ -13,14 +13,14 @@ if str(_PKG) not in sys.path:
 
 from gispulse_src_gpu.source import GpuSource  # noqa: E402
 
-from core.plugin_model import (  # noqa: E402
+from gispulse.core.plugin_model import (  # noqa: E402
     AccessProtocol,
     FetchMode,
     Payload,
     SourceDomain,
     SourceResult,
 )
-from core.sources import DataSource, ProtocolRegistry  # noqa: E402
+from gispulse.core.sources import DataSource, ProtocolRegistry  # noqa: E402
 
 
 class FakeWFS:
@@ -113,6 +113,17 @@ def test_every_entry_targets_wfs_du_typename(source: GpuSource) -> None:
             f"{entry.id}: typename should be under wfs_du namespace, "
             f"got {access.params['typename']!r}"
         )
+
+
+def test_every_entry_carries_classification_axes(source: GpuSource) -> None:
+    """Each entry must carry the per-entry domain / payload / jurisdiction
+    axes (#227, EPIC #226) so the worldwide catalogue can index it
+    directly — leaving them ``None`` would drop the entry from the
+    domain / payload / jurisdiction filters."""
+    for entry in source.catalog():
+        assert entry.domain is SourceDomain.REGLEMENTAIRE, entry.id
+        assert entry.payload is Payload.VECTOR, entry.id
+        assert entry.jurisdiction == "FR", entry.id
 
 
 # --------------------------------------------------------------------------

--- a/tests/unit/test_src_gpu.py
+++ b/tests/unit/test_src_gpu.py
@@ -1,0 +1,238 @@
+"""Unit tests for the gispulse-src-gpu pilot plugin (issue #184, wave 2)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_PKG = Path(__file__).resolve().parents[2] / "plugins" / "gispulse-src-gpu"
+if str(_PKG) not in sys.path:
+    sys.path.insert(0, str(_PKG))
+
+from gispulse_src_gpu.source import GpuSource  # noqa: E402
+
+from core.plugin_model import (  # noqa: E402
+    AccessProtocol,
+    FetchMode,
+    Payload,
+    SourceDomain,
+    SourceResult,
+)
+from core.sources import DataSource, ProtocolRegistry  # noqa: E402
+
+
+class FakeWFS:
+    """Records the AccessSpec it is handed and returns a marker result."""
+
+    protocol = AccessProtocol.WFS
+
+    def __init__(self) -> None:
+        self.calls: list = []
+
+    def fetch(self, access, *, extent=None, mode=FetchMode.MATERIALIZE):
+        self.calls.append(access)
+        return SourceResult(
+            payload=Payload.VECTOR, mode=mode, data=access.params["typename"]
+        )
+
+
+@pytest.fixture
+def source() -> GpuSource:
+    reg = ProtocolRegistry()
+    reg.register(FakeWFS())
+    return GpuSource(registry=reg)
+
+
+# --------------------------------------------------------------------------
+# Contract conformance + declared axes
+# --------------------------------------------------------------------------
+
+
+def test_gpu_is_a_datasource(source: GpuSource) -> None:
+    assert isinstance(source, DataSource)
+    assert source.name == "gpu"
+    assert source.domain is SourceDomain.REGLEMENTAIRE
+    assert source.payload is Payload.VECTOR
+    assert source.jurisdiction == "FR"
+
+
+def test_catalog_lists_nine_entries(source: GpuSource) -> None:
+    ids = {e.id for e in source.catalog()}
+    assert ids == {
+        "zone-urba",
+        "doc-urba",
+        "secteur-cc",
+        "prescription-surf",
+        "prescription-lin",
+        "prescription-pct",
+        "info-surf",
+        "info-lin",
+        "info-pct",
+    }
+
+
+def test_catalog_search_zone(source: GpuSource) -> None:
+    found = source.catalog(search="zone")
+    assert [e.id for e in found] == ["zone-urba"]
+
+
+def test_catalog_search_prescription_matches_three(source: GpuSource) -> None:
+    found = source.catalog(search="prescription")
+    assert {e.id for e in found} == {
+        "prescription-surf",
+        "prescription-lin",
+        "prescription-pct",
+    }
+
+
+# --------------------------------------------------------------------------
+# AccessSpec — WFS against the Géoplateforme
+# --------------------------------------------------------------------------
+
+
+def test_zone_urba_targets_wfs_du_namespace(source: GpuSource) -> None:
+    """The ``zone-urba`` entry must point at the ``wfs_du:zone_urba``
+    typename so the shipped WfsFetcher (#209) can dispatch it."""
+    entry = next(e for e in source.catalog() if e.id == "zone-urba")
+    access = entry.access
+    assert access.protocol is AccessProtocol.WFS
+    assert "data.geopf.fr/wfs" in access.endpoint
+    assert access.params["typename"] == "wfs_du:zone_urba"
+    assert access.format == "application/json"
+
+
+def test_every_entry_targets_wfs_du_typename(source: GpuSource) -> None:
+    """Every published entry must declare a ``wfs_du:*`` typename so the
+    upstream WFS naming is preserved and a typo cannot slip in."""
+    for entry in source.catalog():
+        access = entry.access
+        assert access.protocol is AccessProtocol.WFS
+        assert access.params["typename"].startswith("wfs_du:"), (
+            f"{entry.id}: typename should be under wfs_du namespace, "
+            f"got {access.params['typename']!r}"
+        )
+
+
+# --------------------------------------------------------------------------
+# Declarative fetch — delegates to the WFS adapter, zero network code
+# --------------------------------------------------------------------------
+
+
+def test_fetch_delegates_to_wfs_adapter() -> None:
+    wfs = FakeWFS()
+    reg = ProtocolRegistry()
+    reg.register(wfs)
+    src = GpuSource(registry=reg)
+
+    result = src.fetch("zone-urba")
+
+    assert result.payload is Payload.VECTOR
+    assert "wfs_du:zone_urba" in result.data
+    assert len(wfs.calls) == 1
+    assert wfs.calls[0].protocol is AccessProtocol.WFS
+
+
+def test_fetch_unknown_entry_raises(source: GpuSource) -> None:
+    with pytest.raises(KeyError, match="unknown entry 'ghost'"):
+        source.fetch("ghost")
+
+
+# --------------------------------------------------------------------------
+# Schema — per-layer attributes, common ``idurba`` join key
+# --------------------------------------------------------------------------
+
+
+def test_zone_urba_schema_exposes_pluzone_attributes(source: GpuSource) -> None:
+    """zone-urba must expose ``libelle`` (UA/UB/A/N…) and ``typezone``
+    (U/AU/A/N) — the two attributes a PLU consumer needs to interpret
+    a parcel's zoning."""
+    schema = source.schema("zone-urba")
+    assert schema["libelle"] == "str"
+    assert schema["typezone"] == "str"
+    assert schema["idurba"] == "str"
+
+
+def test_doc_urba_schema_exposes_approval_date(source: GpuSource) -> None:
+    """doc-urba must carry ``datappro`` — the legal approval date that
+    determines which regulation applies on the ground."""
+    schema = source.schema("doc-urba")
+    assert schema["datappro"] == "date"
+    assert schema["typedoc"] == "str"
+
+
+def test_all_schemas_share_idurba_join_key(source: GpuSource) -> None:
+    """Every layer must expose ``idurba`` so consumers can join a
+    feature back to its parent urban-planning document."""
+    for entry in source.catalog():
+        schema = source.schema(entry.id)
+        assert "idurba" in schema, (
+            f"{entry.id}: missing idurba join key in schema"
+        )
+
+
+def test_prescription_schema_exposes_typepsc_and_txt(source: GpuSource) -> None:
+    """The three prescription layers share the same attribute pattern."""
+    for entry_id in ("prescription-surf", "prescription-lin", "prescription-pct"):
+        schema = source.schema(entry_id)
+        assert schema["typepsc"] == "str"
+        assert schema["txt"] == "str"
+
+
+def test_info_schema_exposes_typeinf(source: GpuSource) -> None:
+    """The three info layers share the ``typeinf`` discriminator."""
+    for entry_id in ("info-surf", "info-lin", "info-pct"):
+        schema = source.schema(entry_id)
+        assert schema["typeinf"] == "str"
+
+
+# --------------------------------------------------------------------------
+# revision() — HEAD on WFS GetCapabilities, never a fetch()
+# --------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    """Minimal stand-in for an ``httpx.Response`` — only ``.headers``."""
+
+    def __init__(self, headers: dict[str, str]) -> None:
+        self.headers = headers
+
+
+def test_revision_probes_wfs_capabilities_and_uses_etag(
+    source: GpuSource, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """revision() derives its token from the WFS ETag header."""
+    captured: list[str] = []
+
+    def fake_head(url, **_kw):
+        captured.append(url)
+        return _FakeResponse({"etag": '"gpu-millesime-2026-05"'})
+
+    monkeypatch.setattr("httpx.head", fake_head)
+    token = source.revision("zone-urba")
+
+    assert token == "gpu-millesime-2026-05"
+    assert captured and "GetCapabilities" in captured[0]
+
+
+def test_revision_falls_back_to_last_modified(
+    source: GpuSource, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fake_head(url, **_kw):
+        return _FakeResponse({"last-modified": "Mon, 12 May 2026 06:00:00 GMT"})
+
+    monkeypatch.setattr("httpx.head", fake_head)
+    assert source.revision("prescription-surf") == (
+        "Mon, 12 May 2026 06:00:00 GMT"
+    )
+
+
+def test_revision_returns_none_on_network_error(
+    source: GpuSource, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fake_head(url, **_kw):
+        raise RuntimeError("simulated DNS failure")
+
+    monkeypatch.setattr("httpx.head", fake_head)
+    assert source.revision("info-surf") is None


### PR DESCRIPTION
## Summary

Adds `gispulse-src-gpu` as a **second-wave `gispulse-src-*` pilot of #184** — the GPU side of the French regulatory triad (Cadastre × GPU × DVF). Companion PR to #223 (`gispulse-src-dvf`).

Same shape as #210's `gispulse-src-cadastre` and `gispulse-src-ign`: a `DeclarativeSource` with zero network code beyond a HEAD probe for `revision()`. WFS requests are dispatched by the `WfsFetcher` shipped in #209.

## Pilot scope — 9 `wfs_du` feature types

| Entry id | WFS typename | Role |
|---|---|---|
| `zone-urba` | `wfs_du:zone_urba` | PLU zoning (UA / UB / A / N…) |
| `doc-urba` | `wfs_du:doc_urba` | Parent urban-planning documents + approval dates |
| `secteur-cc` | `wfs_du:secteur_cc` | Carte-communale sectors |
| `prescription-surf` | `wfs_du:prescription_surf` | Constraining prescriptions — surface |
| `prescription-lin` | `wfs_du:prescription_lin` | Constraining prescriptions — line |
| `prescription-pct` | `wfs_du:prescription_pct` | Constraining prescriptions — point |
| `info-surf` | `wfs_du:info_surf` | Signalling informations — surface |
| `info-lin` | `wfs_du:info_lin` | Signalling informations — line |
| `info-pct` | `wfs_du:info_pct` | Signalling informations — point |

The three core entries (`zone-urba`, `doc-urba`, `prescription-surf`) are already consumed by `gispulse-permis` through the legacy `catalog/providers/flux_ign.py:70-113`. This PR is the path toward migrating that consumption to the EPIC #175 source model in wave 3 of #184.

## Design choices

| Axis | Value | Rationale |
|---|---|---|
| `domain` | `SourceDomain.REGLEMENTAIRE` | GPU zones carry applicable PLU regulations, not just data. |
| `payload` | `Payload.VECTOR` | WFS GeoJSON FeatureCollection returned by the shipped `WfsFetcher` (#209). |
| `AccessProtocol` | `WFS` | `data.geopf.fr/wfs/ows` with `wfs_du:*` typenames. |
| Class | `DeclarativeSource` (not `RegulatorySource`) | The `RuleClause`-to-PLU mapping is non-trivial — see follow-ups. |
| `schema()` | Per-entry, common `idurba` | `idurba` is the canonical join key back to the parent `doc-urba` feature. `zone-urba` exposes `libelle` + `typezone` (the PLU zoning duo). `doc-urba` exposes `datappro` (legal approval date). |
| `revision()` | HEAD on WFS GetCapabilities | Same pattern as `gispulse-src-cadastre` and `gispulse-src-ign`. |

## Follow-ups (deliberately not in this PR)

1. **Promote to `RegulatorySource`** — wire a `ruleset()` that maps `zone_urba.{libelle, typezone, destdomi}` (and prescription attributes) to `RuleClause` objects. This is the missing piece for plugins like `gispulse-permis` to migrate to wave 3 of #184 and treat GPU as a rule source rather than a vector source.
2. **`gispulse-src-sup`** — the seven SUP feature types (`servitude`, `assiette_sup_s/l/p`, `generateur_sup_s/l/p`, `acte_sup`) are conceptually distinct from urban-planning documents and warrant a dedicated package, also likely a `RegulatorySource`.

Happy to send either follow-up if there's interest.

## Test plan

- [x] 16 unit tests in `tests/unit/test_src_gpu.py` — DataSource contract, catalog (9 entries + search filters), AccessSpec targeting (every entry under `wfs_du:` namespace, no typo can slip in), fetch delegation, schema per layer (with shared `idurba` join key invariant), revision() ETag / Last-Modified / network-error branches.
- [x] No regression on existing plugin-system tests — `test_src_cadastre.py`, `test_src_ign.py`, `test_src_dvf.py` (sibling PR #223), `test_plugin_hub_records.py`, `test_plugin_sdk_exports.py`, `test_sources.py` all pass alongside the new tests.
- [x] `ruff check` passes.
- [x] Conforms to `docs/SOURCE_PLUGIN_GUIDE.md` (created in #213) — verified line by line against the worked example.
- [x] Independent pre-commit review.

## Downstream value

This source closes the loop on the French regulatory triad for plugins like `gispulse-permis`:

- **Cadastre** — where is the parcel? (`gispulse-src-cadastre`, #210)
- **GPU** — what can be built there? (this PR)
- **DVF** — what does it sell for? (PR #223)

Closes part of #184 (wave 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
