### PR TITLE
feat(v19): worldwide aggregator HTTP endpoints (A10, #236)

### DIFF
--- a/src/gispulse/adapters/http/routers/catalog_router.py
+++ b/src/gispulse/adapters/http/routers/catalog_router.py
@@ -14,7 +14,11 @@ from fastapi import APIRouter, HTTPException, Query, Request
 from gispulse import get_app
 from gispulse.catalog.models import CatalogDomain, FluxEntry, FluxProtocol, OpenDataEntry
 from gispulse.catalog import registry as catalog_registry
-from gispulse.adapters.http.schemas import CatalogImportRequest
+from gispulse.adapters.http.schemas import (
+    CatalogImportRequest,
+    VirtualDatasetCreate,
+    VirtualDatasetMaterialize,
+)
 
 log = logging.getLogger(__name__)
 
@@ -425,3 +429,260 @@ async def _import_opendata_download(
         }
     finally:
         shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# Worldwide aggregator — lazy catalogue + virtual datasets (EPIC #226, A10 #236)
+# ---------------------------------------------------------------------------
+
+_WORLDWIDE_FETCHERS = None
+
+
+def _worldwide_fetchers():
+    """A dedicated registry of the core worldwide fetchers.
+
+    Kept *separate* from the process-wide ``PROTOCOLS`` so the worldwide
+    aggregator never overrides the legacy #192 catalog-import adapters
+    that share the STAC / OGC-Features protocol slots. Built once.
+    """
+    global _WORLDWIDE_FETCHERS
+    if _WORLDWIDE_FETCHERS is None:
+        from gispulse.core.fetchers import register_core_fetchers
+        from gispulse.core.sources import ProtocolRegistry
+
+        registry = ProtocolRegistry()
+        register_core_fetchers(registry)
+        _WORLDWIDE_FETCHERS = registry
+    return _WORLDWIDE_FETCHERS
+
+
+def _worldwide_source(name: str = "worldwide"):
+    """Resolve a worldwide-style ``DataSource`` from :data:`SOURCES`.
+
+    The first-party ``worldwide`` catalogue is registered on first use so
+    the endpoint is self-sufficient even when the ``gispulse.data_sources``
+    entry-point hooks have not been run. A test may pre-register a mock
+    under the same name and it is honoured here.
+    """
+    from gispulse.core.sources import SOURCES
+
+    try:
+        return SOURCES.get(name)
+    except KeyError:
+        if name != "worldwide":
+            raise HTTPException(404, f"Unknown data source '{name}'") from None
+        from gispulse.plugins.worldwide_source import WorldwideCatalogSource
+
+        source = WorldwideCatalogSource()
+        SOURCES.register(source)
+        return source
+
+
+def _serialize_worldwide_entry(entry) -> dict:
+    """Flat JSON projection of a catalogue entry — the four axes inline."""
+    return {
+        "id": entry.id,
+        "name": entry.name,
+        "domain": entry.domain.value if entry.domain else None,
+        "payload": entry.payload.value if entry.payload else None,
+        "jurisdiction": entry.jurisdiction,
+        "protocol": entry.access.protocol.value,
+        "family": entry.metadata.get("family"),
+        "endpoint": entry.access.endpoint,
+        "revision_token": entry.revision_token,
+        "metadata": entry.metadata,
+    }
+
+
+def _parse_bbox(raw: str | None) -> tuple[float, float, float, float] | None:
+    """Parse a ``minx,miny,maxx,maxy`` query string into a bbox tuple."""
+    if not raw:
+        return None
+    parts = raw.split(",")
+    if len(parts) != 4:
+        raise HTTPException(400, "bbox must be 'minx,miny,maxx,maxy'")
+    try:
+        minx, miny, maxx, maxy = (float(p) for p in parts)
+    except ValueError:
+        raise HTTPException(400, "bbox components must be numbers") from None
+    return (minx, miny, maxx, maxy)
+
+
+@router.get("/worldwide")
+def list_worldwide(
+    search: str | None = None,
+    domain: str | None = Query(None, description="SourceDomain value"),
+    payload: str | None = Query(None, description="Payload value"),
+    jurisdiction: str | None = Query(None, description="Coverage code, e.g. FR / world"),
+    protocol: str | None = Query(None, description="AccessProtocol value"),
+    family: str | None = Query(None, description="Catalogue family grouping"),
+):
+    """List the worldwide catalogue, filtered on the four classification axes."""
+    source = _worldwide_source()
+    try:
+        entries = source.catalog(
+            search,
+            domain=domain,
+            payload=payload,
+            jurisdiction=jurisdiction,
+            protocol=protocol,
+            family=family,
+        )
+    except Exception as exc:  # noqa: BLE001 — surface a bad catalogue as 502
+        raise HTTPException(502, f"worldwide catalogue unavailable: {exc}") from exc
+    return [_serialize_worldwide_entry(e) for e in entries]
+
+
+@router.post("/virtual", status_code=201)
+def create_virtual_dataset(body: VirtualDatasetCreate):
+    """Create a lazy virtual dataset from one worldwide-catalogue entry."""
+    from gispulse.core.sources import ProtocolNotSupported
+    from gispulse.persistence.virtual_dataset import VIRTUAL_DATASETS, to_dataset_meta
+
+    source = _worldwide_source(body.source)
+    entry = next(
+        (e for e in source.catalog() if e.id == body.entry_id), None
+    )
+    if entry is None:
+        raise HTTPException(404, f"Catalogue entry '{body.entry_id}' not found")
+
+    try:
+        vds = VIRTUAL_DATASETS.create(
+            entry, source_name=body.source, protocols=_worldwide_fetchers()
+        )
+    except ProtocolNotSupported as exc:
+        raise HTTPException(
+            422, f"no fetcher for entry '{body.entry_id}': {exc}"
+        ) from exc
+    return to_dataset_meta(vds)
+
+
+@router.get("/virtual/{virtual_id:path}/preview")
+def preview_virtual_dataset(virtual_id: str, bbox: str | None = None):
+    """Preview a virtual dataset — materialise the bbox-scoped view and count."""
+    from gispulse.persistence.duckdb_engine import DuckDBSession
+    from gispulse.persistence.virtual_dataset import (
+        VIRTUAL_DATASETS,
+        VirtualDatasetError,
+        count_features,
+        materialize_virtual_view,
+        to_dataset_meta,
+    )
+
+    try:
+        vds = VIRTUAL_DATASETS.get(virtual_id)
+    except KeyError:
+        raise HTTPException(404, f"Virtual dataset '{virtual_id}' not found") from None
+
+    box = _parse_bbox(bbox)
+    try:
+        with DuckDBSession() as session:
+            view = materialize_virtual_view(
+                session, vds, bbox=box, protocols=_worldwide_fetchers()
+            )
+            count = count_features(session, view)
+    except VirtualDatasetError as exc:
+        raise HTTPException(422, str(exc)) from exc
+    except Exception as exc:  # noqa: BLE001 — a remote-scan failure ⇒ 502
+        raise HTTPException(502, f"preview failed: {exc}") from exc
+    return to_dataset_meta(vds, feature_count=count, bbox=box)
+
+
+@router.post("/virtual/{virtual_id:path}/materialize", status_code=201)
+def materialize_virtual_dataset(
+    virtual_id: str, body: VirtualDatasetMaterialize, request: Request
+):
+    """Materialise a virtual dataset into a real local project dataset."""
+    from gispulse.core.plugin_model import FetchMode
+    from gispulse.persistence.virtual_dataset import VIRTUAL_DATASETS
+
+    try:
+        vds = VIRTUAL_DATASETS.get(virtual_id)
+    except KeyError:
+        raise HTTPException(404, f"Virtual dataset '{virtual_id}' not found") from None
+
+    box = tuple(body.bbox) if body.bbox else None
+    # Re-run the same fetcher in MATERIALIZE mode — vds.entry carries the
+    # declarative access block, so no DataSource lookup is needed.
+    try:
+        result = _worldwide_fetchers().dispatch_fetch(
+            vds.entry.access, extent=box, mode=FetchMode.MATERIALIZE
+        )
+    except Exception as exc:  # noqa: BLE001 — fetch transport error ⇒ 502
+        raise HTTPException(502, f"materialisation failed: {exc}") from exc
+    return _register_materialized(result, vds, body, box, request)
+
+
+def _register_materialized(
+    result, vds, body: VirtualDatasetMaterialize, bbox, request: Request
+) -> dict:
+    """Register a materialised :class:`SourceResult` as a local dataset."""
+    from gispulse.core.models import Dataset
+    from gispulse.persistence.io import dataset_from_file
+
+    dataset_repo = request.app.state.dataset_repo
+    data_dir: Path = request.app.state.data_dir
+    layer_cache: dict = getattr(request.app.state, "layer_cache", {})
+
+    dataset_id = uuid4()
+    dest_dir = data_dir / str(dataset_id)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    ds_name = body.name or vds.name
+    metadata = {
+        "virtual_id": vds.id,
+        "catalog_entry": vds.entry_id,
+        "source": vds.source_name,
+        "bbox": list(bbox) if bbox else None,
+    }
+
+    data = result.data
+    if isinstance(data, (str, Path)) and Path(data).exists():
+        final_path = dest_dir / Path(data).name
+        shutil.copy2(str(data), str(final_path))
+    elif hasattr(data, "to_file"):  # a GeoDataFrame
+        gdf = data
+        if body.crs and body.crs != "EPSG:4326" and getattr(gdf, "crs", None):
+            try:
+                gdf = gdf.to_crs(body.crs)
+            except Exception:  # noqa: BLE001 — keep source CRS on failure
+                pass
+        safe_layer = "".join(c if c.isalnum() else "_" for c in vds.entry_id)
+        final_path = dest_dir / f"{safe_layer}.gpkg"
+        gdf.to_file(str(final_path), driver="GPKG", layer=safe_layer)
+    else:
+        shutil.rmtree(dest_dir, ignore_errors=True)
+        raise HTTPException(502, "materialisation returned no usable data")
+
+    try:
+        dataset = dataset_from_file(str(final_path))
+    except Exception:  # noqa: BLE001 — non-vector payload (e.g. parquet)
+        dataset = Dataset(format=final_path.suffix.lstrip(".").upper() or None)
+    dataset.id = dataset_id
+    dataset.name = ds_name
+    dataset.source_path = str(final_path)
+    dataset.metadata = metadata
+    dataset_repo.save(dataset)
+
+    try:
+        from gispulse.adapters.http.layer_utils import build_layer_meta, load_layers
+
+        layers = load_layers(str(final_path))
+        layer_metas = [build_layer_meta(str(final_path), ln) for ln in layers]
+        layer_cache[str(dataset_id)] = layer_metas
+    except Exception:  # noqa: BLE001 — layer cache is best-effort
+        layer_metas = []
+
+    return {
+        "id": str(dataset_id),
+        "name": ds_name,
+        "source_path": str(final_path),
+        "source_type": "materialized",
+        "format": dataset.format,
+        "crs": dataset.crs,
+        "file_size": final_path.stat().st_size,
+        "layers": layer_metas,
+        "virtual_id": vds.id,
+        "catalog_entry": vds.entry_id,
+        "bbox": list(bbox) if bbox else None,
+        "created_at": dataset.created_at.isoformat(),
+    }

--- a/src/gispulse/adapters/http/schemas.py
+++ b/src/gispulse/adapters/http/schemas.py
@@ -390,6 +390,45 @@ class CatalogImportRequest(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Worldwide aggregator schemas (EPIC #226 — A10 #236)
+# ---------------------------------------------------------------------------
+
+
+class VirtualDatasetCreate(BaseModel):
+    """Create a lazy virtual dataset from one worldwide-catalogue entry."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        json_schema_extra={
+            "example": {"entry_id": "overture-places", "source": "worldwide"}
+        },
+    )
+
+    entry_id: str = Field(..., description="Catalogue entry id (e.g. 'overture-places').")
+    source: str = Field("worldwide", description="Data source name the entry belongs to.")
+
+
+class VirtualDatasetMaterialize(BaseModel):
+    """Materialise a virtual dataset into a real local project dataset."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        json_schema_extra={
+            "example": {"name": "Overture places — Paris", "bbox": [2.2, 48.8, 2.5, 48.9]}
+        },
+    )
+
+    name: str | None = Field(None, description="Override name for the created dataset.")
+    bbox: list[float] | None = Field(
+        None,
+        description="Bounding box [west, south, east, north] pushed into the fetch.",
+        min_length=4,
+        max_length=4,
+    )
+    crs: str = Field("EPSG:4326", description="Target CRS for the materialised data.")
+
+
+# ---------------------------------------------------------------------------
 # Scenario schemas
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_catalog_worldwide_router.py
+++ b/tests/unit/test_catalog_worldwide_router.py
@@ -1,0 +1,229 @@
+"""Unit tests for A10 (#236) — worldwide aggregator HTTP endpoints.
+
+The ``worldwide`` data source is mocked in :data:`SOURCES` with a
+fake over a *local* GeoParquet fixture, so the preview / materialise
+roundtrips move zero bytes off the box.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from gispulse.core.plugin_model import (
+    AccessProtocol,
+    AccessSpec,
+    Payload,
+    SourceDomain,
+)
+from gispulse.core.sources import SOURCES, SourceEntryRef
+from gispulse.persistence.virtual_dataset import VIRTUAL_DATASETS
+
+
+# -- a local-parquet fixture + a fake worldwide source ----------------------
+
+
+@pytest.fixture(scope="module")
+def parquet_fixture(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """A 3-row GeoParquet file with an Overture-style ``bbox`` struct."""
+    import duckdb
+
+    path = tmp_path_factory.mktemp("ww") / "places.parquet"
+    con = duckdb.connect()
+    con.execute(
+        f"""
+        COPY (
+          SELECT * FROM (VALUES
+            (1, 'alpha', {{'xmin': 0.0,  'ymin': 0.0,  'xmax': 1.0,  'ymax': 1.0}}),
+            (2, 'beta',  {{'xmin': 10.0, 'ymin': 10.0, 'xmax': 11.0, 'ymax': 11.0}}),
+            (3, 'gamma', {{'xmin': 0.5,  'ymin': 0.5,  'xmax': 1.5,  'ymax': 1.5}})
+          ) AS t(id, name, bbox)
+        ) TO '{path}' (FORMAT PARQUET)
+        """
+    )
+    con.close()
+    return path
+
+
+def _entry(endpoint: str) -> SourceEntryRef:
+    return SourceEntryRef(
+        id="test-places",
+        name="Test Places",
+        access=AccessSpec(
+            protocol=AccessProtocol.REMOTE_TABLE,
+            endpoint=endpoint,
+            params={"glob": "", "hive_partitioning": False},
+        ),
+        domain=SourceDomain.OBSERVATION,
+        payload=Payload.VECTOR,
+        jurisdiction="world",
+        revision_token="t0",
+        metadata={"family": "test-family", "provider": "Test"},
+    )
+
+
+class _FakeWorldwideSource:
+    """A minimal stand-in for ``WorldwideCatalogSource`` (SOURCES mock)."""
+
+    name = "worldwide"
+
+    def __init__(self, entries: list[SourceEntryRef]) -> None:
+        self._entries = list(entries)
+
+    def catalog(
+        self,
+        search: str | None = None,
+        *,
+        domain: str | None = None,
+        payload: str | None = None,
+        jurisdiction: str | None = None,
+        protocol: str | None = None,
+        family: str | None = None,
+    ) -> list[SourceEntryRef]:
+        out = []
+        for e in self._entries:
+            q = search.lower() if search else None
+            if q and q not in e.id.lower() and q not in e.name.lower():
+                continue
+            if domain and (not e.domain or e.domain.value != domain):
+                continue
+            if payload and (not e.payload or e.payload.value != payload):
+                continue
+            if jurisdiction and e.jurisdiction != jurisdiction:
+                continue
+            if protocol and e.access.protocol.value != protocol:
+                continue
+            if family and e.metadata.get("family") != family:
+                continue
+            out.append(e)
+        return out
+
+    def entries(self) -> list[SourceEntryRef]:
+        return list(self._entries)
+
+
+@pytest.fixture()
+def client(
+    parquet_fixture: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> TestClient:
+    from gispulse.adapters.http.app import create_app
+    from gispulse.adapters.http.rate_limit import limiter
+
+    monkeypatch.setenv("GISPULSE_STORAGE", "memory")
+    os.environ["GISPULSE_STORAGE"] = "memory"
+    limiter.enabled = False
+
+    SOURCES.clear()
+    SOURCES.register(_FakeWorldwideSource([_entry(str(parquet_fixture))]))
+    VIRTUAL_DATASETS.clear()
+
+    app = create_app(data_dir=tmp_path)
+    try:
+        yield TestClient(app)
+    finally:
+        SOURCES.clear()
+        VIRTUAL_DATASETS.clear()
+
+
+# -- GET /api/catalog/worldwide ---------------------------------------------
+
+
+def test_list_worldwide_returns_entries(client: TestClient) -> None:
+    r = client.get("/api/catalog/worldwide")
+    assert r.status_code == 200
+    body = r.json()
+    assert len(body) == 1
+    entry = body[0]
+    assert entry["id"] == "test-places"
+    assert entry["domain"] == "observation"
+    assert entry["payload"] == "vector"
+    assert entry["jurisdiction"] == "world"
+    assert entry["protocol"] == "remote-table"
+    assert entry["family"] == "test-family"
+
+
+def test_list_worldwide_filters_by_axis(client: TestClient) -> None:
+    assert len(client.get("/api/catalog/worldwide?domain=observation").json()) == 1
+    assert client.get("/api/catalog/worldwide?domain=imagerie").json() == []
+    assert len(client.get("/api/catalog/worldwide?family=test-family").json()) == 1
+    assert len(client.get("/api/catalog/worldwide?protocol=remote-table").json()) == 1
+
+
+# -- POST /api/catalog/virtual ----------------------------------------------
+
+
+def test_create_virtual_dataset(client: TestClient) -> None:
+    r = client.post("/api/catalog/virtual", json={"entry_id": "test-places"})
+    assert r.status_code == 201
+    body = r.json()
+    assert body["id"] == "virtual:worldwide/test-places"
+    assert body["source_type"] == "virtual"
+    assert body["file_size"] == 0
+    assert body["feature_count"] is None
+
+
+def test_create_virtual_unknown_entry_returns_404(client: TestClient) -> None:
+    r = client.post("/api/catalog/virtual", json={"entry_id": "missing"})
+    assert r.status_code == 404
+
+
+# -- GET /api/catalog/virtual/{id}/preview ----------------------------------
+
+
+def test_preview_virtual_dataset(client: TestClient) -> None:
+    client.post("/api/catalog/virtual", json={"entry_id": "test-places"})
+    r = client.get("/api/catalog/virtual/virtual:worldwide/test-places/preview")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["source_type"] == "virtual"
+    assert body["feature_count"] == 3
+
+
+def test_preview_virtual_dataset_with_bbox(client: TestClient) -> None:
+    client.post("/api/catalog/virtual", json={"entry_id": "test-places"})
+    r = client.get(
+        "/api/catalog/virtual/virtual:worldwide/test-places/preview?bbox=0,0,5,5"
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["feature_count"] == 2
+    assert body["virtual_bbox"] == [0.0, 0.0, 5.0, 5.0]
+
+
+def test_preview_unknown_virtual_returns_404(client: TestClient) -> None:
+    r = client.get("/api/catalog/virtual/virtual:worldwide/ghost/preview")
+    assert r.status_code == 404
+
+
+def test_preview_rejects_malformed_bbox(client: TestClient) -> None:
+    client.post("/api/catalog/virtual", json={"entry_id": "test-places"})
+    r = client.get(
+        "/api/catalog/virtual/virtual:worldwide/test-places/preview?bbox=1,2,3"
+    )
+    assert r.status_code == 400
+
+
+# -- POST /api/catalog/virtual/{id}/materialize -----------------------------
+
+
+def test_materialize_virtual_dataset(client: TestClient) -> None:
+    client.post("/api/catalog/virtual", json={"entry_id": "test-places"})
+    r = client.post(
+        "/api/catalog/virtual/virtual:worldwide/test-places/materialize",
+        json={"name": "Materialised places"},
+    )
+    assert r.status_code == 201
+    body = r.json()
+    assert body["name"] == "Materialised places"
+    assert body["virtual_id"] == "virtual:worldwide/test-places"
+    assert Path(body["source_path"]).exists()
+
+
+def test_materialize_unknown_virtual_returns_404(client: TestClient) -> None:
+    r = client.post(
+        "/api/catalog/virtual/virtual:worldwide/ghost/materialize", json={}
+    )
+    assert r.status_code == 404


### PR DESCRIPTION
## A10 of EPIC #226 — agrégateur de données géo mondiales

Expose `WorldwideCatalogSource` (A8, #257) et le `VirtualDatasetRegistry`
(A9, #258) au portail via quatre endpoints catalogue.

### Endpoints — `adapters/http/routers/catalog_router.py`

| Méthode | Route | Rôle |
|---|---|---|
| `GET` | `/api/catalog/worldwide` | liste le catalogue, filtre sur les 4 axes (`domain`/`payload`/`jurisdiction`/`protocol`) + `family` |
| `POST` | `/api/catalog/virtual` | crée un dataset virtuel depuis une entrée catalogue |
| `GET` | `/api/catalog/virtual/{id}/preview` | matérialise la vue bbox-scopée et compte les features |
| `POST` | `/api/catalog/virtual/{id}/materialize` | matérialise en dataset local de projet |

### Choix de conception
- La source worldwide est résolue via `core.sources.SOURCES` (**mockable** ; le catalogue first-party est enregistré paresseusement s'il est absent).
- Les 4 fetchers cœur vont dans une **`ProtocolRegistry` dédiée**, séparée du `PROTOCOLS` global → l'agrégateur n'écrase jamais les adaptateurs legacy #192 d'import catalogue qui partagent les slots STAC / OGC-Features.
- `materialize` ré-exécute le fetcher en mode `MATERIALIZE` sur `vds.entry.access` (pas de lookup `DataSource`), puis enregistre le résultat en `Dataset` (chemin fichier ou GeoDataFrame).
- Schémas `VirtualDatasetCreate` / `VirtualDatasetMaterialize` ajoutés à `schemas.py`.

### Tests
- **10 tests unitaires**, **zéro réseau** — un GeoParquet fixture local tient lieu de source worldwide, exerçant create / preview / pushdown bbox / materialize + les 404/400.
- `ruff` clean. Régression : les tests de self-registration des fetchers legacy (`test_stac_fetcher`, `test_wfs_fetcher`) restent verts grâce au registre dédié.

Closes #236.

🤖 Generated with [Claude Code](https://claude.com/claude-code)