### PR TITLE
docs(plugins): add READMEs for gispulse-src-* plugins

### DIFF
--- a/plugins/gispulse-src-cadastre/README.md
+++ b/plugins/gispulse-src-cadastre/README.md
@@ -1,0 +1,61 @@
+# gispulse-src-cadastre
+
+French cadastre data source for GISPulse — parcels, communes and buildings via IGN Géoplateforme WFS (domain: `FONCIER`, jurisdiction: `FR`).
+
+## Provider
+
+| Field          | Value                                              |
+|----------------|----------------------------------------------------|
+| Upstream producer | IGN (Institut national de l'information géographique et forestière) |
+| Redistributor  | IGN Géoplateforme (public WFS, no API key required) |
+| Dataset        | Parcellaire Express (`CADASTRALPARCELS.PARCELLAIRE_EXPRESS`) |
+| Licence        | Licence Ouverte 2.0                                |
+| Cadence        | Annual millésime (dataset-wide)                    |
+
+## Entries
+
+| id         | Label                      | AccessProtocol | Endpoint                          | WFS typename                                  | Payload | Jurisdiction |
+|------------|----------------------------|----------------|-----------------------------------|-----------------------------------------------|---------|--------------|
+| `parcelles` | Parcelles cadastrales      | `WFS`          | `https://data.geopf.fr/wfs/ows`   | `CADASTRALPARCELS.PARCELLAIRE_EXPRESS:parcelle` | VECTOR  | FR           |
+| `communes`  | Communes cadastrales       | `WFS`          | `https://data.geopf.fr/wfs/ows`   | `CADASTRALPARCELS.PARCELLAIRE_EXPRESS:commune`  | VECTOR  | FR           |
+| `batiments` | Bâtiments cadastraux       | `WFS`          | `https://data.geopf.fr/wfs/ows`   | `CADASTRALPARCELS.PARCELLAIRE_EXPRESS:batiment` | VECTOR  | FR           |
+
+Schema highlights:
+
+- **parcelles**: `idu`, `commune`, `section`, `numero`, `contenance` (int), `geometry`
+- **communes**: `idu`, `nom`, `code_insee`, `geometry`
+- **batiments**: `idu`, `nature`, `geometry`
+
+## Revision
+
+`revision(entry_id)` issues a single **HTTP HEAD** against the Géoplateforme WFS GetCapabilities URL:
+
+```
+https://data.geopf.fr/wfs/ows?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetCapabilities
+```
+
+The freshness token is derived from the `ETag` header (preferred) or the `Last-Modified` header. The Parcellaire Express millésime is dataset-wide, so all three entries share one probe. Returns `None` — meaning "freshness unknown" — when the endpoint is unreachable or exposes neither header; the source watcher skips it rather than emit a spurious change.
+
+## Usage
+
+```python
+from gispulse.plugins.api import get_catalog_entry
+
+entry = get_catalog_entry("cadastre", "parcelles")
+# entry.access.protocol → AccessProtocol.WFS
+# entry.access.endpoint → "https://data.geopf.fr/wfs/ows"
+# entry.access.params   → {"typename": "CADASTRALPARCELS.PARCELLAIRE_EXPRESS:parcelle"}
+```
+
+The plugin registers automatically via the `gispulse.data_sources` entry-point when installed:
+
+```bash
+pip install gispulse-src-cadastre
+```
+
+## References
+
+- Issue upstream: [#184](https://github.com/imagodata/gispulse/issues/184) (pilot wave 1 — `DeclarativeSource` contract)
+- Issue upstream: [#198](https://github.com/imagodata/gispulse/issues/198) (`revision()` freshness probe)
+- EPIC: [#175](https://github.com/imagodata/gispulse/issues/175) (SOURCE→CAPABILITY→SINK unified plugins)
+- Data portal: <https://data.geopf.fr/>

--- a/plugins/gispulse-src-dvf/README.md
+++ b/plugins/gispulse-src-dvf/README.md
@@ -1,0 +1,63 @@
+# gispulse-src-dvf
+
+French real-estate transactions (DVF) data source for GISPulse — Etalab geo-enriched GeoParquet mirror (domain: `STATISTIQUE`, jurisdiction: `FR`).
+
+## Provider
+
+| Field             | Value                                                         |
+|-------------------|---------------------------------------------------------------|
+| Upstream producer | DGFiP (Direction générale des finances publiques)             |
+| Provider (runtime)| Etalab (`metadata.provider = "Etalab"`)                       |
+| Redistributor     | data.gouv.fr / `files.data.gouv.fr`                           |
+| Dataset           | Demandes de Valeurs Foncières (DVF)                           |
+| Mirror            | `files.data.gouv.fr/geo-dvf` (geo-enriched GeoParquet)        |
+| Licence           | Licence Ouverte 2.0                                           |
+| Cadence           | Semestrial (April / October — rolling 5-year window)          |
+
+## Entries
+
+| id          | Label                                        | AccessProtocol  | Endpoint                                                               | Payload | Jurisdiction |
+|-------------|----------------------------------------------|-----------------|------------------------------------------------------------------------|---------|--------------|
+| `mutations` | Mutations DVF (transactions immobilières)    | `REMOTE_TABLE`  | `https://files.data.gouv.fr/geo-dvf/latest/parquet/full.parquet`       | TABLE   | FR           |
+
+Schema highlights (field names mirror the Etalab geo-dvf CSV header):
+
+`id_mutation`, `date_mutation`, `nature_mutation`, `valeur_fonciere`, `type_local`, `surface_reelle_bati`, `surface_terrain`, `code_commune`, `nom_commune`, `code_departement`, `prefixe_section`, `section`, `numero_plan`, `id_parcelle` (synthesised join key), `longitude`, `latitude`
+
+The `AccessProtocol.REMOTE_TABLE` adapter is handled by `GeoParquetS3Fetcher` (A3, issue #229, shipped in core since v1.9.0): it scans `full.parquet` via DuckDB `read_parquet` + `httpfs` with bbox predicate pushdown — a foncier query on one département touches a few MB of the national file, not 2 GB.
+
+## Revision
+
+`revision(entry_id)` issues a single **HTTP GET** against the data.gouv.fr dataset metadata API:
+
+```
+https://www.data.gouv.fr/api/1/datasets/demandes-de-valeurs-foncieres/
+```
+
+It parses the top-level `last_modified` ISO-8601 field from the JSON response. A HEAD request is not used because the `static.data.gouv.fr` edge returns neither `ETag` nor `Last-Modified` for resource files. Returns `None` — meaning "freshness unknown" — on any network error, non-2xx response, malformed JSON, or missing field.
+
+## Usage
+
+```python
+from gispulse.plugins.api import get_catalog_entry
+
+entry = get_catalog_entry("dvf", "mutations")
+# entry.access.protocol → AccessProtocol.REMOTE_TABLE
+# entry.access.endpoint → "https://files.data.gouv.fr/geo-dvf/latest/parquet/full.parquet"
+# entry.access.format   → "application/parquet"
+```
+
+The plugin registers automatically via the `gispulse.data_sources` entry-point when installed:
+
+```bash
+pip install gispulse-src-dvf
+```
+
+## References
+
+- Issue upstream: [#184](https://github.com/imagodata/gispulse/issues/184) (pilot wave 2 — `Payload.TABLE` source)
+- Issue upstream: [#198](https://github.com/imagodata/gispulse/issues/198) (`revision()` freshness probe)
+- Issue upstream: [#229](https://github.com/imagodata/gispulse/issues/229) (`GeoParquetS3Fetcher` — `REMOTE_TABLE` transport, A3)
+- PR merged: [#223](https://github.com/imagodata/gispulse/pull/223)
+- EPIC: [#175](https://github.com/imagodata/gispulse/issues/175)
+- Data portal: <https://www.data.gouv.fr/fr/datasets/demandes-de-valeurs-foncieres/>

--- a/plugins/gispulse-src-gpu/README.md
+++ b/plugins/gispulse-src-gpu/README.md
@@ -1,0 +1,81 @@
+# gispulse-src-gpu
+
+French urban-planning documents data source for GISPulse — Géoportail de l'Urbanisme WFS layers: zoning, prescriptions and informational layers (domain: `REGLEMENTAIRE`, jurisdiction: `FR`).
+
+## Provider
+
+| Field             | Value                                                                                     |
+|-------------------|-------------------------------------------------------------------------------------------|
+| Upstream producer | IGN + DGALN (Direction générale de l'aménagement, du logement et de la nature)            |
+| Platform          | Géoportail de l'Urbanisme (<https://www.geoportail-urbanisme.gouv.fr/>)                   |
+| Redistributor     | IGN Géoplateforme (public WFS `wfs_du` namespace, no API key required)                    |
+| Mandate           | Loi ALUR / ordonnance 2013-1184 (dematerialised urban-planning documents)                 |
+| Licence           | Licence Ouverte 2.0                                                                       |
+| Cadence           | Continuous (updated as communes publish/approve new PLU documents)                        |
+
+> **Note:** `GpuSource` is declared with `SourceDomain.REGLEMENTAIRE` and is semantically a `RegulatorySource`. Promotion (wiring `ruleset()` over the `wfs_du` attributes) is deferred to a follow-up plugin once the `RuleClause`-to-PLU mapping is stabilised.
+
+> **Note:** Servitudes d'utilité publique (SUP — `servitude`, `assiette_sup_*`, `generateur_sup_*`, `acte_sup`) are intentionally **not** in this plugin. They are conceptually distinct and warrant a dedicated `gispulse-src-sup` package.
+
+## Entries
+
+All entries use `AccessProtocol.WFS`, endpoint `https://data.geopf.fr/wfs/ows`, format `application/json`.
+
+| id                    | Label                                                     | WFS typename                    | Payload | Jurisdiction |
+|-----------------------|-----------------------------------------------------------|---------------------------------|---------|--------------|
+| `zone-urba`           | Zones d'urbanisme (PLU, PLUi, POS)                        | `wfs_du:zone_urba`              | VECTOR  | FR           |
+| `doc-urba`            | Documents d'urbanisme — emprises et métadonnées           | `wfs_du:doc_urba`               | VECTOR  | FR           |
+| `secteur-cc`          | Secteurs de carte communale                               | `wfs_du:secteur_cc`             | VECTOR  | FR           |
+| `prescription-surf`   | Prescriptions surfaciques                                 | `wfs_du:prescription_surf`      | VECTOR  | FR           |
+| `prescription-lin`    | Prescriptions linéaires                                   | `wfs_du:prescription_lin`       | VECTOR  | FR           |
+| `prescription-pct`    | Prescriptions ponctuelles                                 | `wfs_du:prescription_pct`       | VECTOR  | FR           |
+| `info-surf`           | Informations surfaciques                                  | `wfs_du:info_surf`              | VECTOR  | FR           |
+| `info-lin`            | Informations linéaires                                    | `wfs_du:info_lin`               | VECTOR  | FR           |
+| `info-pct`            | Informations ponctuelles                                  | `wfs_du:info_pct`               | VECTOR  | FR           |
+
+Schema highlights:
+
+- **Common fields** (all entries): `gid` (int), `idurba` (str — parent document id, joins to `doc-urba`), `geometry`
+- **zone-urba**: adds `libelle`, `libelong`, `typezone` (U/AU/A/N), `destdomi`, `nomfic`, `urlfic`
+- **doc-urba**: adds `typedoc` (PLU/PLUi/POS/CC/RNU), `datappro`, `datefin`, `datvalid`, `intercoid`, `insee`, `siren`
+- **secteur-cc**: adds `libelle`, `libelong`, `typesect` (constructible/non-constructible), `insee`
+- **prescription-{surf,lin,pct}**: adds `libelle`, `txt`, `typepsc`, `stypepsc`, `nomfic`, `urlfic`
+- **info-{surf,lin,pct}**: adds `libelle`, `txt`, `typeinf`, `stypeinf`, `nomfic`, `urlfic`
+
+## Revision
+
+`revision(entry_id)` issues a single **HTTP HEAD** against the Géoplateforme WFS GetCapabilities URL:
+
+```
+https://data.geopf.fr/wfs/ows?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetCapabilities
+```
+
+The freshness token is derived from the `ETag` header (preferred) or the `Last-Modified` header. The GPU millésime is service-wide (one consolidated GetCapabilities for all `wfs_du` layers), so all nine entries share one probe. Returns `None` — meaning "freshness unknown" — when the endpoint is unreachable or exposes neither header.
+
+## Usage
+
+```python
+from gispulse.plugins.api import get_catalog_entry
+
+entry = get_catalog_entry("gpu", "zone-urba")
+# entry.access.protocol → AccessProtocol.WFS
+# entry.access.endpoint → "https://data.geopf.fr/wfs/ows"
+# entry.access.params   → {"typename": "wfs_du:zone_urba"}
+
+entry = get_catalog_entry("gpu", "doc-urba")
+entry = get_catalog_entry("gpu", "prescription-surf")
+```
+
+The plugin registers automatically via the `gispulse.data_sources` entry-point when installed:
+
+```bash
+pip install gispulse-src-gpu
+```
+
+## References
+
+- Issue upstream: [#184](https://github.com/imagodata/gispulse/issues/184) (pilot wave 2 — multi-entry regulatory source)
+- Issue upstream: [#198](https://github.com/imagodata/gispulse/issues/198) (`revision()` freshness probe)
+- PR merged: [#224](https://github.com/imagodata/gispulse/pull/224)
+- EPIC: [#175](https://github.com/imagodata/gispulse/issues/175)
+- Data portal: <https://www.geoportail-urbanisme.gouv.fr/>

--- a/plugins/gispulse-src-ign/README.md
+++ b/plugins/gispulse-src-ign/README.md
@@ -1,0 +1,68 @@
+# gispulse-src-ign
+
+IGN reference data source for GISPulse — BD TOPO vector layers and Admin Express administrative boundaries via IGN Géoplateforme WFS (domain: `BASE`, jurisdiction: `FR`).
+
+## Provider
+
+| Field             | Value                                                                     |
+|-------------------|---------------------------------------------------------------------------|
+| Upstream producer | IGN (Institut national de l'information géographique et forestière)        |
+| Redistributor     | IGN Géoplateforme (public WFS, no API key required)                       |
+| Datasets          | BD TOPO v3 (`BDTOPO_V3`), Admin Express COG (`ADMINEXPRESS-COG.LATEST`)   |
+| Licence           | Licence Ouverte 2.0                                                       |
+| Cadence           | Annual millésime (service-wide)                                            |
+
+> **Note:** GEOFLA is deprecated upstream. The `geofla` entry id is kept as a legacy alias of the Admin Express `communes` entry and resolves transparently.
+
+## Entries
+
+All entries use `AccessProtocol.WFS`, endpoint `https://data.geopf.fr/wfs/ows`, format `application/json`.
+
+| id             | Label                          | WFS typename                           | Dataset        | Payload | Jurisdiction |
+|----------------|--------------------------------|----------------------------------------|----------------|---------|--------------|
+| `batiments`    | Bâtiments (BD TOPO)            | `BDTOPO_V3:batiment`                   | BD TOPO v3     | VECTOR  | FR           |
+| `routes`       | Tronçons de route (BD TOPO)    | `BDTOPO_V3:troncon_de_route`           | BD TOPO v3     | VECTOR  | FR           |
+| `cours_eau`    | Cours d'eau (BD TOPO)          | `BDTOPO_V3:cours_d_eau`                | BD TOPO v3     | VECTOR  | FR           |
+| `communes`     | Communes (Admin Express)       | `ADMINEXPRESS-COG.LATEST:commune`      | Admin Express  | VECTOR  | FR           |
+| `departements` | Départements (Admin Express)   | `ADMINEXPRESS-COG.LATEST:departement`  | Admin Express  | VECTOR  | FR           |
+| `regions`      | Régions (Admin Express)        | `ADMINEXPRESS-COG.LATEST:region`       | Admin Express  | VECTOR  | FR           |
+
+> **Legacy alias:** `geofla` resolves to `communes` in `_entry()` / `revision()` lookups but is **not** listed by `entries()` or `catalog()`. Use `communes` for new code; `geofla` is accepted silently for backwards-compat.
+
+## Revision
+
+`revision(entry_id)` issues a single **HTTP HEAD** against the Géoplateforme WFS GetCapabilities URL:
+
+```
+https://data.geopf.fr/wfs/ows?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetCapabilities
+```
+
+The freshness token is derived from the `ETag` header (preferred) or the `Last-Modified` header. The IGN millésime is service-wide, so all six entries share one probe. The legacy `geofla` alias is resolved before the id is validated. Returns `None` — meaning "freshness unknown" — when the endpoint is unreachable or exposes neither header.
+
+## Usage
+
+```python
+from gispulse.plugins.api import get_catalog_entry
+
+entry = get_catalog_entry("ign", "communes")
+# entry.access.protocol → AccessProtocol.WFS
+# entry.access.endpoint → "https://data.geopf.fr/wfs/ows"
+# entry.access.params   → {"typename": "ADMINEXPRESS-COG.LATEST:commune"}
+
+# Legacy alias — resolves to communes internally (not listed in catalog):
+entry = get_catalog_entry("ign", "geofla")  # equivalent to communes
+```
+
+The plugin registers automatically via the `gispulse.data_sources` entry-point when installed:
+
+```bash
+pip install gispulse-src-ign
+```
+
+## References
+
+- Issue upstream: [#194](https://github.com/imagodata/gispulse/issues/194) (pilot — multi-layer `DeclarativeSource`, BD TOPO + Admin Express)
+- Issue upstream: [#197](https://github.com/imagodata/gispulse/issues/197) (source watcher)
+- Issue upstream: [#198](https://github.com/imagodata/gispulse/issues/198) (`revision()` freshness probe)
+- EPIC: [#175](https://github.com/imagodata/gispulse/issues/175)
+- Data portal: <https://data.geopf.fr/>


### PR DESCRIPTION
## Summary

- Adds `README.md` to each of the four `gispulse-src-*` source plugins: `cadastre`, `dvf`, `gpu`, `ign`
- Each README follows a consistent structure: Provider table, Entries table (id / label / AccessProtocol / WFS typename or endpoint / Payload / Jurisdiction), Revision pattern, Python usage snippet, upstream issue references
- Content extracted directly from `source.py` and `pyproject.toml` — code is the source of truth

## Notable findings (corrected before commit)

- **dvf**: corrected `GeoParquetS3Fetcher` issue ref from `#256` to `#229` (A3); clarified that `metadata.provider = "Etalab"` while upstream producer is DGFiP
- **ign**: clarified that `geofla` legacy alias is resolved by `_entry()`/`revision()` but is **not** listed by `entries()`/`catalog()`
- **gpu**: 9 entries documented (zone-urba, doc-urba, secteur-cc, 3 prescriptions, 3 informations); noted that SUP layers are intentionally excluded (see plugin docstring)

## Test plan

- [ ] Verify each README entry table matches `entries()` in `source.py`
- [ ] Verify `AccessProtocol` column (WFS vs REMOTE_TABLE) per plugin
- [ ] Verify revision pattern description vs actual `revision()` implementation
- [ ] Spot-check issue number references against upstream issue tracker

🤖 Generated with [Claude Code](https://claude.com/claude-code)