### PR TITLE
feat(fetcher): high-level OGC client for data packs — T1

### DIFF
--- a/src/gispulse/core/fetchers/ogc_client.py
+++ b/src/gispulse/core/fetchers/ogc_client.py
@@ -1,0 +1,167 @@
+"""Story T1 (#267) — high-level OGC client for data packs.
+
+The OSS engine already ships :class:`OGCFeaturesFetcher` and the consolidated
+transport in :mod:`gispulse.adapters.ogc.wfs_client`. A data pack, however,
+does not want to construct an ``AccessSpec`` to fetch one collection — it
+wants a one-liner: *given an endpoint and a typename, give me a
+GeoDataFrame*.
+
+This module is that one-liner. It is intentionally thin (no transport, no
+caching, no pagination logic of its own): it normalises the input, picks
+the right transport function (classic WFS vs OGC API Features), and surfaces
+network errors as a single explicit exception type so callers can react
+without depending on httpx internals.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+from gispulse.core.logging import get_logger
+from gispulse.core.models import OGCSourceConfig
+
+if TYPE_CHECKING:  # pragma: no cover
+    import geopandas as gpd
+
+
+log = get_logger(__name__)
+
+__all__ = [
+    "OGCClientError",
+    "OGCEndpointUnreachable",
+    "fetch_features",
+]
+
+
+Protocol = Literal["wfs", "ogc_api_features"]
+
+
+class OGCClientError(Exception):
+    """Base error for the high-level OGC client."""
+
+
+class OGCEndpointUnreachable(OGCClientError):
+    """The remote service could not be reached (DNS / connect / read timeout).
+
+    Carries the *original* exception as ``__cause__`` so debuggers can see
+    the underlying ``httpx.ConnectError`` / ``httpx.ReadTimeout`` without the
+    caller having to depend on httpx in its own code.
+    """
+
+
+def fetch_features(
+    *,
+    endpoint: str,
+    typename: str,
+    protocol: Protocol = "ogc_api_features",
+    crs: str = "EPSG:4326",
+    bbox: tuple[float, float, float, float] | None = None,
+    version: str = "2.0.0",
+    max_features: int | None = None,
+    query: dict[str, str] | None = None,
+    auth: dict[str, str] | None = None,
+) -> "gpd.GeoDataFrame":
+    """Fetch one collection from a WFS or OGC API Features endpoint.
+
+    Args:
+        endpoint: Base URL of the service. For WFS this is the ``?service=WFS``
+            URL; for OGC API Features it is the landing page (no trailing
+            ``/collections/...``).
+        typename: Collection / typeName to fetch (e.g. ``wfs_du:zone_urba``).
+        protocol: ``"wfs"`` for classic WFS, ``"ogc_api_features"`` for the
+            REST API Features. Default ``"ogc_api_features"``.
+        crs: Requested SRS, default ``"EPSG:4326"`` (CRS84 for OAPIF).
+        bbox: Server-side spatial filter as ``(minx, miny, maxx, maxy)``.
+        version: WFS version (ignored for OGC API Features). Default ``2.0.0``.
+        max_features: Per-page limit handed to the underlying client; the
+            transport handles pagination above that ceiling.
+        query: Extra query parameters merged in (e.g. ``CQL_FILTER`` for WFS).
+        auth: Auth dict accepted by the transport (e.g. basic).
+
+    Returns:
+        A ``geopandas.GeoDataFrame`` with the requested features and the
+        requested CRS.
+
+    Raises:
+        OGCEndpointUnreachable: the service could not be reached.
+        OGCClientError: any other failure surfaced by the transport (kept as
+            ``__cause__``).
+        ValueError: invalid ``endpoint``/``typename`` arguments.
+    """
+    if not endpoint or not isinstance(endpoint, str):
+        raise ValueError("endpoint must be a non-empty string")
+    if not typename or not isinstance(typename, str):
+        raise ValueError("typename must be a non-empty string")
+    if protocol not in ("wfs", "ogc_api_features"):
+        raise ValueError(
+            f"protocol must be 'wfs' or 'ogc_api_features', got {protocol!r}"
+        )
+
+    cfg = OGCSourceConfig(
+        source_type=protocol,
+        url=endpoint,
+        layer_name=typename,
+        version=version,
+        crs=crs,
+        auth=auth,
+        max_features=max_features,
+        params=dict(query or {}),
+    )
+
+    # Lazy import — keep the data-pack code path from pulling httpx and
+    # geopandas at import time.
+    from gispulse.adapters.ogc import wfs_client as _wfs
+
+    try:
+        if protocol == "wfs":
+            gdf = _wfs.fetch_wfs(cfg, bbox=bbox)
+        else:
+            gdf = _wfs.fetch_ogc_api_features(cfg, bbox=bbox)
+    except Exception as exc:  # noqa: BLE001 — funnel into a typed surface
+        if _is_unreachable(exc):
+            log.warning(
+                "ogc_endpoint_unreachable",
+                endpoint=endpoint,
+                typename=typename,
+                error=str(exc),
+            )
+            raise OGCEndpointUnreachable(
+                f"OGC endpoint unreachable: {endpoint!r} — {exc!s}"
+            ) from exc
+        raise OGCClientError(
+            f"OGC fetch failed for {typename!r} at {endpoint!r}: {exc!s}"
+        ) from exc
+
+    log.info(
+        "ogc_features_fetched",
+        protocol=protocol,
+        endpoint=endpoint,
+        typename=typename,
+        rows=len(gdf),
+    )
+    return gdf
+
+
+def _is_unreachable(exc: BaseException) -> bool:
+    """Recognise connect / DNS / read-timeout failures across httpx versions.
+
+    We can't always rely on importing httpx (it may not be installed in a
+    bare data-pack test env), so we match the class name walking the MRO.
+    """
+    sentinels = {
+        "ConnectError",
+        "ConnectTimeout",
+        "ReadTimeout",
+        "TimeoutException",
+        "RemoteProtocolError",
+        # Stdlib equivalents some transports raise.
+        "ConnectionError",
+        "ConnectionRefusedError",
+        "ConnectionResetError",
+        "TimeoutError",
+        "OSError",
+    }
+    for cls in type(exc).mro():
+        if cls.__name__ in sentinels:
+            return True
+    return False

--- a/tests/unit/test_ogc_client.py
+++ b/tests/unit/test_ogc_client.py
@@ -1,0 +1,228 @@
+"""Tests for the high-level OGC client (story T1, issue #267).
+
+The transport itself (``adapters/ogc/wfs_client``) already has its own
+fixture-based suite; here we only validate the data-pack-facing surface:
+argument normalisation, protocol dispatch, network-error translation.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from gispulse.core.fetchers import ogc_client
+
+
+class _FakeGDF:
+    """Stand-in for a GeoDataFrame — len() must work, nothing else."""
+
+    def __init__(self, n: int = 3) -> None:
+        self.n = n
+
+    def __len__(self) -> int:
+        return self.n
+
+
+# ---------------------------------------------------------------------------
+# Argument validation
+# ---------------------------------------------------------------------------
+
+
+def test_empty_endpoint_rejected() -> None:
+    with pytest.raises(ValueError, match="endpoint"):
+        ogc_client.fetch_features(endpoint="", typename="x")
+
+
+def test_empty_typename_rejected() -> None:
+    with pytest.raises(ValueError, match="typename"):
+        ogc_client.fetch_features(endpoint="http://x", typename="")
+
+
+def test_unknown_protocol_rejected() -> None:
+    with pytest.raises(ValueError, match="protocol"):
+        ogc_client.fetch_features(
+            endpoint="http://x", typename="y", protocol="rest"  # type: ignore[arg-type]
+        )
+
+
+# ---------------------------------------------------------------------------
+# Protocol dispatch — same contract for WFS and OGC API Features
+# ---------------------------------------------------------------------------
+
+
+def test_wfs_dispatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``protocol="wfs"`` calls fetch_wfs, not fetch_ogc_api_features."""
+    seen: dict[str, Any] = {}
+
+    def _fake_wfs(cfg, bbox=None):
+        seen["called"] = "wfs"
+        seen["cfg"] = cfg
+        seen["bbox"] = bbox
+        return _FakeGDF()
+
+    def _fake_oapif(cfg, bbox=None):
+        seen["called"] = "oapif"
+        return _FakeGDF()
+
+    from gispulse.adapters.ogc import wfs_client
+
+    monkeypatch.setattr(wfs_client, "fetch_wfs", _fake_wfs)
+    monkeypatch.setattr(wfs_client, "fetch_ogc_api_features", _fake_oapif)
+
+    gdf = ogc_client.fetch_features(
+        endpoint="https://geo.example/wfs",
+        typename="ns:layer",
+        protocol="wfs",
+        bbox=(1.0, 2.0, 3.0, 4.0),
+        crs="EPSG:2154",
+    )
+    assert isinstance(gdf, _FakeGDF)
+    assert seen["called"] == "wfs"
+    cfg = seen["cfg"]
+    assert cfg.source_type == "wfs"
+    assert cfg.url == "https://geo.example/wfs"
+    assert cfg.layer_name == "ns:layer"
+    assert cfg.crs == "EPSG:2154"
+    assert seen["bbox"] == (1.0, 2.0, 3.0, 4.0)
+
+
+def test_oapif_dispatch_is_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No ``protocol`` argument defaults to OGC API Features."""
+    seen: dict[str, Any] = {}
+
+    def _fake_wfs(cfg, bbox=None):
+        seen["called"] = "wfs"
+        return _FakeGDF()
+
+    def _fake_oapif(cfg, bbox=None):
+        seen["called"] = "oapif"
+        seen["cfg"] = cfg
+        return _FakeGDF()
+
+    from gispulse.adapters.ogc import wfs_client
+
+    monkeypatch.setattr(wfs_client, "fetch_wfs", _fake_wfs)
+    monkeypatch.setattr(wfs_client, "fetch_ogc_api_features", _fake_oapif)
+
+    ogc_client.fetch_features(
+        endpoint="https://geo.example",
+        typename="land_use",
+    )
+    assert seen["called"] == "oapif"
+    assert seen["cfg"].source_type == "ogc_api_features"
+
+
+def test_query_params_flow_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, Any] = {}
+
+    def _fake_oapif(cfg, bbox=None):
+        seen["cfg"] = cfg
+        return _FakeGDF()
+
+    from gispulse.adapters.ogc import wfs_client
+
+    monkeypatch.setattr(wfs_client, "fetch_ogc_api_features", _fake_oapif)
+
+    ogc_client.fetch_features(
+        endpoint="https://geo.example",
+        typename="land_use",
+        query={"filter": "type='A'", "limit": "200"},
+        max_features=500,
+    )
+    cfg = seen["cfg"]
+    assert cfg.params == {"filter": "type='A'", "limit": "200"}
+    assert cfg.max_features == 500
+
+
+# ---------------------------------------------------------------------------
+# Network error translation — single typed surface, no httpx leak
+# ---------------------------------------------------------------------------
+
+
+class _ConnectError(Exception):
+    """Mimic httpx.ConnectError without importing httpx in the test."""
+
+    # Name matters: ``_is_unreachable`` matches by class name across MRO.
+
+    def __init__(self, msg: str = "connect refused") -> None:
+        super().__init__(msg)
+
+
+# Reset the qualname so the MRO check sees ``ConnectError``.
+_ConnectError.__name__ = "ConnectError"
+
+
+def test_unreachable_endpoint_raises_typed_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _boom(cfg, bbox=None):
+        raise _ConnectError()
+
+    from gispulse.adapters.ogc import wfs_client
+
+    monkeypatch.setattr(wfs_client, "fetch_ogc_api_features", _boom)
+
+    with pytest.raises(ogc_client.OGCEndpointUnreachable) as excinfo:
+        ogc_client.fetch_features(
+            endpoint="https://does-not-exist.invalid",
+            typename="x",
+        )
+    # Original exception preserved as __cause__ so callers can drill in.
+    assert isinstance(excinfo.value.__cause__, _ConnectError)
+
+
+def test_unknown_transport_error_wrapped_as_ogcclient_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _boom(cfg, bbox=None):
+        raise RuntimeError("parser exploded")
+
+    from gispulse.adapters.ogc import wfs_client
+
+    monkeypatch.setattr(wfs_client, "fetch_ogc_api_features", _boom)
+
+    with pytest.raises(ogc_client.OGCClientError) as excinfo:
+        ogc_client.fetch_features(
+            endpoint="https://geo.example", typename="x"
+        )
+    assert "parser exploded" in str(excinfo.value)
+    # Not classified as "unreachable" — it's a content-level failure.
+    assert not isinstance(excinfo.value, ogc_client.OGCEndpointUnreachable)
+
+
+def test_stdlib_timeout_classified_as_unreachable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stdlib ``TimeoutError`` is unreachable too — covers retry-less callers."""
+
+    def _boom(cfg, bbox=None):
+        raise TimeoutError("read timeout")
+
+    from gispulse.adapters.ogc import wfs_client
+
+    monkeypatch.setattr(wfs_client, "fetch_ogc_api_features", _boom)
+
+    with pytest.raises(ogc_client.OGCEndpointUnreachable):
+        ogc_client.fetch_features(
+            endpoint="https://geo.example", typename="x"
+        )
+
+
+def test_value_errors_in_transport_are_not_unreachable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bad arguments raised by the transport surface as OGCClientError, not unreachable."""
+
+    def _boom(cfg, bbox=None):
+        raise ValueError("invalid bbox")
+
+    from gispulse.adapters.ogc import wfs_client
+
+    monkeypatch.setattr(wfs_client, "fetch_ogc_api_features", _boom)
+
+    with pytest.raises(ogc_client.OGCClientError) as excinfo:
+        ogc_client.fetch_features(
+            endpoint="https://geo.example", typename="x"
+        )
+    assert not isinstance(excinfo.value, ogc_client.OGCEndpointUnreachable)


