### PR TITLE
feat(extensionhub): PyPI data-pack discovery channel — T5

### DIFF
--- a/src/gispulse/core/plugin_hub.py
+++ b/src/gispulse/core/plugin_hub.py
@@ -91,6 +91,21 @@ _BUNDLED_DATA_PACK_MANIFESTS: tuple[Path, ...] = (
 # (``*.yml`` / ``*.yaml`` / ``*.json``) — the user-dir discovery channel.
 _DATA_PACKS_DIR_ENV = "GISPULSE_DATA_PACKS_DIR"
 
+# Third-party PyPI data packs declare an entry-point here; the value must
+# be a callable that returns an iterable of file paths to manifest YAML/JSON.
+# Typical implementation in a sibling package::
+#
+#     def manifest_paths():
+#         from importlib.resources import files
+#         return [files("my_pack") / "manifests" / "zoning.yml"]
+#
+#     # pyproject.toml
+#     [project.entry-points."gispulse.data_packs"]
+#     my_pack = "my_pack._gispulse_entry:manifest_paths"
+#
+# Single-string returns are also accepted for the common one-manifest case.
+_DATA_PACK_ENTRYPOINT_GROUP = "gispulse.data_packs"
+
 
 def _tier_from_str(value: object) -> Tier:
     """Map a tier string to :class:`Tier`, defaulting to community."""
@@ -557,14 +572,28 @@ PluginHub = ExtensionHub
 def _data_pack_manifest_paths() -> list[tuple[Path, Origin]]:
     """Locate every data-pack manifest file, paired with its origin.
 
-    Bundled first-party manifests come first (``Origin.INTERNAL``);
-    manifests under ``GISPULSE_DATA_PACKS_DIR`` follow as
-    ``Origin.EXTERNAL``. Missing files / directories are silently
-    skipped — discovery must never hard-fail.
+    Three discovery channels, walked in this order so first-party always
+    wins on a duplicate name and PyPI packs are reproducible across
+    environments:
+
+    1. Bundled first-party manifests (``Origin.INTERNAL``).
+    2. Third-party PyPI distributions exposing the
+       ``gispulse.data_packs`` entry-point — story T5 (#269). Each
+       entry-point is a callable returning either a path or an iterable
+       of paths; a malformed entry is logged and skipped, never raised.
+    3. Manifests under ``GISPULSE_DATA_PACKS_DIR`` (``Origin.EXTERNAL``).
+
+    Missing files / directories are silently skipped — discovery must
+    never hard-fail, that would brick any ``pip install`` of the engine
+    on a partially-installed system.
     """
     paths: list[tuple[Path, Origin]] = [
         (p, Origin.INTERNAL) for p in _BUNDLED_DATA_PACK_MANIFESTS if p.is_file()
     ]
+
+    for ep_path in _entrypoint_data_pack_paths():
+        paths.append((ep_path, Origin.EXTERNAL))
+
     user_dir = os.environ.get(_DATA_PACKS_DIR_ENV, "").strip()
     if user_dir:
         root = Path(user_dir).expanduser()
@@ -573,6 +602,75 @@ def _data_pack_manifest_paths() -> list[tuple[Path, Origin]]:
                 for p in sorted(root.glob(pattern)):
                     paths.append((p, Origin.EXTERNAL))
     return paths
+
+
+def _entrypoint_data_pack_paths() -> list[Path]:
+    """Resolve every manifest path exposed via ``gispulse.data_packs``.
+
+    Each entry-point loads to a callable; the callable returns either a
+    single path-like or an iterable of path-likes. Any failure (load,
+    call, non-existent path, surprising return type) is logged and
+    contributes zero paths — *one* bad pack must not lock out the rest.
+    """
+    out: list[Path] = []
+    for ep in _eps(_DATA_PACK_ENTRYPOINT_GROUP):
+        try:
+            factory = ep.load()
+        except Exception as exc:  # noqa: BLE001 — isolate a bad pack
+            log.warning(
+                "data_pack_entrypoint_load_failed", name=ep.name, error=str(exc)
+            )
+            continue
+        if not callable(factory):
+            log.warning(
+                "data_pack_entrypoint_not_callable",
+                name=ep.name,
+                type=type(factory).__name__,
+            )
+            continue
+        try:
+            result = factory()
+        except Exception as exc:  # noqa: BLE001
+            log.warning(
+                "data_pack_entrypoint_call_failed",
+                name=ep.name,
+                error=str(exc),
+            )
+            continue
+        # Accept either a single path-like or an iterable of path-likes.
+        # ``str``/``os.PathLike`` are themselves iterable so handle them
+        # explicitly to avoid iterating their characters.
+        if isinstance(result, (str, os.PathLike)):
+            items: list[Any] = [result]
+        else:
+            try:
+                items = list(result)
+            except TypeError:
+                log.warning(
+                    "data_pack_entrypoint_bad_return",
+                    name=ep.name,
+                    type=type(result).__name__,
+                )
+                continue
+        for item in items:
+            try:
+                p = Path(os.fspath(item))
+            except TypeError:
+                log.warning(
+                    "data_pack_entrypoint_bad_item",
+                    name=ep.name,
+                    type=type(item).__name__,
+                )
+                continue
+            if not p.is_file():
+                log.warning(
+                    "data_pack_entrypoint_missing_file",
+                    name=ep.name,
+                    path=str(p),
+                )
+                continue
+            out.append(p)
+    return out
 
 
 def _read_manifest(path: Path) -> dict[str, Any] | None:

--- a/tests/unit/test_data_pack_pypi_discovery.py
+++ b/tests/unit/test_data_pack_pypi_discovery.py
@@ -1,0 +1,283 @@
+"""Tests for the third PyPI discovery channel (story T5, issue #269).
+
+Validates that data packs installed via PyPI — declaring an entry-point in
+the ``gispulse.data_packs`` group — are picked up by ExtensionHub, alongside
+the bundled OSS manifests and the ``GISPULSE_DATA_PACKS_DIR`` user-dir
+channel, and that one bad pack never locks out the rest.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Iterable
+
+import pytest
+
+from gispulse.core import plugin_hub
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ep(name: str, factory) -> SimpleNamespace:
+    """Build a minimal stand-in for an importlib.metadata EntryPoint."""
+    return SimpleNamespace(name=name, load=lambda: factory)
+
+
+def _write_manifest(dirpath: Path, name: str, content: str = "source-catalog") -> Path:
+    """Write a minimal valid data-pack manifest and return its path."""
+    payload = {
+        "name": name,
+        "content": content,
+        "version": "1.0.0",
+        "display_name": name.title(),
+        "description": "fixture",
+        "tier": "community",
+        "entries": [],
+    }
+    p = dirpath / f"{name}.json"
+    p.write_text(json.dumps(payload), encoding="utf-8")
+    return p
+
+
+@pytest.fixture
+def patch_entrypoints(monkeypatch: pytest.MonkeyPatch):
+    """Replace ``_eps`` so we feed our own entry-points into the scanner."""
+
+    def factory(items_by_group: dict[str, list]) -> None:
+        def fake_eps(group: str):
+            return list(items_by_group.get(group, []))
+
+        monkeypatch.setattr(plugin_hub, "_eps", fake_eps)
+
+    return factory
+
+
+# ---------------------------------------------------------------------------
+# Happy path — manifest discovered through an entry-point
+# ---------------------------------------------------------------------------
+
+
+def test_entrypoint_returning_single_path_is_discovered(
+    tmp_path: Path, patch_entrypoints, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A pack whose entry-point returns one path lands in the discovery list."""
+    monkeypatch.delenv(plugin_hub._DATA_PACKS_DIR_ENV, raising=False)
+    manifest = _write_manifest(tmp_path, "my_pack")
+
+    def factory_single() -> Path:
+        return manifest
+
+    patch_entrypoints(
+        {plugin_hub._DATA_PACK_ENTRYPOINT_GROUP: [_ep("my_pack", factory_single)]}
+    )
+
+    paths = plugin_hub._data_pack_manifest_paths()
+    assert (manifest, plugin_hub.Origin.EXTERNAL) in paths
+
+
+def test_entrypoint_returning_iterable_is_discovered(
+    tmp_path: Path, patch_entrypoints, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A pack returning multiple manifest paths discovers all of them."""
+    monkeypatch.delenv(plugin_hub._DATA_PACKS_DIR_ENV, raising=False)
+    a = _write_manifest(tmp_path, "pack_a")
+    b = _write_manifest(tmp_path, "pack_b")
+
+    def factory_many() -> Iterable[Path]:
+        return [a, b]
+
+    patch_entrypoints(
+        {plugin_hub._DATA_PACK_ENTRYPOINT_GROUP: [_ep("multi", factory_many)]}
+    )
+
+    found = {path for path, _ in plugin_hub._data_pack_manifest_paths()}
+    assert a in found and b in found
+
+
+def test_entrypoint_returning_string_path_is_discovered(
+    tmp_path: Path, patch_entrypoints, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A bare ``str`` return is treated as one path, not iterated char-by-char."""
+    monkeypatch.delenv(plugin_hub._DATA_PACKS_DIR_ENV, raising=False)
+    manifest = _write_manifest(tmp_path, "stringy")
+
+    def factory_str() -> str:
+        return str(manifest)
+
+    patch_entrypoints(
+        {plugin_hub._DATA_PACK_ENTRYPOINT_GROUP: [_ep("stringy", factory_str)]}
+    )
+
+    paths = plugin_hub._data_pack_manifest_paths()
+    assert (manifest, plugin_hub.Origin.EXTERNAL) in paths
+
+
+# ---------------------------------------------------------------------------
+# Resilience — one bad pack never locks out the rest
+# ---------------------------------------------------------------------------
+
+
+def test_bad_entrypoint_does_not_break_others(
+    tmp_path: Path,
+    patch_entrypoints,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Mix one broken EP and one valid EP; only the valid manifest is kept."""
+    monkeypatch.delenv(plugin_hub._DATA_PACKS_DIR_ENV, raising=False)
+    good = _write_manifest(tmp_path, "good")
+
+    def bad_load_factory() -> Path:
+        raise RuntimeError("ka-boom")
+
+    bad_ep = SimpleNamespace(
+        name="bad",
+        load=lambda: (_ for _ in ()).throw(ImportError("module not found")),
+    )
+    good_ep = _ep("good", lambda: good)
+    patch_entrypoints(
+        {plugin_hub._DATA_PACK_ENTRYPOINT_GROUP: [bad_ep, good_ep]}
+    )
+
+    paths = plugin_hub._data_pack_manifest_paths()
+    assert (good, plugin_hub.Origin.EXTERNAL) in paths
+    # bad pack contributed zero paths (its load() raised so the file we
+    # would have created never existed); compare against a run with only
+    # the good entry-point.
+    patch_entrypoints(
+        {plugin_hub._DATA_PACK_ENTRYPOINT_GROUP: [_ep("good", lambda: good)]}
+    )
+    baseline = plugin_hub._data_pack_manifest_paths()
+    assert len(paths) == len(baseline)
+
+
+def test_non_callable_entrypoint_is_skipped(
+    tmp_path: Path, patch_entrypoints, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv(plugin_hub._DATA_PACKS_DIR_ENV, raising=False)
+    not_callable = SimpleNamespace(name="not_callable", load=lambda: "this-is-a-string")
+    patch_entrypoints({plugin_hub._DATA_PACK_ENTRYPOINT_GROUP: [not_callable]})
+
+    paths = plugin_hub._data_pack_manifest_paths()
+    # only bundled manifests (no EP, no env-var) — count is finite & does not crash
+    assert all(p[0].is_file() for p in paths)
+
+
+def test_callable_raising_at_call_is_skipped(
+    tmp_path: Path, patch_entrypoints, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv(plugin_hub._DATA_PACKS_DIR_ENV, raising=False)
+
+    def boom() -> Path:
+        raise RuntimeError("nope")
+
+    patch_entrypoints(
+        {plugin_hub._DATA_PACK_ENTRYPOINT_GROUP: [_ep("boom", boom)]}
+    )
+
+    paths = plugin_hub._data_pack_manifest_paths()
+    assert sum(1 for p, _ in paths if "boom" in str(p)) == 0
+
+
+def test_callable_returning_bad_type_is_skipped(
+    tmp_path: Path, patch_entrypoints, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A return type that is neither path-like nor iterable is logged + skipped."""
+    monkeypatch.delenv(plugin_hub._DATA_PACKS_DIR_ENV, raising=False)
+    patch_entrypoints(
+        {plugin_hub._DATA_PACK_ENTRYPOINT_GROUP: [_ep("garbage", lambda: 42)]}
+    )
+
+    paths = plugin_hub._data_pack_manifest_paths()
+    assert all(not str(p[0]).endswith("42") for p in paths)
+
+
+def test_callable_returning_iterable_with_garbage_skips_only_garbage(
+    tmp_path: Path, patch_entrypoints, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Within an iterable, non-path-like items are skipped one-by-one."""
+    monkeypatch.delenv(plugin_hub._DATA_PACKS_DIR_ENV, raising=False)
+    ok = _write_manifest(tmp_path, "ok")
+
+    def factory_mixed():
+        return [ok, 42, object()]
+
+    patch_entrypoints(
+        {plugin_hub._DATA_PACK_ENTRYPOINT_GROUP: [_ep("mixed", factory_mixed)]}
+    )
+
+    paths = plugin_hub._data_pack_manifest_paths()
+    assert (ok, plugin_hub.Origin.EXTERNAL) in paths
+
+
+def test_missing_file_path_is_skipped(
+    tmp_path: Path, patch_entrypoints, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv(plugin_hub._DATA_PACKS_DIR_ENV, raising=False)
+    ghost = tmp_path / "does-not-exist.yml"
+    patch_entrypoints(
+        {plugin_hub._DATA_PACK_ENTRYPOINT_GROUP: [_ep("ghost", lambda: ghost)]}
+    )
+
+    paths = plugin_hub._data_pack_manifest_paths()
+    assert ghost not in {p for p, _ in paths}
+
+
+# ---------------------------------------------------------------------------
+# Cohabitation — the new channel does not regress bundle + user-dir
+# ---------------------------------------------------------------------------
+
+
+def test_bundle_user_dir_and_entrypoint_cohabit(
+    tmp_path: Path, patch_entrypoints, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """All three channels feed into the same discovery list, bundle first."""
+    # user-dir
+    user_dir = tmp_path / "user"
+    user_dir.mkdir()
+    user_pack = _write_manifest(user_dir, "user_pack")
+    monkeypatch.setenv(plugin_hub._DATA_PACKS_DIR_ENV, str(user_dir))
+
+    # entry-point
+    ep_pack = _write_manifest(tmp_path, "ep_pack")
+    patch_entrypoints(
+        {plugin_hub._DATA_PACK_ENTRYPOINT_GROUP: [_ep("ep_pack", lambda: ep_pack)]}
+    )
+
+    paths = plugin_hub._data_pack_manifest_paths()
+    # bundled manifest comes first (Origin.INTERNAL); EP and user-dir both EXTERNAL.
+    internals = [p for p, o in paths if o is plugin_hub.Origin.INTERNAL]
+    externals = [p for p, o in paths if o is plugin_hub.Origin.EXTERNAL]
+    assert any(p.is_file() for p in internals)
+    assert ep_pack in externals
+    assert user_pack in externals
+
+
+# ---------------------------------------------------------------------------
+# Full end-to-end through the hub — a PyPI pack lights up as a DATA_PACK record
+# ---------------------------------------------------------------------------
+
+
+def test_end_to_end_pypi_pack_registered_as_data_pack_record(
+    tmp_path: Path, patch_entrypoints, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An EP-discovered manifest becomes an ACTIVE DATA_PACK record in the hub."""
+    monkeypatch.delenv(plugin_hub._DATA_PACKS_DIR_ENV, raising=False)
+    manifest = _write_manifest(tmp_path, "pypi_visible_pack")
+
+    # No host EXTENSION entry-points either — keep the inventory minimal.
+    patch_entrypoints(
+        {plugin_hub._DATA_PACK_ENTRYPOINT_GROUP: [_ep("pypi_visible_pack", lambda: manifest)]}
+    )
+
+    hub = plugin_hub.ExtensionHub()
+    hub._discover_data_packs()
+    names = {
+        r.name for r in hub.records_by_kind(plugin_hub.PluginKind.DATA_PACK)
+    }
+    assert "pypi_visible_pack" in names


### PR DESCRIPTION
Implements story **T5** of EPIC #265 (Regulatory data-packs, M1) — the
missing core OSS story without which `pip install gispulse-data-*` would
be invisible to ExtensionHub.

## What

Adds a third discovery channel to `ExtensionHub._discover_data_packs`:

| Channel | Priority | Origin |
|---|---|---|
| Bundled first-party manifests | 1 | `INTERNAL` |
| **`gispulse.data_packs` entry-point (PyPI)** — new | 2 | `EXTERNAL` |
| `GISPULSE_DATA_PACKS_DIR` user-dir scan | 3 | `EXTERNAL` |

Each entry-point is a callable returning a path-like or an iterable of
path-likes pointing at manifest YAML/JSON files. Single-string returns
are accepted (and **not** iterated char-by-char).

## Why this story exists

The audit R5 (`audit_r5_datapack_regime_2026_05_19.md`) flagged this as
a hard pre-requisite missing from the original cadrage: without it,
`pip install gispulse-data-regulatory` would not register the pack at
all — there was no PyPI channel.

## Q-PyPI-3 — settled

Entry-point wins over naming-convention scan. It's the standard Python
mechanism, works for packs that don't fit `gispulse-data-*`, and is
explicit at install time. Scan-by-name can be added later if a need
appears.

## Acceptance criteria (from #269)

- [x] Given a third-party package exposing `gispulse.data_packs`, when
      ExtensionHub scans, then its manifests are discovered.
- [x] Given a malformed manifest, when scanned, log + skip, never crash.
- [x] Cohabits with the two existing channels (bundle + user-dir)
      without regression.
- [x] Tests without network using a fixture distribution.

## Resilience

One bad pack must never lock out the rest. Every failure path is
isolated and logged with a specific event name (`data_pack_entrypoint_*`):
load error, non-callable, raising call, surprising return type, garbage
items inside a returned iterable, missing file on disk.

## Tests

11 new unit cases in `tests/unit/test_data_pack_pypi_discovery.py`
covering happy path, return-type tolerance, failure isolation, and a
full end-to-end through the hub. Existing `test_data_pack_regime` suite
(13 tests) stays green.

Local run: `11 passed in 0.20s` + `13 passed in 3.75s`.

## Out of scope

- Signature verification of the discovered manifests — story G1a (#271).
- Format of regulatory-zoning packs — story T3 (#270), depends on this PR.

Refs: #265 (EPIC), #269 (story), #275 (REL-J5).

Signed-off-by: Marco <simon.ducournau@gmail.com>