### PR TITLE
feat(fetchers): support {key} URL templates in AccessSpec

### DIFF
--- a/src/gispulse/core/fetchers/base.py
+++ b/src/gispulse/core/fetchers/base.py
@@ -32,6 +32,7 @@ from gispulse.core.plugin_model import (
     FetchMode,
     Payload,
     SourceResult,
+    resolve_access_endpoint,
 )
 from gispulse.core.ssrf import guard_outbound_url
 
@@ -82,6 +83,25 @@ class LazyFetcher(ABC):
         """
         guard_outbound_url(url)
 
+    # -- endpoint templating ----------------------------------------------
+
+    @staticmethod
+    def _resolve_endpoint(access: AccessSpec) -> AccessSpec:
+        """Thin wrapper over :func:`resolve_access_endpoint`.
+
+        Kept on :class:`LazyFetcher` for two reasons:
+
+        * direct fetcher invocations (tests, advanced consumers calling
+          ``HttpFileFetcher().fetch(access)`` outside the registry) still
+          go through it, so a templated access is resolved before the
+          SSRF guard fires;
+        * ``ProtocolRegistry.dispatch_fetch`` already resolves up-front,
+          so the call here is idempotent — an already-resolved endpoint
+          has no ``{`` and short-circuits in
+          :func:`resolve_access_endpoint`'s hot path.
+        """
+        return resolve_access_endpoint(access)
+
     # -- subclass hooks ----------------------------------------------------
 
     @abstractmethod
@@ -115,6 +135,7 @@ class LazyFetcher(ABC):
         ``metadata[DUCKDB_SCAN_KEY]``; the endpoint is echoed back in
         ``reference``.
         """
+        access = self._resolve_endpoint(access)
         self._guard(access.endpoint)
         scan = self._reference_scan(access, extent)
         log.debug("lazy_fetch_reference", protocol=self.protocol.value)
@@ -129,6 +150,7 @@ class LazyFetcher(ABC):
         self, access: AccessSpec, *, extent: Any | None = None
     ) -> SourceResult:
         """Run a full ``MATERIALIZE`` fetch — a local copy of the data."""
+        access = self._resolve_endpoint(access)
         self._guard(access.endpoint)
         log.debug("lazy_fetch_materialize", protocol=self.protocol.value)
         return self._materialize(access, extent)

--- a/src/gispulse/core/plugin_model.py
+++ b/src/gispulse/core/plugin_model.py
@@ -13,7 +13,8 @@ must stay cheap to import and free of circular dependencies.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+import string
+from dataclasses import dataclass, field, replace
 from enum import Enum
 from typing import Any
 
@@ -283,6 +284,95 @@ class AccessSpec:
     params: dict[str, Any] = field(default_factory=dict)
     format: str | None = None
     auth: str | None = None  # token/key name, resolved via LicenceProvider for pro
