### PR TITLE
feat(v19): concrete core fetchers — geoparquet-s3, ogc-features, stac, http-file (#229-#232)

### DIFF
--- a/src/gispulse/core/fetchers/__init__.py
+++ b/src/gispulse/core/fetchers/__init__.py
@@ -29,14 +29,22 @@ def _core_fetchers() -> list[LazyFetcher]:
 
     Each of issues A3-A6 appends its adapter import here. Kept as a
     function (not a module-level list) so the heavy per-protocol imports
-    stay lazy — ``import gispulse`` must not pull DuckDB / httpx.
+    stay lazy — ``import gispulse`` must not pull DuckDB / httpx. The
+    fetcher *modules* themselves only import the stdlib + ``core`` at
+    module scope; their DuckDB / httpx / client imports are deferred into
+    the fetch methods, so this roster is cheap to build.
     """
-    fetchers: list[LazyFetcher] = []
-    # A3 #229 — from .geoparquet_s3 import GeoParquetS3Fetcher; fetchers.append(...)
-    # A4 #230 — from .ogc_features  import OGCFeaturesFetcher;  fetchers.append(...)
-    # A5 #231 — from .stac          import STACFetcher;         fetchers.append(...)
-    # A6 #232 — from .http_file     import HttpFileFetcher;     fetchers.append(...)
-    return fetchers
+    from .geoparquet_s3 import GeoParquetS3Fetcher  # A3 #229 — REMOTE_TABLE
+    from .http_file import HttpFileFetcher          # A6 #232 — DOWNLOAD
+    from .ogc_features import OGCFeaturesFetcher    # A4 #230 — OGC_FEATURES
+    from .stac import STACFetcher                   # A5 #231 — STAC
+
+    return [
+        GeoParquetS3Fetcher(),
+        OGCFeaturesFetcher(),
+        STACFetcher(),
+        HttpFileFetcher(),
+    ]
 
 
 def register_core_fetchers(

--- a/src/gispulse/core/fetchers/geoparquet_s3.py
+++ b/src/gispulse/core/fetchers/geoparquet_s3.py
@@ -1,0 +1,131 @@
+"""A3 (issue #229) — remote GeoParquet fetcher for the worldwide aggregator.
+
+``GeoParquetS3Fetcher`` is the core transport adapter for
+:attr:`~gispulse.core.plugin_model.AccessProtocol.REMOTE_TABLE`: a Hive-
+partitioned GeoParquet lake reachable over ``s3://`` / ``https://`` and
+read zero-copy by DuckDB ``httpfs`` (loaded by ``DuckDBSession.open()``,
+A7).
+
+The lazy path emits a ``read_parquet(...)`` scan; when a bounding box is
+supplied it is pushed down against the Overture ``bbox`` struct column
+(``bbox.xmin/.ymin/.xmax/.ymax``) so DuckDB prunes row groups before any
+bytes leave the lake. The materialise path runs a ``COPY ... TO`` into a
+local ``.parquet`` file.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from gispulse.core.fetchers.base import LazyFetcher
+from gispulse.core.logging import get_logger
+from gispulse.core.plugin_model import (
+    AccessProtocol,
+    AccessSpec,
+    FetchMode,
+    Payload,
+    SourceResult,
+)
+
+log = get_logger(__name__)
+
+__all__ = ["GeoParquetS3Fetcher"]
+
+
+def _bbox_predicate(extent: Any | None, column: str) -> str | None:
+    """Build a DuckDB ``WHERE`` predicate against an Overture ``bbox`` struct.
+
+    Returns ``None`` when ``extent`` is falsy. The predicate keeps every
+    row whose ``bbox`` struct *intersects* ``extent`` — a standard
+    separating-axis test on ``(xmin, ymin, xmax, ymax)``.
+    """
+    if not extent:
+        return None
+    minx, miny, maxx, maxy = (float(c) for c in extent)
+    return (
+        f"{column}.xmin <= {maxx} AND {column}.xmax >= {minx} "
+        f"AND {column}.ymin <= {maxy} AND {column}.ymax >= {miny}"
+    )
+
+
+class GeoParquetS3Fetcher(LazyFetcher):
+    """Remote GeoParquet lake adapter — lazy ``read_parquet`` + ``COPY``.
+
+    ``access.params`` recognised keys:
+
+    * ``bbox_column`` — name of the Overture-style struct column used for
+      bbox pushdown (default ``"bbox"``).
+    * ``hive_partitioning`` — set ``False`` to disable Hive partition
+      inference (default ``True``).
+    * ``glob`` — scan suffix appended to the endpoint (default ``"/**"``);
+      pass ``""`` when the endpoint is a single ``.parquet`` file.
+    """
+
+    protocol: ClassVar[AccessProtocol] = AccessProtocol.REMOTE_TABLE
+    payload: ClassVar[Payload] = Payload.VECTOR
+
+    # -- internal helpers --------------------------------------------------
+
+    @staticmethod
+    def _scan_glob(access: AccessSpec) -> str:
+        """Endpoint + glob suffix — a single URI DuckDB can ``read_parquet``."""
+        glob = access.params.get("glob", "/**")
+        endpoint = access.endpoint.rstrip("/") if glob else access.endpoint
+        return f"{endpoint}{glob}"
+
+    @classmethod
+    def _read_parquet(cls, access: AccessSpec) -> str:
+        """``read_parquet('<uri>', hive_partitioning=true)`` table function."""
+        uri = cls._scan_glob(access).replace("'", "''")
+        hive = access.params.get("hive_partitioning", True)
+        hive_sql = "true" if hive else "false"
+        return f"read_parquet('{uri}', hive_partitioning={hive_sql})"
+
+    # -- LazyFetcher hooks -------------------------------------------------
+
+    def _reference_scan(self, access: AccessSpec, extent: Any | None) -> str:
+        """Lazy scan: ``read_parquet`` wrapped in a bbox sub-query if needed."""
+        scan = self._read_parquet(access)
+        column = access.params.get("bbox_column", "bbox")
+        predicate = _bbox_predicate(extent, column)
+        if predicate is None:
+            return scan
+        # Wrap in a sub-query so the pushed-down WHERE survives whatever
+        # the VirtualDatasetRegistry (A9 #235) wraps the scan with.
+        return f"(SELECT * FROM {scan} WHERE {predicate})"
+
+    def _materialize(self, access: AccessSpec, extent: Any | None) -> SourceResult:
+        """Copy the (optionally bbox-clipped) lake into a local parquet file.
+
+        DuckDB / :class:`DuckDBSession` are imported lazily — ``import
+        gispulse`` must stay free of the engine. The destination path is
+        carried in ``access.params['local_path']`` (default: a temp file).
+        """
+        import tempfile
+
+        from gispulse.persistence.duckdb_engine import DuckDBSession
+
+        local_path = access.params.get("local_path")
+        if not local_path:
+            handle = tempfile.NamedTemporaryFile(suffix=".parquet", delete=False)
+            handle.close()
+            local_path = handle.name
+
+        select = self._reference_scan(access, extent)
+        # _reference_scan already yields either a table function or a
+        # sub-query; both are valid in a FROM clause.
+        dest = str(local_path).replace("'", "''")
+        copy_sql = (
+            f"COPY (SELECT * FROM {select}) TO '{dest}' (FORMAT PARQUET)"
+        )
+        # DuckDBSession.open() loads httpfs + spatial (A7).
+        with DuckDBSession() as session:
+            session.conn.execute(copy_sql)
+        log.info("geoparquet_materialized", path=local_path)
+        return SourceResult(
+            payload=self.payload,
+            mode=FetchMode.MATERIALIZE,
+            data=local_path,
+            extent=tuple(extent) if extent else None,
+            metadata={"copy_sql": copy_sql},
+        )

--- a/src/gispulse/core/fetchers/http_file.py
+++ b/src/gispulse/core/fetchers/http_file.py
@@ -1,0 +1,151 @@
+"""A6 (issue #232) — remote-file fetcher for the worldwide aggregator.
+
+``HttpFileFetcher`` is the core transport adapter for
+:attr:`~gispulse.core.plugin_model.AccessProtocol.DOWNLOAD`: a plain
+remote file (CSV with lat/lon columns, GeoJSON, GeoPackage, …) reached
+over HTTP.
+
+The lazy path leans on DuckDB's ``/vsicurl/`` GDAL streaming so the file
+is read in place by ``ST_Read`` (spatial formats) or ``read_csv_auto``
+(point CSVs). The materialise path streams the file to local disk with
+``httpx`` — both heavy imports stay inside the methods.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from gispulse.core.fetchers.base import LazyFetcher
+from gispulse.core.logging import get_logger
+from gispulse.core.plugin_model import (
+    AccessProtocol,
+    AccessSpec,
+    FetchMode,
+    Payload,
+    SourceResult,
+)
+
+log = get_logger(__name__)
+
+__all__ = ["HttpFileFetcher"]
+
+#: File extensions DuckDB's ``spatial`` extension reads through ``ST_Read``
+#: (the GDAL/OGR driver). A CSV is handled separately — it needs explicit
+#: lat/lon → geometry construction.
+_SPATIAL_SUFFIXES = (".geojson", ".json", ".gpkg", ".fgb", ".shp", ".gml")
+
+
+def _vsicurl(endpoint: str) -> str:
+    """Wrap an HTTP(S) endpoint in a GDAL ``/vsicurl/`` virtual path.
+
+    Local paths and already-wrapped paths are returned untouched, so the
+    same fetcher serves offline fixtures.
+    """
+    if endpoint.startswith(("http://", "https://")):
+        return f"/vsicurl/{endpoint}"
+    return endpoint
+
+
+class HttpFileFetcher(LazyFetcher):
+    """Remote single-file adapter — ``/vsicurl/`` lazy scan + streamed download.
+
+    ``access.params`` recognised keys:
+
+    * ``lat`` / ``lon`` — column names for a point CSV (default
+      ``"latitude"`` / ``"longitude"``); only consulted for ``.csv``.
+    * ``layer`` — layer name for a multi-layer source (GPKG).
+    * ``local_path`` — materialise destination (default: a temp file).
+
+    The payload is declared :attr:`~gispulse.core.plugin_model.Payload.VECTOR`
+    — the v1.9.0 download protocol targets vector files.
+    """
+
+    protocol: ClassVar[AccessProtocol] = AccessProtocol.DOWNLOAD
+    payload: ClassVar[Payload] = Payload.VECTOR
+
+    # -- internal helpers --------------------------------------------------
+
+    @staticmethod
+    def _is_csv(endpoint: str) -> bool:
+        return endpoint.split("?")[0].lower().endswith(".csv")
+
+    @staticmethod
+    def _bbox_clause(extent: Any | None, geom_expr: str) -> str:
+        """``WHERE`` clause keeping geometries inside ``extent``, or ``""``."""
+        if not extent:
+            return ""
+        minx, miny, maxx, maxy = (float(c) for c in extent)
+        envelope = (
+            f"ST_MakeEnvelope({minx}, {miny}, {maxx}, {maxy})"
+        )
+        return f" WHERE ST_Intersects({geom_expr}, {envelope})"
+
+    def _csv_scan(self, access: AccessSpec, extent: Any | None) -> str:
+        """Point-CSV scan: ``read_csv_auto`` + ``ST_Point`` geometry build."""
+        uri = _vsicurl(access.endpoint).replace("'", "''")
+        lat = access.params.get("lat", "latitude")
+        lon = access.params.get("lon", "longitude")
+        geom = f'ST_Point("{lon}", "{lat}")'
+        where = self._bbox_clause(extent, geom)
+        return (
+            f"(SELECT *, {geom} AS geometry "
+            f"FROM read_csv_auto('{uri}'){where})"
+        )
+
+    def _spatial_scan(self, access: AccessSpec, extent: Any | None) -> str:
+        """Spatial-file scan via ``ST_Read`` (GeoJSON / GPKG / FGB / SHP)."""
+        uri = _vsicurl(access.endpoint).replace("'", "''")
+        layer = access.params.get("layer")
+        st_read = f"ST_Read('{uri}'"
+        if layer:
+            st_read += f", layer='{str(layer).replace(chr(39), chr(39) * 2)}'"
+        st_read += ")"
+        where = self._bbox_clause(extent, "geom")
+        if not where:
+            return st_read
+        return f"(SELECT * FROM {st_read}{where})"
+
+    # -- LazyFetcher hooks -------------------------------------------------
+
+    def _reference_scan(self, access: AccessSpec, extent: Any | None) -> str:
+        """Lazy scan — CSV gets ``read_csv_auto``, everything else ``ST_Read``.
+
+        An unrecognised suffix falls through to ``ST_Read``; GDAL probes
+        the driver from the file content.
+        """
+        endpoint_l = access.endpoint.split("?")[0].lower()
+        if self._is_csv(access.endpoint):
+            return self._csv_scan(access, extent)
+        if not endpoint_l.endswith(_SPATIAL_SUFFIXES):
+            log.debug("http_file_unknown_suffix", endpoint=access.endpoint)
+        return self._spatial_scan(access, extent)
+
+    def _materialize(self, access: AccessSpec, extent: Any | None) -> SourceResult:
+        """Stream the remote file to local disk with ``httpx``.
+
+        ``extent`` is not applied here — a raw file download is verbatim;
+        spatial clipping happens once the copy is loaded. The path is
+        returned in :attr:`SourceResult.data`.
+        """
+        import tempfile
+
+        import httpx
+
+        local_path = access.params.get("local_path")
+        if not local_path:
+            suffix = "." + access.endpoint.split("?")[0].rsplit(".", 1)[-1]
+            handle = tempfile.NamedTemporaryFile(suffix=suffix, delete=False)
+            handle.close()
+            local_path = handle.name
+
+        with httpx.stream("GET", access.endpoint, follow_redirects=True) as resp:
+            resp.raise_for_status()
+            with open(local_path, "wb") as fh:
+                for chunk in resp.iter_bytes():
+                    fh.write(chunk)
+        log.info("http_file_materialized", path=local_path)
+        return SourceResult(
+            payload=self.payload,
+            mode=FetchMode.MATERIALIZE,
+            data=local_path,
+        )

--- a/src/gispulse/core/fetchers/ogc_features.py
+++ b/src/gispulse/core/fetchers/ogc_features.py
@@ -1,0 +1,149 @@
+"""A4 (issue #230) — OGC API Features / WFS fetcher for the aggregator.
+
+``OGCFeaturesFetcher`` is the core transport adapter for
+:attr:`~gispulse.core.plugin_model.AccessProtocol.OGC_FEATURES` (it also
+covers classic ``WFS`` — both are GeoJSON-over-HTTP feature services).
+
+The lazy path emits a DuckDB ``ST_Read`` scan against the OGC API
+Features ``/items`` URL: the GDAL ``OAPIF`` driver streams the collection
+zero-copy, and the bbox is pushed down through the standard ``bbox=``
+query parameter so the server filters before sending. The materialise
+path delegates to the consolidated WFS client
+(``gispulse.adapters.ogc.wfs_client``) — the transport, pagination and
+GeoParquet caching are *not* reimplemented here.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from gispulse.core.fetchers.base import LazyFetcher
+from gispulse.core.logging import get_logger
+from gispulse.core.plugin_model import (
+    AccessProtocol,
+    AccessSpec,
+    FetchMode,
+    Payload,
+    SourceResult,
+)
+
+log = get_logger(__name__)
+
+__all__ = ["OGCFeaturesFetcher"]
+
+
+def _bbox_param(extent: Any | None) -> str | None:
+    """Render ``extent`` as an OGC API Features ``bbox`` value, or ``None``.
+
+    The OGC API Features spec expects ``minx,miny,maxx,maxy`` (CRS84).
+    """
+    if not extent:
+        return None
+    return ",".join(str(float(c)) for c in extent)
+
+
+class OGCFeaturesFetcher(LazyFetcher):
+    """OGC API Features / WFS adapter — lazy ``ST_Read`` + WFS-client copy.
+
+    ``access.params`` recognised keys:
+
+    * ``collection`` / ``layer_name`` — the collection (``typeName``) to
+      fetch. Required for both modes.
+    * ``version`` — WFS version for the materialise path (default
+      ``"2.0.0"``).
+    * ``crs`` — requested SRS (default ``"EPSG:4326"``).
+    * ``source_type`` — ``"wfs"`` or ``"ogc_api_features"`` (default
+      ``"ogc_api_features"``) — selects the materialise client function.
+    * ``max_features`` — per-page limit handed to the WFS client.
+
+    ``access.endpoint`` is the service base URL (the landing page for
+    OGC API Features, the WFS endpoint for classic WFS).
+    """
+
+    protocol: ClassVar[AccessProtocol] = AccessProtocol.OGC_FEATURES
+    payload: ClassVar[Payload] = Payload.VECTOR
+
+    # -- internal helpers --------------------------------------------------
+
+    @staticmethod
+    def _collection(access: AccessSpec) -> str:
+        """The collection / typeName, from ``params``. Raises if absent."""
+        coll = access.params.get("collection") or access.params.get("layer_name")
+        if not coll:
+            raise ValueError(
+                "OGCFeaturesFetcher needs access.params['collection'] "
+                "(the OGC API Features collection / WFS typeName)"
+            )
+        return str(coll)
+
+    def _items_url(self, access: AccessSpec, extent: Any | None) -> str:
+        """Build the ``/collections/<id>/items`` URL with a bbox query.
+
+        GDAL's ``OAPIF`` driver consumes this URL directly; the ``bbox``
+        query parameter is the OGC-standard server-side spatial filter.
+        """
+        base = access.endpoint.rstrip("/")
+        url = f"{base}/collections/{self._collection(access)}/items"
+        bbox = _bbox_param(extent)
+        sep = "&" if "?" in url else "?"
+        url = f"{url}{sep}f=json"
+        if bbox is not None:
+            url = f"{url}&bbox={bbox}"
+        return url
+
+    # -- LazyFetcher hooks -------------------------------------------------
+
+    def _reference_scan(self, access: AccessSpec, extent: Any | None) -> str:
+        """Lazy scan: ``ST_Read('<items-url>')`` — GDAL OAPIF, bbox pushed down.
+
+        The bbox is carried inside the URL (the OGC API ``bbox`` query
+        parameter), so the server — not DuckDB — does the filtering.
+        """
+        url = self._items_url(access, extent).replace("'", "''")
+        return f"ST_Read('{url}')"
+
+    def _materialize(self, access: AccessSpec, extent: Any | None) -> SourceResult:
+        """Download the collection via the consolidated WFS client.
+
+        Delegates to :func:`gispulse.adapters.ogc.wfs_client.fetch_wfs`
+        or :func:`~gispulse.adapters.ogc.wfs_client.fetch_ogc_api_features`
+        — the transport, pagination and caching live there (no reinvented
+        WFS client). The result GeoDataFrame is returned in
+        :attr:`SourceResult.data`.
+        """
+        from gispulse.adapters.ogc.wfs_client import (
+            fetch_ogc_api_features,
+            fetch_wfs,
+        )
+        from gispulse.core.models import OGCSourceConfig
+
+        source_type = str(
+            access.params.get("source_type", "ogc_api_features")
+        ).lower()
+        cfg = OGCSourceConfig(
+            source_type="wfs" if source_type == "wfs" else "ogc_api_features",
+            url=access.endpoint,
+            layer_name=self._collection(access),
+            version=str(access.params.get("version", "2.0.0")),
+            crs=str(access.params.get("crs", "EPSG:4326")),
+            auth=access.params.get("auth"),
+            max_features=access.params.get("max_features"),
+            params=dict(access.params.get("query", {})),
+        )
+        bbox = tuple(float(c) for c in extent) if extent else None
+        if cfg.source_type == "wfs":
+            gdf = fetch_wfs(cfg, bbox=bbox)
+        else:
+            gdf = fetch_ogc_api_features(cfg, bbox=bbox)
+        log.info(
+            "ogc_features_materialized",
+            collection=cfg.layer_name,
+            rows=len(gdf),
+        )
+        return SourceResult(
+            payload=self.payload,
+            mode=FetchMode.MATERIALIZE,
+            data=gdf,
+            crs=cfg.crs,
+            extent=bbox,
+        )

--- a/src/gispulse/core/fetchers/stac.py
+++ b/src/gispulse/core/fetchers/stac.py
@@ -1,0 +1,160 @@
+"""A5 (issue #231) — STAC fetcher for the worldwide aggregator.
+
+``STACFetcher`` is the core transport adapter for
+:attr:`~gispulse.core.plugin_model.AccessProtocol.STAC`: a SpatioTemporal
+Asset Catalog whose items expose Cloud-Optimized GeoTIFF assets.
+
+Both modes wrap the consolidated STAC client
+(``gispulse.catalog.providers.stac_client.STACClient``) — the catalog
+search, the optional ``pystac-client`` path and the Planetary Computer
+signing are *not* reimplemented here.
+
+* lazy (``REFERENCE``) — search the catalog and return the chosen COG
+  asset href in :attr:`SourceResult.reference`; the raster is consumed
+  live by ``rasterio`` / GDAL ``/vsicurl/``. The STAC ``bbox`` is the
+  spatial pushdown — the catalog filters items server-side.
+* materialise (``MATERIALIZE``) — call ``STACClient.download_asset`` to
+  pull the COG to local disk.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from gispulse.core.fetchers.base import LazyFetcher
+from gispulse.core.logging import get_logger
+from gispulse.core.plugin_model import (
+    AccessProtocol,
+    AccessSpec,
+    FetchMode,
+    Payload,
+    SourceResult,
+)
+
+log = get_logger(__name__)
+
+__all__ = ["STACFetcher"]
+
+#: Default STAC asset key — most COG catalogs publish a browse asset
+#: under ``"visual"``; override via ``access.params['asset']``.
+_DEFAULT_ASSET = "visual"
+
+
+class STACFetcher(LazyFetcher):
+    """STAC catalog adapter — lazy COG href + ``download_asset`` materialise.
+
+    ``access.params`` recognised keys:
+
+    * ``collections`` — list of STAC collection IDs to search (required).
+    * ``datetime`` — ISO 8601 date / interval (default ``""`` = any).
+    * ``asset`` — asset key to expose / download (default ``"visual"``).
+    * ``query`` — CQL2 / STAC query-extension dict (e.g. cloud-cover).
+    * ``limit`` — max items returned by the search (default ``10``).
+    * ``output_dir`` — materialise destination directory (default a temp
+      dir).
+
+    ``access.endpoint`` is the STAC catalog root URL. ``extent`` is the
+    search bbox ``(minx, miny, maxx, maxy)`` in EPSG:4326 — it is the
+    spatial pushdown handed straight to ``STACClient.search``.
+
+    The payload is :attr:`~gispulse.core.plugin_model.Payload.RASTER`.
+    """
+
+    protocol: ClassVar[AccessProtocol] = AccessProtocol.STAC
+    payload: ClassVar[Payload] = Payload.RASTER
+
+    # -- internal helpers --------------------------------------------------
+
+    @staticmethod
+    def _collections(access: AccessSpec) -> list[str]:
+        """The STAC collection IDs to search. Raises if absent."""
+        cols = access.params.get("collections")
+        if not cols:
+            raise ValueError(
+                "STACFetcher needs access.params['collections'] "
+                "(a non-empty list of STAC collection IDs)"
+            )
+        return [str(c) for c in cols]
+
+    @staticmethod
+    def _bbox(extent: Any | None) -> list[float]:
+        """``extent`` as a STAC bbox list, or worldwide when ``None``.
+
+        A search needs a bbox; ``None`` means 'no spatial pushdown' →
+        the whole-world extent.
+        """
+        if not extent:
+            return [-180.0, -90.0, 180.0, 90.0]
+        return [float(c) for c in extent]
+
+    def _search(self, access: AccessSpec, extent: Any | None) -> list[dict]:
+        """Run the catalog search — the bbox is the spatial pushdown."""
+        from gispulse.catalog.providers.stac_client import STACClient
+
+        client = STACClient(access.endpoint)
+        return client.search(
+            bbox=self._bbox(extent),
+            datetime=str(access.params.get("datetime", "")),
+            collections=self._collections(access),
+            limit=int(access.params.get("limit", 10)),
+            query=access.params.get("query"),
+        )
+
+    # -- LazyFetcher hooks -------------------------------------------------
+
+    def _reference_scan(self, access: AccessSpec, extent: Any | None) -> str:
+        """Return the first matching COG asset href — *not* a DuckDB scan.
+
+        STAC yields rasters; a raster ``REFERENCE`` is a COG URL consumed
+        live by GDAL, not a SQL table function. The base stores this
+        string under ``metadata[DUCKDB_SCAN_KEY]`` and also echoes
+        ``access.endpoint`` in ``SourceResult.reference``; the COG href is
+        the load-bearing value here.
+        """
+        items = self._search(access, extent)
+        if not items:
+            raise LookupError(
+                f"STAC search returned no items for {access.endpoint!r} "
+                f"(collections={self._collections(access)})"
+            )
+        asset_key = str(access.params.get("asset", _DEFAULT_ASSET))
+        assets = items[0].get("assets", {})
+        if asset_key not in assets:
+            raise KeyError(
+                f"asset {asset_key!r} absent from STAC item; "
+                f"available: {sorted(assets)}"
+            )
+        href = assets[asset_key].get("href", "")
+        if not href:
+            raise KeyError(f"STAC asset {asset_key!r} has no 'href'")
+        log.debug("stac_reference_href", asset=asset_key)
+        return str(href)
+
+    def _materialize(self, access: AccessSpec, extent: Any | None) -> SourceResult:
+        """Download the chosen COG asset via ``STACClient.download_asset``.
+
+        Transport / signing live in the STAC client — this only picks the
+        first matching item and hands the asset key over.
+        """
+        import tempfile
+
+        from gispulse.catalog.providers.stac_client import STACClient
+
+        items = self._search(access, extent)
+        if not items:
+            raise LookupError(
+                f"STAC search returned no items for {access.endpoint!r}"
+            )
+        asset_key = str(access.params.get("asset", _DEFAULT_ASSET))
+        output_dir = access.params.get("output_dir") or tempfile.mkdtemp(
+            prefix="gispulse-stac-"
+        )
+        client = STACClient(access.endpoint)
+        local_path = client.download_asset(items[0], asset_key, str(output_dir))
+        log.info("stac_materialized", path=local_path, asset=asset_key)
+        return SourceResult(
+            payload=self.payload,
+            mode=FetchMode.MATERIALIZE,
+            data=local_path,
+            extent=tuple(float(c) for c in extent) if extent else None,
+        )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,40 @@
+"""Pytest fixtures for the v1.9.0 core-fetcher tests (#229-#232).
+
+The :class:`~gispulse.core.fetchers.base.LazyFetcher` SSRF guard (#199)
+does a real DNS resolution. CI must do **zero network**, so the tests
+patch :func:`gispulse.core.ssrf.resolve_all` to map every test host to a
+fixed *public* IP — the rest of the guard logic (``is_blocked_address``)
+then runs for real. Loopback / private literals such as ``127.0.0.1``
+are passed straight through (no DNS needed) so the SSRF-rejection tests
+still exercise the genuine block path.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+#: A globally-routable public IP. is_blocked_address() rejects private /
+#: loopback / link-local / *reserved* ranges — RFC-5737 documentation IPs
+#: (203.0.113.x) are flagged reserved, so a genuinely public address is
+#: needed for the test hosts to pass the SSRF guard.
+_PUBLIC_TEST_IP = "8.8.8.8"
+
+
+@pytest.fixture
+def offline_ssrf(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Resolve every non-literal test host to a public IP — no network.
+
+    A host that is already an IP literal (e.g. ``127.0.0.1``) is returned
+    verbatim, so the SSRF guard still blocks loopback/private addresses.
+    """
+
+    def _fake_resolve(hostname: str) -> list[str]:
+        # An IP literal: hand it back so is_blocked_address judges it.
+        parts = hostname.split(".")
+        if len(parts) == 4 and all(p.isdigit() for p in parts):
+            return [hostname]
+        return [_PUBLIC_TEST_IP]
+
+    import gispulse.core.ssrf as ssrf
+
+    monkeypatch.setattr(ssrf, "resolve_all", _fake_resolve)

--- a/tests/unit/test_fetchers_base.py
+++ b/tests/unit/test_fetchers_base.py
@@ -120,15 +120,38 @@ def test_guard_leaves_local_file_paths_alone() -> None:
 # --------------------------------------------------------------------------
 
 
-def test_register_core_fetchers_empty_roster_is_safe() -> None:
-    # A2 ships no concrete fetcher yet — registering must be a no-op, not a
-    # crash, until A3-A6 populate the roster.
-    assert register_core_fetchers(ProtocolRegistry()) == 0
+def test_register_core_fetchers_registers_the_full_roster() -> None:
+    # A3-A6 (#229-#232) populate the roster: four generic transport
+    # adapters, one per AccessProtocol family.
+    reg = ProtocolRegistry()
+    assert register_core_fetchers(reg) == 4
+    for protocol in (
+        AccessProtocol.REMOTE_TABLE,
+        AccessProtocol.OGC_FEATURES,
+        AccessProtocol.STAC,
+        AccessProtocol.DOWNLOAD,
+    ):
+        assert isinstance(reg.get_fetcher(protocol), LazyFetcher)
 
 
 def test_register_core_fetchers_defaults_to_global_registry() -> None:
-    assert register_core_fetchers() == 0  # touches PROTOCOLS, registers nothing
-    assert isinstance(PROTOCOLS, ProtocolRegistry)
+    # register_core_fetchers() with no argument files the four core
+    # adapters into the process-wide PROTOCOLS registry. It is destructive
+    # (override=True) — snapshot and restore so this test does not bleed
+    # into the #192 adapters that self-register into PROTOCOLS at import.
+    saved_fetchers = dict(PROTOCOLS._fetchers)
+    saved_writers = dict(PROTOCOLS._writers)
+    try:
+        assert register_core_fetchers() == 4  # touches PROTOCOLS
+        assert isinstance(PROTOCOLS, ProtocolRegistry)
+        assert isinstance(
+            PROTOCOLS.get_fetcher(AccessProtocol.REMOTE_TABLE), LazyFetcher
+        )
+    finally:
+        PROTOCOLS._fetchers.clear()
+        PROTOCOLS._fetchers.update(saved_fetchers)
+        PROTOCOLS._writers.clear()
+        PROTOCOLS._writers.update(saved_writers)
 
 
 def test_fake_fetcher_registers_into_a_registry() -> None:

--- a/tests/unit/test_geoparquet_s3_fetcher.py
+++ b/tests/unit/test_geoparquet_s3_fetcher.py
@@ -1,0 +1,141 @@
+"""Unit tests for A3 (#229) — ``GeoParquetS3Fetcher``.
+
+Zero network: the lazy path is pure SQL string-building, and the
+materialise path's only network actor (``DuckDBSession``) is monkey-
+patched with a recording fake.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gispulse.core.fetchers import DUCKDB_SCAN_KEY
+from gispulse.core.fetchers.geoparquet_s3 import GeoParquetS3Fetcher
+from gispulse.core.plugin_model import (
+    AccessProtocol,
+    AccessSpec,
+    FetchMode,
+    Payload,
+)
+from gispulse.core.ssrf import SSRFError
+
+# Every test exercises the LazyFetcher SSRF guard; the offline_ssrf
+# fixture (tests/unit/conftest.py) keeps DNS resolution off the network.
+pytestmark = pytest.mark.usefixtures("offline_ssrf")
+
+
+def _access(endpoint: str, **params: object) -> AccessSpec:
+    return AccessSpec(
+        protocol=AccessProtocol.REMOTE_TABLE, endpoint=endpoint, params=params
+    )
+
+
+# -- contract ---------------------------------------------------------------
+
+
+def test_protocol_and_payload() -> None:
+    assert GeoParquetS3Fetcher.protocol is AccessProtocol.REMOTE_TABLE
+    assert GeoParquetS3Fetcher.payload is Payload.VECTOR
+
+
+# -- lazy scan --------------------------------------------------------------
+
+
+def test_reference_scan_emits_read_parquet_with_hive() -> None:
+    result = GeoParquetS3Fetcher().virtual_table(
+        _access("s3://overture/release")
+    )
+    scan = result.metadata[DUCKDB_SCAN_KEY]
+    assert scan == (
+        "read_parquet('s3://overture/release/**', hive_partitioning=true)"
+    )
+    assert result.mode is FetchMode.REFERENCE
+    assert result.data is None
+
+
+def test_reference_scan_pushdown_bbox_against_overture_struct() -> None:
+    result = GeoParquetS3Fetcher().virtual_table(
+        _access("s3://overture/release"), extent=(1.0, 2.0, 3.0, 4.0)
+    )
+    scan = result.metadata[DUCKDB_SCAN_KEY]
+    # Wrapped in a sub-query carrying the bbox-struct WHERE predicate.
+    assert scan.startswith("(SELECT * FROM read_parquet(")
+    assert "bbox.xmin <= 3.0" in scan
+    assert "bbox.xmax >= 1.0" in scan
+    assert "bbox.ymin <= 4.0" in scan
+    assert "bbox.ymax >= 2.0" in scan
+
+
+def test_reference_scan_custom_bbox_column() -> None:
+    result = GeoParquetS3Fetcher().virtual_table(
+        _access("s3://lake/data", bbox_column="geo_bbox"),
+        extent=(0, 0, 1, 1),
+    )
+    assert "geo_bbox.xmin" in result.metadata[DUCKDB_SCAN_KEY]
+
+
+def test_reference_scan_single_file_no_glob() -> None:
+    result = GeoParquetS3Fetcher().virtual_table(
+        _access("https://host/places.parquet", glob="")
+    )
+    assert result.metadata[DUCKDB_SCAN_KEY] == (
+        "read_parquet('https://host/places.parquet', hive_partitioning=true)"
+    )
+
+
+def test_reference_scan_hive_can_be_disabled() -> None:
+    result = GeoParquetS3Fetcher().virtual_table(
+        _access("s3://lake/data", hive_partitioning=False)
+    )
+    assert "hive_partitioning=false" in result.metadata[DUCKDB_SCAN_KEY]
+
+
+# -- mode dispatch ----------------------------------------------------------
+
+
+def test_fetch_materialize_runs_copy_to_parquet(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: object
+) -> None:
+    executed: list[str] = []
+
+    class _FakeConn:
+        def execute(self, sql: str) -> None:
+            executed.append(sql)
+
+    class _FakeSession:
+        conn = _FakeConn()
+
+        def __enter__(self) -> "_FakeSession":
+            return self
+
+        def __exit__(self, *exc: object) -> None:
+            return None
+
+    import gispulse.persistence.duckdb_engine as duckdb_engine
+
+    monkeypatch.setattr(duckdb_engine, "DuckDBSession", _FakeSession)
+
+    dest = str(tmp_path / "out.parquet")  # type: ignore[operator]
+    result = GeoParquetS3Fetcher().fetch(
+        _access("s3://overture/release", local_path=dest),
+        mode=FetchMode.MATERIALIZE,
+        extent=(0, 0, 10, 10),
+    )
+    assert result.mode is FetchMode.MATERIALIZE
+    assert result.data == dest
+    assert len(executed) == 1
+    assert executed[0].startswith("COPY (SELECT * FROM ")
+    assert f"TO '{dest}' (FORMAT PARQUET)" in executed[0]
+    # bbox pushdown survives into the COPY.
+    assert "bbox.xmin" in executed[0]
+
+
+# -- SSRF guard -------------------------------------------------------------
+
+
+@pytest.mark.parametrize("mode", [FetchMode.REFERENCE, FetchMode.MATERIALIZE])
+def test_fetch_rejects_private_address(mode: FetchMode) -> None:
+    with pytest.raises(SSRFError):
+        GeoParquetS3Fetcher().fetch(
+            _access("http://127.0.0.1/lake"), mode=mode
+        )

--- a/tests/unit/test_http_file_fetcher.py
+++ b/tests/unit/test_http_file_fetcher.py
@@ -1,0 +1,156 @@
+"""Unit tests for A6 (#232) — ``HttpFileFetcher``.
+
+Zero network: the lazy path is pure SQL/URL string-building; the
+materialise path's only network actor (``httpx.stream``) is monkey-
+patched with a recording fake.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gispulse.core.fetchers import DUCKDB_SCAN_KEY
+from gispulse.core.fetchers.http_file import HttpFileFetcher
+from gispulse.core.plugin_model import (
+    AccessProtocol,
+    AccessSpec,
+    FetchMode,
+    Payload,
+)
+from gispulse.core.ssrf import SSRFError
+
+# offline_ssrf (tests/unit/conftest.py) keeps the SSRF guard's DNS
+# resolution off the network — CI does zero network.
+pytestmark = pytest.mark.usefixtures("offline_ssrf")
+
+
+def _access(endpoint: str, **params: object) -> AccessSpec:
+    return AccessSpec(
+        protocol=AccessProtocol.DOWNLOAD, endpoint=endpoint, params=params
+    )
+
+
+# -- contract ---------------------------------------------------------------
+
+
+def test_protocol_and_payload() -> None:
+    assert HttpFileFetcher.protocol is AccessProtocol.DOWNLOAD
+    assert HttpFileFetcher.payload is Payload.VECTOR
+
+
+# -- lazy scan: spatial files ----------------------------------------------
+
+
+def test_reference_scan_geojson_via_vsicurl_st_read() -> None:
+    result = HttpFileFetcher().virtual_table(
+        _access("https://host.example.org/cities.geojson")
+    )
+    assert result.metadata[DUCKDB_SCAN_KEY] == (
+        "ST_Read('/vsicurl/https://host.example.org/cities.geojson')"
+    )
+    assert result.mode is FetchMode.REFERENCE
+
+
+def test_reference_scan_gpkg_with_layer() -> None:
+    result = HttpFileFetcher().virtual_table(
+        _access("https://host.example.org/data.gpkg", layer="parcels")
+    )
+    scan = result.metadata[DUCKDB_SCAN_KEY]
+    assert "/vsicurl/https://host.example.org/data.gpkg" in scan
+    assert "layer='parcels'" in scan
+
+
+def test_reference_scan_pushdown_bbox_for_spatial_file() -> None:
+    result = HttpFileFetcher().virtual_table(
+        _access("https://host.example.org/cities.geojson"),
+        extent=(1.0, 2.0, 3.0, 4.0),
+    )
+    scan = result.metadata[DUCKDB_SCAN_KEY]
+    assert scan.startswith("(SELECT * FROM ST_Read(")
+    assert "ST_Intersects(geom, ST_MakeEnvelope(1.0, 2.0, 3.0, 4.0))" in scan
+
+
+# -- lazy scan: point CSV ---------------------------------------------------
+
+
+def test_reference_scan_csv_builds_st_point_geometry() -> None:
+    result = HttpFileFetcher().virtual_table(
+        _access(
+            "https://host.example.org/sites.csv", lat="lat", lon="lng"
+        )
+    )
+    scan = result.metadata[DUCKDB_SCAN_KEY]
+    assert 'read_csv_auto(' in scan
+    assert 'ST_Point("lng", "lat") AS geometry' in scan
+
+
+def test_reference_scan_csv_default_lat_lon_columns() -> None:
+    result = HttpFileFetcher().virtual_table(
+        _access("https://host.example.org/sites.csv")
+    )
+    assert 'ST_Point("longitude", "latitude")' in result.metadata[DUCKDB_SCAN_KEY]
+
+
+def test_reference_scan_csv_pushdown_bbox() -> None:
+    result = HttpFileFetcher().virtual_table(
+        _access("https://host.example.org/sites.csv"),
+        extent=(0.0, 0.0, 5.0, 5.0),
+    )
+    scan = result.metadata[DUCKDB_SCAN_KEY]
+    assert "ST_Intersects(" in scan
+    assert "ST_MakeEnvelope(0.0, 0.0, 5.0, 5.0)" in scan
+
+
+def test_reference_scan_local_path_not_vsicurl_wrapped() -> None:
+    result = HttpFileFetcher().virtual_table(_access("/tmp/local.geojson"))
+    assert result.metadata[DUCKDB_SCAN_KEY] == "ST_Read('/tmp/local.geojson')"
+
+
+# -- mode dispatch ----------------------------------------------------------
+
+
+def test_fetch_materialize_streams_file_to_disk(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: object
+) -> None:
+    class _FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def iter_bytes(self):
+            yield b"chunk-1"
+            yield b"chunk-2"
+
+        def __enter__(self) -> "_FakeResponse":
+            return self
+
+        def __exit__(self, *exc: object) -> None:
+            return None
+
+    def _fake_stream(method: str, url: str, **kw: object) -> _FakeResponse:
+        assert method == "GET"
+        return _FakeResponse()
+
+    import httpx
+
+    monkeypatch.setattr(httpx, "stream", _fake_stream)
+
+    dest = str(tmp_path / "out.geojson")  # type: ignore[operator]
+    result = HttpFileFetcher().fetch(
+        _access("https://host.example.org/cities.geojson", local_path=dest),
+        mode=FetchMode.MATERIALIZE,
+    )
+    assert result.mode is FetchMode.MATERIALIZE
+    assert result.data == dest
+    with open(dest, "rb") as fh:
+        assert fh.read() == b"chunk-1chunk-2"
+
+
+# -- SSRF guard -------------------------------------------------------------
+
+
+@pytest.mark.parametrize("mode", [FetchMode.REFERENCE, FetchMode.MATERIALIZE])
+def test_fetch_rejects_private_address(mode: FetchMode) -> None:
+    with pytest.raises(SSRFError):
+        HttpFileFetcher().fetch(
+            _access("http://127.0.0.1/data.geojson"), mode=mode
+        )

--- a/tests/unit/test_ogc_features_fetcher.py
+++ b/tests/unit/test_ogc_features_fetcher.py
@@ -1,0 +1,144 @@
+"""Unit tests for A4 (#230) — ``OGCFeaturesFetcher``.
+
+Zero network: the lazy path builds an ``ST_Read`` URL string, and the
+materialise path's only network actors (the WFS client functions) are
+monkey-patched with recording fakes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gispulse.core.fetchers import DUCKDB_SCAN_KEY
+from gispulse.core.fetchers.ogc_features import OGCFeaturesFetcher
+from gispulse.core.plugin_model import (
+    AccessProtocol,
+    AccessSpec,
+    FetchMode,
+    Payload,
+)
+from gispulse.core.ssrf import SSRFError
+
+# offline_ssrf (tests/unit/conftest.py) keeps the SSRF guard's DNS
+# resolution off the network — CI does zero network.
+pytestmark = pytest.mark.usefixtures("offline_ssrf")
+
+
+def _access(endpoint: str, **params: object) -> AccessSpec:
+    return AccessSpec(
+        protocol=AccessProtocol.OGC_FEATURES, endpoint=endpoint, params=params
+    )
+
+
+# -- contract ---------------------------------------------------------------
+
+
+def test_protocol_and_payload() -> None:
+    assert OGCFeaturesFetcher.protocol is AccessProtocol.OGC_FEATURES
+    assert OGCFeaturesFetcher.payload is Payload.VECTOR
+
+
+# -- lazy scan --------------------------------------------------------------
+
+
+def test_reference_scan_emits_st_read_items_url() -> None:
+    result = OGCFeaturesFetcher().virtual_table(
+        _access("https://api.example.org/ogc", collection="buildings")
+    )
+    scan = result.metadata[DUCKDB_SCAN_KEY]
+    assert scan == (
+        "ST_Read('https://api.example.org/ogc/collections/buildings"
+        "/items?f=json')"
+    )
+    assert result.mode is FetchMode.REFERENCE
+
+
+def test_reference_scan_pushdown_bbox_query_param() -> None:
+    result = OGCFeaturesFetcher().virtual_table(
+        _access("https://api.example.org/ogc", collection="parcels"),
+        extent=(1.0, 2.0, 3.0, 4.0),
+    )
+    scan = result.metadata[DUCKDB_SCAN_KEY]
+    # OGC API Features pushdown: a server-side bbox= query parameter.
+    assert "bbox=1.0,2.0,3.0,4.0" in scan
+
+
+def test_reference_scan_layer_name_alias() -> None:
+    result = OGCFeaturesFetcher().virtual_table(
+        _access("https://api.example.org/ogc", layer_name="roads")
+    )
+    assert "/collections/roads/items" in result.metadata[DUCKDB_SCAN_KEY]
+
+
+def test_missing_collection_raises() -> None:
+    with pytest.raises(ValueError, match="collection"):
+        OGCFeaturesFetcher().virtual_table(_access("https://api.example.org/ogc"))
+
+
+# -- mode dispatch ----------------------------------------------------------
+
+
+def test_fetch_materialize_delegates_to_ogc_api_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict] = []
+
+    def _fake_ogc(cfg: object, bbox: object = None) -> str:
+        calls.append({"cfg": cfg, "bbox": bbox})
+        return "GDF-ogc"
+
+    def _fake_wfs(cfg: object, bbox: object = None) -> str:  # pragma: no cover
+        raise AssertionError("WFS path must not run for source_type=ogc")
+
+    import gispulse.adapters.ogc.wfs_client as wfs_client
+
+    monkeypatch.setattr(wfs_client, "fetch_ogc_api_features", _fake_ogc)
+    monkeypatch.setattr(wfs_client, "fetch_wfs", _fake_wfs)
+
+    result = OGCFeaturesFetcher().fetch(
+        _access("https://api.example.org/ogc", collection="buildings"),
+        mode=FetchMode.MATERIALIZE,
+        extent=(0, 0, 10, 10),
+    )
+    assert result.mode is FetchMode.MATERIALIZE
+    assert result.data == "GDF-ogc"
+    assert len(calls) == 1
+    assert calls[0]["bbox"] == (0.0, 0.0, 10.0, 10.0)
+    assert calls[0]["cfg"].layer_name == "buildings"
+    assert calls[0]["cfg"].source_type == "ogc_api_features"
+
+
+def test_fetch_materialize_routes_to_wfs_when_source_type_wfs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict] = []
+
+    def _fake_wfs(cfg: object, bbox: object = None) -> str:
+        calls.append({"cfg": cfg, "bbox": bbox})
+        return "GDF-wfs"
+
+    import gispulse.adapters.ogc.wfs_client as wfs_client
+
+    monkeypatch.setattr(wfs_client, "fetch_wfs", _fake_wfs)
+
+    result = OGCFeaturesFetcher().fetch(
+        _access(
+            "https://geo.example.org/wfs",
+            collection="topp:states",
+            source_type="wfs",
+        ),
+        mode=FetchMode.MATERIALIZE,
+    )
+    assert result.data == "GDF-wfs"
+    assert calls[0]["cfg"].source_type == "wfs"
+
+
+# -- SSRF guard -------------------------------------------------------------
+
+
+@pytest.mark.parametrize("mode", [FetchMode.REFERENCE, FetchMode.MATERIALIZE])
+def test_fetch_rejects_private_address(mode: FetchMode) -> None:
+    with pytest.raises(SSRFError):
+        OGCFeaturesFetcher().fetch(
+            _access("http://127.0.0.1/ogc", collection="x"), mode=mode
+        )

--- a/tests/unit/test_stac_core_fetcher.py
+++ b/tests/unit/test_stac_core_fetcher.py
@@ -1,0 +1,161 @@
+"""Unit tests for A5 (#231) — ``STACFetcher`` (the v1.9.0 core adapter).
+
+Distinct from ``test_stac_fetcher.py``, which covers the older #192
+``adapters.stac`` fetcher. Zero network: ``STACClient`` is monkey-patched
+with a recording fake.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gispulse.core.fetchers import DUCKDB_SCAN_KEY
+from gispulse.core.fetchers.stac import STACFetcher
+from gispulse.core.plugin_model import (
+    AccessProtocol,
+    AccessSpec,
+    FetchMode,
+    Payload,
+)
+from gispulse.core.ssrf import SSRFError
+
+# offline_ssrf (tests/unit/conftest.py) keeps the SSRF guard's DNS
+# resolution off the network — CI does zero network.
+pytestmark = pytest.mark.usefixtures("offline_ssrf")
+
+_ITEMS = [
+    {
+        "id": "scene-1",
+        "assets": {
+            "B04": {"href": "https://stac.example.org/scene-1/B04.tif"},
+            "visual": {"href": "https://stac.example.org/scene-1/visual.tif"},
+        },
+    }
+]
+
+
+def _access(endpoint: str, **params: object) -> AccessSpec:
+    return AccessSpec(
+        protocol=AccessProtocol.STAC, endpoint=endpoint, params=params
+    )
+
+
+@pytest.fixture
+def fake_stac(monkeypatch: pytest.MonkeyPatch) -> list:
+    """Patch STACClient — returns the recorded search/download call list."""
+    calls: list = []
+
+    class _FakeClient:
+        def __init__(self, url: str, timeout: int = 30) -> None:
+            calls.append({"op": "init", "url": url})
+
+        def search(self, *, bbox, datetime, collections, limit=10, query=None):
+            calls.append(
+                {
+                    "op": "search",
+                    "bbox": bbox,
+                    "datetime": datetime,
+                    "collections": collections,
+                    "limit": limit,
+                    "query": query,
+                }
+            )
+            return _ITEMS
+
+        def download_asset(self, item, asset_key, output_dir, overwrite=False):
+            calls.append(
+                {"op": "download", "asset": asset_key, "dir": output_dir}
+            )
+            return f"{output_dir}/{asset_key}.tif"
+
+    import gispulse.catalog.providers.stac_client as stac_client
+
+    monkeypatch.setattr(stac_client, "STACClient", _FakeClient)
+    return calls
+
+
+# -- contract ---------------------------------------------------------------
+
+
+def test_protocol_and_payload() -> None:
+    assert STACFetcher.protocol is AccessProtocol.STAC
+    assert STACFetcher.payload is Payload.RASTER
+
+
+# -- lazy reference ---------------------------------------------------------
+
+
+def test_reference_yields_cog_asset_href(fake_stac: list) -> None:
+    result = STACFetcher().virtual_table(
+        _access("https://stac.example.org", collections=["sentinel-2"])
+    )
+    # The COG href is the load-bearing REFERENCE value.
+    assert result.metadata[DUCKDB_SCAN_KEY] == (
+        "https://stac.example.org/scene-1/visual.tif"
+    )
+    assert result.mode is FetchMode.REFERENCE
+    assert result.payload is Payload.RASTER
+
+
+def test_reference_pushdown_bbox_into_stac_search(fake_stac: list) -> None:
+    STACFetcher().virtual_table(
+        _access("https://stac.example.org", collections=["sentinel-2"]),
+        extent=(1.0, 2.0, 3.0, 4.0),
+    )
+    search = next(c for c in fake_stac if c["op"] == "search")
+    # STAC pushdown: the bbox is handed straight to the catalog search.
+    assert search["bbox"] == [1.0, 2.0, 3.0, 4.0]
+
+
+def test_reference_no_extent_searches_worldwide(fake_stac: list) -> None:
+    STACFetcher().virtual_table(
+        _access("https://stac.example.org", collections=["sentinel-2"])
+    )
+    search = next(c for c in fake_stac if c["op"] == "search")
+    assert search["bbox"] == [-180.0, -90.0, 180.0, 90.0]
+
+
+def test_reference_custom_asset_key(fake_stac: list) -> None:
+    result = STACFetcher().virtual_table(
+        _access(
+            "https://stac.example.org",
+            collections=["sentinel-2"],
+            asset="B04",
+        )
+    )
+    assert result.metadata[DUCKDB_SCAN_KEY].endswith("/B04.tif")
+
+
+def test_missing_collections_raises(fake_stac: list) -> None:
+    with pytest.raises(ValueError, match="collections"):
+        STACFetcher().virtual_table(_access("https://stac.example.org"))
+
+
+# -- materialise ------------------------------------------------------------
+
+
+def test_fetch_materialize_downloads_asset(fake_stac: list) -> None:
+    result = STACFetcher().fetch(
+        _access(
+            "https://stac.example.org",
+            collections=["sentinel-2"],
+            asset="visual",
+            output_dir="/tmp/stac-out",
+        ),
+        mode=FetchMode.MATERIALIZE,
+    )
+    assert result.mode is FetchMode.MATERIALIZE
+    assert result.data == "/tmp/stac-out/visual.tif"
+    download = next(c for c in fake_stac if c["op"] == "download")
+    assert download["asset"] == "visual"
+
+
+# -- SSRF guard -------------------------------------------------------------
+
+
+@pytest.mark.parametrize("mode", [FetchMode.REFERENCE, FetchMode.MATERIALIZE])
+def test_fetch_rejects_private_address(mode: FetchMode) -> None:
+    with pytest.raises(SSRFError):
+        STACFetcher().fetch(
+            _access("http://127.0.0.1/stac", collections=["x"]), mode=mode
+        )


### PR DESCRIPTION
## A3-A6 of EPIC #226 — agrégateur de données géo mondiales

Adds the four concrete `LazyFetcher` adapters to the core roster, on top
of the fetcher foundation merged in #255.

| Issue | Fetcher | Protocole | Comportement |
|---|---|---|---|
| #229 | `GeoParquetS3Fetcher` | `REMOTE_TABLE` | `read_parquet` + `httpfs`, pushdown bbox |
| #230 | `OGCFeaturesFetcher` | `OGC_FEATURES` | `ST_Read` sur l'URL items paginée, route WFS |
| #231 | `STACFetcher` | `STAC` | STAC search, hrefs d'assets COG, signature Planetary Computer |
| #232 | `HttpFileFetcher` | `DOWNLOAD` | `/vsicurl` GeoJSON/GPKG, CSV lat/lon → `ST_Point` |

### Notes d'implémentation
- Les imports DuckDB / httpx / clients restent **différés** dans les méthodes de fetch — `import gispulse` reste léger.
- `_core_fetchers()` reste une fonction (pas une liste module-level) pour garder les imports par protocole paresseux.

### Tests
- **51 tests unitaires**, zéro réseau — la fixture `offline_ssrf` (`tests/unit/conftest.py`) patche la résolution DNS du garde SSRF (#199).
- `ruff check` clean.

Closes #229, #230, #231, #232.

🤖 Generated with [Claude Code](https://claude.com/claude-code)