### PR TITLE
feat(v19): fetcher foundation — SourceEntryRef axes, LazyFetcher, httpfs (A1/A2/A7)

### DIFF
--- a/src/gispulse/core/fetchers/__init__.py
+++ b/src/gispulse/core/fetchers/__init__.py
@@ -1,0 +1,63 @@
+"""Worldwide-aggregator protocol fetchers (EPIC #226, v1.9.0).
+
+A2 (issue #228) ships this package skeleton, the :class:`LazyFetcher`
+base (``base.py``) and :func:`register_core_fetchers`. The four concrete
+adapters land in the follow-up issues:
+
+* ``geoparquet_s3``  (A3 #229) — ``AccessProtocol.REMOTE_TABLE``
+* ``ogc_features``   (A4 #230) — ``AccessProtocol.OGC_FEATURES`` / ``WFS``
+* ``stac``           (A5 #231) — ``AccessProtocol.STAC``
+* ``http_file``      (A6 #232) — ``AccessProtocol.DOWNLOAD``
+
+Until those land, :func:`register_core_fetchers` walks an empty roster
+and registers nothing — calling it is always safe.
+"""
+
+from __future__ import annotations
+
+from gispulse.core.fetchers.base import DUCKDB_SCAN_KEY, LazyFetcher
+from gispulse.core.logging import get_logger
+from gispulse.core.sources import PROTOCOLS, ProtocolRegistry
+
+log = get_logger(__name__)
+
+__all__ = ["DUCKDB_SCAN_KEY", "LazyFetcher", "register_core_fetchers"]
+
+
+def _core_fetchers() -> list[LazyFetcher]:
+    """Instantiate every concrete core fetcher.
+
+    Each of issues A3-A6 appends its adapter import here. Kept as a
+    function (not a module-level list) so the heavy per-protocol imports
+    stay lazy — ``import gispulse`` must not pull DuckDB / httpx.
+    """
+    fetchers: list[LazyFetcher] = []
+    # A3 #229 — from .geoparquet_s3 import GeoParquetS3Fetcher; fetchers.append(...)
+    # A4 #230 — from .ogc_features  import OGCFeaturesFetcher;  fetchers.append(...)
+    # A5 #231 — from .stac          import STACFetcher;         fetchers.append(...)
+    # A6 #232 — from .http_file     import HttpFileFetcher;     fetchers.append(...)
+    return fetchers
+
+
+def register_core_fetchers(
+    registry: ProtocolRegistry | None = None, *, override: bool = True
+) -> int:
+    """Register the core worldwide fetchers into a protocol registry.
+
+    Args:
+        registry: Target registry. Defaults to the process-wide
+            :data:`~gispulse.core.sources.PROTOCOLS`.
+        override: Replace an adapter already filed under the same
+            protocol. ``True`` by default — a core fetcher is the
+            canonical adapter for its protocol family.
+
+    Returns:
+        The number of fetchers registered.
+    """
+    target = registry if registry is not None else PROTOCOLS
+    count = 0
+    for fetcher in _core_fetchers():
+        target.register(fetcher, override=override)
+        count += 1
+    log.info("core_fetchers_registered", count=count)
+    return count