+
+
+def resolve_access_endpoint(access: AccessSpec) -> AccessSpec:
+    """Interpolate ``{key}`` placeholders in ``access.endpoint`` from params.
+
+    A :class:`~gispulse.plugins.api.DeclarativeSource` can declare a
+    single entry per logical dataset and let the consumer choose a
+    sub-zone at fetch time::
+
+        AccessSpec(
+            protocol=AccessProtocol.DOWNLOAD,
+            endpoint=".../departements/{departement}/file-{departement}.gz",
+            params={"departement": "75"},
+        )
+
+    Idempotent for the supported inputs — a resolved endpoint has no
+    ``{`` and short-circuits on re-entry — and protocol-agnostic.
+    ``ProtocolRegistry.dispatch_fetch`` runs it before the SSRF guard so
+    every adapter — :class:`LazyFetcher` subclass or structural
+    ``Fetcher`` — receives a concrete URL. :class:`LazyFetcher` itself
+    re-runs it (no-op when the dispatch layer already resolved) so
+    direct fetcher invocations stay safe.
+
+    Precondition: ``params`` values are pre-encoded URL fragments — a
+    value that itself contains an unescaped ``{`` would re-templatise
+    the endpoint and trip the malformed/missing-param checks on the
+    next pass. Use ``urllib.parse.quote`` upstream if the value is
+    user-supplied.
+
+    Only bare ``{key}`` placeholders are accepted. Empty ``{}``, numeric
+    ``{0}``, attribute ``{a.b}``, index ``{a[0]}``, conversion
+    ``{key!r}`` and format-spec ``{key:>3}`` placeholders all alter the
+    rendered URL in ways callers rarely expect, and are rejected with a
+    contextual :class:`ValueError`. Escaped ``{{literal}}`` braces are
+    left untouched.
+
+    Raises:
+        ValueError: a placeholder is malformed, carries a conversion or
+            format spec, or has no matching ``params`` key.
+    """
+    endpoint = access.endpoint
+    # Hot path: untemplated endpoints pay nothing — no parse, no alloc.
+    if "{" not in endpoint:
+        return access
+    try:
+        parsed = list(string.Formatter().parse(endpoint))
+    except ValueError as exc:
+        raise ValueError(
+            f"malformed endpoint template {endpoint!r}: {exc}"
+        ) from exc
+    for _, name, format_spec, conversion in parsed:
+        if name is None:
+            continue
+        if name == "":
+            raise ValueError(
+                f"malformed endpoint template {endpoint!r}: "
+                f"empty placeholder; expected named '{{key}}'"
+            )
+        if name.isdigit() or "." in name or "[" in name:
+            raise ValueError(
+                f"malformed endpoint template {endpoint!r}: "
+                f"placeholder {{{name}}} must be a bare named key, "
+                f"not a positional/attribute/index reference"
+            )
+        if conversion:
+            raise ValueError(
+                f"malformed endpoint template {endpoint!r}: "
+                f"placeholder {{{name}!{conversion}}} carries a "
+                f"conversion flag; only bare '{{key}}' is accepted"
+            )
+        if format_spec:
+            raise ValueError(
+                f"malformed endpoint template {endpoint!r}: "
+                f"placeholder {{{name}:{format_spec}}} carries a "
+                f"format spec; only bare '{{key}}' is accepted"
+            )
+    fields = [name for _, name, _, _ in parsed if name]
+    if not fields:
+        # Only ``{{literal}}`` escapes — leave the access untouched on
+        # the hot path; ``format_map`` would copy and unescape, we
+        # avoid that allocation here.
+        return access
+    missing = [f for f in fields if f not in access.params]
+    if missing:
+        raise ValueError(
+            f"endpoint template {endpoint!r} requires params "
+            f"{missing!r}, got keys {sorted(access.params)!r}"
+        )
+    return replace(access, endpoint=endpoint.format_map(access.params))
 
 
 @dataclass

--- a/src/gispulse/core/sources.py
+++ b/src/gispulse/core/sources.py
@@ -152,12 +152,24 @@ class ProtocolRegistry:
     ) -> SourceResult:
         """Resolve ``access.protocol`` to a fetcher and run it.
 
-        The endpoint is SSRF-checked first (issue #199): a declared
-        source — or a third-party plugin — must not steer a fetch at an
-        internal address. Non-HTTP endpoints (file paths) are left alone.
+        Resolution order:
+
+        1. **Endpoint templating** (:func:`resolve_access_endpoint`) —
+           ``{key}`` placeholders in ``access.endpoint`` are interpolated
+           from ``access.params`` so every adapter, ``LazyFetcher``
+           subclass *or* structural ``Fetcher`` (REST/WFS/STAC adapters
+           registered into ``PROTOCOLS`` by #192), sees a concrete URL.
+        2. **SSRF guard** (issue #199) — runs against the *resolved*
+           endpoint, so a template host (e.g. ``{host}``) cannot bypass
+           the policy by deferring its concrete form.
+        3. **Dispatch** to the registered fetcher.
+
+        Non-HTTP endpoints (file paths) skip the SSRF guard.
         """
+        from gispulse.core.plugin_model import resolve_access_endpoint
         from gispulse.core.ssrf import guard_outbound_url
 