### PR DESCRIPTION
Implements story **T1** of EPIC #265 (Regulatory data-packs, M1).

## What

`gispulse.core.fetchers.ogc_client.fetch_features(...)` — a one-liner the
data-pack code path can use without constructing an `AccessSpec`:

```python
fetch_features(
    endpoint="https://data.geopf.fr/wfs/ows",
    typename="wfs_du:zone_urba",
    protocol="wfs",
    bbox=(2.0, 48.5, 2.6, 49.0),
    crs="EPSG:4326",
)  # -> geopandas.GeoDataFrame
```

## Design — intentionally thin

- The consolidated transport (`adapters/ogc/wfs_client`) already owns
  pagination + GeoParquet caching;
- The existing `OGCFeaturesFetcher` (A4 / #230) already drives both
  protocols and is reused as-is.
- What this module adds:
  - argument normalisation (typename / endpoint / protocol checks);
  - protocol dispatch (`"wfs"` vs `"ogc_api_features"`);
  - **typed failure surface** — network errors become
    `OGCEndpointUnreachable` so a data-pack can react without depending
    on httpx classes; the original exception is preserved as `__cause__`.

## Acceptance criteria (from #267)

- [x] WFS endpoint + typename → features fetched with pagination + bbox
      (delegated to the consolidated client, covered upstream).
- [x] OGC API Features endpoint → same contract via the same call.
- [x] Unreachable endpoint → explicit, typed error (`OGCEndpointUnreachable`),
      no crash.
- [x] Tests without network (transport is monkey-patched in fixtures).

## Géoplateforme note

The 1 layer / URL limitation (effective 15/06/2026) is naturally
respected — `fetch_features` is per-typename by design.

## Tests

10 unit cases in `tests/unit/test_ogc_client.py` — argument validation,
WFS vs OAPIF dispatch, query/max_features pass-through, unreachable
errors classified across httpx-style and stdlib `TimeoutError`,
content-level errors (`ValueError`) **not** misclassified as unreachable.

Local run: `10 passed in 2.12s`.

## Out of scope

- Per-country mapping (story T2 / data-pack).
- Format of the data-pack manifest itself (story T3 / #270).
- New transport — none added, this PR is a facade.

Refs: #265 (EPIC), #267 (story), #275 (REL-J5).

Signed-off-by: Marco <simon.ducournau@gmail.com>