### PR TITLE
feat(extensionhub): Ed25519 signature gate for data packs — G1a

### DIFF
--- a/src/gispulse/core/data_pack_signature.py
+++ b/src/gispulse/core/data_pack_signature.py
@@ -1,0 +1,139 @@
+"""Story G1a (#271) — Ed25519 signature of data-pack manifests.
+
+This module sits between the unified licence format (story L0, #266) and
+the third-party PyPI discovery channel (story T5, #269). It defines the
+*shape* of a signed data-pack manifest and provides the verifier that
+ExtensionHub calls during discovery.
+
+The signing side (private key, key rotation, packaging) lives in
+``gispulse-enterprise`` and in the regulatory data-pack repo
+(``gispulse-data-regulatory``, story G1b). The OSS engine only owns the
+verifier — that's what gating "Pro/Enterprise-only data-packs via
+signature" means in practice.
+
+Canonicalisation note
+---------------------
+
+We reuse :func:`gispulse.core.licence_format.canonicalise` so the bytes
+hashed for signing are identical to the licence-payload format. The
+``signature`` field is removed from the dict before canonicalisation —
+otherwise the signature would have to commit to itself.
+"""
+
+from __future__ import annotations
+
+import base64
+from typing import Any, Mapping
+
+from gispulse.core.licence_format import canonicalise
+from gispulse.core.logging import get_logger
+
+log = get_logger(__name__)
+
+__all__ = [
+    "DataPackSignatureError",
+    "canonical_manifest_bytes",
+    "sign_manifest_dict",
+    "verify_manifest_dict",
+]
+
+
+class DataPackSignatureError(Exception):
+    """Raised when a data-pack signature cannot be verified."""
+
+
+def canonical_manifest_bytes(manifest_dict: Mapping[str, Any]) -> bytes:
+    """Return the byte string to sign / verify for a manifest.
+
+    The ``signature`` key — if present — is dropped before canonicalisation
+    so the verifier can recompute the same bytes the signer originally fed
+    to the private key. Everything else is sorted-key, compact JSON, UTF-8.
+    """
+    payload = {k: v for k, v in manifest_dict.items() if k != "signature"}
+    return canonicalise(payload)
+
+
+def _b64url_encode(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(text: str) -> bytes:
+    padded = text + "=" * (-len(text) % 4)
+    return base64.urlsafe_b64decode(padded)
+
+
+def sign_manifest_dict(
+    manifest_dict: Mapping[str, Any], private_key: Any
+) -> str:
+    """Compute the urlsafe-base64 Ed25519 signature of ``manifest_dict``.
+
+    The dict is canonicalised first (``signature`` key stripped). The
+    private key must be a ``cryptography`` ``Ed25519PrivateKey``.
+
+    This helper exists in the OSS module purely so tests can round-trip a
+    real signature. In production the signing happens upstream
+    (``gispulse-enterprise`` / data-pack release pipeline) and the OSS
+    engine only verifies.
+    """
+    body = canonical_manifest_bytes(manifest_dict)
+    return _b64url_encode(private_key.sign(body))
+
+
+def verify_manifest_dict(
+    manifest_dict: Mapping[str, Any], signature: str, public_key: Any
+) -> bool:
+    """Verify that ``signature`` matches ``manifest_dict`` under ``public_key``.
+
+    Args:
+        manifest_dict: the raw manifest mapping as read from disk (the
+            ``signature`` field may or may not be present; it is removed
+            internally before verification).
+        signature: urlsafe-base64 Ed25519 signature.
+        public_key: a ``cryptography`` ``Ed25519PublicKey``.
+
+    Raises:
+        DataPackSignatureError: any failure — bad base64, public-key
+            mismatch, tampered manifest. The original exception is
+            preserved as ``__cause__``.
+
+    Returns:
+        ``True`` on success. The boolean return keeps the call site
+        flexible (``if verify_manifest_dict(...)`` works alongside the
+        explicit exception path).
+    """
+    if not isinstance(signature, str) or not signature.strip():
+        raise DataPackSignatureError("signature must be a non-empty string")
+    try:
+        sig_bytes = _b64url_decode(signature)
+    except Exception as exc:  # pragma: no cover - base64 raises many subtypes
+        raise DataPackSignatureError(
+            "invalid data-pack signature encoding (base64 decode failed)"
+        ) from exc
+    body = canonical_manifest_bytes(manifest_dict)
+    try:
+        public_key.verify(sig_bytes, body)
+    except Exception as exc:
+        raise DataPackSignatureError(
+            "data-pack signature does not match the manifest"
+        ) from exc
+    return True
+
+
+def load_public_key_b64(b64: str) -> Any:
+    """Load an Ed25519 public key from a base64-encoded DER blob.
+
+    Mirrors how ``persistence.tier`` reads ``GISPULSE_LICENCE_PUBLIC_KEY``,
+    so the same operational tooling can configure both fields.
+    """
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+        Ed25519PublicKey,
+    )
+    from cryptography.hazmat.primitives.serialization import load_der_public_key
+
+    raw = base64.b64decode(b64)
+    key = load_der_public_key(raw)
+    if not isinstance(key, Ed25519PublicKey):
+        raise DataPackSignatureError(
+            "configured data-pack public key is not Ed25519"
+        )
+    return key