+        access = resolve_access_endpoint(access)
         guard_outbound_url(getattr(access, "endpoint", None))
         return self.get_fetcher(access.protocol).fetch(access, extent=extent, mode=mode)
 

--- a/src/gispulse/plugins/worldwide_source.py
+++ b/src/gispulse/plugins/worldwide_source.py
@@ -307,7 +307,13 @@ class WorldwideCatalogSource(DeclarativeSource):
         entry = self._entry(entry_id)
         if entry.revision_token:
             return entry.revision_token
-        return _probe_revision(entry.access.endpoint)
+        # Resolve ``{key}`` templates so the live probe hits — and the
+        # SSRF guard inside ``_probe_revision`` sees — the concrete URL
+        # the dispatcher would reach for an actual fetch.
+        from gispulse.core.plugin_model import resolve_access_endpoint
+
+        resolved = resolve_access_endpoint(entry.access)
+        return _probe_revision(resolved.endpoint)
 
 
 def _probe_revision(endpoint: str) -> str | None:

--- a/tests/unit/test_fetchers_base.py
+++ b/tests/unit/test_fetchers_base.py
@@ -49,8 +49,12 @@ class _FakeFetcher(LazyFetcher):
         )
 
 
-def _access(endpoint: str) -> AccessSpec:
-    return AccessSpec(protocol=AccessProtocol.REMOTE_TABLE, endpoint=endpoint)
+def _access(endpoint: str, **params: object) -> AccessSpec:
+    return AccessSpec(
+        protocol=AccessProtocol.REMOTE_TABLE,
+        endpoint=endpoint,
+        params=dict(params),
+    )
 
 
 # --------------------------------------------------------------------------
@@ -186,3 +190,134 @@ def test_source_entry_ref_accepts_classification_axes() -> None:
     assert ref.domain is SourceDomain.OBSERVATION
     assert ref.payload is Payload.VECTOR
     assert ref.jurisdiction == "world"
