### PR TITLE
feat(v19): VirtualDatasetRegistry — catalogue entries as lazy DuckDB views (A9, #235)

### DIFF
--- a/src/gispulse/persistence/virtual_dataset.py
+++ b/src/gispulse/persistence/virtual_dataset.py
@@ -1,0 +1,332 @@
+"""Lazy virtual datasets — a worldwide-catalogue entry as a DuckDB view (A9, #235).
+
+EPIC #226 (v1.9.0). A *virtual dataset* turns one curated catalogue
+entry (a :class:`~gispulse.core.sources.SourceEntryRef` from
+:class:`WorldwideCatalogSource`, A8) into a DuckDB **view** —
+``CREATE OR REPLACE VIEW … AS SELECT * FROM <scan>`` — without moving any
+bytes. The scan SQL is produced by the protocol fetchers of
+``core/fetchers/`` (A3-A6): ``read_parquet(…)`` for remote GeoParquet,
+``ST_Read(…)`` for OGC Features, and so on.
+
+Nothing here touches the network until :func:`materialize_virtual_view`
+asks a fetcher for the scan. The fetcher is also where a bounding box is
+pushed down — on a *global* source a project bbox is mandatory — so the
+view created for a project only ever scans the rows it needs.
+
+Materialising a virtual dataset into a real project dataset is a
+separate step: re-run the same fetcher in
+:attr:`~gispulse.core.plugin_model.FetchMode.MATERIALIZE` mode.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from typing import Any
+
+from gispulse.core.fetchers import DUCKDB_SCAN_KEY
+from gispulse.core.logging import get_logger
+from gispulse.core.plugin_model import FetchMode
+from gispulse.core.sources import PROTOCOLS, ProtocolRegistry, SourceEntryRef
+
+log = get_logger(__name__)
+
+#: Scheme prefixing every synthetic virtual-dataset id.
+VIRTUAL_ID_SCHEME = "virtual:"
+
+#: Bounding box as ``(minx, miny, maxx, maxy)``.
+BBox = tuple[float, float, float, float]
+
+
+class VirtualDatasetError(RuntimeError):
+    """Raised when a virtual dataset cannot be built or materialised."""
+
+
+# ---------------------------------------------------------------------------
+# Synthetic id helpers
+# ---------------------------------------------------------------------------
+
+
+def make_virtual_id(source_name: str, entry_id: str) -> str:
+    """Build the synthetic id ``virtual:<source>/<entry>``.
+
+    Raises:
+        VirtualDatasetError: ``source_name`` or ``entry_id`` is empty.
+    """
+    if not source_name or not entry_id:
+        raise VirtualDatasetError("source_name and entry_id must both be non-empty")
+    return f"{VIRTUAL_ID_SCHEME}{source_name}/{entry_id}"
+
+
+def parse_virtual_id(virtual_id: str) -> tuple[str, str]:
+    """Split a synthetic id back into ``(source_name, entry_id)``.
+
+    Raises:
+        VirtualDatasetError: the id is not a well-formed virtual id.
+    """
+    if not virtual_id.startswith(VIRTUAL_ID_SCHEME):
+        raise VirtualDatasetError(
+            f"{virtual_id!r} is not a virtual id (expected {VIRTUAL_ID_SCHEME!r} prefix)"
+        )
+    body = virtual_id[len(VIRTUAL_ID_SCHEME) :]
+    source_name, sep, entry_id = body.partition("/")
+    if not sep or not source_name or not entry_id:
+        raise VirtualDatasetError(
+            f"malformed virtual id {virtual_id!r} (expected 'virtual:<source>/<entry>')"
+        )
+    return source_name, entry_id
+
+
+def _safe_view_name(entry_id: str) -> str:
+    """A DuckDB-safe view identifier derived from an entry id."""
+    cleaned = "".join(c if c.isalnum() else "_" for c in entry_id.lower())
+    return f"v_{cleaned}" if cleaned else "v_unnamed"
+
+
+# ---------------------------------------------------------------------------
+# Virtual dataset
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class VirtualDataset:
+    """A catalogue entry exposed as a lazy DuckDB view.
+
+    Identity only — it stores no SQL and touches no network. The scan is
+    resolved (and a bbox pushed down) on demand by
+    :func:`materialize_virtual_view`.
+    """
+
+    id: str
+    source_name: str
+    entry: SourceEntryRef
+
+    @property
+    def entry_id(self) -> str:
+        return self.entry.id
+
+    @property
+    def name(self) -> str:
+        return self.entry.name
+
+    @property
+    def view_name(self) -> str:
+        """The DuckDB view identifier this dataset materialises into."""
+        return _safe_view_name(self.entry.id)
+
+    @property
+    def source_uri(self) -> str:
+        """The watcher-resolvable URI ``<source>://<entry>`` (#197)."""
+        return f"{self.source_name}://{self.entry_id}"
+
+    @property
+    def payload(self) -> str:
+        """Data category — ``vector`` / ``raster`` / … (defaults to vector)."""
+        return self.entry.payload.value if self.entry.payload else "vector"
+
+    @property
+    def crs(self) -> str:
+        """Declared CRS, or the WGS84 default of the worldwide catalogue."""
+        return str(self.entry.metadata.get("crs", "EPSG:4326"))
+
+
+def to_dataset_meta(
+    vds: VirtualDataset,
+    *,
+    feature_count: int | None = None,
+    bbox: BBox | None = None,
+) -> dict[str, Any]:
+    """Project a :class:`VirtualDataset` to a portal ``DatasetMeta`` dict.
+
+    ``source_type`` is ``"virtual"`` and ``file_size`` is ``0`` — a
+    virtual dataset occupies no disk. ``feature_count`` / ``bbox`` are
+    left ``None`` until a preview computes them lazily, bbox-scoped (A10).
+    """
+    metadata = dict(vds.entry.metadata)
+    if vds.entry.domain is not None:
+        metadata.setdefault("domain", vds.entry.domain.value)
+    if vds.entry.jurisdiction is not None:
+        metadata.setdefault("jurisdiction", vds.entry.jurisdiction)
+    metadata.setdefault("protocol", vds.entry.access.protocol.value)
+    return {
+        "id": vds.id,
+        "name": vds.name,
+        "source_type": "virtual",
+        "virtual_source_uri": vds.source_uri,
+        "data_category": vds.payload,
+        "crs": vds.crs,
+        "format": "virtual",
+        "file_size": 0,
+        "feature_count": feature_count,
+        "virtual_bbox": list(bbox) if bbox else None,
+        "metadata": metadata,
+    }
+
+
+# ---------------------------------------------------------------------------
+# View materialisation — the only network-touching path
+# ---------------------------------------------------------------------------
+
+
+def materialize_virtual_view(
+    session: Any,
+    vds: VirtualDataset,
+    *,
+    bbox: BBox | None = None,
+    protocols: ProtocolRegistry | None = None,
+) -> str:
+    """Create (or replace) the DuckDB view backing ``vds`` on ``session``.
+
+    The protocol fetcher resolves the lazy scan; passing ``bbox`` lets it
+    push the spatial predicate down into the scan (e.g. against the
+    Overture ``bbox`` struct) so DuckDB prunes before reading. The view
+    is then ``SELECT * FROM <scan>`` — querying it streams only the
+    bbox-scoped rows.
+
+    Args:
+        session:   An open ``DuckDBSession`` (``httpfs`` loaded by A7).
+        vds:       The virtual dataset to materialise.
+        bbox:      Optional ``(minx, miny, maxx, maxy)`` pushed into the scan.
+        protocols: Fetcher registry. Defaults to the process-wide
+                   :data:`~gispulse.core.sources.PROTOCOLS`.
+
+    Returns:
+        The name of the created view.
+
+    Raises:
+        VirtualDatasetError: the fetcher returned a non-lazy result with
+            no DuckDB scan expression.
+    """
+    registry = protocols if protocols is not None else PROTOCOLS
+    result = registry.dispatch_fetch(
+        vds.entry.access, extent=bbox, mode=FetchMode.REFERENCE
+    )
+    scan = result.metadata.get(DUCKDB_SCAN_KEY)
+    if not scan:
+        raise VirtualDatasetError(
+            f"fetcher for {vds.id} ({vds.entry.access.protocol.value}) returned "
+            f"no '{DUCKDB_SCAN_KEY}' scan — cannot build a lazy view"
+        )
+    view = vds.view_name
+    session.conn.execute(f'CREATE OR REPLACE VIEW "{view}" AS SELECT * FROM {scan}')
+    log.info(
+        "virtual_view_materialized",
+        virtual_id=vds.id,
+        view=view,
+        bbox_scoped=bbox is not None,
+    )
+    return view
+
+
+def count_features(session: Any, view_name: str) -> int:
+    """Return the row count of a materialised virtual view.
+
+    Cheap lazy stat for a portal preview — on a bbox-scoped view it
+    counts only the clipped rows.
+    """
+    row = session.conn.execute(f'SELECT count(*) FROM "{view_name}"').fetchone()
+    return int(row[0]) if row else 0
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class VirtualDatasetRegistry:
+    """Process-wide registry of :class:`VirtualDataset`, keyed by synthetic id.
+
+    Thread-safe. :meth:`create` is the normal entry point — it validates
+    that a fetcher exists for the entry's protocol, then files the
+    dataset; construction touches no network.
+    """
+
+    def __init__(self) -> None:
+        self._items: dict[str, VirtualDataset] = {}
+        self._lock = threading.Lock()
+
+    def create(
+        self,
+        entry: SourceEntryRef,
+        *,
+        source_name: str = "worldwide",
+        protocols: ProtocolRegistry | None = None,
+    ) -> VirtualDataset:
+        """Build, register and return a virtual dataset for ``entry``.
+
+        Raises:
+            ProtocolNotSupported: no fetcher is registered for the
+                entry's ``access.protocol``.
+        """
+        registry = protocols if protocols is not None else PROTOCOLS
+        # Fail fast: a virtual dataset with no fetcher can never be viewed.
+        registry.get_fetcher(entry.access.protocol)
+        vds = VirtualDataset(
+            id=make_virtual_id(source_name, entry.id),
+            source_name=source_name,
+            entry=entry,
+        )
+        self.register(vds)
+        return vds
+
+    def register(self, vds: VirtualDataset) -> None:
+        """File ``vds`` under its id — last registration wins."""
+        with self._lock:
+            self._items[vds.id] = vds
+        log.debug("virtual_dataset_registered", virtual_id=vds.id)
+
+    def get(self, virtual_id: str) -> VirtualDataset:
+        """Return the dataset registered under ``virtual_id``.
+
+        Raises:
+            KeyError: no dataset is registered under that id.
+        """
+        try:
+            return self._items[virtual_id]
+        except KeyError:
+            raise KeyError(
+                f"no virtual dataset {virtual_id!r} "
+                f"(registered: {', '.join(sorted(self._items)) or 'none'})"
+            ) from None
+
+    def list(self) -> list[VirtualDataset]:
+        """Every registered dataset, ordered by id."""
+        with self._lock:
+            return [self._items[k] for k in sorted(self._items)]
+
+    def remove(self, virtual_id: str) -> bool:
+        """Drop ``virtual_id``; return ``True`` if it was present."""
+        with self._lock:
+            return self._items.pop(virtual_id, None) is not None
+
+    def clear(self) -> None:
+        """Drop every registration — used by tests for isolation."""
+        with self._lock:
+            self._items.clear()
+
+    def __len__(self) -> int:
+        return len(self._items)
+
+    def __contains__(self, virtual_id: object) -> bool:
+        return virtual_id in self._items
+
+
+#: Process-wide virtual-dataset registry. The worldwide catalogue HTTP
+#: endpoints (A10 #236) and the ETL pipeline-prepare hook (A11 #237)
+#: share this instance.
+VIRTUAL_DATASETS = VirtualDatasetRegistry()
+
+
+__all__ = [
+    "BBox",
+    "VIRTUAL_ID_SCHEME",
+    "VIRTUAL_DATASETS",
+    "VirtualDataset",
+    "VirtualDatasetError",
+    "VirtualDatasetRegistry",
+    "count_features",
+    "make_virtual_id",
+    "materialize_virtual_view",
+    "parse_virtual_id",
+    "to_dataset_meta",
+]

--- a/tests/unit/test_virtual_dataset.py
+++ b/tests/unit/test_virtual_dataset.py
@@ -1,0 +1,269 @@
+"""Unit tests for A9 (#235) — ``VirtualDatasetRegistry`` and lazy views.
+
+Zero network: the materialisation roundtrip reads a *local* GeoParquet
+fixture built at test time, so CI moves no bytes off the box.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gispulse.core.plugin_model import (
+    AccessProtocol,
+    AccessSpec,
+    FetchMode,
+    Payload,
+    SourceDomain,
+    SourceResult,
+)
+from gispulse.core.sources import ProtocolRegistry, ProtocolNotSupported, SourceEntryRef
+from gispulse.persistence.virtual_dataset import (
+    VIRTUAL_ID_SCHEME,
+    VirtualDataset,
+    VirtualDatasetError,
+    VirtualDatasetRegistry,
+    count_features,
+    make_virtual_id,
+    materialize_virtual_view,
+    parse_virtual_id,
+    to_dataset_meta,
+)
+
+
+# -- fixtures ----------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def parquet_fixture(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """A 3-row GeoParquet file with an Overture-style ``bbox`` struct column."""
+    import duckdb
+
+    path = tmp_path_factory.mktemp("vds") / "places.parquet"
+    con = duckdb.connect()
+    con.execute(
+        f"""
+        COPY (
+          SELECT * FROM (VALUES
+            (1, 'alpha', {{'xmin': 0.0,  'ymin': 0.0,  'xmax': 1.0,  'ymax': 1.0}}),
+            (2, 'beta',  {{'xmin': 10.0, 'ymin': 10.0, 'xmax': 11.0, 'ymax': 11.0}}),
+            (3, 'gamma', {{'xmin': 0.5,  'ymin': 0.5,  'xmax': 1.5,  'ymax': 1.5}})
+          ) AS t(id, name, bbox)
+        ) TO '{path}' (FORMAT PARQUET)
+        """
+    )
+    con.close()
+    return path
+
+
+def _entry(endpoint: str) -> SourceEntryRef:
+    """A REMOTE_TABLE catalogue entry pointing at a single local parquet."""
+    return SourceEntryRef(
+        id="overture-places",
+        name="Overture Maps — Places",
+        access=AccessSpec(
+            protocol=AccessProtocol.REMOTE_TABLE,
+            endpoint=endpoint,
+            params={"glob": "", "hive_partitioning": False},
+        ),
+        domain=SourceDomain.OBSERVATION,
+        payload=Payload.VECTOR,
+        jurisdiction="world",
+        metadata={"provider": "Overture Maps Foundation"},
+    )
+
+
+@pytest.fixture
+def geoparquet_registry() -> ProtocolRegistry:
+    """A fetcher registry with only the REMOTE_TABLE adapter."""
+    from gispulse.core.fetchers.geoparquet_s3 import GeoParquetS3Fetcher
+
+    reg = ProtocolRegistry()
+    reg.register(GeoParquetS3Fetcher())
+    return reg
+
+
+# -- synthetic id helpers ----------------------------------------------------
+
+
+def test_make_and_parse_virtual_id_roundtrip() -> None:
+    vid = make_virtual_id("worldwide", "overture-places")
+    assert vid == "virtual:worldwide/overture-places"
+    assert vid.startswith(VIRTUAL_ID_SCHEME)
+    assert parse_virtual_id(vid) == ("worldwide", "overture-places")
+
+
+def test_make_virtual_id_rejects_empty() -> None:
+    with pytest.raises(VirtualDatasetError):
+        make_virtual_id("", "x")
+    with pytest.raises(VirtualDatasetError):
+        make_virtual_id("worldwide", "")
+
+
+@pytest.mark.parametrize(
+    "bad", ["worldwide/entry", "virtual:noslash", "virtual:/entry", "virtual:src/"]
+)
+def test_parse_virtual_id_rejects_malformed(bad: str) -> None:
+    with pytest.raises(VirtualDatasetError):
+        parse_virtual_id(bad)
+
+
+# -- VirtualDataset properties ----------------------------------------------
+
+
+def test_virtual_dataset_properties() -> None:
+    vds = VirtualDataset(
+        id="virtual:worldwide/overture-places",
+        source_name="worldwide",
+        entry=_entry("/tmp/x.parquet"),
+    )
+    assert vds.entry_id == "overture-places"
+    assert vds.name == "Overture Maps — Places"
+    assert vds.view_name == "v_overture_places"
+    assert vds.source_uri == "worldwide://overture-places"
+    assert vds.payload == "vector"
+    assert vds.crs == "EPSG:4326"
+
+
+def test_to_dataset_meta_shape() -> None:
+    vds = VirtualDataset(
+        id="virtual:worldwide/overture-places",
+        source_name="worldwide",
+        entry=_entry("/tmp/x.parquet"),
+    )
+    meta = to_dataset_meta(vds)
+    assert meta["source_type"] == "virtual"
+    assert meta["file_size"] == 0
+    assert meta["virtual_source_uri"] == "worldwide://overture-places"
+    assert meta["feature_count"] is None
+    assert meta["virtual_bbox"] is None
+    assert meta["data_category"] == "vector"
+    assert meta["metadata"]["domain"] == "observation"
+    assert meta["metadata"]["jurisdiction"] == "world"
+    assert meta["metadata"]["protocol"] == "remote-table"
+
+
+def test_to_dataset_meta_carries_lazy_stats() -> None:
+    vds = VirtualDataset(
+        id="virtual:worldwide/overture-places",
+        source_name="worldwide",
+        entry=_entry("/tmp/x.parquet"),
+    )
+    meta = to_dataset_meta(vds, feature_count=42, bbox=(0.0, 0.0, 1.0, 1.0))
+    assert meta["feature_count"] == 42
+    assert meta["virtual_bbox"] == [0.0, 0.0, 1.0, 1.0]
+
+
+# -- registry ----------------------------------------------------------------
+
+
+def test_registry_create_get_list_remove(geoparquet_registry: ProtocolRegistry) -> None:
+    reg = VirtualDatasetRegistry()
+    vds = reg.create(_entry("/tmp/x.parquet"), protocols=geoparquet_registry)
+    assert vds.id == "virtual:worldwide/overture-places"
+    assert reg.get(vds.id) is vds
+    assert vds.id in reg
+    assert len(reg) == 1
+    assert reg.list() == [vds]
+    assert reg.remove(vds.id) is True
+    assert reg.remove(vds.id) is False
+    assert len(reg) == 0
+
+
+def test_registry_get_unknown_raises() -> None:
+    with pytest.raises(KeyError):
+        VirtualDatasetRegistry().get("virtual:worldwide/missing")
+
+
+def test_registry_clear(geoparquet_registry: ProtocolRegistry) -> None:
+    reg = VirtualDatasetRegistry()
+    reg.create(_entry("/tmp/x.parquet"), protocols=geoparquet_registry)
+    reg.clear()
+    assert len(reg) == 0
+
+
+def test_registry_create_rejects_unsupported_protocol() -> None:
+    # An empty registry has no fetcher for REMOTE_TABLE.
+    with pytest.raises(ProtocolNotSupported):
+        VirtualDatasetRegistry().create(
+            _entry("/tmp/x.parquet"), protocols=ProtocolRegistry()
+        )
+
+
+# -- materialisation roundtrip (local parquet, zero network) ----------------
+
+
+def test_materialize_roundtrip_local_parquet(
+    parquet_fixture: Path, geoparquet_registry: ProtocolRegistry
+) -> None:
+    from gispulse.persistence.duckdb_engine import DuckDBSession
+
+    reg = VirtualDatasetRegistry()
+    vds = reg.create(_entry(str(parquet_fixture)), protocols=geoparquet_registry)
+    with DuckDBSession() as session:
+        view = materialize_virtual_view(session, vds, protocols=geoparquet_registry)
+        assert view == "v_overture_places"
+        assert count_features(session, view) == 3
+
+
+def test_materialize_bbox_pushdown_clips_rows(
+    parquet_fixture: Path, geoparquet_registry: ProtocolRegistry
+) -> None:
+    from gispulse.persistence.duckdb_engine import DuckDBSession
+
+    vds = VirtualDatasetRegistry().create(
+        _entry(str(parquet_fixture)), protocols=geoparquet_registry
+    )
+    with DuckDBSession() as session:
+        # bbox (0,0)-(5,5): keeps 'alpha' and 'gamma', drops 'beta' at (10,10).
+        view = materialize_virtual_view(
+            session, vds, bbox=(0.0, 0.0, 5.0, 5.0), protocols=geoparquet_registry
+        )
+        assert count_features(session, view) == 2
+
+
+def test_materialize_replaces_existing_view(
+    parquet_fixture: Path, geoparquet_registry: ProtocolRegistry
+) -> None:
+    from gispulse.persistence.duckdb_engine import DuckDBSession
+
+    vds = VirtualDatasetRegistry().create(
+        _entry(str(parquet_fixture)), protocols=geoparquet_registry
+    )
+    with DuckDBSession() as session:
+        materialize_virtual_view(session, vds, protocols=geoparquet_registry)
+        # A second call with a bbox must CREATE OR REPLACE, not error.
+        materialize_virtual_view(
+            session, vds, bbox=(0.0, 0.0, 5.0, 5.0), protocols=geoparquet_registry
+        )
+        assert count_features(session, vds.view_name) == 2
+
+
+# -- materialisation error path ---------------------------------------------
+
+
+class _NoScanFetcher:
+    """A Fetcher that returns a REFERENCE result carrying no scan SQL."""
+
+    protocol = AccessProtocol.REMOTE_TABLE
+
+    def fetch(
+        self,
+        access: AccessSpec,
+        *,
+        extent: object | None = None,
+        mode: FetchMode = FetchMode.MATERIALIZE,
+    ) -> SourceResult:
+        return SourceResult(payload=Payload.VECTOR, mode=FetchMode.REFERENCE)
+
+
+def test_materialize_raises_when_fetcher_yields_no_scan() -> None:
+    from gispulse.persistence.duckdb_engine import DuckDBSession
+
+    reg = ProtocolRegistry()
+    reg.register(_NoScanFetcher())
+    vds = VirtualDatasetRegistry().create(_entry("/tmp/x.parquet"), protocols=reg)
+    with DuckDBSession() as session:
+        with pytest.raises(VirtualDatasetError, match="no .* scan"):
+            materialize_virtual_view(session, vds, protocols=reg)


### PR DESCRIPTION
## A9 of EPIC #226 — agrégateur de données géo mondiales

Transforme une entrée du catalogue worldwide (un `SourceEntryRef` de
`WorldwideCatalogSource`, A8 / #257) en **vue DuckDB** lazy, sans déplacer
le moindre octet. Dépend de A2 (#228) et A7 (#233) — tous deux sur `main`.

### Livré — `persistence/virtual_dataset.py`
- **`VirtualDataset`** — identité seule (`id` / `source` / `entry`) : aucun SQL, aucun réseau tant que la vue n'est pas matérialisée.
- **`make_virtual_id` / `parse_virtual_id`** — ids synthétiques `virtual:<source>/<entry>`.
- **`VirtualDatasetRegistry`** (+ singleton `VIRTUAL_DATASETS`) — thread-safe ; `create()` valide qu'un fetcher existe pour le protocole avant d'enregistrer.
- **`materialize_virtual_view()`** — le seul chemin qui touche le réseau : le fetcher de protocole résout le scan lazy et, si un `bbox` est fourni, **pousse le prédicat spatial dans le scan** (struct `bbox` Overture) → DuckDB élague avant de lire.
- **`count_features()` / `to_dataset_meta()`** — stats lazy + projection `DatasetMeta` pour le portail (`source_type:"virtual"`, `file_size:0`, `feature_count`/`bbox` calculés au preview).

### Tests
- **17 tests unitaires**, dont le **roundtrip d'acceptation** : un GeoParquet fixture local est créé, exposé en vue, compté, puis clippé par bbox — **zéro réseau** en CI.
- Helpers id, propriétés `VirtualDataset`, CRUD du registre, `ProtocolNotSupported` sur protocole inconnu, `VirtualDatasetError` quand le fetcher ne renvoie pas de scan.
- `ruff check` clean ; 349 tests de régression verts.

Closes #235.

🤖 Generated with [Claude Code](https://claude.com/claude-code)