--- a/src/gispulse/core/plugin_hub.py
+++ b/src/gispulse/core/plugin_hub.py
@@ -106,6 +106,18 @@ _DATA_PACKS_DIR_ENV = "GISPULSE_DATA_PACKS_DIR"
 # Single-string returns are also accepted for the common one-manifest case.
 _DATA_PACK_ENTRYPOINT_GROUP = "gispulse.data_packs"
 
+# G1a (#271) — Ed25519 public key (base64 DER) used to verify the
+# ``signature`` field of an EXTERNAL data-pack manifest. Mirrors the
+# operational shape of ``GISPULSE_LICENCE_PUBLIC_KEY`` so the same
+# rotation tooling can configure both.
+_DATA_PACK_PUBLIC_KEY_ENV = "GISPULSE_DATA_PACK_PUBLIC_KEY"
+
+# When true, EXTERNAL manifests without a ``signature`` are refused.
+# Default false so a fresh install with no rotation tooling still loads
+# the bundled packs and unsigned community packs. Recommended in CI for
+# any deploy that ships gated content.
+_DATA_PACK_REQUIRE_SIGNATURE_ENV = "GISPULSE_DATA_PACK_REQUIRE_SIGNATURE"
+
 
 def _tier_from_str(value: object) -> Tier:
     """Map a tier string to :class:`Tier`, defaulting to community."""
@@ -425,19 +437,25 @@ class ExtensionHub:
     def _discover_data_packs(self) -> None:
         """Discover declarative data packs — the data regime of the hub.
 
-        The v1.8.0 ExtensionHub refonte (Chantier C) adds a second
-        discovery regime alongside Python entry-points: declarative
-        YAML/JSON manifests that ship *data* (templates, catalog sources,
-        basemaps, projections) and never code. Scans the bundled
-        first-party manifests plus any manifest files under the
-        ``GISPULSE_DATA_PACKS_DIR`` directory.
+        Three discovery channels are walked: bundled first-party manifests
+        (``Origin.INTERNAL``), third-party PyPI packs exposing the
+        ``gispulse.data_packs`` entry-point, and manifests under
+        ``GISPULSE_DATA_PACKS_DIR``.
 
         Each manifest becomes a :class:`~core.plugin_model.PluginRecord`
         of kind :attr:`~core.plugin_model.PluginKind.DATA_PACK` in the
         single unified inventory. No code is imported, so a data pack
-        never reaches ``FAILED`` — trust is trivially ``verified`` and
-        tier gating is fully data-driven; a malformed manifest is logged
-        and skipped.
+        never reaches ``FAILED`` — trust is data-driven; a malformed
+        manifest is logged and skipped.
+
+        G1a (#271) signature gate: an EXTERNAL manifest carrying
+        ``signature`` is verified against
+        ``GISPULSE_DATA_PACK_PUBLIC_KEY`` before being registered. A bad
+        signature is logged and dropped so a tampered pack never reaches
+        an ACTIVE record. Bundled INTERNAL manifests are exempt — the OSS
+        tree is the source of truth. Unsigned EXTERNAL manifests are
+        admitted by default (rollout-friendly); set
+        ``GISPULSE_DATA_PACK_REQUIRE_SIGNATURE=true`` to refuse them.
         """
         for path, origin in _data_pack_manifest_paths():
             raw = _read_manifest(path)