+
+
+# --------------------------------------------------------------------------
+# Endpoint templating — resolve {key} placeholders from access.params
+# --------------------------------------------------------------------------
+
+
+def test_resolve_endpoint_noop_when_no_placeholder() -> None:
+    # The hot path: untemplated endpoints must be returned unchanged so
+    # existing core entries (worldwide_catalog.yml) pay nothing.
+    access = _access("https://example.com/data.parquet")
+    assert LazyFetcher._resolve_endpoint(access) is access
+
+
+def test_resolve_endpoint_interpolates_single_placeholder() -> None:
+    access = _access(
+        "https://example.com/{region}/data.parquet", region="eu"
+    )
+    resolved = LazyFetcher._resolve_endpoint(access)
+    assert resolved.endpoint == "https://example.com/eu/data.parquet"
+    # ``params`` is preserved — protocol adapters still read ``layer``,
+    # ``lat``/``lon`` etc. from it after resolution.
+    assert resolved.params == {"region": "eu"}
+
+
+def test_resolve_endpoint_interpolates_multiple_placeholders() -> None:
+    access = _access(
+        "https://host/{a}/{b}/{a}-file.json",
+        a="01",
+        b="parcelles",
+    )
+    resolved = LazyFetcher._resolve_endpoint(access)
+    assert resolved.endpoint == "https://host/01/parcelles/01-file.json"
+
+
+def test_resolve_endpoint_missing_param_raises_with_clear_message() -> None:
+    access = _access(
+        "https://host/{departement}/file-{layer}.gz", departement="75"
+    )
+    with pytest.raises(ValueError, match=r"requires params \['layer'\]"):
+        LazyFetcher._resolve_endpoint(access)
+
+
+def test_resolve_endpoint_malformed_template_raises() -> None:
+    # An unclosed brace is a malformed Python format string — surface
+    # the error early instead of letting ``format_map`` crash deep down.
+    access = _access("https://host/{unterminated", value="x")
+    with pytest.raises(ValueError, match=r"malformed endpoint template"):
+        LazyFetcher._resolve_endpoint(access)
+
+
+def test_resolve_endpoint_rejects_empty_positional_placeholder() -> None:
+    # ``{}`` is a positional placeholder — meaningless for a URL template
+    # (callers must spell the key) and a silent no-op would hide bugs.
+    access = _access("https://host/{}/file.parquet", value="x")
+    with pytest.raises(ValueError, match=r"empty placeholder"):
+        LazyFetcher._resolve_endpoint(access)
+
+
+def test_resolve_endpoint_rejects_numeric_placeholder() -> None:
+    # ``{0}`` is a positional index — confusing and would interact with
+    # ``params["0"]`` in surprising ways. Reject up front.
+    access = AccessSpec(
+        protocol=AccessProtocol.REMOTE_TABLE,
+        endpoint="https://example.com/{0}/file.parquet",
+        params={"0": "value"},
+    )
+    with pytest.raises(ValueError, match=r"positional/attribute/index"):
+        LazyFetcher._resolve_endpoint(access)
+
+
+def test_resolve_endpoint_rejects_attribute_or_index_placeholder() -> None:
+    access = _access("https://example.com/{cfg.host}/file", cfg="x")
+    with pytest.raises(ValueError, match=r"positional/attribute/index"):
+        LazyFetcher._resolve_endpoint(access)
+
+
+def test_resolve_endpoint_rejects_conversion_flag() -> None:
+    # ``{key!r}`` would inject quotes around the value — not what a URL
+    # template author meant. Reject so the typo is loud.
+    access = _access("https://example.com/{key!r}/file.parquet", key="x")
+    with pytest.raises(ValueError, match=r"conversion flag"):
+        LazyFetcher._resolve_endpoint(access)
+
+
+def test_resolve_endpoint_rejects_format_spec() -> None:
+    # ``{key:>3}`` would pad the value — again not URL semantics.
+    access = _access("https://example.com/{key:>3}/file.parquet", key="x")
+    with pytest.raises(ValueError, match=r"format spec"):
+        LazyFetcher._resolve_endpoint(access)
+
+
+def test_resolve_endpoint_escaped_braces_are_not_placeholders() -> None:
+    # ``{{`` is a literal brace in ``str.format`` — leave the endpoint
+    # alone (no params lookup) and unescape via ``format_map`` at fetch.
+    access = _access("https://host/{{literal}}/data.parquet")
+    resolved = LazyFetcher._resolve_endpoint(access)
+    # ``{`` was present so we go through the parse path, but no fields
+    # were found → access returned unchanged.
+    assert resolved is access
+
+
+def test_virtual_table_resolves_template_before_dispatch() -> None:
+    result = _FakeFetcher().virtual_table(
+        _access("https://example.com/{dpt}/data.parquet", dpt="75")
+    )
+    # The scan SQL — built by ``_reference_scan`` from the resolved
+    # access — must show the interpolated endpoint, not the template.
+    assert result.metadata[DUCKDB_SCAN_KEY] == (
+        "read_parquet('https://example.com/75/data.parquet')"
+    )
+    assert result.reference == "https://example.com/75/data.parquet"
+
+
+def test_materialize_resolves_template_before_dispatch() -> None:
+    result = _FakeFetcher().fetch(
+        _access("https://example.com/{dpt}/data.parquet", dpt="75"),
+        mode=FetchMode.MATERIALIZE,
+    )
+    assert result.data == "rows@https://example.com/75/data.parquet"
+
+
+def test_ssrf_guard_runs_against_resolved_endpoint() -> None:
+    # A template resolving to a private address must still be rejected —
+    # SSRF policy must see the URL that will actually be reached, not
+    # the templated form.
+    with pytest.raises(SSRFError):
+        _FakeFetcher().fetch(
+            _access("http://{addr}/secret", addr="127.0.0.1"),
+            mode=FetchMode.REFERENCE,
+        )

--- a/tests/unit/test_sources.py
+++ b/tests/unit/test_sources.py
@@ -138,6 +138,50 @@ def test_dispatch_fetch_resolves_and_runs(registry: ProtocolRegistry) -> None:
     assert result.mode is FetchMode.REFERENCE
 
 