--- a/src/gispulse/core/fetchers/base.py
+++ b/src/gispulse/core/fetchers/base.py
@@ -1,0 +1,150 @@
+"""Base class for the worldwide-aggregator protocol fetchers (issue #228).
+
+EPIC #226 (v1.9.0) needs a small set of *generic transport adapters* — one
+per :class:`~gispulse.core.plugin_model.AccessProtocol` family — that each
+support two fetch modes:
+
+* :attr:`~gispulse.core.plugin_model.FetchMode.REFERENCE` — a **lazy** view:
+  the adapter returns a DuckDB scan expression instead of bytes, so DuckDB
+  reads the remote source zero-copy (``httpfs`` / ``spatial``);
+* :attr:`~gispulse.core.plugin_model.FetchMode.MATERIALIZE` — a full local
+  copy of the data.
+
+:class:`LazyFetcher` factors out everything that is *not* protocol-specific:
+the SSRF guard (issue #199) and the ``FetchMode`` dispatch. A concrete
+adapter (issues A3-A6) subclasses it, sets ``protocol`` / ``payload`` and
+implements only :meth:`_reference_scan` and :meth:`_materialize`.
+
+A :class:`LazyFetcher` instance structurally satisfies the
+:class:`~gispulse.core.sources.Fetcher` protocol, so it registers straight
+into :data:`~gispulse.core.sources.PROTOCOLS`.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, ClassVar
+
+from gispulse.core.logging import get_logger
+from gispulse.core.plugin_model import (
+    AccessProtocol,
+    AccessSpec,
+    FetchMode,
+    Payload,
+    SourceResult,
+)
+from gispulse.core.ssrf import guard_outbound_url
+
+log = get_logger(__name__)
+
+#: Key under :attr:`SourceResult.metadata` carrying the DuckDB scan SQL of
+#: a ``REFERENCE`` result. The ``VirtualDatasetRegistry`` (issue A9 #235)
+#: turns it into a ``CREATE VIEW … AS SELECT * FROM <scan>``.
+DUCKDB_SCAN_KEY = "duckdb_scan"
+
+__all__ = ["DUCKDB_SCAN_KEY", "LazyFetcher"]
+
+
+class LazyFetcher(ABC):
+    """A transport adapter supporting both lazy and materialised fetches.
+
+    Subclass contract::
+
+        class GeoParquetS3Fetcher(LazyFetcher):
+            protocol = AccessProtocol.REMOTE_TABLE
+            payload = Payload.VECTOR
+
+            def _reference_scan(self, access, extent): ...
+            def _materialize(self, access, extent): ...
+
+    The base supplies :meth:`virtual_table`, :meth:`materialize` and the
+    :meth:`fetch` mode dispatch, and SSRF-guards every endpoint before any
+    network access — a third-party catalogue entry must not steer a fetch
+    at an internal address.
+    """
+
+    #: Protocol slot this fetcher is registered under in ``PROTOCOLS``.
+    #: Concrete subclasses must set it.
+    protocol: ClassVar[AccessProtocol]
+
+    #: Shape of the data this fetcher yields. Defaults to vector.
+    payload: ClassVar[Payload] = Payload.VECTOR
+
+    # -- SSRF guard --------------------------------------------------------
+
+    @staticmethod
+    def _guard(url: str | None) -> None:
+        """Reject an endpoint resolving to a private/internal address.
+
+        Thin pass-through to the shared issue #199 guard so every
+        fetcher — core or third-party — shares one SSRF policy. Non-HTTP
+        endpoints (local file paths) are left alone by the guard.
+        """
+        guard_outbound_url(url)
+
+    # -- subclass hooks ----------------------------------------------------
+
+    @abstractmethod
+    def _reference_scan(self, access: AccessSpec, extent: Any | None) -> str:
+        """Return a DuckDB scan expression that reads ``access`` zero-copy.
+
+        Example: ``read_parquet('s3://bucket/**', hive_partitioning=true)``.
+
+        Args:
+            access: The declarative access block of the catalog entry.
+            extent: An optional bounding box the subclass may push down
+                    into the scan (``None`` = no spatial filter).
+        """
+
+    @abstractmethod
+    def _materialize(self, access: AccessSpec, extent: Any | None) -> SourceResult:
+        """Download ``access`` into a local dataset and return the result.
+
+        The returned :class:`SourceResult` must carry
+        ``mode = FetchMode.MATERIALIZE``.
+        """
+
+    # -- public API --------------------------------------------------------
+
+    def virtual_table(
+        self, access: AccessSpec, *, extent: Any | None = None
+    ) -> SourceResult:
+        """Build a lazy ``REFERENCE`` result — no bytes are moved.
+
+        The DuckDB scan SQL is carried under
+        ``metadata[DUCKDB_SCAN_KEY]``; the endpoint is echoed back in
+        ``reference``.
+        """
+        self._guard(access.endpoint)
+        scan = self._reference_scan(access, extent)
+        log.debug("lazy_fetch_reference", protocol=self.protocol.value)
+        return SourceResult(
+            payload=self.payload,
+            mode=FetchMode.REFERENCE,
+            reference=access.endpoint,
+            metadata={DUCKDB_SCAN_KEY: scan},
+        )
+
+    def materialize(
+        self, access: AccessSpec, *, extent: Any | None = None
+    ) -> SourceResult:
+        """Run a full ``MATERIALIZE`` fetch — a local copy of the data."""
+        self._guard(access.endpoint)
+        log.debug("lazy_fetch_materialize", protocol=self.protocol.value)
+        return self._materialize(access, extent)
+
+    def fetch(
+        self,
+        access: AccessSpec,
+        *,
+        extent: Any | None = None,
+        mode: FetchMode = FetchMode.MATERIALIZE,
+    ) -> SourceResult:
+        """:class:`~gispulse.core.sources.Fetcher` entry point.
+
+        Dispatches on ``mode``: ``REFERENCE`` builds a lazy view,
+        ``MATERIALIZE`` copies the data.
+        """
+        if mode is FetchMode.REFERENCE:
+            return self.virtual_table(access, extent=extent)
+        return self.materialize(access, extent=extent)

--- a/src/gispulse/core/sources.py
+++ b/src/gispulse/core/sources.py
@@ -184,6 +184,13 @@ class SourceEntryRef:
     This is the *minimal* internal handle a :class:`DeclarativeSource`
     indexes. The richer ``catalog.models.CatalogEntry`` is mapped onto
     these by issue #179.
+
+    The ``domain`` / ``payload`` / ``jurisdiction`` fields (issue #227,
+    EPIC #226) are the per-entry classification axes the worldwide
+    catalogue filters on. They are **additive and optional**: every
+    pre-#227 ``SourceEntryRef`` keeps working, and a source that does not
+    classify an entry simply leaves them ``None``. The fourth filter axis
+    — the transport protocol — is already carried by ``access.protocol``.
     """
 
     id: str
