### PR TITLE
feat(normalize): declarative ZoningElement normaliser — T2

### DIFF
--- a/src/gispulse/core/zoning_normalizer.py
+++ b/src/gispulse/core/zoning_normalizer.py
@@ -1,0 +1,165 @@
+"""Declarative normaliser: source records → ZoningElement common schema.
+
+Story T2 of EPIC #265 (regulatory data-packs M1). The 8-field schema is
+inspired by INSPIRE PlannedLandUse ``ZoningElement``. The normaliser itself
+lives in the OSS core; per-country mapping tables live in the data-pack.
+
+Schéma cible (8 champs)::
+
+    geometry        — keep as-is from the source; CRS resolved separately
+    zone_code       — short code/identifier of the zone (str)
+    zone_label      — human-readable label (str)
+    hilucs_class    — best-effort INSPIRE HILUCS class (str | None)
+    plan_id         — identifier of the plan that defines the zone
+    plan_date       — date the plan was adopted/approved (ISO-8601 str)
+    regulation_ref  — link or reference to the regulatory text
+    source_country  — ISO-3166-1 alpha-2 country code (e.g. "FR")
+
+Mapping DSL (intentionally tiny — extensible later)::
+
+    mapping = ZoningMapping(
+        source_country="FR",
+        crs="EPSG:2154",
+        fields={
+            "zone_code": "libelle",
+            "zone_label": "libelong",
+            "plan_id": "idurba",
+            "plan_date": "dateappro",
+            "regulation_ref": "nomfic",
+        },
+        hilucs={
+            # source zone code → HILUCS class (best-effort, optional)
+            "U": "1_PrimaryProduction_Residential",
+            "AU": "1_PrimaryProduction_Residential",
+            "A": "1_PrimaryProduction_Agriculture",
+            "N": "4_OtherUses_NaturalAreas",
+        },
+        hilucs_key="zone_code",  # column to look up in `hilucs`
+    )
+
+Then::
+
+    out = normalize(records, mapping)
+
+The DSL keeps the contract simple: a *field* mapping is a flat
+``{target: source_key}`` table; HILUCS is a separate lookup so a missing
+match leaves the target ``None`` rather than crashing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Mapping
+
+__all__ = [
+    "ZONING_ELEMENT_FIELDS",
+    "ZoningMapping",
+    "ZoningNormalisationError",
+    "normalize",
+    "normalize_record",
+]
+
+
+ZONING_ELEMENT_FIELDS: tuple[str, ...] = (
+    "geometry",
+    "zone_code",
+    "zone_label",
+    "hilucs_class",
+    "plan_id",
+    "plan_date",
+    "regulation_ref",
+    "source_country",
+)
+"""The 8 cible fields of the ZoningElement common schema, in canonical order."""
+
+
+_MAPPABLE = frozenset(ZONING_ELEMENT_FIELDS) - {
+    "geometry",  # always passthrough from `geometry_key`
+    "hilucs_class",  # resolved via `hilucs` lookup, never a plain rename
+    "source_country",  # comes from ZoningMapping.source_country, not records
+}
+
+
+class ZoningNormalisationError(ValueError):
+    """Raised on a malformed mapping or an unresolvable required field."""
+
+
+@dataclass(frozen=True)
+class ZoningMapping:
+    """Declarative mapping from one source's schema to ``ZoningElement``.
+
+    Args:
+        source_country: ISO-3166-1 alpha-2 country code. Mandatory — the
+            common schema is unusable without it.
+        crs: EPSG identifier (``"EPSG:2154"``) for the source geometries.
+            Mandatory — silent-CRS data is the #1 bug we want to prevent.
+        fields: target field → source key. Targets must be in
+            ``ZONING_ELEMENT_FIELDS`` and not in ``geometry``,
+            ``hilucs_class`` or ``source_country`` (these are handled
+            specially). Missing target keys land as ``None`` in the output.
+        geometry_key: source key for the geometry. Default ``"geometry"``.
+        hilucs: optional best-effort lookup from a source value to a HILUCS
+            class. Misses leave ``hilucs_class`` as ``None``, never crash.
+        hilucs_key: name of the *source* column to look up in ``hilucs``.
+            Defaults to ``"zone_code"`` (after target rename), but accepts
+            an arbitrary source key when the lookup uses a different column.
+    """
+
+    source_country: str
+    crs: str
+    fields: Mapping[str, str] = field(default_factory=dict)
+    geometry_key: str = "geometry"
+    hilucs: Mapping[str, str] | None = None
+    hilucs_key: str = "zone_code"
+
+    def __post_init__(self) -> None:
+        if not self.source_country or len(self.source_country) != 2:
+            raise ZoningNormalisationError(
+                "ZoningMapping.source_country must be an ISO-3166-1 alpha-2 code"
+            )
+        if not self.crs or ":" not in self.crs:
+            raise ZoningNormalisationError(
+                "ZoningMapping.crs must be an explicit EPSG identifier "
+                "(e.g. 'EPSG:2154') — silent-CRS data is not allowed"
+            )
+        bad = set(self.fields) - _MAPPABLE
+        if bad:
+            raise ZoningNormalisationError(
+                f"ZoningMapping.fields keys must be ZoningElement targets and "
+                f"not {{geometry, hilucs_class, source_country}} — got {sorted(bad)}"
+            )
+
+
+def normalize_record(
+    record: Mapping[str, Any], mapping: ZoningMapping
+) -> dict[str, Any]:
+    """Normalise a single source record into the 8-field ZoningElement shape."""
+    out: dict[str, Any] = dict.fromkeys(ZONING_ELEMENT_FIELDS, None)
+    out["source_country"] = mapping.source_country
+    out["geometry"] = record.get(mapping.geometry_key)
+
+    for target, source_key in mapping.fields.items():
+        out[target] = record.get(source_key)
+
+    if mapping.hilucs:
+        # The HILUCS key is a *source* column. If it's been renamed by the
+        # field mapping (e.g. zone_code → libelle in FR), look it up in the
+        # source record under the source key, not the renamed target.
+        source_key = mapping.fields.get(mapping.hilucs_key, mapping.hilucs_key)
+        source_value = record.get(source_key)
+        if source_value is not None:
+            out["hilucs_class"] = mapping.hilucs.get(str(source_value))
+
+    return out
+
+
+def normalize(
+    records: Iterable[Mapping[str, Any]], mapping: ZoningMapping
+) -> list[dict[str, Any]]:
+    """Normalise an iterable of source records into ZoningElement dicts.
+
+    Order is preserved. Records are processed independently; one record's
+    failure does not abort the batch (best-effort: a missing optional field
+    yields ``None``, not an exception).
+    """
+    return [normalize_record(r, mapping) for r in records]

--- a/tests/unit/test_zoning_normalizer.py
+++ b/tests/unit/test_zoning_normalizer.py
@@ -1,0 +1,251 @@
+"""Tests for the ZoningElement declarative normaliser (issue #268, story T2)."""
+
+from __future__ import annotations
+
+import pytest
+
+from gispulse.core.zoning_normalizer import (
+    ZONING_ELEMENT_FIELDS,
+    ZoningMapping,
+    ZoningNormalisationError,
+    normalize,
+    normalize_record,
+)
+
+
+# ---------------------------------------------------------------------------
+# Schema contract — the 8 fields, in canonical order
+# ---------------------------------------------------------------------------
+
+
+def test_schema_has_exactly_eight_fields() -> None:
+    assert len(ZONING_ELEMENT_FIELDS) == 8
+    assert ZONING_ELEMENT_FIELDS == (
+        "geometry",
+        "zone_code",
+        "zone_label",
+        "hilucs_class",
+        "plan_id",
+        "plan_date",
+        "regulation_ref",
+        "source_country",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion: full mapping produces all 8 target fields
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_full_french_record() -> None:
+    """Given a typical FR GPU record + mapping, the output carries the 8 cibles."""
+    mapping = ZoningMapping(
+        source_country="FR",
+        crs="EPSG:2154",
+        fields={
+            "zone_code": "libelle",
+            "zone_label": "libelong",
+            "plan_id": "idurba",
+            "plan_date": "dateappro",
+            "regulation_ref": "nomfic",
+        },
+        hilucs={
+            "U": "1_PrimaryProduction_Residential",
+            "AU": "1_PrimaryProduction_Residential",
+            "A": "1_PrimaryProduction_Agriculture",
+            "N": "4_OtherUses_NaturalAreas",
+        },
+        hilucs_key="zone_code",  # looked up after rename via mapping.fields
+    )
+    record = {
+        "geometry": "POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))",
+        "libelle": "U",
+        "libelong": "Zone urbaine",
+        "idurba": "75056_PLU_2025",
+        "dateappro": "2025-06-18",
+        "nomfic": "https://gpu.gouv.fr/75/PLU/2025/reglement.pdf",
+    }
+    out = normalize_record(record, mapping)
+
+    assert set(out) == set(ZONING_ELEMENT_FIELDS)
+    assert out["geometry"] == "POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))"
+    assert out["zone_code"] == "U"
+    assert out["zone_label"] == "Zone urbaine"
+    assert out["hilucs_class"] == "1_PrimaryProduction_Residential"
+    assert out["plan_id"] == "75056_PLU_2025"
+    assert out["plan_date"] == "2025-06-18"
+    assert out["regulation_ref"] == "https://gpu.gouv.fr/75/PLU/2025/reglement.pdf"
+    assert out["source_country"] == "FR"
+
+
+# ---------------------------------------------------------------------------
+# Acceptance: best-effort HILUCS — no match yields None, no crash
+# ---------------------------------------------------------------------------
+
+
+def test_hilucs_unknown_value_yields_none_not_crash() -> None:
+    mapping = ZoningMapping(
+        source_country="FR",
+        crs="EPSG:2154",
+        fields={"zone_code": "libelle"},
+        hilucs={"U": "1_PrimaryProduction_Residential"},
+        hilucs_key="zone_code",
+    )
+    out = normalize_record({"libelle": "TOTALLY_UNKNOWN_CODE"}, mapping)
+    assert out["zone_code"] == "TOTALLY_UNKNOWN_CODE"
+    assert out["hilucs_class"] is None  # no match, but no exception
+
+
+def test_hilucs_missing_source_field_yields_none_not_crash() -> None:
+    mapping = ZoningMapping(
+        source_country="DK",
+        crs="EPSG:25832",
+        fields={"zone_code": "kode"},
+        hilucs={"U": "1_PrimaryProduction_Residential"},
+        hilucs_key="zone_code",
+    )
+    out = normalize_record({}, mapping)  # source field absent altogether
+    assert out["zone_code"] is None
+    assert out["hilucs_class"] is None
+
+
+def test_hilucs_completely_omitted_is_legal() -> None:
+    """A mapping with no HILUCS table at all leaves the column ``None``."""
+    mapping = ZoningMapping(
+        source_country="NL",
+        crs="EPSG:28992",
+        fields={"zone_code": "code"},
+    )
+    out = normalize_record({"code": "W"}, mapping)
+    assert out["zone_code"] == "W"
+    assert out["hilucs_class"] is None
+
+
+# ---------------------------------------------------------------------------
+# Acceptance: CRS must be explicit
+# ---------------------------------------------------------------------------
+
+
+def test_missing_crs_rejected() -> None:
+    with pytest.raises(ZoningNormalisationError, match="EPSG identifier"):
+        ZoningMapping(source_country="FR", crs="")
+
+
+def test_bare_crs_string_rejected() -> None:
+    with pytest.raises(ZoningNormalisationError, match="EPSG identifier"):
+        ZoningMapping(source_country="FR", crs="2154")  # missing 'EPSG:' prefix
+
+
+def test_explicit_crs_is_carried_on_the_mapping_for_callers() -> None:
+    """The CRS lives on the mapping — callers can use it to set GeoSeries.crs."""
+    m = ZoningMapping(source_country="FR", crs="EPSG:2154", fields={})
+    assert m.crs == "EPSG:2154"
+
+
+# ---------------------------------------------------------------------------
+# Acceptance: source_country must be ISO alpha-2
+# ---------------------------------------------------------------------------
+
+
+def test_source_country_must_be_iso_alpha2() -> None:
+    with pytest.raises(ZoningNormalisationError, match="alpha-2"):
+        ZoningMapping(source_country="FRA", crs="EPSG:2154")
+    with pytest.raises(ZoningNormalisationError, match="alpha-2"):
+        ZoningMapping(source_country="", crs="EPSG:2154")
+
+
+# ---------------------------------------------------------------------------
+# Mapping validation: only ZoningElement targets allowed as field keys
+# ---------------------------------------------------------------------------
+
+
+def test_field_keys_must_be_zoning_element_targets() -> None:
+    with pytest.raises(ZoningNormalisationError, match="ZoningElement targets"):
+        ZoningMapping(
+            source_country="FR",
+            crs="EPSG:2154",
+            fields={"some_random_target": "libelle"},
+        )
+
+
+def test_geometry_key_is_not_a_field_target() -> None:
+    """geometry is handled via geometry_key, not via the field map."""
+    with pytest.raises(ZoningNormalisationError, match="ZoningElement targets"):
+        ZoningMapping(
+            source_country="FR",
+            crs="EPSG:2154",
+            fields={"geometry": "geom"},
+        )
+
+
+def test_hilucs_class_is_not_a_field_target() -> None:
+    """hilucs_class comes from the lookup, never from a direct rename."""
+    with pytest.raises(ZoningNormalisationError, match="ZoningElement targets"):
+        ZoningMapping(
+            source_country="FR",
+            crs="EPSG:2154",
+            fields={"hilucs_class": "categorie"},
+        )
+
+
+def test_source_country_is_not_a_field_target() -> None:
+    """source_country comes from the mapping, never from a record column."""
+    with pytest.raises(ZoningNormalisationError, match="ZoningElement targets"):
+        ZoningMapping(
+            source_country="FR",
+            crs="EPSG:2154",
+            fields={"source_country": "pays"},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Batch behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_iterable_preserves_order_and_count() -> None:
+    mapping = ZoningMapping(
+        source_country="DK",
+        crs="EPSG:25832",
+        fields={"zone_code": "kode"},
+    )
+    records = [{"kode": "BO"}, {"kode": "ER"}, {"kode": "FR"}]
+    out = normalize(records, mapping)
+    assert len(out) == 3
+    assert [row["zone_code"] for row in out] == ["BO", "ER", "FR"]
+
+
+def test_normalize_partial_record_does_not_abort_batch() -> None:
+    """A record missing all source keys still produces a None-filled row."""
+    mapping = ZoningMapping(
+        source_country="NL",
+        crs="EPSG:28992",
+        fields={"zone_code": "code", "zone_label": "naam"},
+    )
+    records = [{"code": "W", "naam": "Wonen"}, {}]
+    out = normalize(records, mapping)
+    assert out[0]["zone_code"] == "W"
+    assert out[0]["zone_label"] == "Wonen"
+    assert out[1]["zone_code"] is None
+    assert out[1]["zone_label"] is None
+    # constants are still set
+    assert out[1]["source_country"] == "NL"
+
+
+# ---------------------------------------------------------------------------
+# HILUCS lookup on a non-renamed source key
+# ---------------------------------------------------------------------------
+
+
+def test_hilucs_lookup_uses_source_key_when_no_rename() -> None:
+    """When hilucs_key matches an unrenamed source column, look it up directly."""
+    mapping = ZoningMapping(
+        source_country="DE",
+        crs="EPSG:25832",
+        fields={"zone_label": "name"},
+        hilucs={"W": "1_PrimaryProduction_Residential"},
+        hilucs_key="art",  # the source column itself, not a target
+    )
+    out = normalize_record({"art": "W", "name": "Wohngebiet"}, mapping)
+    assert out["hilucs_class"] == "1_PrimaryProduction_Residential"
+    assert out["zone_label"] == "Wohngebiet"


### PR DESCRIPTION
Implements story **T2** of EPIC #265 (Regulatory data-packs, M1).

## What

Introduces `gispulse.core.zoning_normalizer`: the OSS engine that maps
heterogeneous source records into the 8-field common schema inspired by
INSPIRE PlannedLandUse `ZoningElement`.

```
geometry, zone_code, zone_label, hilucs_class, plan_id, plan_date,
regulation_ref, source_country
```

## Design — narrow on purpose

- `ZoningMapping` is a flat declarative table `{target -> source_key}`
  plus an optional HILUCS lookup (`{source value -> HILUCS string}`).
  Per-country mapping tables live in the data-pack
  (`gispulse-data-regulatory`), **not** in this module.
- HILUCS is best-effort: a miss leaves `hilucs_class` as `None`, never
  crashes the batch.
- CRS is mandatory and must be explicit (`EPSG:XXXX`). Silent-CRS data
  is the #1 ingestion bug we want to prevent.
- `source_country` is mandatory ISO-3166-1 alpha-2 and carried on the
  mapping (it's a property of the source, not of a record column).
- The field map refuses `geometry`, `hilucs_class` and `source_country`
  as targets so the call site stays legible.

## Acceptance criteria (from #268)

- [x] Given a source response + a declarative mapping, the output carries
      the 8 cible fields.
- [x] Given a source without HILUCS equivalent, the column is `None` and
      the batch does not crash.
- [x] Given a source geometry, the CRS is known/documented (`EPSG:` is
      enforced at mapping construction time).

## Tests

16 unit cases in `tests/unit/test_zoning_normalizer.py` — schema
contract, full FR-style record, best-effort HILUCS (unknown / missing
column / table omitted altogether), CRS enforcement, ISO alpha-2
enforcement, field-target validation, batch order/count, HILUCS lookup
on a non-renamed source column.

Local run: `16 passed in 0.07s`.

## Out of scope

- Per-country mapping tables (live in the data-pack, story P-FR / P-DK /
  P-NL).
- Geometry CRS *reprojection* (the mapping carries the source CRS; the
  caller / fetcher decides whether to reproject to a target frame).
- Q6 (depth of HILUCS mapping per country) — the lookup shape is
  intentionally permissive so a pack can ship coarse or fine tables
  without engine changes.

Refs: #265 (EPIC), #268 (story), #275 (REL-J5).

Signed-off-by: Marco <simon.ducournau@gmail.com>