+def test_dispatch_fetch_interpolates_endpoint_template(
+    registry: ProtocolRegistry,
+) -> None:
+    # Even a structural ``Fetcher`` (here ``FakeWFS``) that does not
+    # subclass ``LazyFetcher`` benefits from ``{key}`` resolution: the
+    # registry resolves once before SSRF + dispatch so every adapter
+    # — Lazy or structural — sees a concrete URL.
+    access = AccessSpec(
+        protocol=AccessProtocol.WFS,
+        endpoint="https://93.184.216.34/{collection}",
+        params={"collection": "parcelles"},
+    )
+    result = registry.dispatch_fetch(access, mode=FetchMode.REFERENCE)
+    assert result.data == "rows@https://93.184.216.34/parcelles"
+
+
+def test_dispatch_fetch_ssrf_guards_resolved_endpoint(
+    registry: ProtocolRegistry,
+) -> None:
+    # A template host resolving to a private literal must still be
+    # rejected — SSRF policy applies to the URL the adapter will reach.
+    from gispulse.core.ssrf import SSRFError
+
+    access = AccessSpec(
+        protocol=AccessProtocol.WFS,
+        endpoint="http://{addr}/wfs",
+        params={"addr": "127.0.0.1"},
+    )
+    with pytest.raises(SSRFError):
+        registry.dispatch_fetch(access, mode=FetchMode.REFERENCE)
+
+
+def test_dispatch_fetch_rejects_missing_template_param(
+    registry: ProtocolRegistry,
+) -> None:
+    access = AccessSpec(
+        protocol=AccessProtocol.WFS,
+        endpoint="https://93.184.216.34/{collection}",
+        params={},
+    )
+    with pytest.raises(ValueError, match=r"requires params \['collection'\]"):
+        registry.dispatch_fetch(access, mode=FetchMode.REFERENCE)
+
+
 def test_dispatch_write_resolves_and_runs(registry: ProtocolRegistry) -> None:
     spec = WriteSpec(protocol=AccessProtocol.DB, destination="postgis://analyse.t")
     report = registry.dispatch_write(SourceResult(payload=Payload.TABLE), spec)

--- a/tests/unit/test_worldwide_source.py
+++ b/tests/unit/test_worldwide_source.py
@@ -153,6 +153,49 @@ def test_revision_unknown_entry_raises() -> None:
         WorldwideCatalogSource().revision("does-not-exist")
 
 
+def test_revision_live_entry_resolves_templated_endpoint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A live (``revision_token: null``) entry with a ``{key}`` template
+    # must probe the *resolved* URL, not the raw template — otherwise
+    # the HEAD goes to a URL no real fetch would ever reach.
+    catalog = _write_catalog(
+        tmp_path,
+        """
+        version: 1
+        entries:
+          - id: templated-live
+            name: Templated live probe
+            family: opendata-fr
+            domain: base
+            payload: vector
+            jurisdiction: FR
+            access:
+              protocol: download
+              endpoint: "https://example.com/{layer}/data.geojson"
+              params:
+                layer: parcels
+            revision_token: null
+        """,
+    )
+
+    captured: dict[str, str] = {}
+
+    def _fake_probe(endpoint: str) -> str | None:
+        captured["endpoint"] = endpoint
+        return "etag-xyz"
+
+    import gispulse.plugins.worldwide_source as ws
+
+    monkeypatch.setattr(ws, "_probe_revision", _fake_probe)
+
+    src = WorldwideCatalogSource(catalog_path=catalog)
+    token = src.revision("templated-live")
+    assert token == "etag-xyz"
+    # The probe saw the interpolated URL, not the ``{layer}`` template.
+    assert captured["endpoint"] == "https://example.com/parcels/data.geojson"
+
+
 # -- SSRF / structural endpoint validation ----------------------------------
 
 


### PR DESCRIPTION
## Contexte

Permet à un `DeclarativeSource` de déclarer **une seule entry par dataset logique** avec un endpoint paramétrable, le `{key}` étant résolu via `access.params` au moment du fetch.