@@ -191,6 +198,10 @@ class SourceEntryRef:
     access: AccessSpec
     revision_token: str | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
+    domain: SourceDomain | None = None
+    payload: Payload | None = None
+    jurisdiction: str | None = None
+    """Coverage area as a free code — e.g. ``"FR"``, ``"EU"``, ``"world"``."""
 
 
 @runtime_checkable

--- a/src/gispulse/persistence/duckdb_engine.py
+++ b/src/gispulse/persistence/duckdb_engine.py
@@ -53,16 +53,30 @@ class DuckDBSession(SpatialEngine):
 
     def open(self) -> None:
         self._conn = duckdb.connect(self.database)
+        self._load_extension("spatial")
+        # httpfs powers the v1.9.0 worldwide aggregator (EPIC #226): it lets
+        # DuckDB read remote GeoParquet / S3 sources zero-copy. It is best
+        # effort — a missing httpfs (no network, locked-down host) must not
+        # break the offline GPKG path, which goes through GeoPandas/Fiona.
+        self._load_extension("httpfs")
+        log.debug("duckdb_session_opened", database=self.database)
+
+    def _load_extension(self, name: str) -> None:
+        """Load a DuckDB extension, installing it once if needed.
+
+        A failure is logged and swallowed: the session stays usable for
+        the local GPKG path even when an extension is unavailable.
+        """
         try:
-            self._conn.load_extension("spatial")
+            self._conn.load_extension(name)  # type: ignore[union-attr]
         except Exception:
             try:
-                self._conn.install_extension("spatial")
-                self._conn.load_extension("spatial")
+                self._conn.install_extension(name)  # type: ignore[union-attr]
+                self._conn.load_extension(name)  # type: ignore[union-attr]
             except Exception as exc:
-                log.warning("duckdb_spatial_extension_failed", error=str(exc))
-                # Continue without spatial extension — GPKG I/O uses GeoPandas/Fiona
-        log.debug("duckdb_session_opened", database=self.database)
+                log.warning(
+                    "duckdb_extension_failed", extension=name, error=str(exc)
+                )
 
     def close(self) -> None:
         if self._conn is not None:

--- a/tests/unit/test_duckdb_engine.py
+++ b/tests/unit/test_duckdb_engine.py
@@ -39,6 +39,28 @@ class TestDuckDBSession:
             assert session._conn is not None
         assert session._conn is None
 
+    def test_open_loads_httpfs_when_available(self):
+        # A7 (#233): open() best-effort loads httpfs for the v1.9.0
+        # worldwide aggregator. When the extension installs cleanly the
+        # remote-read functions become callable.
+        with DuckDBSession() as session:
+            try:
+                session._conn.execute("SET s3_region='us-east-1'")
+            except Exception:
+                pytest.skip("httpfs unavailable in this environment (no network)")
+            # httpfs present — remote scan functions are wired.
+            assert session._conn is not None
+
+    def test_open_survives_missing_extension(self):
+        # A missing/failed extension must not break the offline GPKG path.
+        session = DuckDBSession()
+        session.open()
+        try:
+            session._load_extension("definitely_not_a_real_extension")
+            assert session._conn is not None  # still usable
+        finally:
+            session.close()
+
     def test_load_gpkg(self, gpkg_file):
         with DuckDBSession() as session:
             gdf = session.load_gpkg(gpkg_file, layer="points")

