### PR TITLE
feat(mcp): réaligner le serveur MCP sur le produit actuel (#202-#205)

### DIFF
--- a/docs-site/.vitepress/config.ts
+++ b/docs-site/.vitepress/config.ts
@@ -153,6 +153,7 @@ const frSidebar = {
       items: [
         { text: 'Add-in ArcGIS', link: '/plugins/arcgis' },
         { text: 'Développer un plugin', link: '/plugins/developing' },
+        { text: 'Contribuer des outils MCP', link: '/plugins/mcp-tools' },
       ],
     },
   ],

--- a/docs-site/plugins/mcp-tools.md
+++ b/docs-site/plugins/mcp-tools.md
@@ -1,0 +1,152 @@
+---
+title: Contribuer des outils MCP
+description: Écrire un plugin GISPulse qui ajoute des tools et resources au serveur MCP via l'entry-point gispulse.mcp_tools.
+---
+
+# Contribuer des outils MCP
+
+Le serveur MCP de GISPulse (`gispulse mcp`) expose les use-cases GISPulse à
+un assistant LLM via le protocole [Model Context Protocol](https://modelcontextprotocol.io).
+Un plugin peut **ajouter ses propres tools et resources** à ce serveur sans
+toucher au code de GISPulse, via les entry-points `gispulse.mcp_tools` et
+`gispulse.mcp_resources`.
+
+C'est le même mécanisme de découverte que les capabilities et les data
+sources : l'`ExtensionHub` scanne les entry-points installés, et le serveur
+MCP appelle chaque plugin enregistré au démarrage.
+
+## Le contrat
+
+Un entry-point `gispulse.mcp_tools` doit résoudre vers un objet conforme au
+protocole `McpToolFactory` (voir `gispulse.core.plugin_contracts`) :
+
+| Membre              | Type   | Rôle                                              |
+| ------------------- | ------ | ------------------------------------------------- |
+| `name`              | `str`  | Identifiant du plugin (inventaire `ExtensionHub`, logs). |
+| `register(self, mcp)` | méthode | Appelée une fois par serveur ; attache les tools. |
+
+L'`ExtensionHub` instancie la classe (constructeur **sans argument**), puis
+`gispulse.adapters.mcp.server.register_plugin_mcp_surface` appelle
+`register(server)` sur le serveur FastMCP en cours d'exécution. Un plugin qui
+lève une exception pendant `register` est loggé puis ignoré — il ne fait
+**jamais** tomber le serveur.
+
+`gispulse.mcp_resources` suit exactement le même contrat (`McpResourceFactory`)
+pour contribuer des *resources* au lieu de *tools*.
+
+## Exemple minimal
+
+Le plugin pilote first-party `gispulse.plugins.mcp_pilot` est la référence
+exécutable de ce guide :
+
+```python
+# mon_plugin/mcp_tools.py
+from typing import Any
+
+
+class MesOutilsMcp:
+    """McpToolFactory — contribue un tool au serveur MCP GISPulse."""
+
+    name = "mon-plugin-mcp"
+
+    def register(self, mcp: Any) -> None:
+        @mcp.tool()
+        def coverage_ftth(commune: str) -> dict[str, Any]:
+            """Retourne le taux de couverture FTTH d'une commune.
+
+            Args:
+                commune: Code INSEE de la commune.
+
+            Returns:
+                Dict avec le taux de couverture.
+            """
+            # Imports lourds DANS le corps du tool, pas au niveau module.
+            from mon_plugin.connecteur import interroger_couverture
+
+            return interroger_couverture(commune)
+```
+
+### Déclarer l'entry-point
+
+Dans le `pyproject.toml` du plugin :
+
+```toml
+[project.entry-points."gispulse.mcp_tools"]
+mon-plugin-mcp = "mon_plugin.mcp_tools:MesOutilsMcp"
+```
+
+Après `pip install -e .` (ou l'installation du wheel), l'`ExtensionHub`
+découvre l'entry-point automatiquement. Vérification :
+
+```bash
+python -c "from importlib.metadata import entry_points; \
+  print([e.name for e in entry_points(group='gispulse.mcp_tools')])"
+```
+
+## Règles d'écriture
+
+- **Imports légers.** Le module du plugin est importé pendant la découverte
+  de l'`ExtensionHub`. Les imports lourds (`geopandas`, `requests`,
+  bindings GDAL…) vont **dans le corps du tool**, jamais au niveau module —
+  sinon un simple `gispulse mcp` paie le coût d'import de toute la chaîne.
+
+- **Docstrings = schéma.** FastMCP dérive le schéma JSON du tool depuis la
+  signature et la docstring. Annotez chaque argument et décrivez la valeur
+  de retour : c'est ce que le LLM lit pour décider d'appeler le tool.
+
+- **Renvoyez des dicts JSON-sérialisables.** Pas d'objets `GeoDataFrame`,
+  pas de `dataclass` non sérialisable. En cas d'erreur attendue, renvoyez
+  `{"error": "..."}` plutôt que de lever — le serveur built-in suit cette
+  convention.
+
+- **Scopez les accès fichiers.** Si votre tool prend un chemin, bornez la
+  lecture comme le fait le serveur built-in (#204) via
+  `gispulse.adapters.mcp.workdir.resolve_in_workdir` :
+
+  ```python
+  from gispulse.adapters.mcp.workdir import WorkdirError, resolve_in_workdir
+
+  @mcp.tool()
+  def inspecter(path: str) -> dict:
+      try:
+          chemin = resolve_in_workdir(path)
+      except WorkdirError as exc:
+          return {"error": str(exc)}
+      ...
+  ```
+
+  Un serveur MCP est piloté par un LLM non fiable : un `open(path)` non borné
+  est une faille de path traversal.
+
+- **Passez par `GISPulseApp`.** Si votre tool a besoin d'un use-case GISPulse
+  (catalogue, runtime de triggers, capabilities…), appelez
+  `gispulse.app.get_app()` plutôt que de re-câbler le moteur. Le serveur MCP
+  est un adaptateur *thin* — votre plugin aussi.
+
+## Tester un plugin MCP
+
+L'`ExtensionHub` est un singleton ; appelez `ExtensionHub.reset()` entre les
+tests. On peut injecter un faux entry-point en monkeypatchant
+`gispulse.core.plugin_hub.entry_points` :
+
+```python
+def test_mon_tool_enregistre(monkeypatch):
+    import asyncio
+    from gispulse.adapters.mcp import server as mcp_server
+    from gispulse.core import plugin_hub
+
+    plugin_hub.ExtensionHub.reset()
+    server = mcp_server.create_mcp_server()  # scanne les entry-points réels
+    tools = asyncio.run(server.list_tools())
+    assert "coverage_ftth" in {t.name for t in tools}
+    plugin_hub.ExtensionHub.reset()
+```
+
+Le plugin pilote `gispulse-mcp-pilot` est testé dans
+`tests/unit/test_mcp_pilot_plugin.py` — un bon point de départ à copier.
+
+## Voir aussi
+
+- `gispulse.plugins.mcp_pilot` — implémentation pilote first-party.
+- [Développer un plugin / capability](./developing.md) — capabilities et data sources.
+- `gispulse.core.plugin_contracts` — protocoles `McpToolFactory` / `McpResourceFactory`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,12 @@ dependencies = [
 [project.scripts]
 gispulse = "gispulse.cli:main"
 
+# First-party pilot plugin — reference implementation for MCP-tool authors
+# (#205). Discovered by the ExtensionHub and registered on the MCP server
+# by ``register_plugin_mcp_surface``. See docs-site/plugins/mcp-tools.md.
+[project.entry-points."gispulse.mcp_tools"]
+gispulse-mcp-pilot = "gispulse.plugins.mcp_pilot:PilotMcpTools"
+
 [project.optional-dependencies]
 postgis = ["sqlalchemy>=2.0,<3.0", "geoalchemy2>=0.14,<1.0", "psycopg2-binary>=2.9,<3.0", "asyncpg>=0.29,<1.0"]
 api = ["fastapi>=0.100,<1.0", "uvicorn[standard]>=0.23,<1.0", "watchfiles>=0.21,<2.0", "python-multipart>=0.0.6,<1.0", "requests>=2.28,<3.0", "slowapi>=0.1.9,<1.0", "httpx>=0.24,<1.0"]

--- a/src/gispulse/adapters/mcp/dryrun.py
+++ b/src/gispulse/adapters/mcp/dryrun.py
@@ -1,0 +1,128 @@
+"""Side-effect-free trigger dry-run for the MCP server (issue #202).
+
+``dryrun_trigger`` answers a question an LLM agent asks before it tells a
+human to run ``gispulse watch``: *"given this config and the change-log
+as it stands right now, what would fire?"* — without actually firing it.
+
+How the no-side-effect guarantee is met
+---------------------------------------
+:func:`gispulse.runtime.build_runtime` already exposes the two seams the
+:class:`~gispulse.adapters.esb.action_dispatcher.ActionDispatcher` routes
+**every** outbound effect through:
+
+* ``sql_executor(sql, params)`` — every write action (``set_field``,
+  ``run_sql``, ``tag_field``, ``notify``'s ``pg_notify``, aggregates);
+* ``webhook_client(url, payload)`` — every outbound HTTP call.
+
+We inject **collectors** for both: callables that record their arguments
+and return without touching the database or the network. The dispatcher
+runs its normal evaluation path, so trigger predicates, the DSL and event
+matching all execute for real — only the *effects* are captured instead
+of applied.
+
+One residual write the dispatcher does **not** own is the change-log
+*ack*: after a tick, :class:`ChangeLogWatcher` calls
+``engine.mark_changes_processed(max_id)`` to stamp ``processed = 1`` on
+the rows it handled. A genuine dry-run must not consume the change-log,
+so we neutralise that single method on the live engine instance for the
+duration of the run (an instance-level override — the production
+``GeoPackageEngine`` class is untouched). The rows therefore stay
+``processed = 0`` and a subsequent real ``gispulse watch`` still sees
+them.
+
+This is the "inject a no-op executor that collects the actions" fallback
+the #202 brief calls for: the existing runtime API has no first-class
+``evaluate-without-dispatch`` entry point, and re-driving the watcher's
+private ``_process_row`` loop would duplicate runtime logic — against the
+CLI<->surface symmetry axiom. Wrapping the public seams keeps this
+adapter thin.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+__all__ = ["dryrun_trigger_config"]
+
+
+def dryrun_trigger_config(
+    config_path: str | Path,
+    *,
+    gpkg_override: str | Path | None = None,
+) -> dict[str, Any]:
+    """Evaluate a ``triggers.yaml`` against the live change-log, no effects.
+
+    Args:
+        config_path:   Path to the YAML config (already FS-scoped by the
+                       caller).
+        gpkg_override: Optional GPKG path that wins over the ``gpkg:`` key.
+
+    Returns:
+        ``{gpkg, trigger_count, rows_evaluated, sql_actions, webhook_actions}``
+        where ``sql_actions`` / ``webhook_actions`` are the effects that
+        *would* have run. ``rows_evaluated`` is the number of change-log
+        rows the tick processed.
+    """
+    from gispulse.runtime.config_loader import load_config, to_triggers
+
+    config = load_config(config_path, gpkg_override=gpkg_override)
+    triggers = to_triggers(config)
+
+    sql_calls: list[dict[str, Any]] = []
+    webhook_calls: list[dict[str, Any]] = []
+
+    def _collect_sql(sql: str, params: Any = None) -> list:
+        sql_calls.append({"sql": str(sql), "params": list(params or [])})
+        # Read actions (the aggregate handler iterates the result) expect
+        # an iterable; an empty list is a safe, side-effect-free stand-in.
+        return []
+
+    def _collect_webhook(url: str, payload: dict[str, Any]) -> None:
+        webhook_calls.append({"url": url, "payload": payload})
+
+    rt = _build_runtime(config, triggers, _collect_sql, _collect_webhook)
+    try:
+        _neutralise_ack(rt.engine)
+        rows = rt.run_once()
+    finally:
+        rt.close()
+
+    return {
+        "gpkg": str(config.gpkg),
+        "trigger_count": len(triggers),
+        "rows_evaluated": int(rows),
+        "sql_actions": sql_calls,
+        "webhook_actions": webhook_calls,
+    }
+
+
+def _build_runtime(config: Any, triggers: Any, sql_executor: Any, webhook_client: Any):
+    """Wire a runtime with collecting executors via :class:`GISPulseApp`."""
+    from gispulse.app import get_app
+
+    return get_app().build_watch_runtime(
+        config.gpkg,
+        triggers,
+        webhook_allowlist=config.security.webhook_allowlist,
+        batch_limit=config.runtime.max_batch,
+        sql_executor=sql_executor,
+        webhook_client=webhook_client,
+        validate_rules=config.validate_rules,
+        default_table=config.default_table,
+        layer_sources=config.layers,
+    )
+
+
+def _neutralise_ack(engine: Any) -> None:
+    """Disable ``mark_changes_processed`` on this engine instance.
+
+    The dry-run must leave the change-log untouched so a later real
+    ``gispulse watch`` still picks the rows up. This is an instance-level
+    override; the :class:`GeoPackageEngine` *class* is not modified.
+    """
+
+    def _noop(up_to_id: int) -> int:  # noqa: ARG001 - signature match
+        return 0
+
+    engine.mark_changes_processed = _noop  # type: ignore[method-assign]

--- a/src/gispulse/adapters/mcp/server.py
+++ b/src/gispulse/adapters/mcp/server.py
@@ -6,6 +6,16 @@ state of its own** — the pre-v1.8.0 in-memory ``Rule`` / ``Job`` / ``Dataset``
 repositories are gone; they modelled a rule grammar that predated the
 pipeline-v2 unification and drifted from the rest of the product.
 
+Filesystem scoping (#204)
+-------------------------
+Every tool that takes a path argument routes it through
+:func:`gispulse.adapters.mcp.workdir.resolve_in_workdir`, which bounds the
+read to the **MCP workdir** (``GISPULSE_MCP_WORKDIR`` env var, or the
+process cwd). A path that escapes the workdir is refused with
+``{"error": "path outside MCP workdir: ..."}``. The MCP server is driven
+by an untrusted LLM, so an unbounded ``open(path)`` would be a
+path-traversal sink.
+
 Tools
 -----
 Capabilities:
@@ -20,20 +30,35 @@ Templates:
   list_templates()             -> built-in pipeline templates
   get_template(name)           -> raw template JSON
 
-Datasets / pipelines (read-only — no FS writes, no session state):
+Datasets / pipelines (read-only — workdir-scoped, no session state):
   inspect_dataset(path)        -> layer names of a GeoPackage
   validate_pipeline(path)      -> schema-validate a pipeline JSON file
 
-Plugins:
+Triggers / change-log (workdir-scoped reads; dryrun has no side effects):
+  load_triggers(path)          -> summary of a triggers.yaml config
+  list_triggers(path)          -> detailed trigger list of a config
+  validate_triggers(path, gpkg)-> structural validation against the GPKG
+  inspect_changelog(gpkg, n)   -> _gispulse_change_log status + recent rows
+  watch_status(gpkg)           -> tracked layers + pending change-log count
+  dryrun_trigger(path, gpkg)   -> evaluate a config with NO outbound effects
+
+Plugins / sources:
   list_plugins()               -> ExtensionHub inventory records
+  list_sources()               -> registered ETL data-source plugins
 
 Resources
 ---------
   gispulse://capabilities      -> JSON list of capabilities
   gispulse://templates         -> JSON list of built-in templates
+  gispulse://sources           -> JSON list of ETL data-source plugins
+  gispulse://triggers/{path}   -> JSON summary of a triggers.yaml (template)
+  gispulse://changelog/{path}  -> JSON change-log status of a GPKG (template)
 
-Execution-oriented tools (trigger / changelog / dryrun) and outbound FS
-scoping are tracked separately in the MCP epic (#202–#205).
+The MCP surface is realigned with the rest of the product as part of the
+v1.8.0 MCP epic (#202–#205): execution-oriented trigger / change-log /
+dryrun tools and outbound FS scoping are now part of the built-in
+surface; plugin-contributed tools arrive via the ``gispulse.mcp_tools``
+entry-point (#205).
 """
 
 from __future__ import annotations
@@ -50,6 +75,7 @@ except ImportError as exc:  # pragma: no cover
         "Install it with: pip install fastmcp"
     ) from exc
 
+from gispulse.adapters.mcp.workdir import WorkdirError, resolve_in_workdir
 from gispulse.app import GISPulseApp
 from gispulse.catalog.models import CatalogDomain
 from gispulse.core.logging import get_logger
@@ -88,10 +114,24 @@ def register_builtin_mcp_surface(server: Any) -> None:
         inspect_dataset,
         validate_pipeline,
         list_plugins,
+        list_sources,
+        load_triggers,
+        list_triggers,
+        validate_triggers,
+        inspect_changelog,
+        watch_status,
+        dryrun_trigger,
     ):
         server.tool()(fn)
     server.resource("gispulse://capabilities")(resource_capabilities)
     server.resource("gispulse://templates")(resource_templates)
+    server.resource("gispulse://sources")(resource_sources)
+    # Resource templates — the ``{path}`` placeholder makes FastMCP treat
+    # these as parameterised resources, so an MCP client can read e.g.
+    # ``gispulse://triggers/configs/parcels.yaml``. The path is still
+    # workdir-scoped inside the handler (#204).
+    server.resource("gispulse://triggers/{path}")(resource_triggers)
+    server.resource("gispulse://changelog/{path}")(resource_changelog)
 
 
 def register_plugin_mcp_surface(server: Any) -> None:
@@ -230,43 +270,54 @@ def get_template(name: str) -> dict[str, Any]:
 
 
 # ===========================================================================
-# Dataset / pipeline tools (read-only)
+# Dataset / pipeline tools (read-only, workdir-scoped)
 # ===========================================================================
 
 
 def inspect_dataset(path: str) -> dict[str, Any]:
     """List the layers of a GeoPackage file without loading its features.
 
+    The ``path`` is bounded to the MCP workdir (#204).
+
     Args:
-        path: Absolute path to a ``.gpkg`` file.
+        path: Path to a ``.gpkg`` file, inside the MCP workdir.
 
     Returns:
         Dict with ``path`` and ``layers`` (list of layer names), or an
-        ``error`` key when the file is missing or unreadable.
+        ``error`` key when the file is missing, out of scope, or
+        unreadable.
     """
-    import os
-
-    if not os.path.isfile(path):
+    try:
+        gpkg = resolve_in_workdir(path)
+    except WorkdirError as exc:
+        return {"error": str(exc)}
+    if not gpkg.is_file():
         return {"error": f"File not found: '{path}'"}
     try:
-        layers = _app.list_layers(path)
+        layers = _app.list_layers(gpkg)
     except Exception as exc:
         return {"error": f"Cannot read GeoPackage layers: {exc}"}
-    return {"path": path, "layers": layers}
+    return {"path": str(gpkg), "layers": layers}
 
 
 def validate_pipeline(path: str) -> dict[str, Any]:
     """Schema-validate a pipeline JSON file (v1 or v2 grammar).
 
+    The ``path`` is bounded to the MCP workdir (#204).
+
     Args:
-        path: Path to a pipeline / rules JSON file.
+        path: Path to a pipeline / rules JSON file, inside the workdir.
 
     Returns:
         Dict with ``valid`` (bool). On success it also carries ``name``
         and ``steps`` (count); on failure, ``errors`` (list of strings).
     """
     try:
-        spec = _app.load_pipeline(path, validate=True)
+        pipeline = resolve_in_workdir(path)
+    except WorkdirError as exc:
+        return {"valid": False, "errors": [str(exc)]}
+    try:
+        spec = _app.load_pipeline(pipeline, validate=True)
     except FileNotFoundError as exc:
         return {"valid": False, "errors": [str(exc)]}
     except ValueError as exc:
@@ -277,7 +328,220 @@ def validate_pipeline(path: str) -> dict[str, Any]:
 
 
 # ===========================================================================
-# Plugin tools
+# Trigger / change-log tools (#202)
+# ===========================================================================
+
+
+def _trigger_summary(config: Any) -> dict[str, Any]:
+    """Build the JSON-safe summary dict shared by ``load_triggers`` and the
+    ``gispulse://triggers/{path}`` resource."""
+    triggers: list[dict[str, Any]] = []
+    for entry in config.triggers:
+        if entry.on is not None:
+            when: Any = {"source_changed": entry.on.source_changed}
+            action_types = [a.type for a in entry.actions]
+        else:
+            when = list(entry.when)
+            action_types = [a.type for a in entry.actions]
+        triggers.append(
+            {
+                "id": entry.name,
+                "table": entry.table,
+                "when": when,
+                "action_types": action_types,
+                "enabled": entry.enabled,
+            }
+        )
+    return {
+        "gpkg": str(config.gpkg),
+        "trigger_count": len(config.triggers),
+        "triggers": triggers,
+    }
+
+
+def load_triggers(path: str) -> dict[str, Any]:
+    """Load a ``triggers.yaml`` config and return a structured summary.
+
+    The ``path`` is bounded to the MCP workdir (#204).
+
+    Args:
+        path: Path to a YAML triggers config inside the workdir.
+
+    Returns:
+        ``{path, gpkg, trigger_count, triggers: [...]}`` — or an
+        ``error`` key on a traversal / schema violation.
+    """
+    try:
+        cfg_path = resolve_in_workdir(path)
+        config = _app.load_trigger_config(cfg_path)
+    except Exception as exc:  # noqa: BLE001 - uniform error shape
+        return {"error": str(exc)}
+    summary = _trigger_summary(config)
+    summary["path"] = str(cfg_path)
+    return summary
+
+
+def list_triggers(path: str) -> dict[str, Any]:
+    """Return the detailed trigger list of a ``triggers.yaml`` config.
+
+    The ``path`` is bounded to the MCP workdir (#204).
+
+    Args:
+        path: Path to a YAML triggers config inside the workdir.
+
+    Returns:
+        ``{path, gpkg, trigger_count, triggers: [...]}`` where each
+        trigger carries its predicate and per-action config — or an
+        ``error`` key.
+    """
+    try:
+        cfg_path = resolve_in_workdir(path)
+        config = _app.load_trigger_config(cfg_path)
+    except Exception as exc:  # noqa: BLE001
+        return {"error": str(exc)}
+    triggers: list[dict[str, Any]] = []
+    for entry in config.triggers:
+        actions = [
+            {k: v for k, v in a.model_dump().items() if v is not None}
+            for a in entry.actions
+        ]
+        triggers.append(
+            {
+                "id": entry.name,
+                "table": entry.table,
+                "kind": entry.kind,
+                "pk_col": entry.pk_col,
+                "when": list(entry.when),
+                "predicate": entry.predicate,
+                "source_changed": (
+                    entry.on.source_changed if entry.on is not None else None
+                ),
+                "actions": actions,
+                "enabled": entry.enabled,
+            }
+        )
+    return {
+        "path": str(cfg_path),
+        "gpkg": str(config.gpkg),
+        "trigger_count": len(triggers),
+        "triggers": triggers,
+    }
+
+
+def validate_triggers(path: str, gpkg: str | None = None) -> dict[str, Any]:
+    """Structurally validate a ``triggers.yaml`` against its GeoPackage.
+
+    Runs the schema check *and* opens the GPKG to confirm every DML
+    trigger references a real layer. Both ``path`` and the optional
+    ``gpkg`` override are bounded to the MCP workdir (#204).
+
+    Args:
+        path: Path to a YAML triggers config inside the workdir.
+        gpkg: Optional GPKG path that wins over the config's ``gpkg:``.
+
+    Returns:
+        ``{valid: bool, errors: [...]}``.
+    """
+    try:
+        cfg_path = resolve_in_workdir(path)
+        gpkg_override = resolve_in_workdir(gpkg) if gpkg else None
+    except WorkdirError as exc:
+        return {"valid": False, "errors": [str(exc)]}
+    errors = _app.validate_trigger_config(cfg_path, gpkg_override=gpkg_override)
+    return {"valid": not errors, "errors": errors}
+
+
+def inspect_changelog(gpkg: str, limit: int = 50) -> dict[str, Any]:
+    """Inspect the ``_gispulse_change_log`` of a GeoPackage.
+
+    The ``gpkg`` path is bounded to the MCP workdir (#204).
+
+    Args:
+        gpkg:  Path to a ``.gpkg`` file inside the workdir.
+        limit: Max recent change-log rows to return (1..10000).
+
+    Returns:
+        ``{tracked, pending, latest_seq, recent: [...]}`` — ``tracked``
+        is ``False`` when change-tracking has not been installed. An
+        ``error`` key wraps a traversal violation or an unreadable file.
+    """
+    try:
+        gpkg_path = resolve_in_workdir(gpkg)
+    except WorkdirError as exc:
+        return {"error": str(exc)}
+    try:
+        return _app.changelog_status(gpkg_path, limit=limit)
+    except Exception as exc:  # noqa: BLE001 - report cleanly to the model
+        return {"error": f"Cannot read change-log: {exc}"}
+
+
+def watch_status(gpkg: str) -> dict[str, Any]:
+    """Report change-tracking status for a GeoPackage.
+
+    Combines the installed-trigger scan (which layers are tracked) with
+    the change-log snapshot (how much is pending). The ``gpkg`` path is
+    bounded to the MCP workdir (#204).
+
+    Args:
+        gpkg: Path to a ``.gpkg`` file inside the workdir.
+
+    Returns:
+        ``{gpkg, tracked_layers: {layer: [ops]}, pending, latest_seq}``
+        — or an ``error`` key.
+    """
+    try:
+        gpkg_path = resolve_in_workdir(gpkg)
+    except WorkdirError as exc:
+        return {"error": str(exc)}
+    try:
+        tracked = _app.tracked_layers(gpkg_path)
+        cl = _app.changelog_status(gpkg_path, limit=1)
+    except Exception as exc:  # noqa: BLE001
+        return {"error": f"Cannot read watch status: {exc}"}
+    return {
+        "gpkg": str(gpkg_path),
+        "tracked_layers": tracked,
+        "pending": cl["pending"],
+        "latest_seq": cl["latest_seq"],
+    }
+
+
+def dryrun_trigger(path: str, gpkg: str | None = None) -> dict[str, Any]:
+    """Evaluate a ``triggers.yaml`` against the live change-log — no effects.
+
+    Builds the real headless runtime but injects collecting no-op
+    executors for SQL writes and webhooks, and neutralises the change-log
+    ack. The trigger predicates and DSL run for real; the *effects* are
+    captured instead of applied, so a subsequent ``gispulse watch`` still
+    sees the same pending rows. See :mod:`gispulse.adapters.mcp.dryrun`
+    for the side-effect-free contract.
+
+    Both ``path`` and the optional ``gpkg`` override are bounded to the
+    MCP workdir (#204).
+
+    Args:
+        path: Path to a YAML triggers config inside the workdir.
+        gpkg: Optional GPKG path that wins over the config's ``gpkg:``.
+
+    Returns:
+        ``{gpkg, trigger_count, rows_evaluated, sql_actions,
+        webhook_actions}`` — or an ``error`` key.
+    """
+    from gispulse.adapters.mcp.dryrun import dryrun_trigger_config
+
+    try:
+        cfg_path = resolve_in_workdir(path)
+        gpkg_override = resolve_in_workdir(gpkg) if gpkg else None
+    except WorkdirError as exc:
+        return {"error": str(exc)}
+    try:
+        return dryrun_trigger_config(cfg_path, gpkg_override=gpkg_override)
+    except Exception as exc:  # noqa: BLE001 - report cleanly to the model
+        return {"error": f"Dry-run failed: {exc}"}
+
+
+# ===========================================================================
+# Plugin / source tools
 # ===========================================================================
 
 
@@ -289,6 +553,18 @@ def list_plugins() -> list[dict[str, Any]]:
         templates and extensions — as produced by ``PluginRecord.as_dict``.
     """
     return [rec.as_dict() for rec in _app.list_plugins()]
+
+
+def list_sources() -> list[dict[str, Any]]:
+    """List the ETL data-source plugins registered with the ExtensionHub.
+
+    Data sources are the *extract* leg of the ETL plugin model — plugins
+    published under the ``gispulse.data_sources`` entry-point group.
+
+    Returns:
+        One dict per data-source plugin record.
+    """
+    return _app.list_sources()
 
 
 # ===========================================================================
@@ -304,6 +580,29 @@ def resource_capabilities() -> str:
 def resource_templates() -> str:
     """MCP resource: the built-in pipeline templates (JSON)."""
     return json.dumps(_app.list_templates(), indent=2)
+
+
+def resource_sources() -> str:
+    """MCP resource: the registered ETL data-source plugins (JSON)."""
+    return json.dumps(_app.list_sources(), indent=2)
+
+
+def resource_triggers(path: str) -> str:
+    """MCP resource template: summary of a ``triggers.yaml`` config (JSON).
+
+    Bound as ``gispulse://triggers/{path}``. The ``path`` is workdir-scoped
+    exactly like the :func:`load_triggers` tool.
+    """
+    return json.dumps(load_triggers(path), indent=2, default=str)
+
+
+def resource_changelog(path: str) -> str:
+    """MCP resource template: change-log status of a GeoPackage (JSON).
+
+    Bound as ``gispulse://changelog/{path}``. The ``path`` is workdir-scoped
+    exactly like the :func:`inspect_changelog` tool.
+    """
+    return json.dumps(inspect_changelog(path), indent=2, default=str)
 
 
 # Module-level compatibility instance used by existing imports / launchers.

--- a/src/gispulse/adapters/mcp/workdir.py
+++ b/src/gispulse/adapters/mcp/workdir.py
@@ -1,0 +1,93 @@
+"""Filesystem scoping for the MCP server (issue #204).
+
+Every MCP tool that takes a path argument — ``inspect_dataset``,
+``inspect_changelog``, ``load_triggers``, ``validate_triggers``,
+``list_triggers``, ``dryrun_trigger``, ``watch_status`` — reads a path
+the model picked. An unbounded ``open(path)`` is a path-traversal sink:
+a prompt-injected agent could read ``/etc/passwd`` or exfiltrate any
+GeoPackage on the host.
+
+This module bounds every such read to a single **MCP workdir**:
+
+* ``GISPULSE_MCP_WORKDIR`` env var when set;
+* otherwise the process current working directory.
+
+:func:`resolve_in_workdir` canonicalises a caller-supplied path with
+``Path.resolve()`` and rejects it when it escapes the workdir. The check
+reuses :func:`gispulse.runtime.config_loader._check_within_anchors` — the
+same path-traversal guard the ``gispulse triggers`` CLI already trusts —
+so there is one canonical implementation of "is this path inside an
+allowed root".
+
+Note this is intentionally *stricter* than the CLI's
+:func:`config_loader._safe_anchors` (which accepts cwd **and** ``$HOME``
+**and** ``tempfile.gettempdir()``): an MCP server is driven by an
+untrusted LLM, so it gets a single, explicit root.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from gispulse.runtime.config_loader import ConfigError, _check_within_anchors
+
+__all__ = ["WorkdirError", "get_workdir", "resolve_in_workdir"]
+
+
+class WorkdirError(ValueError):
+    """Raised when a caller-supplied path escapes the MCP workdir."""
+
+
+def get_workdir() -> Path:
+    """Return the directory MCP path arguments are bounded to.
+
+    ``GISPULSE_MCP_WORKDIR`` when set (``~`` expanded), otherwise the
+    process current working directory. The returned path is resolved so
+    later containment checks compare canonical paths.
+    """
+    raw = os.environ.get("GISPULSE_MCP_WORKDIR", "").strip()
+    base = Path(raw).expanduser() if raw else Path.cwd()
+    try:
+        return base.resolve()
+    except OSError:  # pragma: no cover - defensive
+        return base
+
+
+def resolve_in_workdir(path: str | os.PathLike[str], *, must_exist: bool = True) -> Path:
+    """Canonicalise ``path`` and ensure it stays inside the MCP workdir.
+
+    Args:
+        path:       A path string from an MCP tool argument. Relative
+                    paths are anchored to the workdir, not to the
+                    process cwd, so the model never depends on an
+                    implicit location.
+        must_exist: When *True*, also fail if the target is missing.
+
+    Returns:
+        The resolved absolute :class:`~pathlib.Path`.
+
+    Raises:
+        WorkdirError: The path escapes the workdir, or (when
+                      ``must_exist``) does not exist.
+    """
+    workdir = get_workdir()
+    p = Path(path).expanduser()
+    if not p.is_absolute():
+        p = workdir / p
+    try:
+        resolved = p.resolve()
+    except OSError as exc:  # pragma: no cover - defensive
+        raise WorkdirError(f"cannot resolve path {path!s}: {exc}") from exc
+
+    # Reuse the CLI's traversal guard so there is a single implementation.
+    try:
+        _check_within_anchors(resolved, [workdir])
+    except ConfigError as exc:
+        raise WorkdirError(
+            f"path outside MCP workdir: {path!s} (workdir: {workdir})"
+        ) from exc
+
+    if must_exist and not resolved.exists():
+        raise WorkdirError(f"path not found in MCP workdir: {path!s}")
+    return resolved

--- a/src/gispulse/app.py
+++ b/src/gispulse/app.py
@@ -327,9 +327,143 @@ class GISPulseApp:
             for m in ExtensionHub.get().data_pack_manifests()
         ]
 
+    def list_sources(self) -> list[dict]:
+        """Return the ETL data-source plugins registered with the hub.
+
+        Data sources are the *extract* leg of the ETL plugin model —
+        plugins published under the ``gispulse.data_sources`` entry-point
+        group (:data:`core.plugin_model.ENTRYPOINT_GROUPS`). Each dict is
+        the JSON-safe :meth:`PluginRecord.as_dict` projection of one
+        :class:`~gispulse.core.plugin_model.PluginKind.SOURCE` record.
+        """
+        from gispulse.core.plugin_hub import ExtensionHub
+        from gispulse.core.plugin_model import PluginKind
+
+        hub = ExtensionHub.get()
+        return [rec.as_dict() for rec in hub.records_by_kind(PluginKind.SOURCE)]
+
     # ------------------------------------------------------------------
     # Trigger runtime (CDC / watch)
     # ------------------------------------------------------------------
+    def load_trigger_config(
+        self,
+        config_path: "str | Path",
+        *,
+        gpkg_override: "str | Path | None" = None,
+    ) -> Any:
+        """Load + schema-validate a ``triggers.yaml`` config.
+
+        Thin pass-through to :func:`runtime.config_loader.load_config`.
+        Returns the validated :class:`~gispulse.runtime.config_loader.
+        GISPulseConfig`; raises :class:`~gispulse.runtime.config_loader.
+        ConfigError` on a traversal / schema violation.
+        """
+        from gispulse.runtime.config_loader import load_config
+
+        return load_config(config_path, gpkg_override=gpkg_override)
+
+    def validate_trigger_config(
+        self,
+        config_path: "str | Path",
+        *,
+        gpkg_override: "str | Path | None" = None,
+    ) -> list[str]:
+        """Structurally validate a ``triggers.yaml`` against its GPKG.
+
+        Chains :func:`runtime.config_loader.load_config` and
+        :func:`runtime.config_loader.validate_against_gpkg`. Returns the
+        list of human-readable error strings (empty list = valid). A
+        :class:`ConfigError` from the loader is converted into a
+        single-element error list so the caller gets a uniform shape.
+        """
+        from gispulse.runtime.config_loader import (
+            ConfigError,
+            load_config,
+            validate_against_gpkg,
+        )
+
+        try:
+            config = load_config(config_path, gpkg_override=gpkg_override)
+        except ConfigError as exc:
+            return [str(exc)]
+        return validate_against_gpkg(config)
+
+    def changelog_status(
+        self, gpkg_path: "str | Path", *, limit: int = 50
+    ) -> dict[str, Any]:
+        """Summarise the GPKG change-log without booting the runtime.
+
+        Opens the GeoPackage read-only (the same WAL pragmas every other
+        code path uses, via :func:`persistence.gpkg_connection.connect_gpkg`)
+        and reports whether change-tracking is installed, how many rows
+        are still unprocessed, the latest sequence id and the most recent
+        rows.
+
+        Args:
+            gpkg_path: Path to the ``.gpkg`` file.
+            limit:     Max recent rows to return (clamped to 1..10000).
+
+        Returns:
+            ``{tracked, pending, latest_seq, recent: [...]}``.
+        """
+        import sqlite3
+
+        from gispulse.persistence.gpkg_connection import connect_gpkg
+
+        limit = max(1, min(int(limit), 10_000))
+        conn = connect_gpkg(Path(gpkg_path), row_factory=sqlite3.Row)
+        try:
+            exists = conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' "
+                "AND name='_gispulse_change_log'"
+            ).fetchone()
+            if exists is None:
+                return {
+                    "tracked": False,
+                    "pending": 0,
+                    "latest_seq": 0,
+                    "recent": [],
+                }
+            agg = conn.execute(
+                "SELECT COUNT(*) FILTER (WHERE processed = 0) AS pending, "
+                "COALESCE(MAX(id), 0) AS latest FROM _gispulse_change_log"
+            ).fetchone()
+            pending = int(agg["pending"] or 0) if agg else 0
+            latest = int(agg["latest"] or 0) if agg else 0
+            rows = conn.execute(
+                "SELECT id, table_name, operation, row_pk, changed_at, "
+                "processed FROM _gispulse_change_log "
+                "ORDER BY id DESC LIMIT ?",
+                (limit,),
+            ).fetchall()
+            recent = [dict(r) for r in rows]
+            return {
+                "tracked": True,
+                "pending": pending,
+                "latest_seq": latest,
+                "recent": recent,
+            }
+        finally:
+            conn.close()
+
+    def tracked_layers(self, gpkg_path: "str | Path") -> dict[str, list[str]]:
+        """Return ``{layer: [installed trigger ops]}`` for a GeoPackage.
+
+        Thin pass-through to :func:`cli_track._installed_triggers` — the
+        same scan ``gispulse track doctor`` uses — so the MCP
+        ``watch_status`` tool and the CLI agree on what "tracked" means.
+        """
+        import sqlite3
+
+        from gispulse.cli_track import _installed_triggers
+        from gispulse.persistence.gpkg_connection import connect_gpkg
+
+        conn = connect_gpkg(Path(gpkg_path), row_factory=sqlite3.Row)
+        try:
+            return _installed_triggers(conn)
+        finally:
+            conn.close()
+
     def build_watch_runtime(
         self,
         gpkg_path: "str | Path",

--- a/src/gispulse/plugins/mcp_pilot.py
+++ b/src/gispulse/plugins/mcp_pilot.py
@@ -1,0 +1,55 @@
+"""Pilot ``gispulse.mcp_tools`` plugin — reference for MCP-tool authors (#205).
+
+This module is the *worked example* the MCP-tool authoring guide
+(``docs-site/plugins/mcp-tools.md``) walks through. It is a first-party
+plugin that contributes one extra tool to the GISPulse MCP server.
+
+Contract
+--------
+A ``gispulse.mcp_tools`` entry-point must resolve to an object satisfying
+:class:`gispulse.core.plugin_contracts.McpToolFactory`:
+
+* a ``name`` attribute (``str``) — used in the hub inventory and logs;
+* a ``register(self, mcp)`` method — called once per server with the live
+  FastMCP server, where the plugin attaches its tools via ``@mcp.tool()``.
+
+The :class:`~gispulse.core.plugin_hub.ExtensionHub` discovers the
+entry-point, instantiates the class (zero-arg constructor), and
+:func:`gispulse.adapters.mcp.server.register_plugin_mcp_surface` calls
+``register`` on the running server. A plugin that raises during
+``register`` is logged and skipped — it never takes the server down.
+
+Keep the factory import-light: the module is imported during hub
+discovery, so heavy imports (geopandas, requests, …) belong inside the
+tool body, not at module scope.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class PilotMcpTools:
+    """Reference :class:`McpToolFactory` — contributes ``gispulse_pilot_echo``.
+
+    A real plugin would register domain tools here (e.g. a connector that
+    exposes ``query_ftth_coverage``). This pilot keeps the body trivial so
+    the *wiring* is the lesson, not the tool logic.
+    """
+
+    name = "gispulse-mcp-pilot"
+
+    def register(self, mcp: Any) -> None:
+        """Attach this plugin's tools to the FastMCP ``mcp`` server."""
+
+        @mcp.tool()
+        def gispulse_pilot_echo(message: str) -> dict[str, str]:
+            """Echo a message back — proves the MCP-tool plugin wiring works.
+
+            Args:
+                message: Any string the caller wants echoed.
+
+            Returns:
+                ``{"plugin": ..., "echo": message}``.
+            """
+            return {"plugin": PilotMcpTools.name, "echo": message}

--- a/tests/unit/test_mcp_pilot_plugin.py
+++ b/tests/unit/test_mcp_pilot_plugin.py
@@ -1,0 +1,70 @@
+"""Tests for the pilot ``gispulse.mcp_tools`` plugin (issue #205).
+
+``gispulse.plugins.mcp_pilot.PilotMcpTools`` is the reference
+implementation an MCP-tool author copies. These tests verify it honours
+the :class:`McpToolFactory` contract and that its tool reaches a freshly
+created FastMCP server.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+fastmcp = pytest.importorskip("fastmcp")
+
+from gispulse.adapters.mcp import server as mcp_server  # noqa: E402
+from gispulse.core import plugin_hub  # noqa: E402
+from gispulse.core.plugin_contracts import McpToolFactory  # noqa: E402
+from gispulse.plugins.mcp_pilot import PilotMcpTools  # noqa: E402
+
+
+def test_pilot_satisfies_mcp_tool_factory_protocol():
+    """The pilot is a structural McpToolFactory (name + register)."""
+    pilot = PilotMcpTools()
+    assert isinstance(pilot, McpToolFactory)
+    assert pilot.name == "gispulse-mcp-pilot"
+
+
+def test_pilot_registers_echo_tool_on_a_server():
+    """register() attaches gispulse_pilot_echo to a FastMCP server."""
+    import asyncio
+
+    server = fastmcp.FastMCP("test")
+    PilotMcpTools().register(server)
+
+    tools = asyncio.run(server.list_tools())
+    assert "gispulse_pilot_echo" in {t.name for t in tools}
+
+
+def test_pilot_discovered_via_entry_point():
+    """The pilot is published under the gispulse.mcp_tools entry-point.
+
+    Confirms the pyproject.toml declaration is installed so a real
+    ``gispulse mcp`` server picks the plugin up. Skips cleanly when the
+    package metadata has not been (re)installed.
+    """
+    plugin_hub.ExtensionHub.reset()
+    hub = plugin_hub.ExtensionHub.get()
+    names = {factory.name for factory in hub.mcp_tools}
+    plugin_hub.ExtensionHub.reset()
+    if "gispulse-mcp-pilot" not in names:
+        pytest.skip("entry-point metadata not installed (pip install -e .)")
+    assert "gispulse-mcp-pilot" in names
+
+
+def test_pilot_tool_registered_on_default_server():
+    """When the entry-point is installed, the default MCP server carries
+    the pilot tool through register_plugin_mcp_surface."""
+    import asyncio
+
+    plugin_hub.ExtensionHub.reset()
+    server = mcp_server.create_mcp_server()
+    tools = asyncio.run(server.list_tools())
+    tool_names = {t.name for t in tools}
+    plugin_hub.ExtensionHub.reset()
+    if "gispulse-mcp-pilot" not in {
+        f.name for f in plugin_hub.ExtensionHub.get().mcp_tools
+    }:
+        plugin_hub.ExtensionHub.reset()
+        pytest.skip("entry-point metadata not installed (pip install -e .)")
+    assert "gispulse_pilot_echo" in tool_names

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -62,6 +62,14 @@ def test_tools_registered():
         "inspect_dataset",
         "validate_pipeline",
         "list_plugins",
+        # v1.8.0 MCP epic (#202) — trigger / change-log / source surface.
+        "list_sources",
+        "load_triggers",
+        "list_triggers",
+        "validate_triggers",
+        "inspect_changelog",
+        "watch_status",
+        "dryrun_trigger",
     }
     missing = expected - tool_names
     assert not missing, f"Missing tools: {missing}"
@@ -209,8 +217,13 @@ def test_validate_pipeline_missing_file():
     assert result["errors"]
 
 
-def test_validate_pipeline_valid(tmp_path):
-    """validate_pipeline() accepts a well-formed v2 pipeline file."""
+def test_validate_pipeline_valid(monkeypatch, tmp_path):
+    """validate_pipeline() accepts a well-formed v2 pipeline file.
+
+    The MCP workdir is pinned to ``tmp_path`` — since #204 every
+    path-bound tool only reads inside the configured workdir.
+    """
+    monkeypatch.setenv("GISPULSE_MCP_WORKDIR", str(tmp_path))
     spec = {
         "version": 2,
         "name": "smoke",
@@ -226,9 +239,25 @@ def test_validate_pipeline_valid(tmp_path):
     pipeline_file = tmp_path / "pipeline.json"
     pipeline_file.write_text(json.dumps(spec), encoding="utf-8")
 
-    result = mcp_server.validate_pipeline(str(pipeline_file))
+    result = mcp_server.validate_pipeline("pipeline.json")
     assert result["valid"] is True
     assert result["steps"] == 1
+
+
+def test_validate_pipeline_rejects_path_outside_workdir(monkeypatch, tmp_path):
+    """validate_pipeline() refuses a path that escapes the MCP workdir (#204)."""
+    monkeypatch.setenv("GISPULSE_MCP_WORKDIR", str(tmp_path))
+    result = mcp_server.validate_pipeline("../../../etc/passwd")
+    assert result["valid"] is False
+    assert any("workdir" in e for e in result["errors"])
+
+
+def test_inspect_dataset_rejects_path_outside_workdir(monkeypatch, tmp_path):
+    """inspect_dataset() refuses a path that escapes the MCP workdir (#204)."""
+    monkeypatch.setenv("GISPULSE_MCP_WORKDIR", str(tmp_path))
+    result = mcp_server.inspect_dataset("/etc/passwd")
+    assert "error" in result
+    assert "workdir" in result["error"]
 
 
 # ---------------------------------------------------------------------------
@@ -261,3 +290,199 @@ def test_resource_templates_is_valid_json():
     data = json.loads(mcp_server.resource_templates())
     assert isinstance(data, list)
     assert len(data) > 0
+
+
+def test_resource_sources_is_valid_json():
+    """gispulse://sources resource returns a valid JSON list."""
+    data = json.loads(mcp_server.resource_sources())
+    assert isinstance(data, list)
+
+
+# ===========================================================================
+# Trigger / change-log surface (#202) + FS scoping (#204)
+# ===========================================================================
+
+
+@pytest.fixture()
+def tracked_gpkg(tmp_path):
+    """A real GPKG with a change-tracked ``parcels`` table + one pending row."""
+    import sqlite3
+
+    from gispulse.persistence.gpkg_engine import GeoPackageEngine
+
+    gpkg_path = tmp_path / "data.gpkg"
+    engine = GeoPackageEngine(path=gpkg_path)
+    engine.open()
+    try:
+        conn = engine._get_conn()  # noqa: SLF001
+        conn.execute(
+            'CREATE TABLE IF NOT EXISTS "parcels" '
+            "(fid INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, status TEXT)"
+        )
+        conn.commit()
+        engine.enable_change_tracking("parcels")
+    finally:
+        engine.close()
+    # Fire the native triggers from a separate connection.
+    c = sqlite3.connect(str(gpkg_path))
+    try:
+        c.execute('INSERT INTO "parcels"(name, status) VALUES (?, ?)', ("a", "pending"))
+        c.commit()
+    finally:
+        c.close()
+    return gpkg_path
+
+
+@pytest.fixture()
+def triggers_yaml(tmp_path, tracked_gpkg):
+    """A valid triggers.yaml referencing ``tracked_gpkg`` with a webhook action."""
+    cfg = tmp_path / "triggers.yaml"
+    cfg.write_text(
+        "version: 1\n"
+        f"gpkg: {tracked_gpkg}\n"
+        "triggers:\n"
+        "  - name: enrich\n"
+        "    table: parcels\n"
+        "    when: [INSERT]\n"
+        "    actions:\n"
+        "      - type: webhook\n"
+        "        url: https://example.com/hook\n",
+        encoding="utf-8",
+    )
+    return cfg
+
+
+@pytest.fixture()
+def in_workdir(monkeypatch, tmp_path):
+    """Pin the MCP workdir to tmp_path so path-bound tools accept fixtures."""
+    monkeypatch.setenv("GISPULSE_MCP_WORKDIR", str(tmp_path))
+    return tmp_path
+
+
+def test_list_sources_returns_list():
+    """list_sources() returns a JSON-safe list of data-source plugin dicts."""
+    sources = mcp_server.list_sources()
+    assert isinstance(sources, list)
+    json.dumps(sources)
+
+
+def test_load_triggers_summary(in_workdir, triggers_yaml):
+    """load_triggers() summarises a YAML config."""
+    result = mcp_server.load_triggers("triggers.yaml")
+    assert "error" not in result
+    assert result["trigger_count"] == 1
+    t = result["triggers"][0]
+    assert t["id"] == "enrich"
+    assert t["table"] == "parcels"
+    assert t["action_types"] == ["webhook"]
+    assert t["enabled"] is True
+
+
+def test_load_triggers_rejects_path_outside_workdir(in_workdir):
+    """load_triggers() refuses a path that escapes the MCP workdir (#204)."""
+    result = mcp_server.load_triggers("../../../etc/passwd")
+    assert "error" in result
+    assert "workdir" in result["error"]
+
+
+def test_list_triggers_detailed(in_workdir, triggers_yaml):
+    """list_triggers() returns per-trigger detail incl. actions."""
+    result = mcp_server.list_triggers("triggers.yaml")
+    assert "error" not in result
+    assert result["trigger_count"] == 1
+    trig = result["triggers"][0]
+    assert trig["when"] == ["INSERT"]
+    assert trig["actions"][0]["type"] == "webhook"
+
+
+def test_validate_triggers_valid(in_workdir, triggers_yaml):
+    """validate_triggers() accepts a config whose table exists in the GPKG."""
+    result = mcp_server.validate_triggers("triggers.yaml")
+    assert result["valid"] is True
+    assert result["errors"] == []
+
+
+def test_validate_triggers_reports_unknown_table(in_workdir, tmp_path, tracked_gpkg):
+    """validate_triggers() flags a trigger pointing at a missing layer."""
+    cfg = tmp_path / "bad.yaml"
+    cfg.write_text(
+        "version: 1\n"
+        f"gpkg: {tracked_gpkg}\n"
+        "triggers:\n"
+        "  - name: x\n"
+        "    table: no_such_layer\n"
+        "    when: [INSERT]\n"
+        "    actions: [{type: log_event}]\n",
+        encoding="utf-8",
+    )
+    result = mcp_server.validate_triggers("bad.yaml")
+    assert result["valid"] is False
+    assert result["errors"]
+
+
+def test_validate_triggers_rejects_path_outside_workdir(in_workdir):
+    """validate_triggers() refuses a path outside the workdir (#204)."""
+    result = mcp_server.validate_triggers("/etc/passwd")
+    assert result["valid"] is False
+    assert any("workdir" in e for e in result["errors"])
+
+
+def test_inspect_changelog_tracked(in_workdir, tracked_gpkg):
+    """inspect_changelog() reports the pending change-log row."""
+    result = mcp_server.inspect_changelog("data.gpkg")
+    assert result["tracked"] is True
+    assert result["pending"] == 1
+    assert result["latest_seq"] >= 1
+    assert result["recent"]
+    assert result["recent"][0]["table_name"] == "parcels"
+
+
+def test_inspect_changelog_rejects_path_outside_workdir(in_workdir):
+    """inspect_changelog() refuses a path outside the workdir (#204)."""
+    result = mcp_server.inspect_changelog("../../../etc/passwd")
+    assert "error" in result
+    assert "workdir" in result["error"]
+
+
+def test_watch_status_reports_tracked_layers(in_workdir, tracked_gpkg):
+    """watch_status() lists the tracked layers and pending count."""
+    result = mcp_server.watch_status("data.gpkg")
+    assert "error" not in result
+    assert "parcels" in result["tracked_layers"]
+    assert set(result["tracked_layers"]["parcels"]) == {"insert", "update", "delete"}
+    assert result["pending"] == 1
+
+
+def test_dryrun_trigger_has_no_side_effects(in_workdir, triggers_yaml, tracked_gpkg):
+    """dryrun_trigger() evaluates the config without consuming the change-log
+    or firing real webhooks."""
+    result = mcp_server.dryrun_trigger("triggers.yaml")
+    assert "error" not in result
+    assert result["trigger_count"] == 1
+    assert result["rows_evaluated"] == 1
+    # The webhook is *captured*, not sent.
+    assert result["webhook_actions"]
+    assert result["webhook_actions"][0]["url"] == "https://example.com/hook"
+    # The change-log row stays pending — a real `gispulse watch` still sees it.
+    after = mcp_server.inspect_changelog("data.gpkg")
+    assert after["pending"] == 1
+
+
+def test_dryrun_trigger_rejects_path_outside_workdir(in_workdir):
+    """dryrun_trigger() refuses a path outside the workdir (#204)."""
+    result = mcp_server.dryrun_trigger("../../secrets.yaml")
+    assert "error" in result
+    assert "workdir" in result["error"]
+
+
+def test_resource_triggers_template(in_workdir, triggers_yaml):
+    """gispulse://triggers/{path} resource template returns the config summary."""
+    data = json.loads(mcp_server.resource_triggers("triggers.yaml"))
+    assert data["trigger_count"] == 1
+
+
+def test_resource_changelog_template(in_workdir, tracked_gpkg):
+    """gispulse://changelog/{path} resource template returns change-log status."""
+    data = json.loads(mcp_server.resource_changelog("data.gpkg"))
+    assert data["tracked"] is True
+    assert data["pending"] == 1

--- a/tests/unit/test_mcp_workdir.py
+++ b/tests/unit/test_mcp_workdir.py
@@ -1,0 +1,91 @@
+"""Tests for the MCP filesystem-scoping helper (issue #204).
+
+``gispulse.adapters.mcp.workdir`` bounds every path an MCP tool reads to
+the configured MCP workdir, so a prompt-injected agent cannot escape it.
+These tests do not need fastmcp — the helper has no FastMCP dependency.
+"""
+
+from __future__ import annotations
+
+
+import pytest
+
+from gispulse.adapters.mcp.workdir import (
+    WorkdirError,
+    get_workdir,
+    resolve_in_workdir,
+)
+
+
+def test_get_workdir_defaults_to_cwd(monkeypatch, tmp_path):
+    """Without the env var, the workdir is the process cwd."""
+    monkeypatch.delenv("GISPULSE_MCP_WORKDIR", raising=False)
+    monkeypatch.chdir(tmp_path)
+    assert get_workdir() == tmp_path.resolve()
+
+
+def test_get_workdir_honours_env_var(monkeypatch, tmp_path):
+    """GISPULSE_MCP_WORKDIR overrides the cwd."""
+    monkeypatch.setenv("GISPULSE_MCP_WORKDIR", str(tmp_path))
+    assert get_workdir() == tmp_path.resolve()
+
+
+def test_resolve_accepts_file_inside_workdir(monkeypatch, tmp_path):
+    """A path inside the workdir resolves to its canonical absolute form."""
+    monkeypatch.setenv("GISPULSE_MCP_WORKDIR", str(tmp_path))
+    target = tmp_path / "data.gpkg"
+    target.write_text("x", encoding="utf-8")
+    resolved = resolve_in_workdir("data.gpkg")
+    assert resolved == target.resolve()
+
+
+def test_resolve_accepts_nested_path(monkeypatch, tmp_path):
+    """A nested path inside the workdir is accepted."""
+    monkeypatch.setenv("GISPULSE_MCP_WORKDIR", str(tmp_path))
+    nested = tmp_path / "configs"
+    nested.mkdir()
+    target = nested / "triggers.yaml"
+    target.write_text("x", encoding="utf-8")
+    assert resolve_in_workdir("configs/triggers.yaml") == target.resolve()
+
+
+def test_resolve_rejects_parent_traversal(monkeypatch, tmp_path):
+    """A ``../`` escape is refused with a WorkdirError."""
+    monkeypatch.setenv("GISPULSE_MCP_WORKDIR", str(tmp_path))
+    with pytest.raises(WorkdirError, match="outside MCP workdir"):
+        resolve_in_workdir("../../../etc/passwd")
+
+
+def test_resolve_rejects_absolute_path_outside(monkeypatch, tmp_path):
+    """An absolute path outside the workdir is refused."""
+    monkeypatch.setenv("GISPULSE_MCP_WORKDIR", str(tmp_path))
+    with pytest.raises(WorkdirError, match="outside MCP workdir"):
+        resolve_in_workdir("/etc/passwd")
+
+
+def test_resolve_rejects_missing_file_when_must_exist(monkeypatch, tmp_path):
+    """A missing path inside the workdir fails when must_exist is set."""
+    monkeypatch.setenv("GISPULSE_MCP_WORKDIR", str(tmp_path))
+    with pytest.raises(WorkdirError, match="not found"):
+        resolve_in_workdir("does_not_exist.gpkg")
+
+
+def test_resolve_allows_missing_file_when_not_required(monkeypatch, tmp_path):
+    """must_exist=False resolves a not-yet-created path inside the workdir."""
+    monkeypatch.setenv("GISPULSE_MCP_WORKDIR", str(tmp_path))
+    resolved = resolve_in_workdir("future.gpkg", must_exist=False)
+    assert resolved == (tmp_path / "future.gpkg").resolve()
+
+
+def test_resolve_rejects_symlink_escape(monkeypatch, tmp_path):
+    """A symlink pointing outside the workdir is caught after resolution."""
+    monkeypatch.setenv("GISPULSE_MCP_WORKDIR", str(tmp_path))
+    outside = tmp_path.parent / "outside_secret.txt"
+    outside.write_text("secret", encoding="utf-8")
+    link = tmp_path / "link.txt"
+    try:
+        link.symlink_to(outside)
+    except (OSError, NotImplementedError):  # pragma: no cover - platform
+        pytest.skip("symlinks unsupported on this platform")
+    with pytest.raises(WorkdirError, match="outside MCP workdir"):
+        resolve_in_workdir("link.txt")


### PR DESCRIPTION
Réaligne le serveur MCP sur le produit actuel (EPIC #206, v1.8.0). Le surface MCP
exposait le modèle pré-v1.3 et ignorait `triggers.yaml`, le change-log CDC et les
sources ETL. Conforme à l'axiome CLI↔Portal : chaque outil wrappe le runtime
existant via `GISPulseApp`, sans réimplémentation.

## #203 — Branchement runtime réel
`InMemoryRepository` module-level déjà supprimé par v1.8.0 Foundations ; les nouveaux
outils trigger passent par `build_runtime`/`GISPulseApp.build_watch_runtime`.

## #202 — Surface réalignée
7 outils : `load_triggers`, `list_triggers`, `validate_triggers`, `inspect_changelog`,
`watch_status`, `dryrun_trigger`, `list_sources`. 3 resources : `gispulse://sources`
(statique) + templates `gispulse://triggers/{path}` et `gispulse://changelog/{path}`.
5 use-cases thin ajoutés à `GISPulseApp`. Dry-run sans effet de bord : collecteurs
no-op injectés sur `sql_executor`/`webhook_client` + neutralisation de l'ack changelog
au niveau instance (`dryrun.py`).

## #204 — FS scoping
`adapters/mcp/workdir.py` : tout chemin est borné à `GISPULSE_MCP_WORKDIR` (sinon CWD),
via le garde anti-traversal canonique `config_loader._check_within_anchors`. Appliqué
aux 8 outils path-bound (anciens inclus).

## #205 — Plugin pilote + doc
`plugins/mcp_pilot.py` (entry-point `gispulse.mcp_tools`) + guide d'authoring
`docs-site/plugins/mcp-tools.md`.

## Tests
74 tests verts (`test_mcp_server` +18, `test_mcp_workdir` +9, `test_mcp_pilot_plugin`
+4). `ruff` clean.

## Note hors-scope
`tests/runtime/test_config_loader.py::test_module_does_not_call_unsafe_yaml_load`
échoue déjà sur `main` (chemin `gispulse/` flat hardcodé, séquelle de la consolidation
`src/gispulse/` v1.8.0). À traiter en issue séparée.

Closes #202, #203, #204, #205. Avance #206.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