@@ -449,6 +467,10 @@ class ExtensionHub:
                 log.warning(
                     "data_pack_manifest_invalid", path=str(path), error=str(exc)
                 )
+                continue
+            if origin is Origin.EXTERNAL and not _accept_data_pack_signature(
+                manifest, raw, path
+            ):
                 continue
             rec = PluginRecord(
                 name=manifest.name,
@@ -701,6 +723,105 @@ def _read_manifest(path: Path) -> dict[str, Any] | None:
         log.warning("data_pack_manifest_not_a_mapping", path=str(path))
         return None
     return raw
+
+
+_DATA_PACK_PUBLIC_KEY_CACHE: dict[str, Any] = {}
+
+
+def _data_pack_public_key() -> Any | None:
+    """Return the configured Ed25519 public key, or ``None`` if absent.
+
+    Cached on the env-var value so a key rotation requires a restart but
+    repeated discovery calls during the same process are cheap.
+    """
+    raw = os.environ.get(_DATA_PACK_PUBLIC_KEY_ENV, "").strip()
+    if not raw:
+        return None
+    if raw in _DATA_PACK_PUBLIC_KEY_CACHE:
+        return _DATA_PACK_PUBLIC_KEY_CACHE[raw]
+    try:
+        from gispulse.core.data_pack_signature import load_public_key_b64
+
+        key = load_public_key_b64(raw)
+    except Exception as exc:  # noqa: BLE001 — gracefully degrade
+        log.warning(
+            "data_pack_public_key_unavailable",
+            env=_DATA_PACK_PUBLIC_KEY_ENV,
+            error=str(exc),
+        )
+        return None
+    _DATA_PACK_PUBLIC_KEY_CACHE[raw] = key
+    return key
+
+
+def _require_data_pack_signature() -> bool:
+    """True when ``GISPULSE_DATA_PACK_REQUIRE_SIGNATURE`` is truthy."""
+    raw = os.environ.get(_DATA_PACK_REQUIRE_SIGNATURE_ENV, "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def _accept_data_pack_signature(
+    manifest: "DataPackManifest", raw: dict[str, Any], path: Path
+) -> bool:
+    """Gate an EXTERNAL data-pack on its Ed25519 signature.
+
+    Returns:
+        ``True`` if the manifest should be registered; ``False`` if it
+        must be dropped (bad signature, or signature required but missing
+        / unverifiable). Always logs the decision.
+
+    Policy (G1a, #271):
+
+    * unsigned manifest + signature not required → admit;
+    * unsigned manifest + signature required → drop;
+    * signed manifest but no public key configured → drop (we cannot
+      validate the claim, so refusing is the safe default);
+    * signed manifest + key configured + valid signature → admit;
+    * signed manifest + key configured + invalid signature → drop.
+    """
+    public_key = _data_pack_public_key()
+    has_sig = bool(manifest.signature)
+
+    if not has_sig:
+        if _require_data_pack_signature():
+            log.warning(
+                "data_pack_signature_required_missing",
+                name=manifest.name,
+                path=str(path),
+            )
+            return False
+        return True
+
+    if public_key is None:
+        log.warning(
+            "data_pack_signature_no_public_key",
+            name=manifest.name,
+            path=str(path),
+        )
+        return False
+
+    from gispulse.core.data_pack_signature import (
+        DataPackSignatureError,
+        verify_manifest_dict,
+    )
+
+    try:
+        verify_manifest_dict(raw, manifest.signature or "", public_key)
+    except DataPackSignatureError as exc:
+        log.warning(
+            "data_pack_signature_invalid",
+            name=manifest.name,
+            path=str(path),
+            error=str(exc),
+        )
+        return False
+
+    log.debug(
+        "data_pack_signature_verified",
+        name=manifest.name,
+        path=str(path),
+    )
+    return True
 
 
 def _eps(group: str):

--- a/src/gispulse/core/plugin_model.py
+++ b/src/gispulse/core/plugin_model.py
@@ -251,6 +251,10 @@ class DataPackManifest:
     tier: Tier = Tier.COMMUNITY
     entries: list[dict[str, Any]] = field(default_factory=list)
     metadata: dict[str, Any] = field(default_factory=dict)
+    # G1a (#271): Ed25519 signature of the canonical JSON of the manifest
+    # *without* this field. Optional — bundled OSS manifests don't carry
+    # one; third-party PyPI packs sign with the gispulse-enterprise key.
+    signature: str | None = None
 
     @classmethod
     def from_dict(cls, raw: dict[str, Any]) -> "DataPackManifest":
@@ -271,6 +275,12 @@ class DataPackManifest:
         except ValueError:
             tier = Tier.COMMUNITY
         entries = list(raw.get("entries", []) or [])
+        signature = raw.get("signature")
+        if signature is not None and not isinstance(signature, str):
+            raise ValueError(
+                f"data pack {name!r}: 'signature' must be a string, "
+                f"got {type(signature).__name__}"
+            )
         return cls(
             name=name,
             content=content,
@@ -280,6 +290,7 @@ class DataPackManifest:
             tier=tier,
             entries=entries,
             metadata=dict(raw.get("metadata", {}) or {}),
+            signature=signature,
         )
 
 

--- a/tests/unit/test_data_pack_signature.py
+++ b/tests/unit/test_data_pack_signature.py
@@ -1,0 +1,278 @@
+"""Tests for the Ed25519 data-pack signature (story G1a, issue #271).
+
+Two layers:
+
+* ``data_pack_signature`` module — pure verifier round-trip;
+* ExtensionHub integration — the discovery gate that drops a tampered or
+  unverifiable EXTERNAL manifest before it ever lands in the inventory.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    PublicFormat,
+)
+
+from gispulse.core import plugin_hub
+from gispulse.core.data_pack_signature import (
+    DataPackSignatureError,
+    canonical_manifest_bytes,
+    sign_manifest_dict,
+    verify_manifest_dict,
+)
+from gispulse.core.plugin_model import (
+    DataPackManifest,
+    Origin,
+    PluginKind,
+)
+
+
+@pytest.fixture
+def keypair() -> tuple[Ed25519PrivateKey, Ed25519PublicKey]:
+    priv = Ed25519PrivateKey.generate()
+    return priv, priv.public_key()
+
+
+@pytest.fixture
+def public_key_b64(keypair) -> str:
+    _, pub = keypair
+    der = pub.public_bytes(Encoding.DER, PublicFormat.SubjectPublicKeyInfo)
+    return base64.b64encode(der).decode("ascii")
+
+
+# ---------------------------------------------------------------------------
+# Verifier round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_drops_signature_field() -> None:
+    """A pre-existing ``signature`` key must NOT influence canonicalisation."""
+    base = {"name": "x", "content": "source-catalog", "tier": "pro"}
+    a = canonical_manifest_bytes(base)
+    b = canonical_manifest_bytes({**base, "signature": "irrelevant"})
+    assert a == b
+
+
+def test_sign_then_verify_roundtrip(keypair) -> None:
+    priv, pub = keypair
+    manifest = {
+        "name": "fr-zoning",
+        "content": "source-catalog",
+        "version": "1.0.0",
+        "tier": "pro",
+        "entries": [{"id": "gpu-zone-urba"}],
+    }
+    sig = sign_manifest_dict(manifest, priv)
+    assert verify_manifest_dict(manifest, sig, pub) is True
+
+
+def test_verify_ignores_signature_field_in_dict(keypair) -> None:
+    """Verifier accepts the same dict whether or not it carries the field."""
+    priv, pub = keypair
+    manifest = {"name": "x", "content": "source-catalog", "tier": "pro"}
+    sig = sign_manifest_dict(manifest, priv)
+    enriched = {**manifest, "signature": sig}  # what a real packed manifest looks like
+    assert verify_manifest_dict(enriched, sig, pub) is True
+
+
+def test_tampered_manifest_rejected(keypair) -> None:
+    priv, pub = keypair
+    manifest = {"name": "x", "content": "source-catalog", "tier": "pro"}
+    sig = sign_manifest_dict(manifest, priv)
+    tampered = {**manifest, "tier": "enterprise"}  # silently upgrade tier
+    with pytest.raises(DataPackSignatureError, match="does not match"):
+        verify_manifest_dict(tampered, sig, pub)
+
+
+def test_foreign_key_rejected() -> None:
+    priv_a = Ed25519PrivateKey.generate()
+    priv_b = Ed25519PrivateKey.generate()
+    manifest = {"name": "x", "content": "source-catalog", "tier": "pro"}
+    sig = sign_manifest_dict(manifest, priv_a)
+    with pytest.raises(DataPackSignatureError, match="does not match"):
+        verify_manifest_dict(manifest, sig, priv_b.public_key())
+
+
+def test_empty_signature_rejected(keypair) -> None:
+    _, pub = keypair
+    with pytest.raises(DataPackSignatureError, match="non-empty"):
+        verify_manifest_dict({"name": "x"}, "   ", pub)
+
+
+# ---------------------------------------------------------------------------
+# DataPackManifest carries the signature field
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_from_dict_carries_signature(keypair) -> None:
+    priv, _ = keypair
+    raw = {"name": "x", "content": "source-catalog", "tier": "pro"}
+    raw["signature"] = sign_manifest_dict(raw, priv)
+    m = DataPackManifest.from_dict(raw)
+    assert m.signature == raw["signature"]
+
+
+def test_manifest_from_dict_signature_must_be_string() -> None:
+    raw = {
+        "name": "x",
+        "content": "source-catalog",
+        "tier": "pro",
+        "signature": 42,  # not a string
+    }
+    with pytest.raises(ValueError, match="signature"):
+        DataPackManifest.from_dict(raw)
+
+
+# ---------------------------------------------------------------------------
+# Hub integration — the discovery gate
+# ---------------------------------------------------------------------------
+
+
+def _write_manifest(
+    dirpath: Path, name: str, *, signature: str | None = None
+) -> Path:
+    payload = {
+        "name": name,
+        "content": "source-catalog",
+        "version": "1.0.0",
+        "display_name": name.title(),
+        "description": "fixture",
+        "tier": "community",
+        "entries": [],
+    }
+    if signature is not None:
+        payload["signature"] = signature
+    p = dirpath / f"{name}.json"
+    p.write_text(json.dumps(payload), encoding="utf-8")
+    return p
+
+
+@pytest.fixture(autouse=True)
+def _clear_pubkey_cache():
+    plugin_hub._DATA_PACK_PUBLIC_KEY_CACHE.clear()
+
+
+def test_unsigned_external_pack_admitted_by_default(
+    tmp_path, monkeypatch
+) -> None:
+    """Default rollout-friendly policy: unsigned EXTERNAL packs are admitted."""
+    monkeypatch.setenv(plugin_hub._DATA_PACKS_DIR_ENV, str(tmp_path))
+    monkeypatch.delenv(plugin_hub._DATA_PACK_PUBLIC_KEY_ENV, raising=False)
+    monkeypatch.delenv(plugin_hub._DATA_PACK_REQUIRE_SIGNATURE_ENV, raising=False)
+    _write_manifest(tmp_path, "open_pack")
+
+    hub = plugin_hub.ExtensionHub()
+    hub._discover_data_packs()
+    names = {r.name for r in hub.records_by_kind(PluginKind.DATA_PACK)}
+    assert "open_pack" in names
+
+
+def test_unsigned_external_pack_dropped_when_required(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv(plugin_hub._DATA_PACKS_DIR_ENV, str(tmp_path))
+    monkeypatch.setenv(plugin_hub._DATA_PACK_REQUIRE_SIGNATURE_ENV, "true")
+    _write_manifest(tmp_path, "open_pack")
+
+    hub = plugin_hub.ExtensionHub()
+    hub._discover_data_packs()
+    names = {r.name for r in hub.records_by_kind(PluginKind.DATA_PACK)}
+    assert "open_pack" not in names
+
+
+def _write_signed_manifest(
+    dirpath: Path, name: str, priv: Ed25519PrivateKey
+) -> Path:
+    """Write a manifest and sign exactly what's on disk."""
+    payload = {
+        "name": name,
+        "content": "source-catalog",
+        "version": "1.0.0",
+        "display_name": name.title(),
+        "description": "fixture",
+        "tier": "community",
+        "entries": [],
+    }
+    payload["signature"] = sign_manifest_dict(payload, priv)
+    p = dirpath / f"{name}.json"
+    p.write_text(json.dumps(payload), encoding="utf-8")
+    return p
+
+
+def test_signed_external_pack_admitted(
+    tmp_path, monkeypatch, keypair, public_key_b64
+) -> None:
+    priv, _ = keypair
+    monkeypatch.setenv(plugin_hub._DATA_PACKS_DIR_ENV, str(tmp_path))
+    monkeypatch.setenv(plugin_hub._DATA_PACK_PUBLIC_KEY_ENV, public_key_b64)
+
+    _write_signed_manifest(tmp_path, "signed_pack", priv)
+
+    hub = plugin_hub.ExtensionHub()
+    hub._discover_data_packs()
+    names = {r.name for r in hub.records_by_kind(PluginKind.DATA_PACK)}
+    assert "signed_pack" in names
+
+
+def test_tampered_signed_pack_dropped(
+    tmp_path, monkeypatch, keypair, public_key_b64
+) -> None:
+    """A pack whose manifest was edited after signing must NOT register."""
+    priv, _ = keypair
+    monkeypatch.setenv(plugin_hub._DATA_PACKS_DIR_ENV, str(tmp_path))
+    monkeypatch.setenv(plugin_hub._DATA_PACK_PUBLIC_KEY_ENV, public_key_b64)
+
+    # Sign legitimately, then tamper after the signature is computed.
+    p = _write_signed_manifest(tmp_path, "shady", priv)
+    raw = json.loads(p.read_text(encoding="utf-8"))
+    raw["tier"] = "enterprise"  # silent tier upgrade
+    p.write_text(json.dumps(raw), encoding="utf-8")
+
+    hub = plugin_hub.ExtensionHub()
+    hub._discover_data_packs()
+    names = {r.name for r in hub.records_by_kind(PluginKind.DATA_PACK)}
+    assert "shady" not in names
+
+
+def test_signed_pack_dropped_when_no_public_key_configured(
+    tmp_path, monkeypatch, keypair
+) -> None:
+    """If a manifest claims a signature but no key is configured, refuse it."""
+    priv, _ = keypair
+    monkeypatch.setenv(plugin_hub._DATA_PACKS_DIR_ENV, str(tmp_path))
+    monkeypatch.delenv(plugin_hub._DATA_PACK_PUBLIC_KEY_ENV, raising=False)
+    _write_signed_manifest(tmp_path, "claims_signature", priv)
+
+    hub = plugin_hub.ExtensionHub()
+    hub._discover_data_packs()
+    names = {r.name for r in hub.records_by_kind(PluginKind.DATA_PACK)}
+    assert "claims_signature" not in names
+
+
+def test_bundled_internal_pack_exempt_from_signature_gate(
+    tmp_path, monkeypatch
+) -> None:
+    """INTERNAL (bundled OSS) manifests are not gated — they're the source of truth."""
+    monkeypatch.delenv(plugin_hub._DATA_PACKS_DIR_ENV, raising=False)
+    monkeypatch.setenv(plugin_hub._DATA_PACK_REQUIRE_SIGNATURE_ENV, "true")
+
+    hub = plugin_hub.ExtensionHub()
+    hub._discover_data_packs()
+    # The bundled templates manifest produces at least one DATA_PACK record
+    # even though it carries no signature and signature is "required".
+    internals = [
+        r
+        for r in hub.records_by_kind(PluginKind.DATA_PACK)
+        if r.origin is Origin.INTERNAL
+    ]
+    assert internals, "bundled INTERNAL data pack should always register"


### PR DESCRIPTION
Implements story **G1a** of EPIC #265 (Regulatory data-packs, M1) — the
OSS-side verifier and discovery gate for the data-pack manifest
signature. Pairs with story L0 (#266 / PR #280) for the canonicalisation
primitive and with story G1b (`gispulse-data-regulatory#2`) for the
signing side.

> **Stacked on `feat/l0-licence-format`** (PR #280). The diff against
> `main` will include both commits until L0 lands. Retarget to `main`
> after L0 is squashed.

## What

- `DataPackManifest.signature: str | None`. A non-string at load time
  is a hard `ValueError` (no silent type-coercion).
- `gispulse.core.data_pack_signature`:
  - `canonical_manifest_bytes()` reuses
    `licence_format.canonicalise` so signed manifests and signed
    licences share **one** canonicalisation;
  - `sign_manifest_dict()` (test-only round-trip helper) +
    `verify_manifest_dict()` (production verifier);
  - `load_public_key_b64()` mirrors `GISPULSE_LICENCE_PUBLIC_KEY` so
    the same rotation tooling configures both fields.
- `ExtensionHub._discover_data_packs` discovery gate:

| Channel | Signature | Public key | Outcome |
|---|---|---|---|
| INTERNAL (bundle) | any | any | admit (exempt) |
| EXTERNAL | absent | n/a | admit (unless `REQUIRE_SIGNATURE=true`) |
| EXTERNAL | present + valid | configured | admit |
| EXTERNAL | present + tampered | configured | **drop** + `data_pack_signature_invalid` |
| EXTERNAL | present | absent | **drop** + `data_pack_signature_no_public_key` |
| EXTERNAL | absent | n/a | **drop** when `REQUIRE_SIGNATURE=true` |

## Q-PyPI-2 — kept open

The plan leaves "shared key vs separate key" for the SRE story. G1a
accepts a dedicated `GISPULSE_DATA_PACK_PUBLIC_KEY` env, so a future
decision to share or split the keys does not require any change here.

## Acceptance criteria (from #271)

- [x] Given a signed manifest + correct public key, it registers
      successfully.
- [x] Given a tampered manifest (post-signature edit), it is dropped
      with an explicit log event.
- [x] Given a foreign signature (wrong key), it is dropped.
- [x] Given a signed manifest with no public key configured, the safe
      default is to drop.
- [x] Bundled INTERNAL manifests are exempt — the OSS tree is the
      source of truth.
- [x] Unsigned EXTERNAL admitted by default to avoid bricking unsigned
      community packs.
- [x] Opt-in strict mode via `GISPULSE_DATA_PACK_REQUIRE_SIGNATURE`.

## Tests

14 new unit cases in `tests/unit/test_data_pack_signature.py`. Existing
`test_data_pack_regime` (13) and the L0 suite (17) stay green — 44
passed locally.

## Out of scope

- Signing of the first regulatory pack (story G1b, repo
  `gispulse-data-regulatory#2`).
- Format of regulatory-zoning manifests (story T3, #270).
- Settings-level integration (kept on env vars to mirror the licence
  pattern; a `data_pack_public_key` field in `core.config` is a clean
  follow-up).

Refs: #265 (EPIC), #271 (story), #266 (L0), #275 (REL-J5).

Signed-off-by: Marco <simon.ducournau@gmail.com>