```python
AccessSpec(
    protocol=AccessProtocol.DOWNLOAD,
    endpoint=".../departements/{departement}/file-{departement}.gz",
    params={"departement": "75"},
)
```

## Motivation

`gispulse-src-cadastre` (foncier, vague 2) doit pouvoir ingérer le bulk Etalab (`cadastre.data.gouv.fr`, 101 départements × 4 couches). La convention worldwide_catalog (#257) est "1 entry = 1 dataset cohérent" — sans support template, on aurait dû soit hardcoder 404 entries explicites, soit splitter en plugin séparé `-bulk`. Ce patch débloque la shape propre : 4 entries (parcelles/communes/sections/batiments), dpt résolu à l'exécution.

Le besoin remonte aussi pour les autres datasets géographiques partitionnés par sous-zone (DVF si on switch vers les fichiers communaux, RGE ALTI par dalle IGN, etc.).

## Placement

Helper module-level `resolve_access_endpoint()` dans `src/gispulse/core/plugin_model.py`, à côté de `AccessSpec`. Appelé à trois endroits :

| Site | Pourquoi |
|---|---|
| `ProtocolRegistry.dispatch_fetch` (`core/sources.py`) | Résout AVANT le SSRF guard → tous les adapters profitent (LazyFetcher subclasses + structurels REST/WFS/STAC de #192) |
| `LazyFetcher` (`core/fetchers/base.py`) | Wrapper idempotent — préserve les appels directs hors registry (tests, consumers avancés). No-op si dispatch_fetch a déjà résolu. |
| `WorldwideCatalogSource.revision()` (`plugins/worldwide_source.py`) | Le live HEAD probe de A14 (#240) probe l'URL résolue — sinon le watcher proberait la mauvaise URL pour les entries templated |

## Grammaire stricte

Seul `{key}` bare est accepté. Tous les autres formats Python sont rejetés avec une `ValueError` contextualisée :

| Rejeté | Raison |
|---|---|
| `{}` (positionnel vide) | meaningless pour URL |
| `{0}` (numérique) | confusing avec `params["0"]` |
| `{a.b}` / `{a[0]}` | attribute/index lookup non voulu |
| `{key!r}` (conversion) | injecterait des quotes |
| `{key:>3}` (format-spec) | padderait la valeur |

`{{literal}}` braces restent littérales.

**Précondition** : les valeurs de `params` doivent être des fragments URL pré-encodés (`urllib.parse.quote` upstream pour valeurs user-supplied).

## SSRF (#199)

Résolution AVANT guard à chaque site → un template host (`{addr}` ⇒ `127.0.0.1`) est rejeté après résolution, jamais silently bypassed.

## Tests

- `test_fetchers_base.py` : 13 cas (résolution, rejets, SSRF wrapper)
- `test_sources.py` : 3 cas sur `dispatch_fetch` avec un `FakeWFS` structural (**pas LazyFetcher**) — templating, SSRF post-résolution, param manquant
- `test_worldwide_source.py` : `revision()` probe l'URL résolue
- **193 tests verts** au global (full v1.9 fetcher suite + worldwide + ETL sources + virtual_dataset)
- `ruff check` clean

## Review

Diff relu en **3 round-trips Codex** (acpx) sur la grammaire des placeholders + **1 round-trip Codex** sur l'archi canonique + **1 round-trip Codex** sur le refactor :
- Round 1 grammaire : `if name` filtrait à tort `name == ""` (positional vide silencieusement no-op)
- Round 2 grammaire : `{0}`, `{key!r}`, `{key:>3}` acceptés alors que le contrat est `{key}` simple
- Audit archi : extension de scope vers `ProtocolRegistry.dispatch_fetch` pour couvrir les structurels
- Round refactor 1 : `worldwide_source.revision()` probait l'URL brute, pas résolue
- Round final : **APPROVED**

## Suivi

Sera consommé immédiatement par une PR `gispulse-src-cadastre` (vague 2 follow-up de #194/#196) qui ajoute les entries bulk Etalab avec endpoint template `{departement}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)