### PR TITLE
feat(v19): worldwide aggregator backend — A11/A13/A14/A15

### DIFF
--- a/src/gispulse/adapters/http/routers/pipelines_router.py
+++ b/src/gispulse/adapters/http/routers/pipelines_router.py
@@ -78,8 +78,19 @@ class PipelineExecuteRequest(BaseModel):
     triggers: list[TriggerSpecIn] = Field(default_factory=list, description="Inline triggers.")
     ref_layers: dict[str, str] = Field(default_factory=dict, description="Named reference layers.")
     dataset_id: UUID | None = Field(None, description="Dataset UUID to execute against.")
-    input_path: str | None = Field(None, description="Direct file path (alternative to dataset_id).")
+    input_path: str | None = Field(
+        None,
+        description="Direct file path, or a 'virtual:<source>/<entry>' id "
+        "(alternative to dataset_id).",
+    )
     layer: str | None = Field(None, description="Layer name for multi-layer inputs.")
+    bbox: list[float] | None = Field(
+        None,
+        description="Bounding box [minx, miny, maxx, maxy] pushed down into "
+        "virtual-dataset ref layers / inputs (mandatory for global sources).",
+        min_length=4,
+        max_length=4,
+    )
 
 
 class StepResultOut(BaseModel):
@@ -226,6 +237,46 @@ def _validate_pipeline(steps: list[StepSpecIn], ref_layers: dict[str, str] | Non
 
 
 # ---------------------------------------------------------------------------
+# Virtual-dataset pipeline-prepare hook (A11, #237)
+# ---------------------------------------------------------------------------
+
+
+def _bbox_tuple(payload: PipelineExecuteRequest) -> tuple | None:
+    """The request bbox as a tuple, or ``None``."""
+    return tuple(payload.bbox) if payload.bbox else None
+
+
+def _resolve_virtual_primary(virtual_id: str, bbox: tuple | None):
+    """Materialise a ``virtual:`` ``input_path`` into the primary GeoDataFrame."""
+    from gispulse.core.pipeline import prepare_virtual_input
+
+    try:
+        return prepare_virtual_input(virtual_id, bbox=bbox)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=f"Virtual dataset not found: {exc}")
+    except Exception as exc:
+        raise HTTPException(
+            status_code=502, detail=f"Failed to materialise virtual input: {exc}"
+        )
+
+
+def _add_virtual_ref_layers(spec: "PipelineSpec", inputs: dict, bbox: tuple | None) -> None:
+    """Run the pipeline-prepare hook — merge virtual ref layers into ``inputs``."""
+    from gispulse.core.pipeline import prepare_virtual_inputs
+
+    try:
+        inputs.update(prepare_virtual_inputs(spec, bbox=bbox))
+    except KeyError as exc:
+        raise HTTPException(
+            status_code=404, detail=f"Virtual ref layer not found: {exc}"
+        )
+    except Exception as exc:
+        raise HTTPException(
+            status_code=502, detail=f"Failed to materialise virtual ref layer: {exc}"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
 
@@ -256,10 +307,15 @@ def execute_pipeline(
         except Exception as exc:
             raise HTTPException(status_code=400, detail=f"Failed to load dataset: {exc}")
     elif payload.input_path:
-        try:
-            gdf = read_vector(payload.input_path, layer=payload.layer)
-        except Exception as exc:
-            raise HTTPException(status_code=400, detail=f"Failed to load file: {exc}")
+        from gispulse.core.pipeline import is_virtual_ref
+
+        if is_virtual_ref(payload.input_path):
+            gdf = _resolve_virtual_primary(payload.input_path, _bbox_tuple(payload))
+        else:
+            try:
+                gdf = read_vector(payload.input_path, layer=payload.layer)
+            except Exception as exc:
+                raise HTTPException(status_code=400, detail=f"Failed to load file: {exc}")
     else:
         raise HTTPException(status_code=422, detail="Provide either dataset_id or input_path.")
 
@@ -275,9 +331,16 @@ def execute_pipeline(
         payload.triggers, payload.ref_layers,
     )
 
-    # Load ref_layers as GeoDataFrames
+    # Load ref_layers as GeoDataFrames. Virtual ref layers
+    # ('virtual:<source>/<entry>') are materialised by the prepare hook;
+    # file-path ref layers go through read_vector.
+    from gispulse.core.pipeline import is_virtual_ref
+
     inputs: dict[str, gpd.GeoDataFrame] = {"input": gdf}
+    _add_virtual_ref_layers(spec, inputs, _bbox_tuple(payload))
     for alias, source_path in spec.ref_layers.items():
+        if is_virtual_ref(source_path):
+            continue
         try:
             inputs[alias] = read_vector(source_path)
         except Exception as exc:
@@ -369,10 +432,15 @@ def execute_pipeline_steps(
         except Exception as exc:
             raise HTTPException(status_code=400, detail=f"Failed to load dataset: {exc}")
     elif payload.input_path:
-        try:
-            gdf = read_vector(payload.input_path, layer=payload.layer)
-        except Exception as exc:
-            raise HTTPException(status_code=400, detail=f"Failed to load file: {exc}")
+        from gispulse.core.pipeline import is_virtual_ref
+
+        if is_virtual_ref(payload.input_path):
+            gdf = _resolve_virtual_primary(payload.input_path, _bbox_tuple(payload))
+        else:
+            try:
+                gdf = read_vector(payload.input_path, layer=payload.layer)
+            except Exception as exc:
+                raise HTTPException(status_code=400, detail=f"Failed to load file: {exc}")
     else:
         raise HTTPException(status_code=422, detail="Provide either dataset_id or input_path.")
 
@@ -400,7 +468,14 @@ def execute_pipeline_steps(
     if dataset_source is None and payload.input_path:
         dataset_source = payload.input_path
 
+    # Virtual ref layers are materialised by the prepare hook (A11, #237);
+    # file / layer-name ref layers go through read_vector below.
+    from gispulse.core.pipeline import is_virtual_ref
+
+    _add_virtual_ref_layers(spec, inputs, _bbox_tuple(payload))
     for alias, source_path in spec.ref_layers.items():
+        if is_virtual_ref(source_path):
+            continue
         try:
             # If source_path looks like a layer name (no path separator, no
             # file extension) and we have a container file, resolve from

--- a/src/gispulse/adapters/mcp/server.py
+++ b/src/gispulse/adapters/mcp/server.py
@@ -45,6 +45,7 @@ Triggers / change-log (workdir-scoped reads; dryrun has no side effects):
 Plugins / sources:
   list_plugins()               -> ExtensionHub inventory records
   list_sources()               -> registered ETL data-source plugins
+  refresh_worldwide_catalog()  -> data.gouv.fr freshness probe of FR entries
 
 Resources
 ---------
@@ -121,6 +122,7 @@ def register_builtin_mcp_surface(server: Any) -> None:
         inspect_changelog,
         watch_status,
         dryrun_trigger,
+        refresh_worldwide_catalog,
     ):
         server.tool()(fn)
     server.resource("gispulse://capabilities")(resource_capabilities)
@@ -565,6 +567,33 @@ def list_sources() -> list[dict[str, Any]]:
         One dict per data-source plugin record.
     """
     return _app.list_sources()
+
+
+def refresh_worldwide_catalog() -> dict[str, Any]:
+    """Probe data.gouv.fr for stale French entries of the worldwide catalogue.
+
+    Walks the worldwide aggregator catalogue (EPIC #226) and, for every
+    entry that declares a ``datagouv_dataset`` slug, queries data.gouv.fr
+    for its current publication timestamp — reporting which curated
+    ``revision_token`` values have drifted (A13, #239).
+
+    The probe is **read-only and idempotent**: it mutates nothing and two
+    calls against an unchanged remote return the same report. The MCP
+    server exposes no URL argument, so the probe is pinned to the
+    data.gouv.fr API host.
+
+    Returns:
+        ``{catalog, checked, entries: [...], stale: [...]}`` — each entry
+        record carries ``current_token`` / ``datagouv_revision`` /
+        ``up_to_date``, or an ``error`` key when its slug failed to
+        resolve.
+    """
+    from gispulse.plugins.datagouv_refresh import refresh_datagouv_entries
+
+    try:
+        return refresh_datagouv_entries()
+    except Exception as exc:  # noqa: BLE001 - report cleanly to the model
+        return {"error": f"Catalogue refresh failed: {exc}"}
 
 
 # ===========================================================================

--- a/src/gispulse/core/data/worldwide_catalog.yml
+++ b/src/gispulse/core/data/worldwide_catalog.yml
@@ -225,6 +225,10 @@ entries:
     revision_token: latest
     metadata:
       provider: Etalab / Cerema
+      # `datagouv_dataset` opts this entry into the A13 (#239) freshness
+      # probe — the `refresh_worldwide_catalog` MCP tool reports drift
+      # between `revision_token` and the live data.gouv.fr publication.
+      datagouv_dataset: demandes-de-valeurs-foncieres-geolocalisees
 
   - id: sirene-geolocalise
     name: Sirene — geolocated establishments (France)
@@ -254,3 +258,4 @@ entries:
     revision_token: latest
     metadata:
       provider: Etalab / DGFiP
+      datagouv_dataset: cadastre

--- a/src/gispulse/core/pipeline.py
+++ b/src/gispulse/core/pipeline.py
@@ -319,6 +319,183 @@ def load_pipeline(path: str | Path, *, validate: bool = True) -> PipelineSpec:
     )
 
 
+# ---------------------------------------------------------------------------
+# Pipeline-prepare hook — virtual datasets as pipeline inputs (A11, #237)
+# ---------------------------------------------------------------------------
+
+#: Prefix marking a ``ref_layers`` value or ``input_path`` as a virtual
+#: dataset id (``virtual:<source>/<entry>``) rather than a file path.
+VIRTUAL_REF_PREFIX = "virtual:"
+
+
+def is_virtual_ref(value: Any) -> bool:
+    """True when ``value`` is a virtual-dataset id (``virtual:…``)."""
+    return isinstance(value, str) and value.startswith(VIRTUAL_REF_PREFIX)
+
+
+def virtual_refs(spec: PipelineSpec) -> dict[str, str]:
+    """Return the ``alias → virtual_id`` subset of ``spec.ref_layers``.
+
+    These ref layers are not files on disk — the pipeline-prepare hook
+    :func:`prepare_virtual_inputs` materialises each into a GeoDataFrame.
+    """
+    return {a: v for a, v in spec.ref_layers.items() if is_virtual_ref(v)}
+
+
+def _worldwide_protocols() -> Any:
+    """A standalone protocol registry holding only the core worldwide fetchers.
+
+    Kept separate from the process-wide ``PROTOCOLS`` so resolving a
+    virtual dataset never disturbs the legacy catalog-import adapters
+    (mirrors ``catalog_router._worldwide_fetchers``).
+    """
+    from gispulse.core.fetchers import register_core_fetchers
+    from gispulse.core.sources import ProtocolRegistry
+
+    registry = ProtocolRegistry()
+    register_core_fetchers(registry)
+    return registry
+
+
+def _resolve_virtual_dataset(virtual_id: str, *, protocols: Any) -> Any:
+    """Return the :class:`VirtualDataset` behind ``virtual_id``.
+
+    Looks the id up in the process-wide ``VIRTUAL_DATASETS`` registry; if
+    it is not filed yet, the backing catalogue entry is resolved from its
+    ``DataSource`` and a virtual dataset is created on the fly.
+
+    Raises:
+        KeyError: the id is unknown to both the registry and its source.
+    """
+    from gispulse.persistence.virtual_dataset import VIRTUAL_DATASETS, parse_virtual_id
+
+    try:
+        return VIRTUAL_DATASETS.get(virtual_id)
+    except KeyError:
+        pass
+
+    from gispulse.core.sources import SOURCES
+
+    source_name, entry_id = parse_virtual_id(virtual_id)
+    source = SOURCES.get(source_name)  # KeyError surfaces to the caller
+    entry = next((e for e in source.catalog() if e.id == entry_id), None)
+    if entry is None:
+        raise KeyError(
+            f"virtual dataset {virtual_id!r}: source {source_name!r} has no "
+            f"entry {entry_id!r}"
+        )
+    return VIRTUAL_DATASETS.create(
+        entry, source_name=source_name, protocols=protocols
+    )
+
+
+def prepare_virtual_input(
+    virtual_id: str,
+    *,
+    bbox: tuple[float, float, float, float] | None = None,
+    protocols: Any | None = None,
+    session_factory: Any | None = None,
+) -> Any:
+    """Resolve one virtual dataset id into a GeoDataFrame (A11, #237).
+
+    Materialises the bbox-scoped lazy DuckDB view backing ``virtual_id``
+    and reads it back as a GeoDataFrame, ready to feed a pipeline step.
+    This is the per-id half of the :func:`prepare_virtual_inputs` hook.
+
+    Args:
+        virtual_id:      A ``virtual:<source>/<entry>`` id.
+        bbox:            Optional ``(minx, miny, maxx, maxy)`` pushed into
+                         the scan — mandatory for global sources.
+        protocols:       Fetcher registry. Defaults to a fresh registry
+                         carrying only the core worldwide fetchers.
+        session_factory: Callable returning a context-manageable DuckDB
+                         session. Defaults to :class:`DuckDBSession`.
+
+    Returns:
+        A GeoDataFrame of the bbox-scoped rows.
+    """
+    from gispulse.persistence.duckdb_engine import DuckDBSession
+    from gispulse.persistence.virtual_dataset import materialize_virtual_view
+
+    registry = protocols if protocols is not None else _worldwide_protocols()
+    vds = _resolve_virtual_dataset(virtual_id, protocols=registry)
+    make_session = session_factory or DuckDBSession
+    with make_session() as session:
+        view = materialize_virtual_view(
+            session, vds, bbox=bbox, protocols=registry
+        )
+        return _view_to_gdf(session, view, crs=vds.crs)
+
+
+def _view_to_gdf(session: Any, view: str, *, crs: str) -> Any:
+    """Read a materialised DuckDB view into a GeoDataFrame.
+
+    The geometry of a worldwide scan (GeoParquet, OGC Features, …) lands
+    in the view as a WKB ``BLOB`` column — by name (``geometry`` /
+    ``geom`` / …) or, failing that, detected as the first binary column.
+    It is decoded with Shapely; a view with no geometry yields a plain
+    (geometry-less) frame so a non-spatial source still flows through.
+    """
+    import geopandas as gpd
+    from shapely import wkb as _wkb
+
+    from gispulse.persistence.duckdb_engine import _find_geom_column
+
+    df = session.conn.execute(f'SELECT * FROM "{view}"').fetchdf()
+    geom_col = _find_geom_column(df)
+    if geom_col is None:
+        return gpd.GeoDataFrame(df)
+    geometries = [
+        _wkb.loads(bytes(b)) if b is not None else None for b in df[geom_col]
+    ]
+    df = df.drop(columns=[geom_col])
+    return gpd.GeoDataFrame(df, geometry=geometries, crs=crs)
+
+
+def prepare_virtual_inputs(
+    spec: PipelineSpec,
+    *,
+    bbox: tuple[float, float, float, float] | None = None,
+    protocols: Any | None = None,
+    session_factory: Any | None = None,
+) -> dict[str, Any]:
+    """Pipeline-prepare hook (A11, #237) — virtual ref layers → GeoDataFrames.
+
+    Scans ``spec.ref_layers`` for values that are virtual-dataset ids
+    (:func:`is_virtual_ref`) and materialises each into a GeoDataFrame
+    keyed by its ref-layer alias. The result is merged into the
+    executor's ``inputs`` dict *before* execution, so a ``datasetSource``
+    node bound to that alias feeds a capability real geometry without any
+    local file ever touching disk.
+
+    File-path ref layers are left untouched — the caller still loads
+    those with :func:`~gispulse.persistence.io.read_vector`.
+
+    Args:
+        spec:            The pipeline whose ``ref_layers`` are scanned.
+        bbox:            Optional bbox pushed into every virtual scan.
+        protocols:       Shared fetcher registry (built once if omitted).
+        session_factory: DuckDB session factory (test seam).
+
+    Returns:
+        ``alias → GeoDataFrame`` for every virtual ref layer; empty when
+        the pipeline declares none.
+    """
+    refs = virtual_refs(spec)
+    if not refs:
+        return {}
+    registry = protocols if protocols is not None else _worldwide_protocols()
+    return {
+        alias: prepare_virtual_input(
+            virtual_id,
+            bbox=bbox,
+            protocols=registry,
+            session_factory=session_factory,
+        )
+        for alias, virtual_id in refs.items()
+    }
+
+
 def pipeline_to_dict(spec: PipelineSpec) -> dict[str, Any]:
     """Serialize a PipelineSpec to a dict (for JSON export)."""
     steps = []

--- a/src/gispulse/plugins/datagouv_refresh.py
+++ b/src/gispulse/plugins/datagouv_refresh.py
@@ -1,0 +1,149 @@
+"""data.gouv.fr catalogue-freshness probe for the worldwide aggregator (A13, #239).
+
+EPIC #226 (v1.9.0). The worldwide catalogue ships a handful of French
+open-data entries (``family: opendata-fr``). Their ``revision_token`` is
+the freshness token :meth:`WorldwideCatalogSource.revision` returns and
+the :class:`SourceWatcherRegistry` (A14) polls.
+
+This module probes the **data.gouv.fr** API for the *current* publication
+timestamp of every catalogue entry that opts in via a
+``metadata.datagouv_dataset`` slug, and reports which entries have
+drifted from the curated ``revision_token``. It backs the
+``refresh_worldwide_catalog`` MCP tool — a *priority-low* deliverable of
+issue #239.
+
+The probe is **read-only and idempotent**: it never mutates the curated,
+comment-rich ``worldwide_catalog.yml`` (a YAML round-trip would strip its
+comments), and two calls against an unchanged remote yield the same
+report. An operator applies a drift by editing the YAML by hand.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable
+
+from gispulse.core.logging import get_logger
+from gispulse.plugins.worldwide_source import DEFAULT_CATALOG_PATH, load_worldwide_catalog
+
+log = get_logger(__name__)
+
+#: data.gouv.fr open API v1 base — a fixed, allow-listed host. The MCP
+#: tool exposes no URL argument, so an untrusted model cannot redirect
+#: the probe at an internal service.
+DATAGOUV_API = "https://www.data.gouv.fr/api/1"
+
+#: Metadata key a catalogue entry sets to opt into the data.gouv probe —
+#: its value is a data.gouv dataset slug or id.
+DATAGOUV_METADATA_KEY = "datagouv_dataset"
+
+
+def _probe_datagouv(dataset_ref: str, *, base: str = DATAGOUV_API) -> str | None:
+    """Return the ``last_modified`` timestamp of a data.gouv.fr dataset.
+
+    SSRF-guarded (#199), short-timeout. Returns ``None`` when the dataset
+    exposes no usable timestamp.
+
+    Raises:
+        Exception: a transport / HTTP error — surfaced per entry by
+            :func:`refresh_datagouv_entries` so one bad slug never
+            aborts the whole probe.
+    """
+    import httpx
+
+    from gispulse.core.ssrf import guard_outbound_url
+
+    url = f"{base}/datasets/{dataset_ref}/"
+    guard_outbound_url(url)
+    resp = httpx.get(
+        url,
+        follow_redirects=True,
+        timeout=10.0,
+        headers={"Accept": "application/json"},
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    internal = data.get("internal") or {}
+    return (
+        data.get("last_modified")
+        or internal.get("last_modified_internal")
+        or data.get("last_update")
+    )
+
+
+def refresh_datagouv_entries(
+    catalog_path: Path | None = None,
+    *,
+    base: str = DATAGOUV_API,
+    probe: Callable[..., str | None] | None = None,
+) -> dict[str, Any]:
+    """Probe data.gouv.fr for every catalogue entry that declares a dataset.
+
+    Walks the worldwide catalogue, and for each entry carrying a
+    :data:`DATAGOUV_METADATA_KEY` slug queries data.gouv.fr for its
+    current publication timestamp. The returned report says which
+    ``revision_token`` values are stale — it changes nothing on disk.
+
+    Args:
+        catalog_path: Catalogue file. Defaults to the shipped one.
+        base:         data.gouv.fr API base (override for tests).
+        probe:        Injected ``(dataset_ref, *, base) -> str | None``
+                      seam — defaults to :func:`_probe_datagouv`. Tests
+                      pass a stub so CI moves no bytes off the box.
+
+    Returns:
+        ``{catalog, checked, entries: [...], stale: [...]}``. Each entry
+        record carries ``id`` / ``datagouv_dataset`` / ``current_token``
+        / ``datagouv_revision`` / ``up_to_date``, or an ``error`` key.
+    """
+    probe_fn = probe or _probe_datagouv
+    entries = load_worldwide_catalog(catalog_path)
+    refreshable = [
+        e for e in entries if e.metadata.get(DATAGOUV_METADATA_KEY)
+    ]
+
+    records: list[dict[str, Any]] = []
+    for entry in refreshable:
+        dataset_ref = str(entry.metadata[DATAGOUV_METADATA_KEY])
+        record: dict[str, Any] = {
+            "id": entry.id,
+            "datagouv_dataset": dataset_ref,
+            "current_token": entry.revision_token,
+        }
+        try:
+            last_modified = probe_fn(dataset_ref, base=base)
+        except Exception as exc:  # noqa: BLE001 — isolate one bad slug
+            record["error"] = str(exc)
+            log.warning(
+                "datagouv_probe_failed", entry=entry.id, dataset=dataset_ref, error=str(exc)
+            )
+            records.append(record)
+            continue
+        new_token = f"datagouv:{last_modified}" if last_modified else None
+        record["datagouv_revision"] = new_token
+        record["up_to_date"] = new_token is not None and new_token == entry.revision_token
+        records.append(record)
+
+    stale = [
+        r["id"]
+        for r in records
+        if "error" not in r and not r["up_to_date"]
+    ]
+    log.info(
+        "datagouv_refresh_probed",
+        checked=len(records),
+        stale=len(stale),
+    )
+    return {
+        "catalog": str(catalog_path or DEFAULT_CATALOG_PATH),
+        "checked": len(records),
+        "entries": records,
+        "stale": stale,
+    }
+
+
+__all__ = [
+    "DATAGOUV_API",
+    "DATAGOUV_METADATA_KEY",
+    "refresh_datagouv_entries",
+]

--- a/src/gispulse/plugins/worldwide_source.py
+++ b/src/gispulse/plugins/worldwide_source.py
@@ -291,6 +291,91 @@ class WorldwideCatalogSource(DeclarativeSource):
             result.append(entry)
         return result
 
+    def revision(self, entry_id: str) -> str | None:
+        """Freshness token for ``entry_id`` (A14, #240).
+
+        For a *versioned* entry the declared ``revision_token`` (a release
+        millésime) is authoritative — it only changes when the catalogue
+        YAML is edited, so it is returned as-is. For a *live* entry
+        (``revision_token: null``) a cheap HTTP ``HEAD`` probes the remote
+        endpoint and derives a token from its ``ETag`` / ``Last-Modified``
+        / ``Content-Length`` headers. The probe is best-effort: any
+        failure (non-HTTP scheme, network error, headerless response)
+        yields ``None`` so the :class:`SourceWatcherRegistry` simply sees
+        no change rather than crashing.
+        """
+        entry = self._entry(entry_id)
+        if entry.revision_token:
+            return entry.revision_token
+        return _probe_revision(entry.access.endpoint)
+
+
+def _probe_revision(endpoint: str) -> str | None:
+    """Best-effort live freshness token from an HTTP ``HEAD`` (A14, #240).
+
+    Only ``http(s)`` endpoints are probed; the request is SSRF-guarded
+    (#199) and short-timeout. Returns a token built from the validator
+    headers, or ``None`` when the endpoint is non-HTTP, unreachable, or
+    exposes no usable header.
+    """
+    scheme = urlparse(endpoint).scheme.lower()
+    if scheme not in ("http", "https"):
+        return None  # s3:// and friends are not HEAD-probeable here
+    try:
+        from gispulse.core.ssrf import guard_outbound_url
+
+        guard_outbound_url(endpoint)
+    except Exception as exc:  # noqa: BLE001 — a blocked URL is never probed
+        log.warning("worldwide_revision_probe_blocked", endpoint=endpoint, error=str(exc))
+        return None
+    try:
+        import httpx
+
+        resp = httpx.head(endpoint, follow_redirects=True, timeout=10.0)
+    except Exception as exc:  # noqa: BLE001 — an unreachable source ⇒ no change
+        log.warning("worldwide_revision_probe_failed", endpoint=endpoint, error=str(exc))
+        return None
+    headers = resp.headers
+    for header in ("etag", "last-modified", "content-length"):
+        value = headers.get(header)
+        if value:
+            return f"{header}:{value}"
+    return None
+
+
+def register_worldwide_watches(
+    watcher: Any,
+    source: WorldwideCatalogSource | None = None,
+    *,
+    entry_ids: list[str] | None = None,
+) -> list[str]:
+    """Register worldwide catalogue entries on a :class:`SourceWatcherRegistry`.
+
+    Wires :meth:`WorldwideCatalogSource.revision` into the freshness
+    watcher (A14, #240): on the next poll an entry whose remote source has
+    moved emits a ``source.changed`` event. Each entry's poll interval is
+    taken from its ``metadata.update_frequency`` label (``quotidien`` /
+    ``hebdomadaire`` / …), defaulting to the watcher's 6 h baseline.
+
+    Args:
+        watcher:   The :class:`SourceWatcherRegistry` to register against.
+        source:    Catalogue source. A fresh :class:`WorldwideCatalogSource`
+                   is built when omitted.
+        entry_ids: Optional allow-list — only these entry ids are watched.
+
+    Returns:
+        The registration keys, one per watched entry.
+    """
+    src = source or WorldwideCatalogSource()
+    keys: list[str] = []
+    for entry in src.entries():
+        if entry_ids is not None and entry.id not in entry_ids:
+            continue
+        frequency = entry.metadata.get("update_frequency")
+        keys.append(watcher.register(src, entry.id, frequency=frequency))
+    log.info("worldwide_watches_registered", count=len(keys))
+    return keys
+
 
 def register() -> None:
     """Entry-point hook for the ``gispulse.data_sources`` group.
@@ -310,4 +395,5 @@ __all__ = [
     "WorldwideCatalogSource",
     "load_worldwide_catalog",
     "register",
+    "register_worldwide_watches",
 ]

--- a/tests/integration/test_worldwide_e2e.py
+++ b/tests/integration/test_worldwide_e2e.py
@@ -1,0 +1,176 @@
+"""End-to-end test for the v1.9.0 worldwide aggregator (A15, #241).
+
+Walks the full EPIC #226 journey against a *local* GeoParquet fixture so
+CI moves zero bytes off the box:
+
+    browse catalogue → create virtual dataset → lazy bbox preview
+    → run an ETL pipeline on the virtual input → materialise to disk
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from gispulse.core.plugin_model import AccessProtocol, AccessSpec, Payload, SourceDomain
+from gispulse.core.sources import SOURCES, SourceEntryRef
+from gispulse.persistence.virtual_dataset import VIRTUAL_DATASETS
+
+
+# -- a local GeoParquet fixture with a real geometry column -----------------
+
+
+@pytest.fixture(scope="module")
+def geo_parquet(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """A 3-point GeoParquet fixture: WKB ``geometry`` + Overture ``bbox`` struct."""
+    import duckdb
+
+    path = tmp_path_factory.mktemp("e2e") / "points.parquet"
+    con = duckdb.connect()
+    con.load_extension("spatial")
+    con.execute(
+        f"""
+        COPY (
+          SELECT id, name,
+                 ST_AsWKB(ST_Point(x, y)) AS geometry,
+                 {{'xmin': x, 'ymin': y, 'xmax': x, 'ymax': y}} AS bbox
+          FROM (VALUES
+            (1, 'alpha', 0.5, 0.5),
+            (2, 'beta',  10.0, 10.0),
+            (3, 'gamma', 1.5, 1.5)
+          ) AS t(id, name, x, y)
+        ) TO '{path}' (FORMAT PARQUET)
+        """
+    )
+    con.close()
+    return path
+
+
+def _entry(endpoint: str) -> SourceEntryRef:
+    return SourceEntryRef(
+        id="test-points",
+        name="Test Points",
+        access=AccessSpec(
+            protocol=AccessProtocol.REMOTE_TABLE,
+            endpoint=endpoint,
+            params={"glob": "", "hive_partitioning": False},
+        ),
+        domain=SourceDomain.OBSERVATION,
+        payload=Payload.VECTOR,
+        jurisdiction="world",
+        revision_token="t0",
+        metadata={"family": "test-family", "provider": "Test"},
+    )
+
+
+class _FakeWorldwideSource:
+    name = "worldwide"
+
+    def __init__(self, entries: list[SourceEntryRef]) -> None:
+        self._entries = list(entries)
+
+    def catalog(self, search: str | None = None, **_: object) -> list[SourceEntryRef]:
+        return list(self._entries)
+
+    def entries(self) -> list[SourceEntryRef]:
+        return list(self._entries)
+
+
+@pytest.fixture
+def client(
+    geo_parquet: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> TestClient:
+    from gispulse.adapters.http.app import create_app
+    from gispulse.adapters.http.rate_limit import limiter
+
+    monkeypatch.setenv("GISPULSE_STORAGE", "memory")
+    os.environ["GISPULSE_STORAGE"] = "memory"
+    limiter.enabled = False
+
+    SOURCES.clear()
+    SOURCES.register(_FakeWorldwideSource([_entry(str(geo_parquet))]))
+    VIRTUAL_DATASETS.clear()
+
+    app = create_app(data_dir=tmp_path)
+    try:
+        yield TestClient(app)
+    finally:
+        SOURCES.clear()
+        VIRTUAL_DATASETS.clear()
+
+
+# -- the full journey --------------------------------------------------------
+
+
+def test_worldwide_aggregator_end_to_end(client: TestClient) -> None:
+    # 1. Browse the worldwide catalogue.
+    listing = client.get("/api/catalog/worldwide")
+    assert listing.status_code == 200
+    assert [e["id"] for e in listing.json()] == ["test-points"]
+
+    # 2. Create a lazy virtual dataset from the entry.
+    created = client.post("/api/catalog/virtual", json={"entry_id": "test-points"})
+    assert created.status_code == 201
+    virtual_id = created.json()["id"]
+    assert virtual_id == "virtual:worldwide/test-points"
+
+    # 3. Lazy bbox-scoped preview — (0,0)-(5,5) keeps 2 of the 3 points.
+    preview = client.get(
+        f"/api/catalog/virtual/{virtual_id}/preview?bbox=0,0,5,5"
+    )
+    assert preview.status_code == 200
+    assert preview.json()["feature_count"] == 2
+
+    # 4. ETL — run a pipeline whose primary input is the virtual dataset
+    #    (A11 pipeline-prepare hook materialises it before execution).
+    etl = client.post(
+        "/pipelines/execute",
+        json={
+            "name": "buffer_worldwide",
+            "input_path": virtual_id,
+            "bbox": [0.0, 0.0, 5.0, 5.0],
+            "steps": [
+                {"id": "buf", "type": "capability", "capability": "buffer",
+                 "params": {"distance": 100.0}},
+            ],
+        },
+    )
+    assert etl.status_code == 200, etl.text
+    etl_body = etl.json()
+    assert etl_body["steps_executed"] == 1
+    assert etl_body["total_features_out"] == 2  # non-empty ETL result
+
+    # 5. Materialise the virtual dataset into a real on-disk project dataset.
+    materialised = client.post(
+        f"/api/catalog/virtual/{virtual_id}/materialize",
+        json={"name": "Materialised points", "bbox": [0.0, 0.0, 5.0, 5.0]},
+    )
+    assert materialised.status_code == 201
+    body = materialised.json()
+    assert body["virtual_id"] == virtual_id
+    assert Path(body["source_path"]).exists()
+
+
+def test_virtual_ref_layer_feeds_a_two_node_pipeline(client: TestClient) -> None:
+    """A virtual dataset wired as a ref layer feeds a downstream capability."""
+    created = client.post("/api/catalog/virtual", json={"entry_id": "test-points"})
+    virtual_id = created.json()["id"]
+
+    resp = client.post(
+        "/pipelines/execute",
+        json={
+            "name": "ref_layer_virtual",
+            "input_path": virtual_id,
+            "bbox": [0.0, 0.0, 5.0, 5.0],
+            "ref_layers": {"ww": virtual_id},
+            "steps": [
+                {"id": "buf", "type": "capability", "capability": "buffer",
+                 "params": {"distance": 50.0}, "input": "ww"},
+            ],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["total_features_out"] == 2

--- a/tests/unit/test_datagouv_refresh.py
+++ b/tests/unit/test_datagouv_refresh.py
@@ -1,0 +1,126 @@
+"""Unit tests for A13 (#239) — the data.gouv.fr catalogue-freshness probe.
+
+Zero network: the data.gouv.fr probe is exercised through an injected
+stub, so CI moves no bytes off the box.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from gispulse.plugins.datagouv_refresh import (
+    DATAGOUV_METADATA_KEY,
+    refresh_datagouv_entries,
+)
+
+
+# -- a minimal catalogue fixture --------------------------------------------
+
+
+def _write_catalog(tmp_path: Path, *, with_slug: bool = True) -> Path:
+    """Write a tiny worldwide catalogue with two FR open-data entries."""
+    slug_line = (
+        f"      {DATAGOUV_METADATA_KEY}: demandes-de-valeurs-foncieres-geolocalisees"
+        if with_slug
+        else "      provider: Etalab"
+    )
+    path = tmp_path / "catalog.yml"
+    path.write_text(
+        f"""
+version: 1
+entries:
+  - id: dvf-geolocalise
+    name: DVF geolocated
+    domain: statistique
+    payload: vector
+    jurisdiction: FR
+    access:
+      protocol: download
+      endpoint: https://files.data.gouv.fr/geo-dvf/latest/full.csv.gz
+    revision_token: latest
+    metadata:
+{slug_line}
+  - id: overture-places
+    name: Overture Places
+    domain: observation
+    payload: vector
+    jurisdiction: world
+    access:
+      protocol: remote-table
+      endpoint: s3://overturemaps/places/*
+    revision_token: "2025-09-24.0"
+    metadata:
+      provider: Overture
+""",
+        encoding="utf-8",
+    )
+    return path
+
+
+# -- refresh_datagouv_entries ------------------------------------------------
+
+
+def test_refresh_reports_only_entries_with_a_slug(tmp_path: Path) -> None:
+    path = _write_catalog(tmp_path)
+
+    def probe(ref: str, *, base: str) -> str:
+        return "2026-05-01T00:00:00"
+
+    report = refresh_datagouv_entries(path, probe=probe)
+    assert report["checked"] == 1  # only the dvf entry carries a slug
+    record = report["entries"][0]
+    assert record["id"] == "dvf-geolocalise"
+    assert record["datagouv_revision"] == "datagouv:2026-05-01T00:00:00"
+    assert record["up_to_date"] is False
+    assert report["stale"] == ["dvf-geolocalise"]
+
+
+def test_refresh_skips_entries_without_a_slug(tmp_path: Path) -> None:
+    path = _write_catalog(tmp_path, with_slug=False)
+    report = refresh_datagouv_entries(path, probe=lambda r, *, base: "x")
+    assert report["checked"] == 0
+    assert report["entries"] == []
+    assert report["stale"] == []
+
+
+def test_refresh_is_idempotent(tmp_path: Path) -> None:
+    path = _write_catalog(tmp_path)
+
+    def probe(ref: str, *, base: str) -> str:
+        return "2026-05-01T00:00:00"
+
+    first = refresh_datagouv_entries(path, probe=probe)
+    second = refresh_datagouv_entries(path, probe=probe)
+    assert first == second
+
+
+def test_refresh_up_to_date_when_token_matches(tmp_path: Path) -> None:
+    path = _write_catalog(tmp_path)
+    # The catalogue token is 'latest'; make the probe agree with it.
+    report = refresh_datagouv_entries(
+        path, probe=lambda r, *, base: None
+    )
+    # A probe yielding no timestamp ⇒ datagouv_revision None ⇒ not up to date.
+    assert report["entries"][0]["datagouv_revision"] is None
+    assert report["entries"][0]["up_to_date"] is False
+
+
+def test_refresh_isolates_a_failing_slug(tmp_path: Path) -> None:
+    path = _write_catalog(tmp_path)
+
+    def boom(ref: str, *, base: str) -> str:
+        raise RuntimeError("404 Not Found")
+
+    report = refresh_datagouv_entries(path, probe=boom)
+    record = report["entries"][0]
+    assert "error" in record
+    assert "404" in record["error"]
+    # An entry that errored is never reported as stale.
+    assert report["stale"] == []
+
+
+def test_refresh_shipped_catalogue_lists_fr_entries() -> None:
+    """The curated catalogue ships at least the DVF + cadastre slugs."""
+    report = refresh_datagouv_entries(probe=lambda r, *, base: "2026-01-01")
+    ids = {r["id"] for r in report["entries"]}
+    assert {"dvf-geolocalise", "cadastre-etalab-parcelles"} <= ids

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -70,9 +70,24 @@ def test_tools_registered():
         "inspect_changelog",
         "watch_status",
         "dryrun_trigger",
+        # v1.9.0 worldwide aggregator (A13, #239) — data.gouv.fr probe.
+        "refresh_worldwide_catalog",
     }
     missing = expected - tool_names
     assert not missing, f"Missing tools: {missing}"
+
+
+def test_refresh_worldwide_catalog_tool(monkeypatch):
+    """The A13 (#239) catalogue-freshness tool runs without touching the net."""
+    from gispulse.plugins import datagouv_refresh
+
+    monkeypatch.setattr(
+        datagouv_refresh, "_probe_datagouv", lambda ref, *, base: "2026-01-01"
+    )
+    report = mcp_server.refresh_worldwide_catalog()
+    assert "error" not in report
+    assert report["checked"] >= 1
+    assert all("id" in rec for rec in report["entries"])
 
 
 def test_plugin_tool_registered(monkeypatch):

--- a/tests/unit/test_pipeline_virtual.py
+++ b/tests/unit/test_pipeline_virtual.py
@@ -1,0 +1,232 @@
+"""Unit tests for A11 (#237) — the virtual-dataset pipeline-prepare hook.
+
+Zero network: every virtual dataset points at a *local* GeoParquet
+fixture built at test time, so CI moves no bytes off the box.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gispulse.core.fetchers import register_core_fetchers
+from gispulse.core.pipeline import (
+    PipelineSpec,
+    StepSpec,
+    is_virtual_ref,
+    prepare_virtual_input,
+    prepare_virtual_inputs,
+    virtual_refs,
+)
+from gispulse.core.plugin_model import (
+    AccessProtocol,
+    AccessSpec,
+    Payload,
+    SourceDomain,
+)
+from gispulse.core.sources import SOURCES, ProtocolRegistry, SourceEntryRef
+from gispulse.orchestration.pipeline_executor import PipelineExecutor
+from gispulse.persistence.virtual_dataset import VIRTUAL_DATASETS, make_virtual_id
+
+
+# -- fixtures ----------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def geo_parquet(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """A 3-point GeoParquet fixture: a real WKB ``geometry`` + ``bbox`` struct."""
+    import duckdb
+
+    path = tmp_path_factory.mktemp("pv") / "points.parquet"
+    con = duckdb.connect()
+    con.load_extension("spatial")
+    con.execute(
+        f"""
+        COPY (
+          SELECT id, name,
+                 ST_AsWKB(ST_Point(x, y)) AS geometry,
+                 {{'xmin': x, 'ymin': y, 'xmax': x, 'ymax': y}} AS bbox
+          FROM (VALUES
+            (1, 'alpha', 0.5, 0.5),
+            (2, 'beta',  10.0, 10.0),
+            (3, 'gamma', 1.5, 1.5)
+          ) AS t(id, name, x, y)
+        ) TO '{path}' (FORMAT PARQUET)
+        """
+    )
+    con.close()
+    return path
+
+
+def _entry(endpoint: str, entry_id: str = "points") -> SourceEntryRef:
+    """A REMOTE_TABLE catalogue entry over a single local parquet file."""
+    return SourceEntryRef(
+        id=entry_id,
+        name="Test Points",
+        access=AccessSpec(
+            protocol=AccessProtocol.REMOTE_TABLE,
+            endpoint=endpoint,
+            params={"glob": "", "hive_partitioning": False},
+        ),
+        domain=SourceDomain.OBSERVATION,
+        payload=Payload.VECTOR,
+        jurisdiction="world",
+        metadata={"family": "test"},
+    )
+
+
+@pytest.fixture
+def core_protocols() -> ProtocolRegistry:
+    """A registry carrying only the core worldwide fetchers."""
+    reg = ProtocolRegistry()
+    register_core_fetchers(reg)
+    return reg
+
+
+@pytest.fixture(autouse=True)
+def _clean_registries():
+    """Isolate the process-wide virtual-dataset / source registries."""
+    VIRTUAL_DATASETS.clear()
+    yield
+    VIRTUAL_DATASETS.clear()
+    SOURCES.clear()
+
+
+class _FakeSource:
+    """A minimal worldwide-style source exposing one entry."""
+
+    name = "worldwide"
+
+    def __init__(self, entry: SourceEntryRef) -> None:
+        self._entry = entry
+
+    def catalog(self, search: str | None = None, **_: object) -> list[SourceEntryRef]:
+        return [self._entry]
+
+    def entries(self) -> list[SourceEntryRef]:
+        return [self._entry]
+
+
+# -- is_virtual_ref / virtual_refs ------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("virtual:worldwide/overture-places", True),
+        ("virtual:x/y", True),
+        ("data/zones.gpkg", False),
+        ("", False),
+        (None, False),
+        (123, False),
+    ],
+)
+def test_is_virtual_ref(value: object, expected: bool) -> None:
+    assert is_virtual_ref(value) is expected
+
+
+def test_virtual_refs_extracts_only_virtual_subset() -> None:
+    spec = PipelineSpec(
+        name="mixed",
+        ref_layers={
+            "zones": "data/zones.gpkg",
+            "ww": "virtual:worldwide/points",
+        },
+    )
+    assert virtual_refs(spec) == {"ww": "virtual:worldwide/points"}
+
+
+def test_prepare_virtual_inputs_empty_when_no_virtual_refs(
+    core_protocols: ProtocolRegistry,
+) -> None:
+    spec = PipelineSpec(name="files", ref_layers={"zones": "data/zones.gpkg"})
+    assert prepare_virtual_inputs(spec, protocols=core_protocols) == {}
+
+
+# -- prepare_virtual_input ---------------------------------------------------
+
+
+def test_prepare_virtual_input_resolves_registered_dataset(
+    geo_parquet: Path, core_protocols: ProtocolRegistry
+) -> None:
+    vds = VIRTUAL_DATASETS.create(_entry(str(geo_parquet)), protocols=core_protocols)
+    gdf = prepare_virtual_input(vds.id, protocols=core_protocols)
+    assert len(gdf) == 3
+    assert gdf.geometry.name == "geometry"
+    assert not gdf.geometry.isna().any()
+
+
+def test_prepare_virtual_input_pushes_bbox_down(
+    geo_parquet: Path, core_protocols: ProtocolRegistry
+) -> None:
+    vds = VIRTUAL_DATASETS.create(_entry(str(geo_parquet)), protocols=core_protocols)
+    # bbox (0,0)-(5,5) keeps 'alpha' + 'gamma', drops 'beta' at (10,10).
+    gdf = prepare_virtual_input(
+        vds.id, bbox=(0.0, 0.0, 5.0, 5.0), protocols=core_protocols
+    )
+    assert len(gdf) == 2
+    assert set(gdf["name"]) == {"alpha", "gamma"}
+
+
+def test_prepare_virtual_input_lazily_creates_from_source(
+    geo_parquet: Path, core_protocols: ProtocolRegistry
+) -> None:
+    """An id absent from VIRTUAL_DATASETS is resolved via its DataSource."""
+    SOURCES.register(_FakeSource(_entry(str(geo_parquet))))
+    virtual_id = make_virtual_id("worldwide", "points")
+    assert virtual_id not in VIRTUAL_DATASETS
+    gdf = prepare_virtual_input(virtual_id, protocols=core_protocols)
+    assert len(gdf) == 3
+    assert virtual_id in VIRTUAL_DATASETS
+
+
+def test_prepare_virtual_input_unknown_id_raises(
+    core_protocols: ProtocolRegistry,
+) -> None:
+    SOURCES.register(_FakeSource(_entry("/tmp/x.parquet")))
+    with pytest.raises(KeyError):
+        prepare_virtual_input(
+            "virtual:worldwide/ghost", protocols=core_protocols
+        )
+
+
+# -- prepare_virtual_inputs (the spec-level hook) ----------------------------
+
+
+def test_prepare_virtual_inputs_resolves_spec_ref_layers(
+    geo_parquet: Path, core_protocols: ProtocolRegistry
+) -> None:
+    vds = VIRTUAL_DATASETS.create(_entry(str(geo_parquet)), protocols=core_protocols)
+    spec = PipelineSpec(
+        name="hook",
+        steps=[StepSpec(id="s", capability="buffer", input="ww")],
+        ref_layers={"ww": vds.id, "local": "data/zones.gpkg"},
+    )
+    resolved = prepare_virtual_inputs(spec, protocols=core_protocols)
+    assert set(resolved) == {"ww"}  # the file ref layer is left to read_vector
+    assert len(resolved["ww"]) == 3
+
+
+# -- acceptance: datasetSource (virtual) -> buffer produces a non-empty result
+
+
+def test_virtual_dataset_feeds_buffer_pipeline(
+    geo_parquet: Path, core_protocols: ProtocolRegistry
+) -> None:
+    """#237 acceptance — a 2-node pipeline (virtual dataset → buffer)."""
+    vds = VIRTUAL_DATASETS.create(_entry(str(geo_parquet)), protocols=core_protocols)
+    spec = PipelineSpec(
+        name="virtual_buffer",
+        steps=[StepSpec(id="buf", capability="buffer", params={"distance": 1.0}, input="ww")],
+        ref_layers={"ww": vds.id},
+    )
+    inputs = prepare_virtual_inputs(
+        spec, bbox=(0.0, 0.0, 5.0, 5.0), protocols=core_protocols
+    )
+    # The virtual ref layer doubles as the pipeline's primary input.
+    inputs["input"] = inputs["ww"]
+    results = PipelineExecutor().execute(spec, inputs)
+    assert "buf" in results
+    assert not results["buf"].empty
+    assert len(results["buf"]) == 2

--- a/tests/unit/test_worldwide_revision.py
+++ b/tests/unit/test_worldwide_revision.py
@@ -1,0 +1,171 @@
+"""Unit tests for A14 (#240) — worldwide ``revision()`` + watcher wiring.
+
+Zero network: the live HTTP ``HEAD`` probe is exercised through a stubbed
+``httpx.head`` and a no-op SSRF guard, so CI never leaves the box.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gispulse.persistence.source_watcher import SourceWatcherRegistry
+from gispulse.plugins import worldwide_source as ws
+from gispulse.plugins.worldwide_source import (
+    WorldwideCatalogSource,
+    register_worldwide_watches,
+)
+
+
+# -- helpers -----------------------------------------------------------------
+
+
+class _FakeHeaders:
+    """A case-insensitive header mapping like ``httpx.Headers``."""
+
+    def __init__(self, data: dict[str, str]) -> None:
+        self._data = {k.lower(): v for k, v in data.items()}
+
+    def get(self, key: str, default: str | None = None) -> str | None:
+        return self._data.get(key.lower(), default)
+
+
+class _FakeResponse:
+    def __init__(self, headers: dict[str, str]) -> None:
+        self.headers = _FakeHeaders(headers)
+
+
+@pytest.fixture
+def _no_ssrf(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Neutralise the SSRF guard — the probe URLs are synthetic."""
+    monkeypatch.setattr("gispulse.core.ssrf.guard_outbound_url", lambda *a, **k: None)
+
+
+# -- revision(): versioned entries return the declared token -----------------
+
+
+def test_revision_returns_declared_token_for_versioned_entry() -> None:
+    src = WorldwideCatalogSource()
+    # overture-buildings ships a static millésime token in the catalogue.
+    assert src.revision("overture-buildings") == "2025-09-24.0"
+
+
+def test_revision_probes_live_entry(
+    monkeypatch: pytest.MonkeyPatch, _no_ssrf: None
+) -> None:
+    """A null-token (live) entry triggers an HTTP HEAD probe."""
+    import httpx
+
+    monkeypatch.setattr(
+        httpx, "head", lambda *a, **k: _FakeResponse({"ETag": '"abc123"'})
+    )
+    src = WorldwideCatalogSource()
+    # ign-bdtopo-batiment has revision_token: null in the catalogue.
+    assert src.revision("ign-bdtopo-batiment") == 'etag:"abc123"'
+
+
+# -- _probe_revision ---------------------------------------------------------
+
+
+def test_probe_revision_skips_non_http_scheme() -> None:
+    # s3:// endpoints are not HEAD-probeable — no network, returns None.
+    assert ws._probe_revision("s3://bucket/key/*") is None
+
+
+def test_probe_revision_prefers_etag(
+    monkeypatch: pytest.MonkeyPatch, _no_ssrf: None
+) -> None:
+    import httpx
+
+    monkeypatch.setattr(
+        httpx,
+        "head",
+        lambda *a, **k: _FakeResponse(
+            {"ETag": '"v9"', "Last-Modified": "yesterday"}
+        ),
+    )
+    assert ws._probe_revision("https://example.test/data") == 'etag:"v9"'
+
+
+def test_probe_revision_falls_back_to_last_modified(
+    monkeypatch: pytest.MonkeyPatch, _no_ssrf: None
+) -> None:
+    import httpx
+
+    monkeypatch.setattr(
+        httpx,
+        "head",
+        lambda *a, **k: _FakeResponse({"Last-Modified": "Tue, 01 Apr 2025"}),
+    )
+    assert (
+        ws._probe_revision("https://example.test/data")
+        == "last-modified:Tue, 01 Apr 2025"
+    )
+
+
+def test_probe_revision_returns_none_on_network_error(
+    monkeypatch: pytest.MonkeyPatch, _no_ssrf: None
+) -> None:
+    import httpx
+
+    def _boom(*_a: object, **_k: object) -> object:
+        raise httpx.ConnectError("unreachable")
+
+    monkeypatch.setattr(httpx, "head", _boom)
+    assert ws._probe_revision("https://example.test/data") is None
+
+
+def test_probe_revision_returns_none_when_no_validator_header(
+    monkeypatch: pytest.MonkeyPatch, _no_ssrf: None
+) -> None:
+    import httpx
+
+    monkeypatch.setattr(httpx, "head", lambda *a, **k: _FakeResponse({}))
+    assert ws._probe_revision("https://example.test/data") is None
+
+
+# -- register_worldwide_watches ----------------------------------------------
+
+
+def test_register_worldwide_watches_files_static_entries() -> None:
+    src = WorldwideCatalogSource()
+    static = [e.id for e in src.entries() if e.revision_token]
+    watcher = SourceWatcherRegistry()
+    keys = register_worldwide_watches(watcher, src, entry_ids=static)
+    assert keys == [f"worldwide:{eid}" for eid in static]
+    assert watcher.list_watched() == sorted(keys)
+
+
+def test_register_worldwide_watches_entry_ids_filter() -> None:
+    src = WorldwideCatalogSource()
+    watcher = SourceWatcherRegistry()
+    keys = register_worldwide_watches(
+        watcher, src, entry_ids=["overture-buildings"]
+    )
+    assert keys == ["worldwide:overture-buildings"]
+
+
+def test_watcher_fires_when_worldwide_revision_changes() -> None:
+    """A14 acceptance — a moved source makes the watcher emit a change."""
+
+    class _MovingSource:
+        name = "worldwide"
+
+        def __init__(self) -> None:
+            self._rev = "rev-1"
+
+        def entries(self):  # noqa: ANN202 - test stub
+            return []
+
+        def revision(self, entry_id: str) -> str:
+            return self._rev
+
+    src = _MovingSource()
+    watcher = SourceWatcherRegistry()
+    watcher.register(src, "overture-buildings", interval_s=3600)
+    assert watcher.poll() == []  # baseline — no change
+
+    src._rev = "rev-2"  # the remote source moved
+    changes = watcher.poll()
+    assert len(changes) == 1
+    assert changes[0]["revision"] == "rev-2"
+    assert changes[0]["previous"] == "rev-1"


### PR DESCRIPTION
Finishes the **EPIC #226** (v1.9.0 worldwide aggregator) backend slices.

| Issue | Slice | Summary |
|---|---|---|
| #237 | A11 | `prepare_virtual_inputs` pipeline-prepare hook — a `virtual:<source>/<entry>` ref layer / `input_path` is materialised (bbox-scoped DuckDB view → GeoDataFrame) before execution. Wired into both `/pipelines/execute` endpoints (+ `bbox`). |
| #240 | A14 | `WorldwideCatalogSource.revision()` — declared millésime for versioned entries, live HTTP-HEAD probe for live ones. `register_worldwide_watches()` files the catalogue on a `SourceWatcherRegistry`. |
| #239 | A13 | `refresh_worldwide_catalog` MCP tool + `plugins/datagouv_refresh.py` — read-only, idempotent data.gouv.fr freshness probe of FR open-data entries. |
| #241 | A15 | Unit suites (prepare hook, live revision, data.gouv probe) + zero-network E2E (browse → virtual → preview → ETL → materialise). |

## Tests
156 v1.9-scoped tests green, ruff clean. Every test uses a local GeoParquet
fixture / stubbed probe — CI moves zero bytes off the box.

Closes #237, closes #239, closes #240, closes #241.

🤖 Generated with [Claude Code](https://claude.com/claude-code)