### PR TITLE
feat(v19): worldwide catalogue + WorldwideCatalogSource (A8, #234)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,12 @@ gispulse = "gispulse.cli:main"
 [project.entry-points."gispulse.mcp_tools"]
 gispulse-mcp-pilot = "gispulse.plugins.mcp_pilot:PilotMcpTools"
 
+# First-party worldwide geo-data aggregator (A8, #234 — EPIC #226).
+# Discovered by the ExtensionHub as a first-party DataSource; its
+# register() hook files a WorldwideCatalogSource in core.sources.SOURCES.
+[project.entry-points."gispulse.data_sources"]
+worldwide = "gispulse.plugins.worldwide_source:register"
+
 [project.optional-dependencies]
 postgis = ["sqlalchemy>=2.0,<3.0", "geoalchemy2>=0.14,<1.0", "psycopg2-binary>=2.9,<3.0", "asyncpg>=0.29,<1.0"]
 api = ["fastapi>=0.100,<1.0", "uvicorn[standard]>=0.23,<1.0", "watchfiles>=0.21,<2.0", "python-multipart>=0.0.6,<1.0", "requests>=2.28,<3.0", "slowapi>=0.1.9,<1.0", "httpx>=0.24,<1.0"]
@@ -79,7 +85,7 @@ where = ["src"]
 include = ["gispulse*"]
 
 [tool.setuptools.package-data]
-"gispulse.core" = ["pricing_catalog.yml"]
+"gispulse.core" = ["pricing_catalog.yml", "data/*.yml"]
 "gispulse.catalog" = ["data/*.json"]
 
 [tool.ruff]

--- a/src/gispulse/core/data/worldwide_catalog.yml
+++ b/src/gispulse/core/data/worldwide_catalog.yml
@@ -1,0 +1,256 @@
+# GISPulse — Worldwide geo-data catalogue (curated seed)
+#
+# A8 / issue #234, EPIC #226 (v1.9.0 — worldwide aggregator). A small,
+# *curated* and version-controlled set of public geospatial datasets,
+# parsed into `SourceEntryRef`s by `WorldwideCatalogSource`
+# (`gispulse/plugins/worldwide_source.py`).
+#
+# Each entry carries the four classification axes the catalogue filters
+# on — `domain` / `payload` / `jurisdiction` and `access.protocol` —
+# plus a `family` grouping for the portal UI. `domain` must be a value
+# of `core.plugin_model.SourceDomain`, `payload` of `Payload`, and
+# `access.protocol` of `AccessProtocol`.
+#
+# `revision_token` is the freshness token returned by `revision()` for
+# a versioned release; leave it null for a live service — A14 (#240)
+# wires a live freshness probe into the SourceWatcherRegistry.
+#
+# Endpoints are SSRF-checked structurally at load (scheme allow-list +
+# no private/loopback host). The full DNS-resolving SSRF guard (#199)
+# runs per fetch inside `core/fetchers/`.
+
+version: 1
+
+entries:
+  # ---------------------------------------------------------------------
+  # Family 1 — Overture / GeoParquet (remote columnar tables, DuckDB httpfs)
+  # ---------------------------------------------------------------------
+  - id: overture-places
+    name: Overture Maps — Places (points of interest)
+    family: overture-geoparquet
+    domain: observation
+    payload: vector
+    jurisdiction: world
+    access:
+      protocol: remote-table
+      endpoint: s3://overturemaps-us-west-2/release/2025-09-24.0/theme=places/type=place/*
+      params:
+        hive_partitioning: true
+    revision_token: "2025-09-24.0"
+    metadata:
+      provider: Overture Maps Foundation
+      license: CDLA Permissive 2.0
+
+  - id: overture-buildings
+    name: Overture Maps — Buildings
+    family: overture-geoparquet
+    domain: base
+    payload: vector
+    jurisdiction: world
+    access:
+      protocol: remote-table
+      endpoint: s3://overturemaps-us-west-2/release/2025-09-24.0/theme=buildings/type=building/*
+      params:
+        hive_partitioning: true
+    revision_token: "2025-09-24.0"
+    metadata:
+      provider: Overture Maps Foundation
+      license: ODbL 1.0
+
+  - id: overture-transportation
+    name: Overture Maps — Transportation (road segments)
+    family: overture-geoparquet
+    domain: reseau
+    payload: vector
+    jurisdiction: world
+    access:
+      protocol: remote-table
+      endpoint: s3://overturemaps-us-west-2/release/2025-09-24.0/theme=transportation/type=segment/*
+      params:
+        hive_partitioning: true
+    revision_token: "2025-09-24.0"
+    metadata:
+      provider: Overture Maps Foundation
+      license: ODbL 1.0
+
+  - id: vida-open-buildings
+    name: VIDA — Google/Microsoft Open Buildings (combined)
+    family: overture-geoparquet
+    domain: base
+    payload: vector
+    jurisdiction: world
+    access:
+      protocol: remote-table
+      endpoint: s3://us-west-2.opendata.source.coop/vida/google-microsoft-open-buildings/geoparquet/by_country/*
+      params:
+        hive_partitioning: true
+    revision_token: null
+    metadata:
+      provider: VIDA
+      license: CC BY 4.0
+
+  # ---------------------------------------------------------------------
+  # Family 2 — OGC Features / WFS (paginated feature services)
+  # ---------------------------------------------------------------------
+  - id: ign-bdtopo-batiment
+    name: IGN — BD TOPO buildings (France)
+    family: ogc-features
+    domain: base
+    payload: vector
+    jurisdiction: FR
+    access:
+      protocol: wfs
+      endpoint: https://data.geopf.fr/wfs/ows
+      params:
+        typename: BDTOPO_V3:batiment
+      format: application/json
+    revision_token: null
+    metadata:
+      provider: IGN Géoplateforme
+
+  - id: ign-adminexpress-communes
+    name: IGN — Admin Express communes (France)
+    family: ogc-features
+    domain: base
+    payload: vector
+    jurisdiction: FR
+    access:
+      protocol: wfs
+      endpoint: https://data.geopf.fr/wfs/ows
+      params:
+        typename: ADMINEXPRESS-COG.LATEST:commune
+      format: application/json
+    revision_token: null
+    metadata:
+      provider: IGN Géoplateforme
+
+  - id: pdok-bag-panden
+    name: PDOK — BAG buildings (Netherlands)
+    family: ogc-features
+    domain: base
+    payload: vector
+    jurisdiction: NL
+    access:
+      protocol: ogc-features
+      endpoint: https://api.pdok.nl/lv/bag/ogc/v1
+      params:
+        collection: pand
+    revision_token: null
+    metadata:
+      provider: PDOK / Kadaster
+
+  - id: pdok-natura2000
+    name: PDOK — Natura 2000 protected areas (Netherlands)
+    family: ogc-features
+    domain: environnement
+    payload: vector
+    jurisdiction: NL
+    access:
+      protocol: ogc-features
+      endpoint: https://api.pdok.nl/rvo/natura2000/ogc/v1
+      params:
+        collection: natura2000
+    revision_token: null
+    metadata:
+      provider: PDOK / RVO
+
+  # ---------------------------------------------------------------------
+  # Family 3 — STAC imagery (COG assets, searched by extent)
+  # ---------------------------------------------------------------------
+  - id: earth-search-sentinel2-l2a
+    name: Element 84 — Sentinel-2 L2A (earth-search)
+    family: stac-imagery
+    domain: imagerie
+    payload: raster
+    jurisdiction: world
+    access:
+      protocol: stac
+      endpoint: https://earth-search.aws.element84.com/v1
+      params:
+        collection: sentinel-2-l2a
+        asset: visual
+    revision_token: null
+    metadata:
+      provider: Element 84 / AWS Open Data
+
+  - id: planetary-computer-landsat
+    name: Microsoft Planetary Computer — Landsat C2 L2
+    family: stac-imagery
+    domain: imagerie
+    payload: raster
+    jurisdiction: world
+    access:
+      protocol: stac
+      endpoint: https://planetarycomputer.microsoft.com/api/stac/v1
+      params:
+        collection: landsat-c2-l2
+    revision_token: null
+    metadata:
+      provider: Microsoft Planetary Computer
+      requires_signing: true
+      signer: planetary-computer
+
+  - id: planetary-computer-naip
+    name: Microsoft Planetary Computer — NAIP aerial imagery (US)
+    family: stac-imagery
+    domain: imagerie
+    payload: raster
+    jurisdiction: US
+    access:
+      protocol: stac
+      endpoint: https://planetarycomputer.microsoft.com/api/stac/v1
+      params:
+        collection: naip
+    revision_token: null
+    metadata:
+      provider: Microsoft Planetary Computer
+      requires_signing: true
+      signer: planetary-computer
+
+  # ---------------------------------------------------------------------
+  # Family 4 — French open data (direct file download via /vsicurl)
+  # ---------------------------------------------------------------------
+  - id: dvf-geolocalise
+    name: DVF — geolocated property transactions (France)
+    family: opendata-fr
+    domain: statistique
+    payload: vector
+    jurisdiction: FR
+    access:
+      protocol: download
+      endpoint: https://files.data.gouv.fr/geo-dvf/latest/csv/2024/full.csv.gz
+      params:
+        lat: latitude
+        lon: longitude
+    revision_token: latest
+    metadata:
+      provider: Etalab / Cerema
+
+  - id: sirene-geolocalise
+    name: Sirene — geolocated establishments (France)
+    family: opendata-fr
+    domain: statistique
+    payload: vector
+    jurisdiction: FR
+    access:
+      protocol: download
+      endpoint: https://files.data.gouv.fr/insee-sirene-geo/StockEtablissementActif_utf8_geo.csv.gz
+      params:
+        lat: latitude
+        lon: longitude
+    revision_token: null
+    metadata:
+      provider: INSEE / Etalab
+
+  - id: cadastre-etalab-parcelles
+    name: Cadastre Etalab — parcels (France)
+    family: opendata-fr
+    domain: foncier
+    payload: vector
+    jurisdiction: FR
+    access:
+      protocol: download
+      endpoint: https://cadastre.data.gouv.fr/data/etalab-cadastre/latest/geojson/france/cadastre-france-parcelles.json.gz
+    revision_token: latest
+    metadata:
+      provider: Etalab / DGFiP

--- a/src/gispulse/plugins/worldwide_source.py
+++ b/src/gispulse/plugins/worldwide_source.py
@@ -1,0 +1,313 @@
+"""Worldwide geo-data aggregator — first-party ``DataSource`` (A8, #234).
+
+EPIC #226 (v1.9.0). A single curated :class:`DataSource` over
+``core/data/worldwide_catalog.yml`` — not thirty marketplace plugins.
+Published under the ``gispulse.data_sources`` entry-point group in the
+``gispulse`` distribution itself, so the ``ExtensionHub`` resolves it as
+a first-party source and the community tier gate passes with no gating
+code (EPIC #226 design decision #2 — the worldwide catalogue is free).
+
+The catalogue is *declarative*: each YAML entry becomes a
+:class:`~gispulse.core.sources.SourceEntryRef` carrying the four filter
+axes — ``domain`` / ``payload`` / ``jurisdiction`` and
+``access.protocol`` (issue #227) — plus a ``family`` grouping kept in
+``metadata``. ``fetch()`` is inherited from :class:`DeclarativeSource`:
+it delegates to the protocol fetchers registered by
+``core/fetchers/`` (A3-A6, #229-#232).
+
+Endpoints are SSRF-checked *structurally* at load — an allow-listed
+scheme and a non-private host — without any DNS lookup, so importing /
+constructing the source stays network-free. The full DNS-resolving SSRF
+guard (#199) runs per fetch inside :class:`LazyFetcher`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from gispulse.core.logging import get_logger
+from gispulse.core.ssrf import is_blocked_address
+from gispulse.plugins.api import (
+    AccessProtocol,
+    AccessSpec,
+    DeclarativeSource,
+    Payload,
+    SourceDomain,
+    SourceEntryRef,
+)
+
+log = get_logger(__name__)
+
+#: Curated catalogue shipped inside the ``gispulse`` package.
+DEFAULT_CATALOG_PATH = (
+    Path(__file__).resolve().parents[1] / "core" / "data" / "worldwide_catalog.yml"
+)
+
+#: Schemes a catalogue endpoint may use. ``s3`` covers the GeoParquet
+#: remote-table family read by DuckDB ``httpfs``; ``http(s)`` covers OGC
+#: Features, STAC and direct file download.
+_ALLOWED_SCHEMES = frozenset({"http", "https", "s3"})
+
+#: Hostnames that are loopback by name — rejected without a DNS lookup.
+_LOOPBACK_NAMES = frozenset({"localhost", "ip6-localhost"})
+
+#: Sentinel for an unknown enum value passed to :meth:`WorldwideCatalogSource.catalog`
+#: — it equals no entry, so the filter yields an empty result.
+_UNMATCHABLE = object()
+
+
+class WorldwideCatalogError(ValueError):
+    """Raised when ``worldwide_catalog.yml`` is malformed or unsafe."""
+
+
+def _check_endpoint_safe(endpoint: str, entry_id: str) -> None:
+    """Structural SSRF check of a catalogue endpoint — no DNS lookup.
+
+    Rejects a non-allow-listed scheme, a missing host, a literal
+    private/loopback/reserved IP, and a loopback hostname. A public
+    *hostname* is accepted here; the full DNS-resolving guard (#199)
+    runs later, per fetch, inside the protocol fetcher.
+
+    Raises:
+        WorldwideCatalogError: the endpoint is unsafe or malformed.
+    """
+    parsed = urlparse(endpoint)
+    scheme = parsed.scheme.lower()
+    if scheme not in _ALLOWED_SCHEMES:
+        raise WorldwideCatalogError(
+            f"entry {entry_id!r}: endpoint scheme {scheme or '(none)'!r} not "
+            f"allowed (expected one of {sorted(_ALLOWED_SCHEMES)})"
+        )
+    host = (parsed.hostname or "").lower()
+    if not host:
+        raise WorldwideCatalogError(
+            f"entry {entry_id!r}: endpoint {endpoint!r} has no host"
+        )
+    if host in _LOOPBACK_NAMES:
+        raise WorldwideCatalogError(
+            f"entry {entry_id!r}: endpoint host {host!r} is loopback"
+        )
+    # is_blocked_address judges an IP *literal* offline; a hostname is
+    # not an IP so it falls through to the per-fetch guard.
+    try:
+        import ipaddress
+
+        ipaddress.ip_address(host)
+    except ValueError:
+        return  # a hostname — public/private decided at fetch time
+    if is_blocked_address(host):
+        raise WorldwideCatalogError(
+            f"entry {entry_id!r}: endpoint host {host!r} is a private / "
+            f"loopback / reserved address"
+        )
+
+
+def _entry_from_dict(raw: dict[str, Any]) -> SourceEntryRef:
+    """Build one validated :class:`SourceEntryRef` from a YAML entry.
+
+    Raises:
+        WorldwideCatalogError: a required field is missing, an axis
+            value is unknown, or the endpoint fails the SSRF check.
+    """
+    entry_id = raw.get("id")
+    if not entry_id or not isinstance(entry_id, str):
+        raise WorldwideCatalogError(f"catalogue entry missing a string 'id': {raw!r}")
+
+    access_raw = raw.get("access")
+    if not isinstance(access_raw, dict):
+        raise WorldwideCatalogError(f"entry {entry_id!r}: missing 'access' block")
+
+    def _enum(enum: type, value: Any, field: str) -> Any:
+        try:
+            return enum(value)
+        except ValueError:
+            valid = sorted(m.value for m in enum)
+            raise WorldwideCatalogError(
+                f"entry {entry_id!r}: unknown {field} {value!r} "
+                f"(expected one of {valid})"
+            ) from None
+
+    endpoint = access_raw.get("endpoint")
+    if not endpoint or not isinstance(endpoint, str):
+        raise WorldwideCatalogError(f"entry {entry_id!r}: 'access.endpoint' missing")
+    _check_endpoint_safe(endpoint, entry_id)
+
+    access = AccessSpec(
+        protocol=_enum(AccessProtocol, access_raw.get("protocol"), "access.protocol"),
+        endpoint=endpoint,
+        params=dict(access_raw.get("params") or {}),
+        format=access_raw.get("format"),
+    )
+
+    metadata = dict(raw.get("metadata") or {})
+    family = raw.get("family")
+    if family:
+        metadata["family"] = family
+
+    return SourceEntryRef(
+        id=entry_id,
+        name=str(raw.get("name") or entry_id),
+        access=access,
+        revision_token=raw.get("revision_token"),
+        metadata=metadata,
+        domain=_enum(SourceDomain, raw.get("domain"), "domain"),
+        payload=_enum(Payload, raw.get("payload"), "payload"),
+        jurisdiction=raw.get("jurisdiction"),
+    )
+
+
+def load_worldwide_catalog(path: Path | None = None) -> list[SourceEntryRef]:
+    """Parse ``worldwide_catalog.yml`` into validated entries.
+
+    Args:
+        path: Catalogue file. Defaults to the curated one shipped in the
+            ``gispulse`` package (:data:`DEFAULT_CATALOG_PATH`).
+
+    Raises:
+        WorldwideCatalogError: the file is missing, unreadable, not a
+            mapping, or any entry fails validation.
+    """
+    import yaml  # local import — keeps module import cheap
+
+    catalog_path = path or DEFAULT_CATALOG_PATH
+    try:
+        text = catalog_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise WorldwideCatalogError(
+            f"cannot read worldwide catalogue {catalog_path}: {exc}"
+        ) from exc
+
+    data = yaml.safe_load(text)
+    if not isinstance(data, dict):
+        raise WorldwideCatalogError(
+            f"worldwide catalogue {catalog_path} must be a YAML mapping"
+        )
+
+    raw_entries = data.get("entries")
+    if not isinstance(raw_entries, list):
+        raise WorldwideCatalogError(
+            f"worldwide catalogue {catalog_path}: 'entries' must be a list"
+        )
+
+    entries = [_entry_from_dict(raw) for raw in raw_entries]
+    seen: set[str] = set()
+    for entry in entries:
+        if entry.id in seen:
+            raise WorldwideCatalogError(f"duplicate catalogue entry id {entry.id!r}")
+        seen.add(entry.id)
+    return entries
+
+
+class WorldwideCatalogSource(DeclarativeSource):
+    """Curated worldwide geo-data catalogue as a GISPulse data source.
+
+    A :class:`DeclarativeSource` — it only *declares* entries; the fetch
+    round-trip runs through the protocol fetchers (A3-A6). The catalogue
+    spans many themes, so the source-level ``domain`` / ``payload`` are
+    nominal: the authoritative classification lives on each
+    :class:`SourceEntryRef` and :meth:`catalog` filters on it.
+    """
+
+    name = "worldwide"
+    # Nominal source-level axes — the worldwide catalogue is multi-domain;
+    # per-entry SourceEntryRef axes are the ones :meth:`catalog` filters on.
+    domain = SourceDomain.BASE
+    payload = Payload.VECTOR
+    jurisdiction = "*"
+
+    def __init__(
+        self,
+        catalog_path: Path | None = None,
+        registry: Any | None = None,
+    ) -> None:
+        super().__init__(registry)
+        self._catalog_path = catalog_path
+        self._entries = load_worldwide_catalog(catalog_path)
+        log.info("worldwide_catalog_loaded", entries=len(self._entries))
+
+    def entries(self) -> list[SourceEntryRef]:
+        """Return every catalogue entry (already validated at load)."""
+        return list(self._entries)
+
+    def families(self) -> list[str]:
+        """Return the distinct ``family`` groupings, sorted."""
+        return sorted(
+            {
+                str(e.metadata["family"])
+                for e in self._entries
+                if e.metadata.get("family")
+            }
+        )
+
+    def catalog(
+        self,
+        search: str | None = None,
+        *,
+        domain: SourceDomain | str | None = None,
+        payload: Payload | str | None = None,
+        jurisdiction: str | None = None,
+        protocol: AccessProtocol | str | None = None,
+        family: str | None = None,
+    ) -> list[SourceEntryRef]:
+        """Filter the catalogue on the four classification axes.
+
+        ``search`` matches the entry id or name (case-insensitive). The
+        four axes — ``domain`` / ``payload`` / ``jurisdiction`` and the
+        transport ``protocol`` — and the ``family`` grouping each narrow
+        the result when supplied. Enum axes accept either the enum
+        member or its string value. An unknown enum value yields an
+        empty result rather than raising.
+        """
+
+        def _coerce(enum: type, value: Any) -> Any:
+            if value is None or isinstance(value, enum):
+                return value
+            try:
+                return enum(value)
+            except ValueError:
+                return _UNMATCHABLE
+
+        domain_f = _coerce(SourceDomain, domain)
+        payload_f = _coerce(Payload, payload)
+        protocol_f = _coerce(AccessProtocol, protocol)
+
+        q = search.lower() if search else None
+        result: list[SourceEntryRef] = []
+        for entry in self._entries:
+            if q and q not in entry.id.lower() and q not in entry.name.lower():
+                continue
+            if domain_f is not None and entry.domain != domain_f:
+                continue
+            if payload_f is not None and entry.payload != payload_f:
+                continue
+            if jurisdiction is not None and entry.jurisdiction != jurisdiction:
+                continue
+            if protocol_f is not None and entry.access.protocol != protocol_f:
+                continue
+            if family is not None and entry.metadata.get("family") != family:
+                continue
+            result.append(entry)
+        return result
+
+
+def register() -> None:
+    """Entry-point hook for the ``gispulse.data_sources`` group.
+
+    Registers a :class:`WorldwideCatalogSource` in the process-wide
+    ``core.sources.SOURCES`` registry so the source watcher (#197) can
+    resolve ``worldwide://<entry>`` URIs declared in ``triggers.yaml``.
+    """
+    from gispulse.core.sources import SOURCES
+
+    SOURCES.register(WorldwideCatalogSource())
+
+
+__all__ = [
+    "DEFAULT_CATALOG_PATH",
+    "WorldwideCatalogError",
+    "WorldwideCatalogSource",
+    "load_worldwide_catalog",
+    "register",
+]

--- a/tests/unit/test_worldwide_source.py
+++ b/tests/unit/test_worldwide_source.py
@@ -1,0 +1,296 @@
+"""Unit tests for A8 (#234) — ``WorldwideCatalogSource``.
+
+Zero network: the source is a pure declaration parsed from
+``worldwide_catalog.yml``; the endpoint SSRF check is structural (no DNS
+lookup), so these tests need no ``offline_ssrf`` fixture.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from gispulse.core.plugin_model import AccessProtocol, Payload, SourceDomain
+from gispulse.core.sources import SOURCES, DataSource
+from gispulse.plugins.worldwide_source import (
+    DEFAULT_CATALOG_PATH,
+    WorldwideCatalogError,
+    WorldwideCatalogSource,
+    _entry_from_dict,
+    load_worldwide_catalog,
+    register,
+)
+
+_EXPECTED_FAMILIES = {
+    "overture-geoparquet",
+    "ogc-features",
+    "stac-imagery",
+    "opendata-fr",
+}
+
+
+def _write_catalog(tmp_path: Path, body: str) -> Path:
+    path = tmp_path / "catalog.yml"
+    path.write_text(textwrap.dedent(body), encoding="utf-8")
+    return path
+
+
+# -- contract ---------------------------------------------------------------
+
+
+def test_source_contract() -> None:
+    src = WorldwideCatalogSource()
+    assert src.name == "worldwide"
+    assert isinstance(src, DataSource)  # runtime-checkable Protocol
+
+
+def test_default_catalog_ships_in_package() -> None:
+    assert DEFAULT_CATALOG_PATH.is_file()
+
+
+# -- shipped catalogue ------------------------------------------------------
+
+
+def test_loads_shipped_catalogue() -> None:
+    entries = WorldwideCatalogSource().entries()
+    assert len(entries) >= 13
+    # Every entry carries the four classification axes.
+    for e in entries:
+        assert isinstance(e.domain, SourceDomain)
+        assert isinstance(e.payload, Payload)
+        assert e.jurisdiction
+        assert isinstance(e.access.protocol, AccessProtocol)
+        assert e.access.endpoint
+
+
+def test_four_families_seeded() -> None:
+    assert set(WorldwideCatalogSource().families()) == _EXPECTED_FAMILIES
+
+
+def test_entry_ids_are_unique() -> None:
+    entries = WorldwideCatalogSource().entries()
+    assert len(entries) == len({e.id for e in entries})
+
+
+# -- catalog() filtering on the four axes -----------------------------------
+
+
+def test_catalog_no_filter_returns_all() -> None:
+    src = WorldwideCatalogSource()
+    assert len(src.catalog()) == len(src.entries())
+
+
+def test_catalog_filters_by_domain() -> None:
+    hits = WorldwideCatalogSource().catalog(domain=SourceDomain.IMAGERIE)
+    assert hits
+    assert all(e.domain is SourceDomain.IMAGERIE for e in hits)
+
+
+def test_catalog_filters_by_payload_raster_is_stac_only() -> None:
+    hits = WorldwideCatalogSource().catalog(payload=Payload.RASTER)
+    assert hits
+    assert all(e.access.protocol is AccessProtocol.STAC for e in hits)
+
+
+def test_catalog_filters_by_jurisdiction() -> None:
+    hits = WorldwideCatalogSource().catalog(jurisdiction="FR")
+    assert hits
+    assert all(e.jurisdiction == "FR" for e in hits)
+
+
+def test_catalog_filters_by_protocol() -> None:
+    hits = WorldwideCatalogSource().catalog(protocol=AccessProtocol.REMOTE_TABLE)
+    assert hits
+    assert all(e.access.protocol is AccessProtocol.REMOTE_TABLE for e in hits)
+
+
+def test_catalog_filters_by_family() -> None:
+    hits = WorldwideCatalogSource().catalog(family="opendata-fr")
+    assert hits
+    assert all(e.metadata.get("family") == "opendata-fr" for e in hits)
+
+
+def test_catalog_search_matches_id_and_name() -> None:
+    hits = WorldwideCatalogSource().catalog("overture")
+    assert {e.id for e in hits} >= {"overture-places", "overture-buildings"}
+
+
+def test_catalog_axes_accept_string_values() -> None:
+    src = WorldwideCatalogSource()
+    assert src.catalog(domain="imagerie") == src.catalog(domain=SourceDomain.IMAGERIE)
+
+
+def test_catalog_unknown_axis_value_yields_empty() -> None:
+    assert WorldwideCatalogSource().catalog(domain="not-a-domain") == []
+
+
+def test_catalog_combined_filters_narrow() -> None:
+    src = WorldwideCatalogSource()
+    combined = src.catalog(payload=Payload.RASTER, jurisdiction="world")
+    assert combined
+    assert all(
+        e.payload is Payload.RASTER and e.jurisdiction == "world" for e in combined
+    )
+
+
+# -- revision() -------------------------------------------------------------
+
+
+def test_revision_returns_declared_token() -> None:
+    src = WorldwideCatalogSource()
+    assert src.revision("overture-places") == "2025-09-24.0"
+
+
+def test_revision_none_for_live_entry() -> None:
+    # vida-open-buildings declares `revision_token: null`.
+    assert WorldwideCatalogSource().revision("vida-open-buildings") is None
+
+
+def test_revision_unknown_entry_raises() -> None:
+    with pytest.raises(KeyError):
+        WorldwideCatalogSource().revision("does-not-exist")
+
+
+# -- SSRF / structural endpoint validation ----------------------------------
+
+
+def _raw(endpoint: str, protocol: str = "download") -> dict:
+    return {
+        "id": "probe",
+        "name": "Probe",
+        "domain": "base",
+        "payload": "vector",
+        "jurisdiction": "world",
+        "access": {"protocol": protocol, "endpoint": endpoint},
+    }
+
+
+def test_endpoint_private_ip_literal_rejected() -> None:
+    with pytest.raises(WorldwideCatalogError, match="private"):
+        _entry_from_dict(_raw("http://10.0.0.1/data.csv"))
+
+
+def test_endpoint_loopback_ip_rejected() -> None:
+    with pytest.raises(WorldwideCatalogError, match="private|loopback|reserved"):
+        _entry_from_dict(_raw("http://127.0.0.1/data.csv"))
+
+
+def test_endpoint_localhost_hostname_rejected() -> None:
+    with pytest.raises(WorldwideCatalogError, match="loopback"):
+        _entry_from_dict(_raw("http://localhost/data.csv"))
+
+
+def test_endpoint_link_local_metadata_ip_rejected() -> None:
+    # The classic SSRF target — cloud instance metadata.
+    with pytest.raises(WorldwideCatalogError):
+        _entry_from_dict(_raw("http://169.254.169.254/latest/meta-data/"))
+
+
+def test_endpoint_disallowed_scheme_rejected() -> None:
+    with pytest.raises(WorldwideCatalogError, match="scheme"):
+        _entry_from_dict(_raw("file:///etc/passwd"))
+
+
+def test_endpoint_public_hostname_accepted() -> None:
+    entry = _entry_from_dict(_raw("https://files.data.gouv.fr/x.csv"))
+    assert entry.id == "probe"
+
+
+def test_endpoint_s3_scheme_accepted() -> None:
+    entry = _entry_from_dict(_raw("s3://bucket/key/*", protocol="remote-table"))
+    assert entry.access.protocol is AccessProtocol.REMOTE_TABLE
+
+
+# -- load_worldwide_catalog error paths -------------------------------------
+
+
+def test_load_rejects_non_mapping(tmp_path: Path) -> None:
+    path = _write_catalog(tmp_path, "- just\n- a\n- list\n")
+    with pytest.raises(WorldwideCatalogError, match="mapping"):
+        load_worldwide_catalog(path)
+
+
+def test_load_rejects_missing_entries_list(tmp_path: Path) -> None:
+    path = _write_catalog(tmp_path, "version: 1\n")
+    with pytest.raises(WorldwideCatalogError, match="entries"):
+        load_worldwide_catalog(path)
+
+
+def test_load_rejects_duplicate_ids(tmp_path: Path) -> None:
+    path = _write_catalog(
+        tmp_path,
+        """
+        version: 1
+        entries:
+          - id: dup
+            name: A
+            domain: base
+            payload: vector
+            jurisdiction: world
+            access: {protocol: download, endpoint: 'https://a.example.org/a'}
+          - id: dup
+            name: B
+            domain: base
+            payload: vector
+            jurisdiction: world
+            access: {protocol: download, endpoint: 'https://b.example.org/b'}
+        """,
+    )
+    with pytest.raises(WorldwideCatalogError, match="duplicate"):
+        load_worldwide_catalog(path)
+
+
+def test_load_rejects_unknown_domain(tmp_path: Path) -> None:
+    path = _write_catalog(
+        tmp_path,
+        """
+        version: 1
+        entries:
+          - id: bad
+            name: Bad
+            domain: galaxy
+            payload: vector
+            jurisdiction: world
+            access: {protocol: download, endpoint: 'https://x.example.org/x'}
+        """,
+    )
+    with pytest.raises(WorldwideCatalogError, match="domain"):
+        load_worldwide_catalog(path)
+
+
+def test_load_rejects_missing_endpoint(tmp_path: Path) -> None:
+    path = _write_catalog(
+        tmp_path,
+        """
+        version: 1
+        entries:
+          - id: bad
+            name: Bad
+            domain: base
+            payload: vector
+            jurisdiction: world
+            access: {protocol: download}
+        """,
+    )
+    with pytest.raises(WorldwideCatalogError, match="endpoint"):
+        load_worldwide_catalog(path)
+
+
+def test_missing_file_raises() -> None:
+    with pytest.raises(WorldwideCatalogError, match="cannot read"):
+        load_worldwide_catalog(Path("/no/such/worldwide_catalog.yml"))
+
+
+# -- register() entry-point hook --------------------------------------------
+
+
+def test_register_files_source_in_registry() -> None:
+    SOURCES.clear()
+    try:
+        register()
+        src = SOURCES.get("worldwide")
+        assert isinstance(src, WorldwideCatalogSource)
+    finally:
+        SOURCES.clear()


### PR DESCRIPTION
## A8 of EPIC #226 — agrégateur de données géo mondiales

La source curée first-party qui alimente l'agrégateur. Indépendante de la
stack des fetchers concrets (#256) — ne dépend que de A1 (#227, mergé).

### Livré
- **`core/data/worldwide_catalog.yml`** — 14 datasets publics curés, 4 familles :

  | Famille | Protocole | Exemples |
  |---|---|---|
  | `overture-geoparquet` | `remote-table` | Overture places/buildings/transportation, VIDA buildings |
  | `ogc-features` | `wfs` / `ogc-features` | IGN BD TOPO + Admin Express, PDOK BAG + Natura 2000 |
  | `stac-imagery` | `stac` | earth-search Sentinel-2, Planetary Computer Landsat/NAIP |
  | `opendata-fr` | `download` | DVF géolocalisé, Sirene géolocalisé, cadastre Etalab |

- **`gispulse/plugins/worldwide_source.py`** — `WorldwideCatalogSource`, un `DeclarativeSource` qui parse le YAML en `SourceEntryRef`.
  - `catalog()` filtre sur les **4 axes** (`domain` / `payload` / `jurisdiction` / `access.protocol`, #227) + le `family`, et accepte les valeurs enum sous forme de chaîne.
  - `revision()` renvoie le token de fraîcheur déclaré — le sondage live arrive en A14 (#240).
- **Validation SSRF** des endpoints au chargement : allow-list de schémas (`http`/`https`/`s3`) + rejet des hôtes privés/loopback/réservés, **sans résolution DNS** (chargement réseau-free). Le garde DNS complet (#199) tourne par fetch dans `core/fetchers/`.
- Déclaré comme data source first-party `worldwide` via l'entry-point `gispulse.data_sources` ; le YAML est embarqué en package data.

### Tests
- **32 tests unitaires**, zéro réseau — contrat, chargement, filtres 4 axes, `revision()`, rejets SSRF (IP privée, loopback, métadonnées `169.254.169.254`, schéma interdit), chemins d'erreur du loader, hook `register()`.
- `ruff check` clean.

Closes #234.

🤖 Generated with [Claude Code](https://claude.com/claude-code)