### PR TITLE
feat(licence): unified Ed25519 payload format (poste + tenant SaaS) — L0

### DIFF
--- a/src/gispulse/core/licence_format.py
+++ b/src/gispulse/core/licence_format.py
@@ -1,0 +1,255 @@
+"""Unified licence payload format (Mode A poste + Mode B tenant SaaS).
+
+This module defines the **single** Ed25519 payload schema used by:
+
+* the per-machine licence key (``GISPULSE_LICENSE_KEY``) — Mode A;
+* the future SaaS tenant licence — Mode B;
+* the data-pack signature (story G1a, future).
+
+Doctrine (issue #266 / decision D2 of the v2.0.0 plan):
+
+* one schema, versioned via ``schema_version`` so the format can evolve;
+* additive fields only — an OSS verifier reading a newer payload must ignore
+  unknown fields, never crash;
+* signature on a *canonicalised* JSON serialisation so the same payload always
+  produces the same bytes to sign and verify;
+* signing tooling (private key) lives in ``gispulse-enterprise`` — this module
+  only contains verification + encoding helpers usable from tests.
+
+The class ``LicencePayload`` is intentionally permissive: the OSS verifier
+extracts the few fields it acts on (``schema_version``, ``tier``, ``exp``,
+``org``, ``tenant_id``) and keeps the rest in ``extra`` so a future enterprise
+build can read them without a new release of the OSS verifier.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+__all__ = [
+    "SCHEMA_VERSION_CURRENT",
+    "KNOWN_FIELDS",
+    "LicencePayload",
+    "LicenceVerificationError",
+    "canonicalise",
+    "encode_payload",
+    "decode_payload",
+]
+
+
+SCHEMA_VERSION_CURRENT: int = 1
+"""Latest payload schema version this module knows how to interpret natively."""
+
+KNOWN_FIELDS: frozenset[str] = frozenset(
+    {
+        # core (both profiles)
+        "schema_version",
+        "org",
+        "tier",
+        "exp",
+        # tenant profile (additive, optional)
+        "tenant_id",
+        "quotas",
+        "stripe_customer_id",
+        "stripe_subscription_id",
+    }
+)
+"""Field names this version understands. Any other key is preserved in ``extra``."""
+
+
+class LicenceVerificationError(Exception):
+    """Raised when a licence string fails to decode or its signature is invalid."""
+
+
+@dataclass(frozen=True)
+class LicencePayload:
+    """Decoded licence payload — covers both Mode A (poste) and Mode B (tenant).
+
+    All fields beyond ``schema_version`` are optional so the same dataclass can
+    represent both profiles. Unknown fields (forward-compat) land in ``extra``.
+    """
+
+    schema_version: int = SCHEMA_VERSION_CURRENT
+    org: str | None = None
+    tier: str | None = None
+    exp: str | None = None
+    # tenant profile (Mode B) — all optional
+    tenant_id: str | None = None
+    quotas: dict[str, Any] | None = None
+    stripe_customer_id: str | None = None
+    stripe_subscription_id: str | None = None
+    # forward-compat: any unknown key is kept here, never silently dropped
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a plain dict suitable for canonicalisation.
+
+        Drops ``None`` values and merges back ``extra`` (which never overrides
+        a known field — that would be a contract violation).
+        """
+        out: dict[str, Any] = {"schema_version": self.schema_version}
+        for key in (
+            "org",
+            "tier",
+            "exp",
+            "tenant_id",
+            "quotas",
+            "stripe_customer_id",
+            "stripe_subscription_id",
+        ):
+            value = getattr(self, key)
+            if value is not None:
+                out[key] = value
+        for key, value in self.extra.items():
+            if key in out:
+                # Defensive: never let extra shadow a known field.
+                continue
+            out[key] = value
+        return out
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> LicencePayload:
+        """Build a payload from a decoded JSON dict, tolerant of unknown keys.
+
+        Unknown keys go into ``extra`` (no crash, no warning — forward-compat is
+        the explicit contract).
+        """
+        if not isinstance(raw, dict):
+            raise LicenceVerificationError(
+                "licence payload must be a JSON object, got "
+                f"{type(raw).__name__}"
+            )
+        sv = raw.get("schema_version", SCHEMA_VERSION_CURRENT)
+        if not isinstance(sv, int):
+            raise LicenceVerificationError(
+                f"schema_version must be an int, got {type(sv).__name__}"
+            )
+        extra: dict[str, Any] = {
+            k: v for k, v in raw.items() if k not in KNOWN_FIELDS
+        }
+        return cls(
+            schema_version=sv,
+            org=raw.get("org"),
+            tier=raw.get("tier"),
+            exp=raw.get("exp"),
+            tenant_id=raw.get("tenant_id"),
+            quotas=raw.get("quotas"),
+            stripe_customer_id=raw.get("stripe_customer_id"),
+            stripe_subscription_id=raw.get("stripe_subscription_id"),
+            extra=extra,
+        )
+
+    def is_expired(self, *, now: datetime | None = None) -> bool:
+        """True if ``exp`` is set and in the past.
+
+        Absent or unparseable ``exp`` is treated as perpetual (False) — matches
+        the legacy ``persistence.tier`` behaviour to avoid bricking poste
+        licences without an expiry.
+        """
+        if not self.exp:
+            return False
+        # ``Z`` is only accepted by ``datetime.fromisoformat`` from
+        # Python 3.11. Normalise to keep 3.10 tolerant.
+        normalised = self.exp.replace("Z", "+00:00")
+        try:
+            exp_dt = datetime.fromisoformat(normalised)
+        except (ValueError, TypeError):
+            return False
+        if exp_dt.tzinfo is None:
+            exp_dt = exp_dt.replace(tzinfo=timezone.utc)
+        ref = now if now is not None else datetime.now(timezone.utc)
+        return ref > exp_dt
+
+
+def canonicalise(payload: dict[str, Any]) -> bytes:
+    """Return the byte string used both for signing and for verification.
+
+    JSON, UTF-8, sorted keys, compact separators, no whitespace. Stable across
+    runs and Python versions — this is what the Ed25519 signature covers.
+    """
+    return json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode("utf-8")
+
+
+def _b64url_encode(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(text: str) -> bytes:
+    # urlsafe_b64decode is strict about padding; restore it.
+    padded = text + "=" * (-len(text) % 4)
+    return base64.urlsafe_b64decode(padded)
+
+
+def encode_payload(payload: LicencePayload, private_key: Any) -> str:
+    """Serialise + sign a payload. Returns ``"<b64-payload>.<b64-signature>"``.
+
+    ``private_key`` must be a ``cryptography`` ``Ed25519PrivateKey``. This entry
+    point is here so OSS tests can round-trip; the *production* signing key
+    lives only in ``gispulse-enterprise`` — the OSS distribution must never
+    embed it.
+    """
+    body = canonicalise(payload.to_dict())
+    signature = private_key.sign(body)
+    return f"{_b64url_encode(body)}.{_b64url_encode(signature)}"
+
+
+def decode_payload(
+    key_string: str, public_key: Any | None = None
+) -> LicencePayload:
+    """Parse a licence string, optionally verifying the Ed25519 signature.
+
+    Args:
+        key_string: ``"<b64-payload>.<b64-signature>"``.
+        public_key: a ``cryptography`` ``Ed25519PublicKey``. When ``None`` the
+            signature is **not** checked — useful in dev/test paths, never in
+            production gating.
+
+    Raises:
+        LicenceVerificationError: malformed string, bad base64, non-JSON
+            payload, unknown payload shape, or — when ``public_key`` is set —
+            an invalid signature.
+
+    Returns:
+        The decoded ``LicencePayload``. The caller is responsible for tier and
+        expiry policy (this module only owns the format).
+    """
+    if not isinstance(key_string, str):
+        raise LicenceVerificationError(
+            f"licence key must be a string, got {type(key_string).__name__}"
+        )
+    parts = key_string.strip().split(".")
+    if len(parts) != 2 or not all(parts):
+        raise LicenceVerificationError(
+            "invalid licence format — expected '<payload>.<signature>'"
+        )
+    payload_b64, signature_b64 = parts
+    try:
+        body = _b64url_decode(payload_b64)
+        signature = _b64url_decode(signature_b64)
+    except Exception as exc:  # pragma: no cover - base64 raises many subtypes
+        raise LicenceVerificationError(
+            "invalid licence encoding (base64 decode failed)"
+        ) from exc
+
+    if public_key is not None:
+        try:
+            public_key.verify(signature, body)
+        except Exception as exc:
+            raise LicenceVerificationError(
+                "invalid licence signature"
+            ) from exc
+
+    try:
+        raw = json.loads(body.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise LicenceVerificationError(
+            "invalid licence payload (not valid JSON)"
+        ) from exc
+
+    return LicencePayload.from_dict(raw)

--- a/tests/unit/test_licence_format.py
+++ b/tests/unit/test_licence_format.py
@@ -1,0 +1,259 @@
+"""Tests for the unified licence payload format (issue #266, story L0)."""
+
+from __future__ import annotations
+
+import base64
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+
+from gispulse.core.licence_format import (
+    KNOWN_FIELDS,
+    SCHEMA_VERSION_CURRENT,
+    LicencePayload,
+    LicenceVerificationError,
+    canonicalise,
+    decode_payload,
+    encode_payload,
+)
+
+
+@pytest.fixture
+def keypair() -> tuple[Ed25519PrivateKey, Ed25519PublicKey]:
+    priv = Ed25519PrivateKey.generate()
+    return priv, priv.public_key()
+
+
+# ---------------------------------------------------------------------------
+# Round-trip — Mode A (poste) and Mode B (tenant SaaS)
+# ---------------------------------------------------------------------------
+
+
+def test_roundtrip_poste_profile(keypair: tuple[Ed25519PrivateKey, Ed25519PublicKey]) -> None:
+    """Given a poste-profile payload, when signed and verified, then round-trip OK."""
+    priv, pub = keypair
+    payload = LicencePayload(
+        schema_version=SCHEMA_VERSION_CURRENT,
+        org="ACME",
+        tier="pro",
+        exp="2030-01-01T00:00:00Z",
+    )
+    key = encode_payload(payload, priv)
+    out = decode_payload(key, pub)
+    assert out == payload
+
+
+def test_roundtrip_tenant_profile(keypair: tuple[Ed25519PrivateKey, Ed25519PublicKey]) -> None:
+    """Tenant profile (SaaS) round-trips with the same module — no separate path."""
+    priv, pub = keypair
+    payload = LicencePayload(
+        schema_version=SCHEMA_VERSION_CURRENT,
+        org="ACME",
+        tier="pro",
+        exp="2030-01-01T00:00:00Z",
+        tenant_id="tnt_42",
+        quotas={"requests_per_day": 10_000, "datasets": 50},
+        stripe_customer_id="cus_abc",
+        stripe_subscription_id="sub_xyz",
+    )
+    key = encode_payload(payload, priv)
+    out = decode_payload(key, pub)
+    assert out == payload
+    assert out.tenant_id == "tnt_42"
+    assert out.quotas == {"requests_per_day": 10_000, "datasets": 50}
+
+
+# ---------------------------------------------------------------------------
+# Forward compat — unknown fields must NOT crash the OSS verifier
+# ---------------------------------------------------------------------------
+
+
+def test_forward_compat_unknown_fields_preserved(
+    keypair: tuple[Ed25519PrivateKey, Ed25519PublicKey],
+) -> None:
+    """A payload from a *future* schema_version with unknown fields decodes cleanly."""
+    priv, pub = keypair
+    raw = {
+        "schema_version": 99,  # future
+        "org": "Future Corp",
+        "tier": "enterprise",
+        "exp": "2099-12-31T23:59:59Z",
+        "shiny_new_field": {"k": "v"},  # unknown to this verifier
+        "another_one": [1, 2, 3],
+    }
+    body = canonicalise(raw)
+    signature = priv.sign(body)
+    key = (
+        base64.urlsafe_b64encode(body).rstrip(b"=").decode("ascii")
+        + "."
+        + base64.urlsafe_b64encode(signature).rstrip(b"=").decode("ascii")
+    )
+    out = decode_payload(key, pub)
+    assert out.schema_version == 99
+    assert out.org == "Future Corp"
+    assert out.extra == {
+        "shiny_new_field": {"k": "v"},
+        "another_one": [1, 2, 3],
+    }
+    # the well-known fields are still where we expect
+    for k in ("shiny_new_field", "another_one"):
+        assert k not in KNOWN_FIELDS
+
+
+def test_extra_cannot_shadow_known_field() -> None:
+    """``LicencePayload.to_dict`` never lets ``extra`` overwrite a known field."""
+    p = LicencePayload(
+        org="ACME",
+        tier="pro",
+        extra={"tier": "enterprise", "totally_new": True},  # 'tier' shadow attempt
+    )
+    d = p.to_dict()
+    assert d["tier"] == "pro"  # known wins
+    assert d["totally_new"] is True
+
+
+# ---------------------------------------------------------------------------
+# Signature failure cases
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_signature_rejected(
+    keypair: tuple[Ed25519PrivateKey, Ed25519PublicKey],
+) -> None:
+    """Given a tampered signature, when verified, then rejected explicitly."""
+    priv, pub = keypair
+    payload = LicencePayload(org="ACME", tier="pro")
+    key = encode_payload(payload, priv)
+    # flip the last char of the signature half
+    head, sig = key.rsplit(".", 1)
+    tampered = head + "." + ("A" if sig[-1] != "A" else "B") + sig[1:]
+    with pytest.raises(LicenceVerificationError, match="invalid licence signature"):
+        decode_payload(tampered, pub)
+
+
+def test_signature_from_other_key_rejected() -> None:
+    """A payload signed with key A must not verify against key B."""
+    priv_a = Ed25519PrivateKey.generate()
+    priv_b = Ed25519PrivateKey.generate()
+    payload = LicencePayload(org="ACME", tier="pro")
+    key = encode_payload(payload, priv_a)
+    with pytest.raises(LicenceVerificationError, match="invalid licence signature"):
+        decode_payload(key, priv_b.public_key())
+
+
+def test_skip_verification_when_public_key_none(
+    keypair: tuple[Ed25519PrivateKey, Ed25519PublicKey],
+) -> None:
+    """Passing public_key=None skips verification (dev path)."""
+    priv, _ = keypair
+    payload = LicencePayload(org="dev", tier="pro")
+    key = encode_payload(payload, priv)
+    out = decode_payload(key, public_key=None)
+    assert out == payload
+
+
+# ---------------------------------------------------------------------------
+# Format / encoding failure cases
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_string_rejected() -> None:
+    with pytest.raises(LicenceVerificationError, match="invalid licence format"):
+        decode_payload("no-dot-here")
+    with pytest.raises(LicenceVerificationError, match="invalid licence format"):
+        decode_payload(".only-sig")
+    with pytest.raises(LicenceVerificationError, match="invalid licence format"):
+        decode_payload("only-payload.")
+
+
+def test_non_string_key_rejected() -> None:
+    with pytest.raises(LicenceVerificationError, match="must be a string"):
+        decode_payload(123)  # type: ignore[arg-type]
+
+
+def test_non_json_payload_rejected(
+    keypair: tuple[Ed25519PrivateKey, Ed25519PublicKey],
+) -> None:
+    priv, pub = keypair
+    body = b"not-json-at-all"
+    sig = priv.sign(body)
+    key = (
+        base64.urlsafe_b64encode(body).rstrip(b"=").decode("ascii")
+        + "."
+        + base64.urlsafe_b64encode(sig).rstrip(b"=").decode("ascii")
+    )
+    with pytest.raises(LicenceVerificationError, match="not valid JSON"):
+        decode_payload(key, pub)
+
+
+def test_non_object_payload_rejected(
+    keypair: tuple[Ed25519PrivateKey, Ed25519PublicKey],
+) -> None:
+    """JSON arrays/scalars at the root must not be accepted as a payload."""
+    priv, pub = keypair
+    body = json.dumps([1, 2, 3]).encode("utf-8")
+    sig = priv.sign(body)
+    key = (
+        base64.urlsafe_b64encode(body).rstrip(b"=").decode("ascii")
+        + "."
+        + base64.urlsafe_b64encode(sig).rstrip(b"=").decode("ascii")
+    )
+    with pytest.raises(LicenceVerificationError, match="must be a JSON object"):
+        decode_payload(key, pub)
+
+
+def test_non_int_schema_version_rejected(
+    keypair: tuple[Ed25519PrivateKey, Ed25519PublicKey],
+) -> None:
+    priv, pub = keypair
+    body = canonicalise({"schema_version": "v1", "org": "x"})
+    sig = priv.sign(body)
+    key = (
+        base64.urlsafe_b64encode(body).rstrip(b"=").decode("ascii")
+        + "."
+        + base64.urlsafe_b64encode(sig).rstrip(b"=").decode("ascii")
+    )
+    with pytest.raises(LicenceVerificationError, match="schema_version"):
+        decode_payload(key, pub)
+
+
+# ---------------------------------------------------------------------------
+# Canonicalisation determinism
+# ---------------------------------------------------------------------------
+
+
+def test_canonicalisation_is_stable() -> None:
+    """Two equivalent dicts produce the same canonical bytes — required for signing."""
+    a = canonicalise({"b": 2, "a": 1, "c": [3, 1, 2]})
+    b = canonicalise({"c": [3, 1, 2], "a": 1, "b": 2})
+    assert a == b
+    assert a == b'{"a":1,"b":2,"c":[3,1,2]}'
+
+
+# ---------------------------------------------------------------------------
+# Expiry helper — kept narrow on purpose (tier policy lives elsewhere)
+# ---------------------------------------------------------------------------
+
+
+def test_is_expired_perpetual_when_no_exp() -> None:
+    assert LicencePayload(org="x", tier="pro").is_expired() is False
+
+
+def test_is_expired_perpetual_when_garbage_exp() -> None:
+    assert LicencePayload(org="x", tier="pro", exp="not-a-date").is_expired() is False
+
+
+def test_is_expired_true_when_past() -> None:
+    payload = LicencePayload(org="x", tier="pro", exp="2000-01-01T00:00:00Z")
+    assert payload.is_expired() is True
+
+
+def test_is_expired_false_when_future() -> None:
+    future = (datetime.now(timezone.utc) + timedelta(days=1)).isoformat()
+    payload = LicencePayload(org="x", tier="pro", exp=future)
+    assert payload.is_expired() is False


### PR DESCRIPTION
Implements story **L0** of EPIC #265 (Regulatory data-packs, M1).

## What

Introduces `gispulse.core.licence_format`: the single Ed25519 payload schema
shared by

- the per-machine licence key (Mode A — `GISPULSE_LICENSE_KEY`);
- the future SaaS tenant licence (Mode B);
- the data-pack manifest signature (story G1a #271, future PR).

## Why one schema now

Decision D2 of the v2.0.0 plan (`plan_pypi_saas_pro_2026_05_19.md`): unify
the format **before** we sign the first data-pack, so the SaaS doesn't
inherit a divergent format later. Cheap now, structurally expensive later.

## Design

- one dataclass `LicencePayload`, versioned via `schema_version`;
- additive fields only — unknown fields land in `LicencePayload.extra`,
  forward-compat is the explicit contract;
- canonicalised JSON (sort_keys, compact, UTF-8) so bytes-to-sign are
  stable across runs and Python versions;
- signing tooling stays in `gispulse-enterprise`; the OSS distribution
  ships only the verifier + an `encode_payload` helper used by tests for
  round-tripping (no embedded production key).

`persistence.tier._validate_license` is intentionally left untouched: its
current payload `{org, tier, exp}` is already a valid `schema_version=1`
payload, so migrating it is a follow-up with no behaviour change.

## Acceptance criteria (from #266)

- [x] poste-profile round-trip
- [x] tenant-profile round-trip
- [x] unknown `schema_version`/fields tolerated, no crash
- [x] invalid signature rejected explicitly
- [x] two test payload profiles covered
- [x] no dependency on SaaS code (which doesn't exist)

## Tests

17 unit cases in `tests/unit/test_licence_format.py` — round-trip
poste/tenant, forward-compat with `schema_version=99` + unknown fields,
tampered/foreign-key signatures, malformed/non-JSON/non-object payload,
canonicalisation determinism, expiry helper.

Local run: `17 passed in 0.06s`.

## Out of scope

- Migrating `persistence.tier` to this module (no behaviour change today).
- Tenant-licence runtime (Mode B) — lives in the SaaS EPIC (`gispulse-enterprise#506`).
- Data-pack signature itself — story G1a #271, depends on this PR.

Refs: #265 (EPIC), #266 (story), #275 (REL-J5).

Signed-off-by: Marco <simon.ducournau@gmail.com>