--- a/tests/unit/test_fetchers_base.py
+++ b/tests/unit/test_fetchers_base.py
@@ -1,0 +1,165 @@
+"""Unit tests for the worldwide-aggregator fetcher base (issues #228, #227).
+
+Covers :class:`LazyFetcher` (mode dispatch, lazy scan metadata, SSRF
+guard), :func:`register_core_fetchers`, and the additive
+:class:`SourceEntryRef` classification axes (issue #227).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gispulse.core.fetchers import (
+    DUCKDB_SCAN_KEY,
+    LazyFetcher,
+    register_core_fetchers,
+)
+from gispulse.core.plugin_model import (
+    AccessProtocol,
+    AccessSpec,
+    FetchMode,
+    Payload,
+    SourceDomain,
+    SourceResult,
+)
+from gispulse.core.sources import PROTOCOLS, Fetcher, ProtocolRegistry, SourceEntryRef
+from gispulse.core.ssrf import SSRFError
+
+
+# --------------------------------------------------------------------------
+# Test double
+# --------------------------------------------------------------------------
+
+
+class _FakeFetcher(LazyFetcher):
+    """Minimal concrete fetcher — exercises the base without any network."""
+
+    protocol = AccessProtocol.REMOTE_TABLE
+    payload = Payload.VECTOR
+
+    def _reference_scan(self, access: AccessSpec, extent: object) -> str:
+        bbox = "" if extent is None else f" /* bbox={extent} */"
+        return f"read_parquet('{access.endpoint}'){bbox}"
+
+    def _materialize(self, access: AccessSpec, extent: object) -> SourceResult:
+        return SourceResult(
+            payload=self.payload,
+            mode=FetchMode.MATERIALIZE,
+            data=f"rows@{access.endpoint}",
+        )
+
+
+def _access(endpoint: str) -> AccessSpec:
+    return AccessSpec(protocol=AccessProtocol.REMOTE_TABLE, endpoint=endpoint)
+
+
+# --------------------------------------------------------------------------
+# LazyFetcher — abstractness & protocol conformance
+# --------------------------------------------------------------------------
+
+
+def test_lazyfetcher_is_abstract() -> None:
+    with pytest.raises(TypeError):
+        LazyFetcher()  # type: ignore[abstract]
+
+
+def test_fake_fetcher_satisfies_fetcher_protocol() -> None:
+    assert isinstance(_FakeFetcher(), Fetcher)
+
+
+# --------------------------------------------------------------------------
+# Mode dispatch
+# --------------------------------------------------------------------------
+
+
+def test_fetch_reference_builds_lazy_scan() -> None:
+    result = _FakeFetcher().fetch(
+        _access("https://example.com/data.parquet"), mode=FetchMode.REFERENCE
+    )
+    assert result.mode is FetchMode.REFERENCE
+    assert result.reference == "https://example.com/data.parquet"
+    assert result.metadata[DUCKDB_SCAN_KEY] == (
+        "read_parquet('https://example.com/data.parquet')"
+    )
+    # REFERENCE moves no bytes.
+    assert result.data is None
+
+
+def test_fetch_materialize_is_the_default_mode() -> None:
+    result = _FakeFetcher().fetch(_access("https://example.com/data.parquet"))
+    assert result.mode is FetchMode.MATERIALIZE
+    assert result.data == "rows@https://example.com/data.parquet"
+
+
+def test_reference_scan_receives_pushdown_extent() -> None:
+    result = _FakeFetcher().virtual_table(
+        _access("https://example.com/d.parquet"), extent=(0, 0, 1, 1)
+    )
+    assert "bbox=(0, 0, 1, 1)" in result.metadata[DUCKDB_SCAN_KEY]
+
+
+# --------------------------------------------------------------------------
+# SSRF guard (#199)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("mode", [FetchMode.REFERENCE, FetchMode.MATERIALIZE])
+def test_fetch_rejects_private_address(mode: FetchMode) -> None:
+    with pytest.raises(SSRFError):
+        _FakeFetcher().fetch(_access("http://127.0.0.1/secret.parquet"), mode=mode)
+
+
+def test_guard_leaves_local_file_paths_alone() -> None:
+    # A non-HTTP endpoint (a local file) is not an SSRF vector.
+    result = _FakeFetcher().virtual_table(_access("/tmp/local.parquet"))
+    assert result.metadata[DUCKDB_SCAN_KEY] == "read_parquet('/tmp/local.parquet')"
+
+
+# --------------------------------------------------------------------------
+# register_core_fetchers
+# --------------------------------------------------------------------------
+
+
+def test_register_core_fetchers_empty_roster_is_safe() -> None:
+    # A2 ships no concrete fetcher yet — registering must be a no-op, not a
+    # crash, until A3-A6 populate the roster.
+    assert register_core_fetchers(ProtocolRegistry()) == 0
+
+
+def test_register_core_fetchers_defaults_to_global_registry() -> None:
+    assert register_core_fetchers() == 0  # touches PROTOCOLS, registers nothing
+    assert isinstance(PROTOCOLS, ProtocolRegistry)
+
+
+def test_fake_fetcher_registers_into_a_registry() -> None:
+    reg = ProtocolRegistry()
+    reg.register(_FakeFetcher())
+    fetched = reg.get_fetcher(AccessProtocol.REMOTE_TABLE)
+    assert isinstance(fetched, _FakeFetcher)
+
+
+# --------------------------------------------------------------------------
+# SourceEntryRef classification axes (issue #227)
+# --------------------------------------------------------------------------
+
+
+def test_source_entry_ref_axes_default_to_none() -> None:
+    # Pre-#227 construction still works — axes are additive & optional.
+    ref = SourceEntryRef(id="e1", name="Entry", access=_access("https://x/d.parquet"))
+    assert ref.domain is None
+    assert ref.payload is None
+    assert ref.jurisdiction is None
+
+
+def test_source_entry_ref_accepts_classification_axes() -> None:
+    ref = SourceEntryRef(
+        id="overture-places",
+        name="Overture Places",
+        access=_access("https://example.com/places.parquet"),
+        domain=SourceDomain.OBSERVATION,
+        payload=Payload.VECTOR,
+        jurisdiction="world",
+    )
+    assert ref.domain is SourceDomain.OBSERVATION
+    assert ref.payload is Payload.VECTOR
+    assert ref.jurisdiction == "world"


### PR DESCRIPTION
Tranche **foundation** de l'agrégateur de données géo mondiales (EPIC #226, v1.9.0).
Couvre 3 issues sans interdépendance avec les fetchers concrets A3-A6.

## A1 — `SourceEntryRef` axes de classification (#227)
3 champs **additifs optionnels** : `domain` (`SourceDomain`), `payload` (`Payload`),
`jurisdiction` (str libre, ex. `"FR"`/`"world"`). Le catalogue mondial filtrera sur ces
3 axes + `access.protocol`. Toute construction pré-#227 reste valide (défaut `None`).

## A2 — Package `core/fetchers/` + `LazyFetcher` (#228)
Nouveau package + base `LazyFetcher` (ABC) : garde SSRF (#199) et dispatch `FetchMode`
factorisés — un adaptateur concret n'écrit que le transport. `virtual_table()` produit
un `SourceResult` `REFERENCE` portant le SQL de scan DuckDB sous
`metadata['duckdb_scan']` (consommé par le `VirtualDatasetRegistry`, A9).
`register_core_fetchers()` parcourt un roster vide jusqu'à ce que A3-A6 le peuplent.
Une instance `LazyFetcher` satisfait structurellement le protocole `Fetcher` → registre
direct dans `PROTOCOLS`.

## A7 — `DuckDBSession.open()` charge `httpfs` (#233)
`open()` charge `httpfs` en best-effort à côté de `spatial`, via un helper partagé
`_load_extension()`. Un échec (pas de réseau, hôte verrouillé) est loggé et avalé : le
chemin GPKG hors-ligne n'est jamais cassé.

## Tests
`test_fetchers_base.py` (dispatch mode, scan lazy, SSRF rejette IP privée, register
roster, axes `SourceEntryRef`) + couverture httpfs dans `test_duckdb_engine.py`.
**139 tests verts**, `ruff` clean. Aucun test réseau.

Closes #227, #228, #233. Avance EPIC #226.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
