### PR TITLE
feat(elt): SQL push-down for temporal_filter + temporal_join exact (Lot 3e, closes #246 push-down scope)

### DIFF
--- a/src/gispulse/capabilities/_attribute_sql.py
+++ b/src/gispulse/capabilities/_attribute_sql.py
@@ -1,0 +1,379 @@
+"""SQL builders for the attribute-only capabilities (ELT Lot 2, #245).
+
+One builder per ``schema`` / ``selection`` capability. Each turns
+``(dialect, gdf, params, tables)`` into a ``SELECT`` statement, or raises
+:class:`~gispulse.capabilities.sql_pushdown.Untranslatable` to defer to
+the Python implementation.
+
+Wiring lives at the bottom of ``schema.py`` / ``selection.py`` /
+``vector/calculate.py`` via :func:`attach_sql_pushdown` — kept out of
+those files so the capability modules stay readable.
+"""
+
+from __future__ import annotations
+
+import geopandas as gpd
+
+from gispulse.capabilities.sql_pushdown import (
+    Untranslatable,
+    attr_columns,
+    qi,
+    sql_literal,
+    translate_expression,
+)
+from gispulse.persistence.sql_dialect import SQLDialect
+
+# --- dtype → SQL type -------------------------------------------------------
+
+# Maps a pandas dtype (as resolved by schema._resolve_dtype) to the SQL
+# column type for each engine.
+_SQL_TYPES: dict[str, dict[str, str]] = {
+    "duckdb": {
+        "int": "BIGINT",
+        "float": "DOUBLE",
+        "string": "VARCHAR",
+        "boolean": "BOOLEAN",
+        "datetime": "TIMESTAMP",
+    },
+    "postgis": {
+        "int": "BIGINT",
+        "float": "DOUBLE PRECISION",
+        "string": "TEXT",
+        "boolean": "BOOLEAN",
+        "datetime": "TIMESTAMP",
+    },
+}
+
+
+def _type_family(resolved_dtype: str) -> str:
+    """Collapse a resolved pandas dtype to a SQL type family."""
+    d = resolved_dtype.lower()
+    if d.startswith("int"):
+        return "int"
+    if d.startswith("float"):
+        return "float"
+    if d in ("string", "object", "str"):
+        return "string"
+    if d in ("boolean", "bool"):
+        return "boolean"
+    if d.startswith("datetime"):
+        return "datetime"
+    raise Untranslatable(f"dtype {resolved_dtype!r} has no SQL type mapping")
+
+
+def _sql_type(dialect: SQLDialect, resolved_dtype: str) -> str:
+    return _SQL_TYPES[dialect.name][_type_family(resolved_dtype)]
+
+
+# --- projection helpers -----------------------------------------------------
+
+
+def _geom_reg(dialect: SQLDialect, gdf: gpd.GeoDataFrame) -> str:
+    """Name of the geometry column in the *registered* table."""
+    if dialect.name == "duckdb":
+        return dialect.geom_column  # always __wkb
+    return gdf.geometry.name  # PostGIS keeps the GeoDataFrame's name
+
+
+def _ordered_projection(
+    dialect: SQLDialect,
+    gdf: gpd.GeoDataFrame,
+    *,
+    rename: dict[str, str] | None = None,
+    drop: set[str] | None = None,
+    keep: set[str] | None = None,
+) -> str:
+    """Build a column projection that preserves the input column order.
+
+    The geometry column is always kept (under its registered name).
+    *rename* / *drop* / *keep* act on attribute columns only.
+    """
+    rename = rename or {}
+    drop = drop or set()
+    geom_name = gdf.geometry.name
+    geom_reg = _geom_reg(dialect, gdf)
+    parts: list[str] = []
+    for col in gdf.columns:
+        if col == geom_name:
+            parts.append(qi(geom_reg))
+            continue
+        if col in drop:
+            continue
+        if keep is not None and col not in keep:
+            continue
+        if col in rename:
+            parts.append(f"{qi(col)} AS {qi(rename[col])}")
+        else:
+            parts.append(qi(col))
+    return ", ".join(parts)
+
+
+# ===========================================================================
+# schema.py builders
+# ===========================================================================
+
+
+def build_select_columns(dialect, gdf, params, tables) -> str:
+    fields = [c for c in (params.get("fields") or []) if c in attr_columns(gdf)]
+    proj = _ordered_projection(dialect, gdf, keep=set(fields))
+    return f"SELECT {proj} FROM {tables['input']}"
+
+
+def build_drop_field(dialect, gdf, params, tables) -> str:
+    geom_name = gdf.geometry.name
+    drop: set[str] = set()
+    for col in params.get("fields") or []:
+        if col == geom_name:
+            raise Untranslatable("drop_field cannot drop the geometry column")
+        if col in attr_columns(gdf):
+            drop.add(col)
+    proj = _ordered_projection(dialect, gdf, drop=drop)
+    return f"SELECT {proj} FROM {tables['input']}"
+
+
+def build_rename_field(dialect, gdf, params, tables) -> str:
+    mapping = params.get("mapping") or {}
+    geom_name = gdf.geometry.name
+    cols = set(attr_columns(gdf))
+    valid: dict[str, str] = {}
+    for old, new in mapping.items():
+        if old == geom_name or new == geom_name:
+            raise Untranslatable("rename_field cannot touch the geometry column")
+        if old not in cols:
+            continue  # ignore_missing default — Python handles errors=raise
+        if new in cols and new != old:
+            raise Untranslatable(f"rename target {new!r} collides")
+        valid[old] = new
+    proj = _ordered_projection(dialect, gdf, rename=valid)
+    return f"SELECT {proj} FROM {tables['input']}"
+
+
+def build_add_field(dialect, gdf, params, tables) -> str:
+    from gispulse.capabilities.schema import _resolve_dtype
+
+    fields = params.get("fields") or []
+    existing = set(gdf.columns)
+    geom_name = gdf.geometry.name
+    additions: list[str] = []
+    for spec in fields:
+        name = spec.get("name", "")
+        if name == geom_name:
+            raise Untranslatable("add_field cannot overwrite the geometry column")
+        if name in existing:
+            # overwrite / skip semantics — leave to Python.
+            raise Untranslatable(f"add_field target {name!r} already exists")
+        sql_type = _sql_type(dialect, _resolve_dtype(spec.get("dtype", "string")))
+        lit = sql_literal(spec.get("default"))
+        additions.append(f"CAST({lit} AS {sql_type}) AS {qi(name)}")
+    if not additions:
+        raise Untranslatable("add_field has no new columns")
+    return f"SELECT *, {', '.join(additions)} FROM {tables['input']}"
+
+
+def build_cast_field(dialect, gdf, params, tables) -> str:
+    from gispulse.capabilities.schema import _resolve_dtype
+
+    casts = params.get("casts") or {}
+    errors = params.get("errors", "raise")
+    if errors == "ignore":
+        raise Untranslatable("cast_field errors='ignore' is not SQL-expressible")
+    if errors == "coerce" and dialect.name != "duckdb":
+        raise Untranslatable("cast_field errors='coerce' needs DuckDB TRY_CAST")
+    cast_fn = "TRY_CAST" if errors == "coerce" else "CAST"
+    geom_name = gdf.geometry.name
+    cols = set(attr_columns(gdf))
+    cast_map: dict[str, str] = {}
+    for col, dtype_spec in casts.items():
+        if col == geom_name:
+            raise Untranslatable("cast_field cannot cast the geometry column")
+        if col not in cols:
+            raise Untranslatable(f"cast_field column {col!r} absent")
+        cast_map[col] = _sql_type(dialect, _resolve_dtype(dtype_spec))
+    parts: list[str] = []
+    for col in gdf.columns:
+        if col == geom_name:
+            parts.append(qi(_geom_reg(dialect, gdf)))
+        elif col in cast_map:
+            parts.append(f"{cast_fn}({qi(col)} AS {cast_map[col]}) AS {qi(col)}")
+        else:
+            parts.append(qi(col))
+    return f"SELECT {', '.join(parts)} FROM {tables['input']}"
+
+
+def build_coalesce_fields(dialect, gdf, params, tables) -> str:
+    sources = params.get("sources") or []
+    target = params.get("target_col", "")
+    cols = set(attr_columns(gdf))
+    for c in sources:
+        if c not in cols:
+            raise Untranslatable(f"coalesce source {c!r} absent")
+    if target in gdf.columns:
+        raise Untranslatable(f"coalesce target {target!r} already exists")
+    coalesced = "COALESCE(" + ", ".join(qi(c) for c in sources) + ")"
+    return f"SELECT *, {coalesced} AS {qi(target)} FROM {tables['input']}"
+
+
+def build_case_when(dialect, gdf, params, tables) -> str:
+    target = params.get("target_col", "")
+    cases = params.get("cases") or []
+    if target in gdf.columns:
+        raise Untranslatable(f"case_when target {target!r} already exists")
+    whens: list[str] = []
+    for case in cases:
+        when = case.get("when", "")
+        if not when:
+            raise Untranslatable("case_when: empty 'when'")
+        cond = translate_expression(when)
+        then = sql_literal(case.get("then"))
+        whens.append(f"WHEN ({cond}) THEN {then}")
+    else_sql = sql_literal(params.get("else_"))
+    case_expr = "CASE " + " ".join(whens) + f" ELSE {else_sql} END"
+    return f"SELECT *, {case_expr} AS {qi(target)} FROM {tables['input']}"
+
+
+def build_attribute_join(dialect, gdf, params, tables) -> str:
+    left_on = params.get("left_on", "")
+    right_on = params.get("right_on") or left_on
+    how = params.get("how", "left")
+    columns = params.get("columns")
+    prefix = params.get("prefix", "")
+    suffix = params.get("suffix", "")
+    ref = params.get("ref_gdf")
+    if ref is None or not left_on:
+        raise Untranslatable("attribute_join missing ref/left_on")
+    if left_on not in gdf.columns:
+        raise Untranslatable(f"attribute_join left_on {left_on!r} absent")
+    if right_on not in getattr(ref, "columns", []):
+        raise Untranslatable(f"attribute_join right_on {right_on!r} absent")
+    if prefix or suffix:
+        for ch in (prefix, suffix):
+            if ch and not all(c.isalnum() or c == "_" for c in ch):
+                raise Untranslatable("attribute_join prefix/suffix not identifier-safe")
+    _JOIN_SQL = {
+        "left": "LEFT JOIN",
+        "right": "RIGHT JOIN",
+        "inner": "INNER JOIN",
+        "outer": "FULL OUTER JOIN",
+    }
+    if how not in _JOIN_SQL:
+        raise Untranslatable(f"attribute_join how={how!r} unsupported")
+
+    ref_attr = [c for c in attr_columns(ref) if c != right_on]
+    if columns:
+        ref_attr = [c for c in ref_attr if c in columns]
+    imported: list[str] = []
+    for c in ref_attr:
+        alias = f"{prefix}{c}{suffix}"
+        if alias in gdf.columns:
+            raise Untranslatable(f"attribute_join column {alias!r} collides")
+        imported.append(f"r.{qi(c)} AS {qi(alias)}")
+    proj = "i.*" + ("" if not imported else ", " + ", ".join(imported))
+    on = f"i.{qi(left_on)} = r.{qi(right_on)}"
+    return (
+        f"SELECT {proj} FROM {tables['input']} i "
+        f"{_JOIN_SQL[how]} {tables['ref']} r ON {on}"
+    )
+
+
+# ===========================================================================
+# selection.py builders
+# ===========================================================================
+
+
+def _order_by_clause(by, ascending, na_position="last") -> str:
+    cols = [by] if isinstance(by, str) else list(by)
+    if isinstance(ascending, bool):
+        asc = [ascending] * len(cols)
+    else:
+        asc = list(ascending)
+        if len(asc) != len(cols):
+            raise Untranslatable("ascending length mismatch")
+    if na_position not in ("first", "last"):
+        raise Untranslatable(f"na_position {na_position!r} invalid")
+    nulls = "NULLS FIRST" if na_position == "first" else "NULLS LAST"
+    terms = [
+        f"{qi(c)} {'ASC' if a else 'DESC'} {nulls}"
+        for c, a in zip(cols, asc)
+    ]
+    return ", ".join(terms)
+
+
+def build_sort(dialect, gdf, params, tables) -> str:
+    by = params.get("by")
+    if not by:
+        raise Untranslatable("sort without 'by' is a no-op")
+    order = _order_by_clause(
+        by, params.get("ascending", True), params.get("na_position", "last")
+    )
+    return f"SELECT * FROM {tables['input']} ORDER BY {order}"
+
+
+def build_top_n(dialect, gdf, params, tables) -> str:
+    n = params.get("n", 10)
+    by = params.get("by")
+    if n is None or n < 0:
+        raise Untranslatable("top_n needs n >= 0")
+    if not by:
+        # head(n) = input order; SQL has no stable input order — defer.
+        raise Untranslatable("top_n without 'by' relies on input order")
+    order = _order_by_clause(by, params.get("ascending", False))
+    return f"SELECT * FROM {tables['input']} ORDER BY {order} LIMIT {int(n)}"
+
+
+def build_deduplicate(dialect, gdf, params, tables) -> str:
+    keys = params.get("keys")
+    keep = params.get("keep", "first")
+    order_by = params.get("order_by")
+    if not keys:
+        raise Untranslatable("deduplicate needs 'keys'")
+    if not order_by:
+        # 'first'/'last' without order_by means input order — not stable in SQL.
+        raise Untranslatable("deduplicate push-down requires 'order_by'")
+    if keep not in ("first", "last"):
+        raise Untranslatable(f"deduplicate keep={keep!r} invalid")
+    key_cols = [keys] if isinstance(keys, str) else list(keys)
+    for c in key_cols:
+        if c not in gdf.columns:
+            raise Untranslatable(f"deduplicate key {c!r} absent")
+    # keep='last' ⇔ reverse the order so row 1 is the last per group.
+    asc = params.get("ascending", True)
+    if keep == "last":
+        if isinstance(asc, bool):
+            asc = not asc
+        else:
+            asc = [not a for a in asc]
+    order = _order_by_clause(order_by, asc)
+    partition = ", ".join(qi(c) for c in key_cols)
+    geom_name = gdf.geometry.name
+    cols = ", ".join(
+        qi(_geom_reg(dialect, gdf)) if c == geom_name else qi(c)
+        for c in gdf.columns
+    )
+    return (
+        f"SELECT {cols} FROM ("
+        f"SELECT *, ROW_NUMBER() OVER (PARTITION BY {partition} "
+        f"ORDER BY {order}) AS _gp_rn FROM {tables['input']}"
+        f") _gp_sub WHERE _gp_rn = 1"
+    )
+
+
+# ===========================================================================
+# vector/calculate.py builder
+# ===========================================================================
+
+
+def build_calculate(dialect, gdf, params, tables) -> str:
+    expressions = params.get("expressions") or {}
+    geom_name = gdf.geometry.name
+    additions: list[str] = []
+    for col_name, expr in expressions.items():
+        if col_name == geom_name:
+            raise Untranslatable("calculate cannot write the geometry column")
+        if col_name in gdf.columns:
+            # Overwriting an existing column would duplicate it under
+            # `SELECT *` — leave that case to the Python implementation.
+            raise Untranslatable(f"calculate target {col_name!r} already exists")
+        additions.append(f"({translate_expression(expr)}) AS {qi(col_name)}")
+    if not additions:
+        raise Untranslatable("calculate has no expressions")
+    return f"SELECT *, {', '.join(additions)} FROM {tables['input']}"

--- a/src/gispulse/capabilities/_geometry_sql.py
+++ b/src/gispulse/capabilities/_geometry_sql.py
@@ -24,6 +24,7 @@ import geopandas as gpd
 from gispulse.capabilities.sql_pushdown import (
     Untranslatable,
     qi,
+    sql_literal,
     translate_expression,
 )
 from gispulse.persistence.sql_dialect import SQLDialect
@@ -487,4 +488,111 @@ def build_erase(dialect, gdf, params, tables) -> str:
         f"SELECT {projection} FROM {tables['input']} "
         f"WHERE {erased} IS NOT NULL "
         f"AND NOT {dialect.st_is_empty(erased)}"
+    )
+
+
+# ===========================================================================
+# ELT Lot 3e (#246) — temporal_filter + temporal_join (exact strategy)
+# ===========================================================================
+
+
+def build_temporal_filter(dialect, gdf, params, tables) -> str:
+    """``temporal_filter`` — WHERE clause on a datetime column.
+
+    The column is cast to ``TIMESTAMP`` so string-typed time columns
+    (common when GPKG / CSV inputs are not auto-parsed) work too.
+    ``invert=True`` flips the keep-window into an exclude-window while
+    still dropping NULL timestamps — matching the Python ``~mask &
+    times.notna()`` semantics.
+    """
+    time_col = params.get("time_col", "")
+    if not time_col:
+        raise Untranslatable("temporal_filter missing time_col")
+    start = params.get("start")
+    end = params.get("end")
+    if start is None and end is None:
+        raise Untranslatable("temporal_filter needs at least start or end")
+    if time_col not in gdf.columns:
+        raise Untranslatable(f"temporal_filter time_col {time_col!r} absent")
+
+    include_start = params.get("include_start", True)
+    include_end = params.get("include_end", True)
+    col_expr = f"CAST({qi(time_col)} AS TIMESTAMP)"
+    clauses: list[str] = []
+    if start is not None:
+        op = ">=" if include_start else ">"
+        clauses.append(
+            f"{col_expr} {op} CAST({sql_literal(str(start))} AS TIMESTAMP)"
+        )
+    if end is not None:
+        op = "<=" if include_end else "<"
+        clauses.append(
+            f"{col_expr} {op} CAST({sql_literal(str(end))} AS TIMESTAMP)"
+        )
+    window = " AND ".join(clauses)
+
+    if params.get("invert", False):
+        # Mirror the Python ``~mask & times.notna()`` — NULL timestamps
+        # are excluded regardless of inversion.
+        where = f"{qi(time_col)} IS NOT NULL AND NOT ({window})"
+    else:
+        where = window
+    return f"SELECT * FROM {tables['input']} WHERE {where}"
+
+
+def build_temporal_join_exact(dialect, gdf, params, tables) -> str:
+    """``temporal_join`` strategy=``exact`` — equality join on a time key.
+
+    Asof strategies (``backward`` / ``forward`` / ``nearest``) defer to
+    Python: they need LATERAL + tolerance INTERVAL arithmetic with
+    enough dialect divergences (tolerance string parsing, ``by`` groups)
+    that the SQL push-down's risk/reward is poor for now.
+    """
+    strategy = params.get("strategy", "backward")
+    if strategy != "exact":
+        raise Untranslatable(
+            f"temporal_join push-down handles strategy='exact' only (got {strategy!r})"
+        )
+    ref = params.get("ref_gdf")
+    left_on = params.get("left_on", "")
+    if ref is None or not left_on:
+        raise Untranslatable("temporal_join missing ref_gdf / left_on")
+    right_on = params.get("right_on") or left_on
+    if left_on not in gdf.columns:
+        raise Untranslatable(f"temporal_join left_on {left_on!r} absent")
+    if right_on not in getattr(ref, "columns", []):
+        raise Untranslatable(f"temporal_join right_on {right_on!r} absent")
+
+    left_geom = gdf.geometry.name
+    left_attrs = [c for c in gdf.columns if c != left_geom]
+    right_geom = (
+        ref.geometry.name if hasattr(ref, "geometry") else None
+    )
+    # The right key is merged into the left's column — Python drops the
+    # right-side copy unconditionally — so we exclude it from the ref
+    # projection in both `same key name` and `different key name` cases.
+    right_attrs = [
+        c for c in ref.columns
+        if c != right_geom and c != right_on
+    ]
+    columns = params.get("columns")
+    if columns is not None:
+        right_attrs = [c for c in right_attrs if c in columns]
+    collisions = set(left_attrs) & set(right_attrs)
+
+    geom_reg = _geom_reg(dialect, gdf)
+    parts: list[str] = [f"l.{qi(c)} AS {qi(c)}" for c in left_attrs]
+    parts.append(f"l.{qi(geom_reg)} AS {qi(geom_reg)}")
+    for col in right_attrs:
+        alias = f"{col}_ref" if col in collisions else col
+        parts.append(f"r.{qi(col)} AS {qi(alias)}")
+
+    on_clause = (
+        f"CAST(l.{qi(left_on)} AS TIMESTAMP) = "
+        f"CAST(r.{qi(right_on)} AS TIMESTAMP)"
+    )
+    return (
+        f"SELECT {', '.join(parts)} "
+        f"FROM {tables['input']} l "
+        f"LEFT JOIN {tables['ref']} r ON {on_clause}"
     )

--- a/src/gispulse/capabilities/_geometry_sql.py
+++ b/src/gispulse/capabilities/_geometry_sql.py
@@ -21,7 +21,11 @@ from __future__ import annotations
 
 import geopandas as gpd
 
-from gispulse.capabilities.sql_pushdown import Untranslatable, qi
+from gispulse.capabilities.sql_pushdown import (
+    Untranslatable,
+    qi,
+    translate_expression,
+)
 from gispulse.persistence.sql_dialect import SQLDialect
 
 
@@ -215,3 +219,111 @@ def build_simplify(dialect, gdf, params, tables) -> str:
     if src is not None:
         geom = dialect.st_transform(geom, src_srid=meters, dst_srid=src)
     return f"SELECT {_replace_geom_projection(dialect, gdf, geom)} FROM {tables['input']}"
+
+
+# ===========================================================================
+# ELT Lot 3c (#246) — dissolve + spatial_join (group-by / two-layer predicate)
+# ===========================================================================
+
+
+def build_dissolve(dialect, gdf, params, tables) -> str:
+    """``dissolve`` — group-by union with ``first`` on the other columns.
+
+    With ``by=col`` the result has one row per distinct ``col`` value; the
+    geometry of each group is ``ST_Union``-aggregated, every other column
+    keeps an arbitrary value via the dialect's ``first_agg``. With
+    ``by=None`` the whole layer collapses into a single row.
+    """
+    by = params.get("by")
+    geom_name = gdf.geometry.name
+    geom_reg = _geom_reg(dialect, gdf)
+    attrs = [c for c in gdf.columns if c != geom_name]
+    union_expr = dialect.st_union_agg(dialect.geom_ref())
+
+    if by:
+        if by not in attrs:
+            raise Untranslatable(f"dissolve by={by!r} absent from layer")
+        others = [c for c in attrs if c != by]
+        selects = [qi(by), f"{union_expr} AS {qi(geom_reg)}"]
+        for col in others:
+            selects.append(f"{dialect.first_agg(qi(col))} AS {qi(col)}")
+        return (
+            f"SELECT {', '.join(selects)} FROM {tables['input']} "
+            f"GROUP BY {qi(by)}"
+        )
+    # Whole-layer dissolve — one row, no GROUP BY.
+    selects = [f"{union_expr} AS {qi(geom_reg)}"]
+    for col in attrs:
+        selects.append(f"{dialect.first_agg(qi(col))} AS {qi(col)}")
+    return f"SELECT {', '.join(selects)} FROM {tables['input']}"
+
+
+_SJOIN_HOWS = {"inner": "INNER JOIN", "left": "LEFT JOIN", "right": "RIGHT JOIN"}
+_SJOIN_PREDICATES = {
+    "intersects": "st_intersects",
+    "within": "st_within",
+    "contains": "st_contains",
+}
+
+
+def build_spatial_join(dialect, gdf, params, tables) -> str:
+    """``spatial_join`` — keep left attrs+geom, attach right attrs on predicate.
+
+    Reproduces GeoPandas ``sjoin`` column naming: collisions on attribute
+    names get the ``_left`` / ``_right`` suffix; the geometry stays from
+    the left side. ``columns`` restricts which right-side attributes are
+    imported, ``ref_filter`` is translated to a ``WHERE`` clause via the
+    Lot 2 expression translator (declines to Python if non-translatable).
+    """
+    ref = params.get("ref_gdf")
+    if ref is None:
+        raise Untranslatable("spatial_join missing ref_gdf")
+    if gdf.crs is not None and ref.crs is not None and gdf.crs != ref.crs:
+        raise Untranslatable(
+            "spatial_join: CRS mismatch — Python reprojects, SQL does not"
+        )
+    how = params.get("how", "inner")
+    if how not in _SJOIN_HOWS:
+        raise Untranslatable(f"spatial_join how={how!r} unsupported")
+    predicate = params.get("predicate", "intersects")
+    if predicate not in _SJOIN_PREDICATES:
+        raise Untranslatable(f"spatial_join predicate={predicate!r} unsupported")
+
+    left_geom = gdf.geometry.name
+    left_attrs = [c for c in gdf.columns if c != left_geom]
+    right_geom = ref.geometry.name
+    right_attrs = [c for c in ref.columns if c != right_geom]
+    columns = params.get("columns")
+    if columns is not None:
+        right_attrs = [c for c in right_attrs if c in columns]
+    collisions = set(left_attrs) & set(right_attrs)
+
+    geom_reg = _geom_reg(dialect, gdf)
+    parts: list[str] = []
+    for col in left_attrs:
+        alias = f"{col}_left" if col in collisions else col
+        parts.append(f"l.{qi(col)} AS {qi(alias)}")
+    parts.append(f"l.{qi(geom_reg)} AS {qi(geom_reg)}")
+    for col in right_attrs:
+        alias = f"{col}_right" if col in collisions else col
+        parts.append(f"r.{qi(col)} AS {qi(alias)}")
+
+    pred_method = getattr(dialect, _SJOIN_PREDICATES[predicate])
+    on_clause = pred_method(
+        dialect.geom_ref(table="l"), dialect.geom_ref(table="r")
+    )
+
+    ref_filter = params.get("ref_filter")
+    if ref_filter:
+        # translate_expression raises Untranslatable for anything outside
+        # the SQL-pure subset → caller falls back to Python.
+        filter_sql = translate_expression(ref_filter)
+        ref_source = f"(SELECT * FROM {tables['ref']} WHERE {filter_sql}) r"
+    else:
+        ref_source = f"{tables['ref']} r"
+
+    return (
+        f"SELECT {', '.join(parts)} "
+        f"FROM {tables['input']} l "
+        f"{_SJOIN_HOWS[how]} {ref_source} ON {on_clause}"
+    )

--- a/src/gispulse/capabilities/_geometry_sql.py
+++ b/src/gispulse/capabilities/_geometry_sql.py
@@ -1,0 +1,149 @@
+"""SQL builders for the single-layer 1:1 geometry capabilities (ELT Lot 3, #246).
+
+One builder per Tier-1 geometry capability whose operation is a pure
+*per-feature* geometry transform — ``centroid``, ``boundary``,
+``make_valid``, ``convex_hull``, ``envelope``, ``concave_hull`` — plus
+``area_length`` (geometry untouched, two metric columns added).
+
+Each builder produces a ``SELECT`` that rewrites the geometry column
+in place (under its registered name — ``__wkb`` on DuckDB, ``geometry``
+on PostGIS) so no result post-processing is needed: the engine's own
+decoder rebuilds the GeoDataFrame. Builders raise
+:class:`~gispulse.capabilities.sql_pushdown.Untranslatable` to defer the
+non-1:1 modes (``by_group`` / ``dissolve``) and unsupported options to
+the Python implementation.
+
+Wiring lives at the bottom of the capability modules via
+:func:`attach_sql_pushdown`.
+"""
+
+from __future__ import annotations
+
+import geopandas as gpd
+
+from gispulse.capabilities.sql_pushdown import Untranslatable, qi
+from gispulse.persistence.sql_dialect import SQLDialect
+
+
+def _geom_reg(dialect: SQLDialect, gdf: gpd.GeoDataFrame) -> str:
+    """Name of the geometry column in the *registered* table."""
+    return dialect.geom_column if dialect.name == "duckdb" else gdf.geometry.name
+
+
+def _replace_geom_projection(
+    dialect: SQLDialect, gdf: gpd.GeoDataFrame, geom_expr: str
+) -> str:
+    """Projection that rewrites the geometry column in place, order-preserving.
+
+    Every attribute column is passed through; the geometry slot is
+    replaced by *geom_expr* aliased back to the registered geometry
+    column name — uniform across DuckDB and PostGIS, no ``* REPLACE``.
+    """
+    geom_name = gdf.geometry.name
+    reg = _geom_reg(dialect, gdf)
+    parts: list[str] = []
+    for col in gdf.columns:
+        if col == geom_name:
+            parts.append(f"{geom_expr} AS {qi(reg)}")
+        else:
+            parts.append(qi(col))
+    return ", ".join(parts)
+
+
+def _epsg(crs_spec: str) -> int:
+    """Parse an ``EPSG:nnnn`` string to its integer code."""
+    s = str(crs_spec).strip().upper()
+    if s.startswith("EPSG:"):
+        s = s[5:]
+    try:
+        return int(s)
+    except ValueError:
+        raise Untranslatable(f"crs {crs_spec!r} is not an EPSG code") from None
+
+
+# ===========================================================================
+# Pure 1:1 geometry transforms
+# ===========================================================================
+
+
+def build_centroid(dialect, gdf, params, tables) -> str:
+    expr = dialect.st_centroid(dialect.geom_ref())
+    return f"SELECT {_replace_geom_projection(dialect, gdf, expr)} FROM {tables['input']}"
+
+
+def build_boundary(dialect, gdf, params, tables) -> str:
+    expr = dialect.st_boundary(dialect.geom_ref())
+    sql = f"SELECT {_replace_geom_projection(dialect, gdf, expr)} FROM {tables['input']}"
+    if params.get("drop_empty", True):
+        # A point's boundary is empty — drop those rows like the Python path.
+        sql += f" WHERE {expr} IS NOT NULL AND {dialect.st_is_empty(expr)} = FALSE"
+    return sql
+
+
+def build_make_valid(dialect, gdf, params, tables) -> str:
+    if params.get("keep_geom_type", False):
+        raise Untranslatable("make_valid keep_geom_type is not SQL-expressible")
+    expr = dialect.st_make_valid(dialect.geom_ref())
+    sql = f"SELECT {_replace_geom_projection(dialect, gdf, expr)} FROM {tables['input']}"
+    if params.get("drop_empty", True):
+        sql += f" WHERE {expr} IS NOT NULL AND {dialect.st_is_empty(expr)} = FALSE"
+    return sql
+
+
+def build_convex_hull(dialect, gdf, params, tables) -> str:
+    expr = dialect.st_convex_hull(dialect.geom_ref())
+    return f"SELECT {_replace_geom_projection(dialect, gdf, expr)} FROM {tables['input']}"
+
+
+def build_envelope(dialect, gdf, params, tables) -> str:
+    expr = dialect.st_envelope(dialect.geom_ref())
+    return f"SELECT {_replace_geom_projection(dialect, gdf, expr)} FROM {tables['input']}"
+
+
+def build_concave_hull(dialect, gdf, params, tables) -> str:
+    ratio = params.get("ratio", 0.3)
+    if not (0.0 <= float(ratio) <= 1.0):
+        raise Untranslatable("concave_hull ratio outside [0, 1]")
+    expr = dialect.st_concave_hull(
+        dialect.geom_ref(), ratio, allow_holes=bool(params.get("allow_holes", False))
+    )
+    return f"SELECT {_replace_geom_projection(dialect, gdf, expr)} FROM {tables['input']}"
+
+
+# ===========================================================================
+# area_length — metric columns, geometry untouched
+# ===========================================================================
+
+
+def build_area_length(dialect, gdf, params, tables) -> str:
+    area_col = params.get("area_col", "area_m2")
+    length_col = params.get("length_col", "length_m")
+    compute_area = params.get("compute_area", True)
+    compute_length = params.get("compute_length", True)
+    if not compute_area and not compute_length:
+        raise Untranslatable("area_length computes neither area nor length")
+    if compute_area and area_col in gdf.columns:
+        raise Untranslatable(f"area_length area_col {area_col!r} already exists")
+    if compute_length and length_col in gdf.columns:
+        raise Untranslatable(f"area_length length_col {length_col!r} already exists")
+
+    geom = dialect.geom_ref()
+    if gdf.crs is not None:
+        src = gdf.crs.to_epsg()
+        if src is None:
+            raise Untranslatable("area_length: source CRS has no EPSG code")
+        geom = dialect.st_transform(
+            geom, src_srid=src, dst_srid=_epsg(params.get("crs_meters", "EPSG:3857"))
+        )
+    adds: list[str] = []
+    if compute_area:
+        adds.append(f"ST_Area({geom}) AS {qi(area_col)}")
+    if compute_length:
+        # GeoPandas `.length` is the total 1-D measure: a polygon's
+        # perimeter, a line's length. ST_Length alone returns 0 for
+        # areal geometries, so add ST_Perimeter — the two are mutually
+        # exclusive per geometry, so the sum reproduces `.length`.
+        adds.append(
+            f"(ST_Length({geom}) + ST_Perimeter({geom})) AS {qi(length_col)}"
+        )
+    return f"SELECT *, {', '.join(adds)} FROM {tables['input']}"

--- a/src/gispulse/capabilities/_geometry_sql.py
+++ b/src/gispulse/capabilities/_geometry_sql.py
@@ -147,3 +147,71 @@ def build_area_length(dialect, gdf, params, tables) -> str:
             f"(ST_Length({geom}) + ST_Perimeter({geom})) AS {qi(length_col)}"
         )
     return f"SELECT *, {', '.join(adds)} FROM {tables['input']}"
+
+
+# ===========================================================================
+# ELT Lot 3b (#246) — aggregating / two-layer / CRS geometry capabilities
+# ===========================================================================
+
+
+def build_union(dialect, gdf, params, tables) -> str:
+    """``union`` — dissolve every feature into one geometry (attrs dropped)."""
+    reg = _geom_reg(dialect, gdf)
+    agg = dialect.st_union_agg(dialect.geom_ref())
+    return f"SELECT {agg} AS {qi(reg)} FROM {tables['input']}"
+
+
+def build_reproject(dialect, gdf, params, tables) -> str:
+    """``reproject`` — ST_Transform to a target CRS (CRS re-stamped post-hoc)."""
+    if gdf.crs is None:
+        raise Untranslatable("reproject: source layer has no CRS")
+    src = gdf.crs.to_epsg()
+    if src is None:
+        raise Untranslatable("reproject: source CRS has no EPSG code")
+    dst = _epsg(params.get("target_crs", "EPSG:4326"))
+    expr = dialect.st_transform(dialect.geom_ref(), src_srid=src, dst_srid=dst)
+    return f"SELECT {_replace_geom_projection(dialect, gdf, expr)} FROM {tables['input']}"
+
+
+def reproject_post(result, params):
+    """Stamp the target CRS — the result decoder infers the *source* CRS."""
+    return result.set_crs(params.get("target_crs", "EPSG:4326"), allow_override=True)
+
+
+def build_symmetric_difference(dialect, gdf, params, tables) -> str:
+    """``symmetric_difference`` — A XOR (unioned reference layer), per feature."""
+    ref_union = (
+        f"(SELECT {dialect.st_union_agg(dialect.geom_ref())} FROM {tables['ref']})"
+    )
+    geom = dialect.geom_ref()
+    xor = dialect.st_sym_difference(geom, ref_union)
+    # Empty / null geometries are passed through unchanged, as in Python.
+    expr = (
+        f"CASE WHEN {geom} IS NULL OR {dialect.st_is_empty(geom)} "
+        f"THEN {geom} ELSE {xor} END"
+    )
+    return f"SELECT {_replace_geom_projection(dialect, gdf, expr)} FROM {tables['input']}"
+
+
+def build_simplify(dialect, gdf, params, tables) -> str:
+    """``simplify`` — Douglas-Peucker, in a metric CRS, round-tripped back."""
+    algorithm = params.get("algorithm", "dp")
+    if algorithm != "dp":
+        raise Untranslatable(f"simplify algorithm {algorithm!r} is not SQL-pushable")
+    tol = params.get("tolerance", 1.0)
+    if tol is None or float(tol) <= 0:
+        raise Untranslatable("simplify requires tolerance > 0")
+    geom = dialect.geom_ref()
+    src = gdf.crs.to_epsg() if gdf.crs is not None else None
+    if gdf.crs is not None and src is None:
+        raise Untranslatable("simplify: source CRS has no EPSG code")
+    if src is not None:
+        meters = _epsg(params.get("crs_meters", "EPSG:3857"))
+        geom = dialect.st_transform(geom, src_srid=src, dst_srid=meters)
+    if params.get("preserve_topology", True):
+        geom = dialect.st_simplify_preserve_topology(geom, tol)
+    else:
+        geom = dialect.st_simplify(geom, tol)
+    if src is not None:
+        geom = dialect.st_transform(geom, src_srid=meters, dst_srid=src)
+    return f"SELECT {_replace_geom_projection(dialect, gdf, geom)} FROM {tables['input']}"

--- a/src/gispulse/capabilities/_geometry_sql.py
+++ b/src/gispulse/capabilities/_geometry_sql.py
@@ -327,3 +327,164 @@ def build_spatial_join(dialect, gdf, params, tables) -> str:
         f"FROM {tables['input']} l "
         f"{_SJOIN_HOWS[how]} {ref_source} ON {on_clause}"
     )
+
+
+# ===========================================================================
+# ELT Lot 3d (#246) — nearest_neighbor + overlay (intersection / erase)
+# ===========================================================================
+
+
+def _two_layer_collision_projection(
+    dialect: SQLDialect,
+    left_gdf: gpd.GeoDataFrame,
+    right_gdf: gpd.GeoDataFrame,
+    *,
+    columns: list[str] | None = None,
+    suffix_left: str = "_left",
+    suffix_right: str = "_right",
+    include_left_geom: bool = True,
+) -> tuple[list[str], set[str]]:
+    """Return collision-aware ``l.col AS …`` / ``r.col AS …`` projections.
+
+    Used by ``spatial_join`` / ``nearest_neighbor`` / ``overlay_*``.
+    Returns ``(parts, collisions)`` — *parts* in order: left attrs,
+    optionally left geometry, then right attrs. Geometry of the right
+    side is never included.
+    """
+    left_geom_name = left_gdf.geometry.name
+    right_geom_name = right_gdf.geometry.name
+    left_attrs = [c for c in left_gdf.columns if c != left_geom_name]
+    right_attrs = [c for c in right_gdf.columns if c != right_geom_name]
+    if columns is not None:
+        right_attrs = [c for c in right_attrs if c in columns]
+    collisions = set(left_attrs) & set(right_attrs)
+    geom_reg = _geom_reg(dialect, left_gdf)
+    parts: list[str] = []
+    for col in left_attrs:
+        alias = f"{col}{suffix_left}" if col in collisions else col
+        parts.append(f"l.{qi(col)} AS {qi(alias)}")
+    if include_left_geom:
+        parts.append(f"l.{qi(geom_reg)} AS {qi(geom_reg)}")
+    for col in right_attrs:
+        alias = f"{col}{suffix_right}" if col in collisions else col
+        parts.append(f"r.{qi(col)} AS {qi(alias)}")
+    return parts, collisions
+
+
+def build_nearest_neighbor(dialect, gdf, params, tables) -> str:
+    """``nearest_neighbor`` — 1-NN via PostGIS's ``<->`` operator.
+
+    Push-down restricted to PostGIS (DuckDB has no KNN operator) and the
+    simple case: ``k=1``, no ``max_distance``, both layers in the *same
+    projected CRS*. Everything else defers to Python.
+    """
+    if dialect.name != "postgis":
+        raise Untranslatable("nearest_neighbor push-down needs PostGIS (<-> operator)")
+    ref = params.get("ref_gdf")
+    if ref is None:
+        raise Untranslatable("nearest_neighbor missing ref_gdf")
+    if int(params.get("k", 1)) != 1:
+        raise Untranslatable("nearest_neighbor push-down handles k=1 only")
+    if params.get("max_distance") is not None:
+        raise Untranslatable("nearest_neighbor max_distance not pushable")
+    if gdf.crs is None or ref.crs is None or str(gdf.crs) != str(ref.crs):
+        raise Untranslatable("nearest_neighbor: layers must share a CRS")
+    if getattr(gdf.crs, "is_geographic", False):
+        raise Untranslatable("nearest_neighbor needs a projected CRS for distance")
+
+    distance_col = params.get("distance_col", "nn_distance")
+    parts, _ = _two_layer_collision_projection(
+        dialect, gdf, ref, columns=params.get("columns")
+    )
+    geom_reg = _geom_reg(dialect, gdf)
+    parts.append(
+        f"ST_Distance(l.{qi(geom_reg)}::geometry, r.{qi(geom_reg)}::geometry) "
+        f"AS {qi(distance_col)}"
+    )
+    return (
+        f"SELECT {', '.join(parts)} "
+        f"FROM {tables['input']} l "
+        f"CROSS JOIN LATERAL ("
+        f"SELECT * FROM {tables['ref']} _r "
+        f"ORDER BY l.{qi(geom_reg)}::geometry <-> _r.{qi(geom_reg)}::geometry "
+        f"LIMIT 1"
+        f") r"
+    )
+
+
+def _overlay_collision_parts(
+    dialect: SQLDialect,
+    gdf: gpd.GeoDataFrame,
+    ref: gpd.GeoDataFrame,
+    *,
+    suffix_left: str = "_1",
+    suffix_right: str = "_2",
+) -> list[str]:
+    """Per-pair attribute projection for ``overlay_intersection``.
+
+    Geometry is emitted separately by the caller (overlay rewrites it via
+    ``ST_Intersection``). Only attribute columns are produced here, with
+    GeoPandas's ``_1`` / ``_2`` suffixes on collision.
+    """
+    parts, _ = _two_layer_collision_projection(
+        dialect, gdf, ref,
+        suffix_left=suffix_left,
+        suffix_right=suffix_right,
+        include_left_geom=False,
+    )
+    return parts
+
+
+def build_overlay_intersection(dialect, gdf, params, tables) -> str:
+    """``overlay_intersection`` — pair-wise ``ST_Intersection`` + attr inheritance."""
+    ref = params.get("ref_gdf")
+    if ref is None or len(ref) == 0:
+        raise Untranslatable("overlay_intersection requires a non-empty ref")
+    if params.get("suffix_left", "_1") != "_1" or params.get("suffix_right", "_2") != "_2":
+        raise Untranslatable("overlay_intersection push-down keeps the GeoPandas default suffixes")
+    if gdf.crs is not None and ref.crs is not None and str(gdf.crs) != str(ref.crs):
+        raise Untranslatable("overlay_intersection: CRS mismatch")
+    keep_geom_type = params.get("keep_geom_type", True)
+
+    geom_reg = _geom_reg(dialect, gdf)
+    left_geom = dialect.geom_ref(table="l")
+    right_geom = dialect.geom_ref(table="r")
+    intersection = dialect.st_intersection(left_geom, right_geom)
+    parts = _overlay_collision_parts(dialect, gdf, ref)
+    parts.append(f"{intersection} AS {qi(geom_reg)}")
+
+    where = [dialect.st_intersects(left_geom, right_geom)]
+    where.append(f"NOT {dialect.st_is_empty(intersection)}")
+    if keep_geom_type:
+        # GeoPandas drops fragments whose geometry type differs from the
+        # primary layer's — e.g. a line dropping out of two edge-touching
+        # polygons. Replicate at the row level.
+        where.append(
+            f"{dialect.st_geometry_type(intersection)} = "
+            f"{dialect.st_geometry_type(left_geom)}"
+        )
+    return (
+        f"SELECT {', '.join(parts)} "
+        f"FROM {tables['input']} l, {tables['ref']} r "
+        f"WHERE {' AND '.join(where)}"
+    )
+
+
+def build_erase(dialect, gdf, params, tables) -> str:
+    """``erase`` — left geometry minus the unioned reference geometry."""
+    ref = params.get("ref_gdf")
+    if ref is None or len(ref) == 0:
+        raise Untranslatable("erase requires a non-empty ref")
+    if gdf.crs is not None and ref.crs is not None and str(gdf.crs) != str(ref.crs):
+        raise Untranslatable("erase: CRS mismatch")
+
+    ref_union = (
+        f"(SELECT {dialect.st_union_agg(dialect.geom_ref())} FROM {tables['ref']})"
+    )
+    erased = dialect.st_difference(dialect.geom_ref(), ref_union)
+    projection = _replace_geom_projection(dialect, gdf, erased)
+    return (
+        f"SELECT {projection} FROM {tables['input']} "
+        f"WHERE {erased} IS NOT NULL "
+        f"AND NOT {dialect.st_is_empty(erased)}"
+    )

--- a/src/gispulse/capabilities/overlay.py
+++ b/src/gispulse/capabilities/overlay.py
@@ -244,3 +244,26 @@ def _overlay_schema() -> dict:
             },
         },
     }
+
+
+# ---------------------------------------------------------------------------
+# ELT Lot 3 (#246) — DuckDB / PostGIS SQL push-down strategies
+# ---------------------------------------------------------------------------
+# overlay_intersection and erase push down cleanly; overlay_union stays on
+# Python — its three-region NaN-attribute semantics is not SQL-portable.
+
+from gispulse.capabilities import _geometry_sql as _gsql  # noqa: E402
+from gispulse.capabilities.sql_pushdown import attach_sql_pushdown  # noqa: E402
+
+attach_sql_pushdown(
+    OverlayIntersectionCapability,
+    _gsql.build_overlay_intersection,
+    gate=lambda p: p.get("ref_gdf") is not None,
+    extra_inputs={"ref": "ref_gdf"},
+)
+attach_sql_pushdown(
+    EraseCapability,
+    _gsql.build_erase,
+    gate=lambda p: p.get("ref_gdf") is not None,
+    extra_inputs={"ref": "ref_gdf"},
+)

--- a/src/gispulse/capabilities/schema.py
+++ b/src/gispulse/capabilities/schema.py
@@ -1116,3 +1116,53 @@ def _jsonable(value):
     if isinstance(value, (pd.Timestamp,)):
         return value.isoformat()
     return str(value)
+
+
+# ---------------------------------------------------------------------------
+# ELT Lot 2 (#245) — DuckDB / PostGIS SQL push-down strategies
+# ---------------------------------------------------------------------------
+
+from gispulse.capabilities import _attribute_sql as _asql  # noqa: E402
+from gispulse.capabilities.sql_pushdown import attach_sql_pushdown  # noqa: E402
+
+attach_sql_pushdown(
+    SelectColumnsCapability,
+    _asql.build_select_columns,
+    gate=lambda p: bool(p.get("fields")),
+)
+attach_sql_pushdown(
+    DropFieldCapability,
+    _asql.build_drop_field,
+    gate=lambda p: bool(p.get("fields")),
+)
+attach_sql_pushdown(
+    RenameFieldCapability,
+    _asql.build_rename_field,
+    gate=lambda p: bool(p.get("mapping")),
+)
+attach_sql_pushdown(
+    AddFieldCapability,
+    _asql.build_add_field,
+    gate=lambda p: bool(p.get("fields")),
+)
+attach_sql_pushdown(
+    CastFieldCapability,
+    _asql.build_cast_field,
+    gate=lambda p: bool(p.get("casts")),
+)
+attach_sql_pushdown(
+    CoalesceFieldsCapability,
+    _asql.build_coalesce_fields,
+    gate=lambda p: bool(p.get("sources")) and bool(p.get("target_col")),
+)
+attach_sql_pushdown(
+    CaseWhenCapability,
+    _asql.build_case_when,
+    gate=lambda p: bool(p.get("target_col")) and bool(p.get("cases")),
+)
+attach_sql_pushdown(
+    AttributeJoinCapability,
+    _asql.build_attribute_join,
+    gate=lambda p: p.get("ref_gdf") is not None and bool(p.get("left_on")),
+    extra_inputs={"ref": "ref_gdf"},
+)

--- a/src/gispulse/capabilities/selection.py
+++ b/src/gispulse/capabilities/selection.py
@@ -311,3 +311,27 @@ class TopNCapability(Capability):
             },
             "required": ["n"],
         }
+
+
+# ---------------------------------------------------------------------------
+# ELT Lot 2 (#245) — DuckDB / PostGIS SQL push-down strategies
+# ---------------------------------------------------------------------------
+
+from gispulse.capabilities import _attribute_sql as _asql  # noqa: E402
+from gispulse.capabilities.sql_pushdown import attach_sql_pushdown  # noqa: E402
+
+attach_sql_pushdown(
+    SortCapability,
+    _asql.build_sort,
+    gate=lambda p: bool(p.get("by")),
+)
+attach_sql_pushdown(
+    TopNCapability,
+    _asql.build_top_n,
+    gate=lambda p: bool(p.get("by")),
+)
+attach_sql_pushdown(
+    DeduplicateCapability,
+    _asql.build_deduplicate,
+    gate=lambda p: bool(p.get("keys")) and bool(p.get("order_by")),
+)

--- a/src/gispulse/capabilities/sql_pushdown.py
+++ b/src/gispulse/capabilities/sql_pushdown.py
@@ -231,6 +231,8 @@ def translate_expression(expr: str) -> str:
 SqlBuilder = Callable[[SQLDialect, gpd.GeoDataFrame, dict, dict], str]
 # An optional eligibility gate evaluated on params alone (no frame).
 SqlGate = Callable[[dict], bool]
+# An optional (result, params) -> result hook run on the decoded result.
+SqlPost = Callable[[gpd.GeoDataFrame, dict], gpd.GeoDataFrame]
 
 
 class _SqlPushdownStrategy(ExecutionStrategy):
@@ -244,12 +246,14 @@ class _SqlPushdownStrategy(ExecutionStrategy):
         *,
         gate: SqlGate | None,
         extra_inputs: dict[str, str],
+        post: "SqlPost | None" = None,
     ):
         self._backend = backend
         self._capability = capability
         self._build = build
         self._gate = gate
         self._extra_inputs = extra_inputs  # logical name -> param key
+        self._post = post
         self.mode = _MODE[backend]
 
     def can_execute(self, ctx: ExecutionContext) -> bool:
@@ -276,7 +280,10 @@ class _SqlPushdownStrategy(ExecutionStrategy):
         except Untranslatable as exc:
             log.debug("sql_pushdown_declined", backend=self._backend, reason=str(exc))
             return self._python_fallback(gdf, ctx.params)
-        return engine.sql_to_gdf(sql)
+        result = engine.sql_to_gdf(sql)
+        if self._post is not None:
+            result = self._post(result, ctx.params)
+        return result
 
     def _python_fallback(self, gdf: gpd.GeoDataFrame, params: dict) -> gpd.GeoDataFrame:
         from gispulse.capabilities.base import safe_execute
@@ -295,6 +302,7 @@ def attach_sql_pushdown(
     *,
     gate: SqlGate | None = None,
     extra_inputs: dict[str, str] | None = None,
+    post: "SqlPost | None" = None,
 ) -> None:
     """Wire DuckDB + PostGIS push-down strategies onto a capability class.
 
@@ -309,14 +317,17 @@ def attach_sql_pushdown(
             ``False`` to defer to Python (e.g. required params absent).
         extra_inputs:   Logical-name → param-key map of additional
             GeoDataFrame inputs to register (e.g. ``{"ref": "ref_gdf"}``).
+        post:           Optional ``(result, params) -> result`` hook run on
+            the decoded GeoDataFrame — e.g. ``reproject`` re-stamps the
+            target CRS, which the engine's result decoder cannot infer.
     """
     instance = capability_cls()
     extras = extra_inputs or {}
     capability_cls._strategies = [
         _SqlPushdownStrategy(
-            "postgis", instance, build, gate=gate, extra_inputs=extras
+            "postgis", instance, build, gate=gate, extra_inputs=extras, post=post
         ),
         _SqlPushdownStrategy(
-            "duckdb", instance, build, gate=gate, extra_inputs=extras
+            "duckdb", instance, build, gate=gate, extra_inputs=extras, post=post
         ),
     ]

--- a/src/gispulse/capabilities/sql_pushdown.py
+++ b/src/gispulse/capabilities/sql_pushdown.py
@@ -1,0 +1,322 @@
+"""Shared SQL push-down infrastructure for non-geometric capabilities.
+
+ELT Lot 2 (issue #245, ADR 0005). The ~12 ``schema`` / ``selection``
+capabilities are *attribute-only* — pure ``SELECT`` / ``CAST`` / ``CASE``
+/ ``ORDER BY`` / ``DISTINCT`` / ``LIMIT``, no geometry maths. This module
+gives them a single, generic DuckDB/PostGIS execution strategy so each
+capability only describes *how to build its SELECT*, not how to register
+data, dispatch, or decode the result.
+
+Design — the push-down is **opportunistic**. A strategy declines (and
+the proven Python/GeoPandas implementation runs) when:
+
+- the active engine is neither DuckDB nor PostGIS;
+- a capability-supplied ``gate`` rejects the params (missing required
+  keys, an empty no-op call — handled by Python so the original
+  ``ValueError`` / passthrough semantics are preserved);
+- the builder raises :class:`Untranslatable` (e.g. a ``calculate``
+  expression that leaves the SQL-pure subset).
+
+Correctness never depends on the SQL path. The geometry column is
+carried through untouched — every generated query keeps the dialect's
+registered geometry column (``__wkb`` on DuckDB, ``geometry`` on PostGIS)
+so the engine's own result decoder rebuilds the GeoDataFrame.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+from typing import Callable
+
+import geopandas as gpd
+
+from gispulse.capabilities.strategy import (
+    ExecutionContext,
+    ExecutionStrategy,
+    StrategyMode,
+)
+from gispulse.core.logging import get_logger
+from gispulse.persistence.sql_dialect import SQLDialect, get_dialect
+
+log = get_logger(__name__)
+
+# PostGIS `register` writes to a prefixed temp table — keep in sync with
+# gispulse.persistence.postgis._TMP_PREFIX.
+_POSTGIS_TMP_PREFIX = "_gispulse_tmp_"
+
+_PRIORITY = {"postgis": 100, "duckdb": 80}
+_MODE = {"postgis": StrategyMode.POSTGIS, "duckdb": StrategyMode.DUCKDB}
+
+__all__ = [
+    "Untranslatable",
+    "qi",
+    "attr_columns",
+    "sql_literal",
+    "translate_expression",
+    "attach_sql_pushdown",
+]
+
+
+class Untranslatable(Exception):
+    """Raised by a builder when the operation cannot be expressed in SQL.
+
+    Not an error: :class:`_SqlPushdownStrategy` catches it and runs the
+    capability's Python implementation instead.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Identifier / literal helpers
+# ---------------------------------------------------------------------------
+
+
+def _registered_table(engine, name: str) -> str:
+    """Return the table name an engine's ``register`` actually creates."""
+    if getattr(engine, "backend_name", "") == "postgis":
+        return f"{_POSTGIS_TMP_PREFIX}{name}"
+    return name
+
+
+def qi(identifier: str) -> str:
+    """Quote a SQL identifier (column / table) with double quotes.
+
+    The capability layer constrains identifiers to
+    ``[A-Za-z_][A-Za-z0-9_]{0,62}``; quoting on top neutralises reserved
+    words. A stray double quote is rejected outright.
+    """
+    if not isinstance(identifier, str) or not identifier or '"' in identifier:
+        raise ValueError(f"Unsafe SQL identifier: {identifier!r}")
+    return f'"{identifier}"'
+
+
+def attr_columns(gdf: gpd.GeoDataFrame) -> list[str]:
+    """Return *gdf*'s column names with the active geometry column removed."""
+    geom = gdf.geometry.name if hasattr(gdf, "geometry") else None
+    return [c for c in gdf.columns if c != geom]
+
+
+def _as_registerable(frame) -> gpd.GeoDataFrame:
+    """Coerce a join reference into something the engines can ``register``.
+
+    A non-spatial reference table (``attribute_join`` accepts a plain
+    ``DataFrame``) is wrapped with a throw-away null-geometry column so
+    ``register`` — which assumes a GeoDataFrame — succeeds. The dummy
+    column is never referenced by the generated JOIN.
+    """
+    if isinstance(frame, gpd.GeoDataFrame):
+        return frame
+    return gpd.GeoDataFrame(
+        frame.copy(),
+        geometry=gpd.GeoSeries([None] * len(frame), crs=None),
+    )
+
+
+def sql_literal(value: object) -> str:
+    """Render a Python scalar as a SQL literal.
+
+    Raises :class:`Untranslatable` for anything that cannot be safely
+    inlined (lists, dicts, geometries, …).
+    """
+    if value is None:
+        return "NULL"
+    if isinstance(value, bool):
+        return "TRUE" if value else "FALSE"
+    if isinstance(value, (int, float)):
+        return repr(value)
+    if isinstance(value, str):
+        return "'" + value.replace("'", "''") + "'"
+    if isinstance(value, (_dt.date, _dt.datetime)):
+        return "'" + value.isoformat() + "'"
+    raise Untranslatable(f"value {value!r} has no safe SQL literal form")
+
+
+# ---------------------------------------------------------------------------
+# pandas-query / eval expression → SQL
+# ---------------------------------------------------------------------------
+
+# Substrings that mean the expression leaves the SQL-pure subset.
+_EXPR_REJECT = ("@", "`", "[", "]", "{", "}", ";", "--", "/*", "**", "~", "//")
+
+
+def translate_expression(expr: str) -> str:
+    """Translate a pandas ``query``/``eval`` expression to portable SQL.
+
+    Handles the SQL-pure subset only — column names, numeric/string
+    literals, arithmetic (``+ - * / %``), comparisons and the boolean
+    connectives ``and`` / ``or`` / ``not``. Anything outside it (method
+    calls, ``@`` variables, indexing, ``**`` / ``//``) raises
+    :class:`Untranslatable`, so the caller falls back to Python.
+
+    ``ST_*`` and other function calls are intentionally *not* supported —
+    ``calculate`` / ``case_when`` push-down covers plain attribute maths.
+    """
+    raw = expr.strip()
+    if not raw:
+        raise Untranslatable("empty expression")
+    for bad in _EXPR_REJECT:
+        if bad in raw:
+            raise Untranslatable(f"expression uses unsupported token {bad!r}")
+
+    out: list[str] = []
+    i, n = 0, len(raw)
+    while i < n:
+        ch = raw[i]
+        if ch in ("'", '"'):  # string literal — re-quote to SQL single quotes
+            j = i + 1
+            while j < n and raw[j] != ch:
+                j += 1
+            if j >= n:
+                raise Untranslatable("unterminated string literal")
+            out.append("'" + raw[i + 1 : j].replace("'", "''") + "'")
+            i = j + 1
+            continue
+        if ch == ".":  # legal only between digits (decimal literal)
+            prev = raw[i - 1] if i > 0 else ""
+            nxt = raw[i + 1] if i + 1 < n else ""
+            if not (prev.isdigit() and nxt.isdigit()):
+                raise Untranslatable("attribute access is not SQL-translatable")
+            out.append(ch)
+            i += 1
+            continue
+        if ch == "=" and i + 1 < n and raw[i + 1] == "=":
+            out.append("=")
+            i += 2
+            continue
+        if ch == "!" and i + 1 < n and raw[i + 1] == "=":
+            out.append("<>")
+            i += 2
+            continue
+        if ch == "(":  # a function call — `name(` — is out of scope
+            if out and out[-1] not in ("(", "AND", "OR", "NOT", "", "+", "-", "*", "/", "%", "=", "<", ">", "<>", "<=", ">="):
+                raise Untranslatable("function calls are not SQL-translatable")
+            out.append(ch)
+            i += 1
+            continue
+        if ch.isalpha() or ch == "_":
+            j = i
+            while j < n and (raw[j].isalnum() or raw[j] == "_"):
+                j += 1
+            word, lowered = raw[i:j], raw[i:j].lower()
+            if lowered in ("and", "or", "not"):
+                out.append(lowered.upper())
+            elif lowered == "true":
+                out.append("TRUE")
+            elif lowered == "false":
+                out.append("FALSE")
+            elif lowered in ("none", "null"):
+                out.append("NULL")
+            else:
+                out.append(qi(word))
+            i = j
+            continue
+        if ch in "0123456789+-*/%)<> \t":
+            out.append(ch)
+            i += 1
+            continue
+        raise Untranslatable(f"unsupported character {ch!r} in expression")
+
+    sql = "".join(out).strip()
+    if not sql:
+        raise Untranslatable("expression translated to empty SQL")
+    return sql
+
+
+# ---------------------------------------------------------------------------
+# Generic strategy
+# ---------------------------------------------------------------------------
+
+# A builder turns (dialect, gdf, params, tables) into a SQL string. It may
+# raise Untranslatable to decline. `tables` maps a logical name ("input",
+# plus any declared extras) to the registered table name.
+SqlBuilder = Callable[[SQLDialect, gpd.GeoDataFrame, dict, dict], str]
+# An optional eligibility gate evaluated on params alone (no frame).
+SqlGate = Callable[[dict], bool]
+
+
+class _SqlPushdownStrategy(ExecutionStrategy):
+    """Generic DuckDB/PostGIS strategy for one attribute-only capability."""
+
+    def __init__(
+        self,
+        backend: str,
+        capability,
+        build: SqlBuilder,
+        *,
+        gate: SqlGate | None,
+        extra_inputs: dict[str, str],
+    ):
+        self._backend = backend
+        self._capability = capability
+        self._build = build
+        self._gate = gate
+        self._extra_inputs = extra_inputs  # logical name -> param key
+        self.mode = _MODE[backend]
+
+    def can_execute(self, ctx: ExecutionContext) -> bool:
+        if getattr(ctx.engine, "backend_name", "") != self._backend:
+            return False
+        if self._gate is not None and not self._gate(ctx.params):
+            return False
+        return True
+
+    def execute(self, gdf: gpd.GeoDataFrame, ctx: ExecutionContext) -> gpd.GeoDataFrame:
+        dialect = get_dialect(self._backend)
+        engine = ctx.engine
+        try:
+            engine.register("_sqlin", gdf)
+            tables = {"input": _registered_table(engine, "_sqlin")}
+            for logical, param_key in self._extra_inputs.items():
+                extra = ctx.params.get(param_key)
+                if extra is None:
+                    raise Untranslatable(f"missing extra input {param_key!r}")
+                reg = f"_sql_{logical}"
+                engine.register(reg, _as_registerable(extra))
+                tables[logical] = _registered_table(engine, reg)
+            sql = self._build(dialect, gdf, ctx.params, tables)
+        except Untranslatable as exc:
+            log.debug("sql_pushdown_declined", backend=self._backend, reason=str(exc))
+            return self._python_fallback(gdf, ctx.params)
+        return engine.sql_to_gdf(sql)
+
+    def _python_fallback(self, gdf: gpd.GeoDataFrame, params: dict) -> gpd.GeoDataFrame:
+        from gispulse.capabilities.base import safe_execute
+
+        clean = {k: v for k, v in params.items() if not k.startswith("_")}
+        return safe_execute(self._capability, gdf, **clean)
+
+    @property
+    def priority(self) -> int:
+        return _PRIORITY[self._backend]
+
+
+def attach_sql_pushdown(
+    capability_cls: type,
+    build: SqlBuilder,
+    *,
+    gate: SqlGate | None = None,
+    extra_inputs: dict[str, str] | None = None,
+) -> None:
+    """Wire DuckDB + PostGIS push-down strategies onto a capability class.
+
+    Call once, just after the class body. Builds a single capability
+    instance shared by both strategies as the Python fallback target.
+
+    Args:
+        capability_cls: The :class:`~gispulse.capabilities.base.Capability`
+            subclass to equip.
+        build:          The SQL builder for this capability.
+        gate:           Optional params-only eligibility predicate. Return
+            ``False`` to defer to Python (e.g. required params absent).
+        extra_inputs:   Logical-name → param-key map of additional
+            GeoDataFrame inputs to register (e.g. ``{"ref": "ref_gdf"}``).
+    """
+    instance = capability_cls()
+    extras = extra_inputs or {}
+    capability_cls._strategies = [
+        _SqlPushdownStrategy(
+            "postgis", instance, build, gate=gate, extra_inputs=extras
+        ),
+        _SqlPushdownStrategy(
+            "duckdb", instance, build, gate=gate, extra_inputs=extras
+        ),
+    ]

--- a/src/gispulse/capabilities/temporal.py
+++ b/src/gispulse/capabilities/temporal.py
@@ -266,3 +266,34 @@ class TemporalJoinCapability(Capability):
             },
             "required": ["left_on"],
         }
+
+
+# ---------------------------------------------------------------------------
+# ELT Lot 3 (#246) — DuckDB / PostGIS SQL push-down strategies
+# ---------------------------------------------------------------------------
+# temporal_filter pushes its time window down as a WHERE clause.
+# temporal_join push-down handles `strategy='exact'` only — the asof
+# strategies (backward / forward / nearest), `tolerance` and `by` groups
+# stay on Python (LATERAL + INTERVAL arithmetic, with dialect quirks).
+
+from gispulse.capabilities import _geometry_sql as _gsql  # noqa: E402
+from gispulse.capabilities.sql_pushdown import attach_sql_pushdown  # noqa: E402
+
+attach_sql_pushdown(
+    TemporalFilterCapability,
+    _gsql.build_temporal_filter,
+    gate=lambda p: (
+        bool(p.get("time_col"))
+        and (p.get("start") is not None or p.get("end") is not None)
+    ),
+)
+attach_sql_pushdown(
+    TemporalJoinCapability,
+    _gsql.build_temporal_join_exact,
+    gate=lambda p: (
+        p.get("strategy", "backward") == "exact"
+        and p.get("ref_gdf") is not None
+        and bool(p.get("left_on"))
+    ),
+    extra_inputs={"ref": "ref_gdf"},
+)

--- a/src/gispulse/capabilities/vector/__init__.py
+++ b/src/gispulse/capabilities/vector/__init__.py
@@ -38,7 +38,6 @@ from gispulse.capabilities.vector.buffer import (  # noqa: F401
     BufferCapability,
     _buffer_kwargs,
     _buffer_params_are_default,
-    _buffer_style_sql,
 )
 
 # Union / Reproject ----------------------------------------------------------

--- a/src/gispulse/capabilities/vector/boundary.py
+++ b/src/gispulse/capabilities/vector/boundary.py
@@ -44,3 +44,13 @@ class BoundaryCapability(Capability):
             },
         }
 
+
+# ---------------------------------------------------------------------------
+# ELT Lot 3 (#246) — DuckDB / PostGIS SQL push-down strategy
+# ---------------------------------------------------------------------------
+
+from gispulse.capabilities import _geometry_sql as _gsql  # noqa: E402
+from gispulse.capabilities.sql_pushdown import attach_sql_pushdown  # noqa: E402
+
+attach_sql_pushdown(BoundaryCapability, _gsql.build_boundary)
+

--- a/src/gispulse/capabilities/vector/buffer.py
+++ b/src/gispulse/capabilities/vector/buffer.py
@@ -6,6 +6,8 @@ import geopandas as gpd
 from gispulse.capabilities.base import Capability
 from gispulse.capabilities.registry import register
 from gispulse.capabilities.strategy import ExecutionContext, ExecutionStrategy, StrategyMode
+from gispulse.persistence.sql_dialect import BufferStyle, get_dialect
+from gispulse.persistence.spatial_queries import buffer_select
 
 
 # ---------------------------------------------------------------------------
@@ -45,23 +47,6 @@ def _buffer_kwargs(
         join_style=_BUFFER_JOIN_STYLES[join_style],
         mitre_limit=float(mitre_limit),
         single_sided=bool(single_sided),
-    )
-
-
-def _buffer_style_sql(
-    quad_segs: int,
-    cap_style: str,
-    join_style: str,
-    mitre_limit: float,
-    single_sided: bool,
-) -> str:
-    """Build the PostGIS/DuckDB ST_Buffer style string."""
-    side = "left" if single_sided else "both"
-    # DuckDB spatial implements ST_Buffer(geom, dist) — no style string yet.
-    # For PostGIS this returns the 3rd parameter.
-    return (
-        f"quad_segs={int(quad_segs)} endcap={cap_style} "
-        f"join={join_style} mitre_limit={float(mitre_limit):.3f} side={side}"
     )
 
 
@@ -156,16 +141,17 @@ class _BufferDuckDBStrategy(ExecutionStrategy):
             gdf = gdf.to_crs(crs_meters)
 
         ctx.engine.register("_input", gdf)
-        # register_gdf stores geometry as __wkb binary column;
-        # convert back to GEOMETRY via ST_GeomFromWKB before ST_Buffer
-        result = ctx.engine.sql_to_gdf(
-            f"SELECT *, ST_Buffer(ST_GeomFromWKB(__wkb), {distance}) AS __wkb_buf "
-            f"FROM _input"
-        )
-        # Replace geometry column with the buffered one
-        if "__wkb_buf" in result.columns:
-            result = result.set_geometry("__wkb_buf").drop(
-                columns=["__wkb"], errors="ignore"
+        # SQL generation is delegated to the dialect-aware layer
+        # (persistence.sql_dialect / spatial_queries) — ELT Lot 1,
+        # ADR 0005. A default-style buffer is the only kind DuckDB can
+        # express; can_execute() already deferred styled buffers to the
+        # Python strategy.
+        dialect = get_dialect(ctx.engine.backend_name)
+        query = buffer_select(dialect, source_table="_input", distance=distance)
+        result = ctx.engine.sql_to_gdf(query.sql)
+        if query.geom_column in result.columns:
+            result = result.set_geometry(query.geom_column).drop(
+                columns=[dialect.geom_column], errors="ignore"
             )
             result = result.rename_geometry("geometry")
 
@@ -189,12 +175,12 @@ class _BufferPostGISStrategy(ExecutionStrategy):
     def execute(self, gdf: gpd.GeoDataFrame, ctx: ExecutionContext) -> gpd.GeoDataFrame:
         distance = float(ctx.params.get("distance", 0.0))
         crs_meters: str = ctx.params.get("crs_meters", "EPSG:3857")
-        style = _buffer_style_sql(
-            int(ctx.params.get("quad_segs", 8)),
-            ctx.params.get("cap_style", "round"),
-            ctx.params.get("join_style", "round"),
-            float(ctx.params.get("mitre_limit", 5.0)),
-            bool(ctx.params.get("single_sided", False)),
+        style = BufferStyle(
+            quad_segs=int(ctx.params.get("quad_segs", 8)),
+            cap_style=ctx.params.get("cap_style", "round"),
+            join_style=ctx.params.get("join_style", "round"),
+            mitre_limit=float(ctx.params.get("mitre_limit", 5.0)),
+            single_sided=bool(ctx.params.get("single_sided", False)),
         )
 
         original_crs = gdf.crs
@@ -202,15 +188,17 @@ class _BufferPostGISStrategy(ExecutionStrategy):
             gdf = gdf.to_crs(crs_meters)
 
         ctx.engine.register("_input", gdf)
-        # Style string is built from validated params (enum-constrained),
-        # safe to inline. Distance is a numeric literal.
-        result = ctx.engine.sql_to_gdf(
-            f"SELECT *, ST_Buffer(geometry::geometry, {distance}, '{style}') "
-            f"AS geometry_buf FROM _input"
+        # Dialect-aware SQL (persistence.sql_dialect / spatial_queries) —
+        # ELT Lot 1, ADR 0005. PostGIS expresses the full ST_Buffer style
+        # string; the style is built from enum-constrained, validated params.
+        dialect = get_dialect(ctx.engine.backend_name)
+        query = buffer_select(
+            dialect, source_table="_input", distance=distance, style=style
         )
-        if "geometry_buf" in result.columns:
-            result = result.set_geometry("geometry_buf").drop(
-                columns=["geometry"], errors="ignore"
+        result = ctx.engine.sql_to_gdf(query.sql)
+        if query.geom_column in result.columns:
+            result = result.set_geometry(query.geom_column).drop(
+                columns=[dialect.geom_column], errors="ignore"
             )
             result = result.rename_geometry("geometry")
 

--- a/src/gispulse/capabilities/vector/calculate.py
+++ b/src/gispulse/capabilities/vector/calculate.py
@@ -200,3 +200,17 @@ class CalculateCapability(Capability):
             },
             "required": ["expressions"],
         }
+
+
+# ---------------------------------------------------------------------------
+# ELT Lot 2 (#245) — DuckDB / PostGIS SQL push-down strategy
+# ---------------------------------------------------------------------------
+
+from gispulse.capabilities import _attribute_sql as _asql  # noqa: E402
+from gispulse.capabilities.sql_pushdown import attach_sql_pushdown  # noqa: E402
+
+attach_sql_pushdown(
+    CalculateCapability,
+    _asql.build_calculate,
+    gate=lambda p: bool(p.get("expressions")),
+)

--- a/src/gispulse/capabilities/vector/centroid_area.py
+++ b/src/gispulse/capabilities/vector/centroid_area.py
@@ -100,3 +100,14 @@ class AreaLengthCapability(Capability):
             },
         }
 
+
+# ---------------------------------------------------------------------------
+# ELT Lot 3 (#246) — DuckDB / PostGIS SQL push-down strategies
+# ---------------------------------------------------------------------------
+
+from gispulse.capabilities import _geometry_sql as _gsql  # noqa: E402
+from gispulse.capabilities.sql_pushdown import attach_sql_pushdown  # noqa: E402
+
+attach_sql_pushdown(CentroidCapability, _gsql.build_centroid)
+attach_sql_pushdown(AreaLengthCapability, _gsql.build_area_length)
+

--- a/src/gispulse/capabilities/vector/clip.py
+++ b/src/gispulse/capabilities/vector/clip.py
@@ -6,6 +6,8 @@ import geopandas as gpd
 from gispulse.capabilities.base import Capability
 from gispulse.capabilities.registry import register
 from gispulse.capabilities.strategy import ExecutionContext, ExecutionStrategy, StrategyMode
+from gispulse.persistence.sql_dialect import get_dialect
+from gispulse.persistence.spatial_queries import clip_select
 
 
 # ---------------------------------------------------------------------------
@@ -78,14 +80,14 @@ class _ClipDuckDBStrategy(ExecutionStrategy):
 
         ctx.engine.register("_clip_input", gdf)
         ctx.engine.register("_clip_mask", mask_gdf)
-        result = ctx.engine.sql_to_gdf(
-            "SELECT i.* REPLACE ("
-            "  ST_Intersection(ST_GeomFromWKB(i.__wkb), ST_GeomFromWKB(m.__wkb)) "
-            "  AS __wkb"
-            ") "
-            "FROM _clip_input i, _clip_mask m "
-            "WHERE ST_Intersects(ST_GeomFromWKB(i.__wkb), ST_GeomFromWKB(m.__wkb))"
+        # Dialect-aware SQL (persistence.sql_dialect / spatial_queries) —
+        # ELT Lot 1, ADR 0005.
+        query = clip_select(
+            get_dialect(ctx.engine.backend_name),
+            source_table="_clip_input",
+            mask_table="_clip_mask",
         )
+        result = ctx.engine.sql_to_gdf(query.sql)
         return result.reset_index(drop=True)
 
     @property
@@ -114,15 +116,16 @@ class _ClipPostGISStrategy(ExecutionStrategy):
 
         ctx.engine.register("_clip_input", gdf)
         ctx.engine.register("_clip_mask", mask_gdf)
-        result = ctx.engine.sql_to_gdf(
-            "SELECT i.*, ST_Intersection(i.geometry::geometry, m.geometry::geometry) "
-            "AS geometry_clip "
-            "FROM _clip_input i, _clip_mask m "
-            "WHERE ST_Intersects(i.geometry::geometry, m.geometry::geometry)"
+        # Dialect-aware SQL (persistence.sql_dialect / spatial_queries) —
+        # ELT Lot 1, ADR 0005.
+        dialect = get_dialect(ctx.engine.backend_name)
+        query = clip_select(
+            dialect, source_table="_clip_input", mask_table="_clip_mask"
         )
-        if "geometry_clip" in result.columns:
-            result = result.set_geometry("geometry_clip").drop(
-                columns=["geometry"], errors="ignore"
+        result = ctx.engine.sql_to_gdf(query.sql)
+        if query.geom_column in result.columns:
+            result = result.set_geometry(query.geom_column).drop(
+                columns=[dialect.geom_column], errors="ignore"
             ).rename_geometry("geometry")
         return result.reset_index(drop=True)
 

--- a/src/gispulse/capabilities/vector/concave_hull.py
+++ b/src/gispulse/capabilities/vector/concave_hull.py
@@ -92,3 +92,17 @@ class ConcaveHullCapability(Capability):
         }
 
 
+# ---------------------------------------------------------------------------
+# ELT Lot 3 (#246) — DuckDB / PostGIS SQL push-down strategy
+# ---------------------------------------------------------------------------
+
+from gispulse.capabilities import _geometry_sql as _gsql  # noqa: E402
+from gispulse.capabilities.sql_pushdown import attach_sql_pushdown  # noqa: E402
+
+attach_sql_pushdown(
+    ConcaveHullCapability,
+    _gsql.build_concave_hull,
+    gate=lambda p: not p.get("by_group") and not p.get("dissolve"),
+)
+
+

--- a/src/gispulse/capabilities/vector/diff.py
+++ b/src/gispulse/capabilities/vector/diff.py
@@ -220,3 +220,22 @@ class VectorDiffCapability(Capability):
         }
 
 
+# ---------------------------------------------------------------------------
+# ELT Lot 3 (#246) — DuckDB / PostGIS SQL push-down strategy
+# ---------------------------------------------------------------------------
+# Only symmetric_difference pushes down — it is a clean per-feature XOR
+# against the unioned reference. vector_diff stays on Python: its
+# row-by-row added/removed/modified diff with Hausdorff tolerance is not
+# a SQL-pure operation.
+
+from gispulse.capabilities import _geometry_sql as _gsql  # noqa: E402
+from gispulse.capabilities.sql_pushdown import attach_sql_pushdown  # noqa: E402
+
+attach_sql_pushdown(
+    SymmetricDifferenceCapability,
+    _gsql.build_symmetric_difference,
+    gate=lambda p: p.get("ref_gdf") is not None,
+    extra_inputs={"ref": "ref_gdf"},
+)
+
+

--- a/src/gispulse/capabilities/vector/dissolve.py
+++ b/src/gispulse/capabilities/vector/dissolve.py
@@ -44,3 +44,20 @@ class DissolveCapability(Capability):
             },
         }
 
+
+# ---------------------------------------------------------------------------
+# ELT Lot 3 (#246) — DuckDB / PostGIS SQL push-down strategy
+# ---------------------------------------------------------------------------
+
+from gispulse.capabilities import _geometry_sql as _gsql  # noqa: E402
+from gispulse.capabilities.sql_pushdown import attach_sql_pushdown  # noqa: E402
+
+attach_sql_pushdown(
+    DissolveCapability,
+    _gsql.build_dissolve,
+    # by=None falls back to Python because gpd.dissolve().reset_index()
+    # then appends a spurious 'index' column from the default RangeIndex —
+    # not a meaningful difference, but reproducing it in SQL has no value.
+    gate=lambda p: bool(p.get("by")),
+)
+

--- a/src/gispulse/capabilities/vector/intersects.py
+++ b/src/gispulse/capabilities/vector/intersects.py
@@ -6,6 +6,8 @@ import geopandas as gpd
 from gispulse.capabilities.base import Capability
 from gispulse.capabilities.registry import register
 from gispulse.capabilities.strategy import ExecutionContext, ExecutionStrategy, StrategyMode
+from gispulse.persistence.sql_dialect import get_dialect
+from gispulse.persistence.spatial_queries import intersects_select
 
 
 # ---------------------------------------------------------------------------
@@ -80,10 +82,14 @@ class _IntersectsDuckDBStrategy(ExecutionStrategy):
         ref_gdf = gpd.GeoDataFrame(geometry=[ref_geom], crs=gdf.crs)
         ctx.engine.register("_is_input", gdf)
         ctx.engine.register("_is_ref", ref_gdf)
-        return ctx.engine.sql_to_gdf(
-            "SELECT i.* FROM _is_input i, _is_ref r "
-            "WHERE ST_Intersects(ST_GeomFromWKB(i.__wkb), ST_GeomFromWKB(r.__wkb))"
-        ).reset_index(drop=True)
+        # Dialect-aware SQL (persistence.sql_dialect / spatial_queries) —
+        # ELT Lot 1, ADR 0005.
+        query = intersects_select(
+            get_dialect(ctx.engine.backend_name),
+            source_table="_is_input",
+            ref_table="_is_ref",
+        )
+        return ctx.engine.sql_to_gdf(query.sql).reset_index(drop=True)
 
     @property
     def priority(self) -> int:
@@ -112,10 +118,14 @@ class _IntersectsPostGISStrategy(ExecutionStrategy):
         ref_gdf = gpd.GeoDataFrame(geometry=[ref_geom], crs=gdf.crs)
         ctx.engine.register("_is_input", gdf)
         ctx.engine.register("_is_ref", ref_gdf)
-        return ctx.engine.sql_to_gdf(
-            "SELECT i.* FROM _is_input i, _is_ref r "
-            "WHERE ST_Intersects(i.geometry::geometry, r.geometry::geometry)"
-        ).reset_index(drop=True)
+        # Dialect-aware SQL (persistence.sql_dialect / spatial_queries) —
+        # ELT Lot 1, ADR 0005.
+        query = intersects_select(
+            get_dialect(ctx.engine.backend_name),
+            source_table="_is_input",
+            ref_table="_is_ref",
+        )
+        return ctx.engine.sql_to_gdf(query.sql).reset_index(drop=True)
 
     @property
     def priority(self) -> int:

--- a/src/gispulse/capabilities/vector/nearest.py
+++ b/src/gispulse/capabilities/vector/nearest.py
@@ -189,5 +189,20 @@ class NearestNeighborCapability(Capability):
 
 
 # ---------------------------------------------------------------------------
+# ELT Lot 3 (#246) — PostGIS-only push-down (DuckDB lacks the <-> operator)
+# ---------------------------------------------------------------------------
+
+from gispulse.capabilities import _geometry_sql as _gsql  # noqa: E402
+from gispulse.capabilities.sql_pushdown import attach_sql_pushdown  # noqa: E402
+
+attach_sql_pushdown(
+    NearestNeighborCapability,
+    _gsql.build_nearest_neighbor,
+    gate=lambda p: p.get("ref_gdf") is not None,
+    extra_inputs={"ref": "ref_gdf"},
+)
+
+
+# ---------------------------------------------------------------------------
 # Advanced geometry constructions
 # ---------------------------------------------------------------------------

--- a/src/gispulse/capabilities/vector/reproject.py
+++ b/src/gispulse/capabilities/vector/reproject.py
@@ -41,3 +41,15 @@ class ReprojectCapability(Capability):
         }
 
 
+# ---------------------------------------------------------------------------
+# ELT Lot 3 (#246) — DuckDB / PostGIS SQL push-down strategy
+# ---------------------------------------------------------------------------
+
+from gispulse.capabilities import _geometry_sql as _gsql  # noqa: E402
+from gispulse.capabilities.sql_pushdown import attach_sql_pushdown  # noqa: E402
+
+attach_sql_pushdown(
+    ReprojectCapability, _gsql.build_reproject, post=_gsql.reproject_post
+)
+
+

--- a/src/gispulse/capabilities/vector/shape_ops_basic.py
+++ b/src/gispulse/capabilities/vector/shape_ops_basic.py
@@ -200,3 +200,18 @@ class EnvelopeCapability(Capability):
                 },
             },
         }
+
+
+# ---------------------------------------------------------------------------
+# ELT Lot 3 (#246) — DuckDB / PostGIS SQL push-down strategies
+# ---------------------------------------------------------------------------
+
+from gispulse.capabilities import _geometry_sql as _gsql  # noqa: E402
+from gispulse.capabilities.sql_pushdown import attach_sql_pushdown  # noqa: E402
+
+# by_group / dissolve are N:1 aggregations — not 1:1 — and stay on Python.
+_per_feature = lambda p: not p.get("by_group") and not p.get("dissolve")  # noqa: E731
+
+attach_sql_pushdown(MakeValidCapability, _gsql.build_make_valid)
+attach_sql_pushdown(ConvexHullCapability, _gsql.build_convex_hull, gate=_per_feature)
+attach_sql_pushdown(EnvelopeCapability, _gsql.build_envelope, gate=_per_feature)

--- a/src/gispulse/capabilities/vector/simplify.py
+++ b/src/gispulse/capabilities/vector/simplify.py
@@ -124,3 +124,17 @@ class SimplifyCapability(Capability):
             },
             "required": ["tolerance"],
         }
+
+
+# ---------------------------------------------------------------------------
+# ELT Lot 3 (#246) — DuckDB / PostGIS SQL push-down strategy (dp algorithm)
+# ---------------------------------------------------------------------------
+
+from gispulse.capabilities import _geometry_sql as _gsql  # noqa: E402
+from gispulse.capabilities.sql_pushdown import attach_sql_pushdown  # noqa: E402
+
+attach_sql_pushdown(
+    SimplifyCapability,
+    _gsql.build_simplify,
+    gate=lambda p: p.get("algorithm", "dp") == "dp",
+)

--- a/src/gispulse/capabilities/vector/spatial_join.py
+++ b/src/gispulse/capabilities/vector/spatial_join.py
@@ -102,3 +102,18 @@ class SpatialJoinCapability(Capability):
             # when ``ref_gdf`` is None, which preserves the contract.
         }
 
+
+# ---------------------------------------------------------------------------
+# ELT Lot 3 (#246) — DuckDB / PostGIS SQL push-down strategy
+# ---------------------------------------------------------------------------
+
+from gispulse.capabilities import _geometry_sql as _gsql  # noqa: E402
+from gispulse.capabilities.sql_pushdown import attach_sql_pushdown  # noqa: E402
+
+attach_sql_pushdown(
+    SpatialJoinCapability,
+    _gsql.build_spatial_join,
+    gate=lambda p: p.get("ref_gdf") is not None,
+    extra_inputs={"ref": "ref_gdf"},
+)
+

--- a/src/gispulse/capabilities/vector/union.py
+++ b/src/gispulse/capabilities/vector/union.py
@@ -29,3 +29,13 @@ class UnionCapability(Capability):
         return {"type": "object", "properties": {}}
 
 
+# ---------------------------------------------------------------------------
+# ELT Lot 3 (#246) — DuckDB / PostGIS SQL push-down strategy
+# ---------------------------------------------------------------------------
+
+from gispulse.capabilities import _geometry_sql as _gsql  # noqa: E402
+from gispulse.capabilities.sql_pushdown import attach_sql_pushdown  # noqa: E402
+
+attach_sql_pushdown(UnionCapability, _gsql.build_union)
+
+

--- a/src/gispulse/persistence/spatial_queries.py
+++ b/src/gispulse/persistence/spatial_queries.py
@@ -1,0 +1,133 @@
+"""Statement builders for the SQL-pushed geometry capabilities.
+
+ELT Lot 1 (issue #244, ADR 0005). One builder per capability that used
+to emit inline SQL — ``buffer`` / ``clip`` / ``intersects``. Each is
+parameterised by a :class:`~gispulse.persistence.sql_dialect.SQLDialect`
+and reproduces, statement for statement, the SQL the capability
+strategies emitted as hand-written f-strings — so pointing a strategy at
+a builder is a behaviour-preserving refactor.
+
+This sits one layer above :mod:`gispulse.persistence.sql_dialect`: the
+dialect spells *expressions* (a buffer, an intersection, a geometry
+reference), the builders here assemble whole ``SELECT`` *statements*.
+
+All table names go through :func:`validate_identifier`; geometry columns
+and aliases are validated inside the dialect. No value is inlined raw.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from gispulse.core.sql_safety import validate_identifier
+from gispulse.persistence.sql_dialect import BufferStyle, SQLDialect
+
+__all__ = [
+    "GeneratedQuery",
+    "buffer_select",
+    "clip_select",
+    "intersects_select",
+]
+
+
+@dataclass(frozen=True)
+class GeneratedQuery:
+    """A generated SQL statement plus the result's geometry column.
+
+    Attributes:
+        sql:         SQL statement ready to hand to ``sql_to_gdf``.
+        geom_column: Name of the geometry column in the result set — the
+            column a strategy should ``set_geometry`` on. For queries
+            that only filter rows (``intersects``) this is the dialect's
+            pass-through geometry column.
+    """
+
+    sql: str
+    geom_column: str
+
+
+def buffer_select(
+    dialect: SQLDialect,
+    *,
+    source_table: str,
+    distance: float,
+    style: BufferStyle | None = None,
+) -> GeneratedQuery:
+    """Build the ``buffer`` push-down query.
+
+    Emits ``SELECT <projection> FROM <source_table>`` where the buffered
+    geometry is derived via :meth:`SQLDialect.project_with_geometry` —
+    ``* REPLACE`` on DuckDB (so the result decoder finds the canonical
+    ``__wkb`` column), an appended ``geometry_buf`` column on PostGIS.
+
+    Raises:
+        UnsupportedInDialect: when *style* is non-default and the dialect
+            cannot express a styled buffer (DuckDB) — the caller falls
+            back to the Python strategy.
+    """
+    validate_identifier(source_table, "source table")
+    buffered = dialect.st_buffer_styled(dialect.geom_ref(), distance, style)
+    projection, geom_col = dialect.project_with_geometry(
+        None, buffered, result_suffix="buf"
+    )
+    sql = f"SELECT {projection} FROM {source_table}"
+    return GeneratedQuery(sql=sql, geom_column=geom_col)
+
+
+def clip_select(
+    dialect: SQLDialect,
+    *,
+    source_table: str,
+    mask_table: str,
+    source_alias: str = "i",
+    mask_alias: str = "m",
+) -> GeneratedQuery:
+    """Build the ``clip`` push-down query.
+
+    Emits an ``ST_Intersection`` of every source feature against the
+    (already unioned) mask, keeping only features that actually
+    intersect. The derived geometry is projected via
+    :meth:`SQLDialect.project_with_geometry` — ``* REPLACE`` on DuckDB so
+    the result keeps the canonical ``__wkb`` name, an appended
+    ``geometry_clip`` column on PostGIS.
+    """
+    validate_identifier(source_table, "source table")
+    validate_identifier(mask_table, "mask table")
+    src = dialect.geom_ref(table=source_alias)
+    msk = dialect.geom_ref(table=mask_alias)
+    projection, geom_col = dialect.project_with_geometry(
+        source_alias, dialect.st_intersection(src, msk), result_suffix="clip"
+    )
+    sql = (
+        f"SELECT {projection} "
+        f"FROM {source_table} {source_alias}, {mask_table} {mask_alias} "
+        f"WHERE {dialect.st_intersects(src, msk)}"
+    )
+    return GeneratedQuery(sql=sql, geom_column=geom_col)
+
+
+def intersects_select(
+    dialect: SQLDialect,
+    *,
+    source_table: str,
+    ref_table: str,
+    source_alias: str = "i",
+    ref_alias: str = "r",
+) -> GeneratedQuery:
+    """Build the ``intersects`` push-down query.
+
+    Emits ``SELECT <src>.* FROM <source> <src>, <ref> <ref> WHERE
+    ST_Intersects(...)`` — a row filter that keeps source features
+    intersecting the reference geometry. No geometry is derived, so the
+    result geometry column is the dialect's pass-through column.
+    """
+    validate_identifier(source_table, "source table")
+    validate_identifier(ref_table, "reference table")
+    src = dialect.geom_ref(table=source_alias)
+    ref = dialect.geom_ref(table=ref_alias)
+    sql = (
+        f"SELECT {source_alias}.* "
+        f"FROM {source_table} {source_alias}, {ref_table} {ref_alias} "
+        f"WHERE {dialect.st_intersects(src, ref)}"
+    )
+    return GeneratedQuery(sql=sql, geom_column=dialect.geom_column)

--- a/src/gispulse/persistence/sql_dialect.py
+++ b/src/gispulse/persistence/sql_dialect.py
@@ -287,6 +287,45 @@ class SQLDialect(ABC):
         validate_identifier(table_alias, "table alias")
         return f"{table_alias}.*"
 
+    # ------------------------------------------------------------------
+    # ELT Lot 3 (#246) — single-layer 1:1 geometry transforms
+    # ------------------------------------------------------------------
+    # DuckDB-spatial and PostGIS spell these identically (``ST_*``); they
+    # are concrete here. :class:`GeoPackageDialect` overrides them to
+    # raise. They are only ever invoked through the DuckDB/PostGIS
+    # push-down strategies, so the SpatiaLite spelling is not specialised.
+
+    def st_boundary(self, geom: str) -> str:
+        """Topological boundary of a geometry."""
+        return f"ST_Boundary({geom})"
+
+    def st_envelope(self, geom: str) -> str:
+        """Axis-aligned bounding-box envelope of a geometry."""
+        return f"ST_Envelope({geom})"
+
+    def st_convex_hull(self, geom: str) -> str:
+        """Convex hull of a geometry."""
+        return f"ST_ConvexHull({geom})"
+
+    def st_concave_hull(
+        self, geom: str, ratio: float, *, allow_holes: bool = False
+    ) -> str:
+        """Concave hull — three-arg form, the one DuckDB-spatial accepts."""
+        holes = "true" if allow_holes else "false"
+        return f"ST_ConcaveHull({geom}, {float(ratio)}, {holes})"
+
+    def st_make_valid(self, geom: str) -> str:
+        """Repaired (validity-corrected) geometry."""
+        return f"ST_MakeValid({geom})"
+
+    def st_simplify(self, geom: str, tolerance: float) -> str:
+        """Douglas-Peucker simplified geometry."""
+        return f"ST_Simplify({geom}, {float(tolerance)})"
+
+    def st_is_empty(self, geom: str) -> str:
+        """Boolean — whether a geometry is empty."""
+        return f"ST_IsEmpty({geom})"
+
 
 class PostGISDialect(SQLDialect):
     """PostgreSQL/PostGIS spatial SQL dialect."""
@@ -595,6 +634,29 @@ class GeoPackageDialect(SQLDialect):
         self, geom_expr: str, *, src_srid: int, dst_srid: int
     ) -> str:
         return self._spatial_not_supported("ST_Transform")
+
+    def st_boundary(self, geom: str) -> str:
+        return self._spatial_not_supported("ST_Boundary")
+
+    def st_envelope(self, geom: str) -> str:
+        return self._spatial_not_supported("ST_Envelope")
+
+    def st_convex_hull(self, geom: str) -> str:
+        return self._spatial_not_supported("ST_ConvexHull")
+
+    def st_concave_hull(
+        self, geom: str, ratio: float, *, allow_holes: bool = False
+    ) -> str:
+        return self._spatial_not_supported("ST_ConcaveHull")
+
+    def st_make_valid(self, geom: str) -> str:
+        return self._spatial_not_supported("ST_MakeValid")
+
+    def st_simplify(self, geom: str, tolerance: float) -> str:
+        return self._spatial_not_supported("ST_Simplify")
+
+    def st_is_empty(self, geom: str) -> str:
+        return self._spatial_not_supported("ST_IsEmpty")
 
 
 # Singleton instances

--- a/src/gispulse/persistence/sql_dialect.py
+++ b/src/gispulse/persistence/sql_dialect.py
@@ -351,6 +351,15 @@ class SQLDialect(ABC):
         """
         return f"ST_SymDifference({a}, {b})"
 
+    def first_agg(self, col: str) -> str:
+        """Pick one value per group — the GeoPandas ``dissolve`` aggfunc.
+
+        PostgreSQL has no ``first`` aggregate; the base spelling picks
+        the first element of ``array_agg``. :class:`DuckDBDialect`
+        overrides with the native ``first()`` aggregate.
+        """
+        return f"(array_agg({col}))[1]"
+
 
 class PostGISDialect(SQLDialect):
     """PostgreSQL/PostGIS spatial SQL dialect."""
@@ -515,6 +524,10 @@ class DuckDBDialect(SQLDialect):
         # DuckDB-spatial has no ST_SymDifference — compose it from the
         # two one-sided differences: (a - b) unioned with (b - a).
         return f"ST_Union(ST_Difference({a}, {b}), ST_Difference({b}, {a}))"
+
+    def first_agg(self, col: str) -> str:
+        # DuckDB has a native first() aggregate — pick one element per group.
+        return f"first({col})"
 
 
 class SpatiaLiteDialect(SQLDialect):
@@ -703,6 +716,9 @@ class GeoPackageDialect(SQLDialect):
 
     def st_sym_difference(self, a: str, b: str) -> str:
         return self._spatial_not_supported("ST_SymDifference")
+
+    def first_agg(self, col: str) -> str:
+        return self._spatial_not_supported("first_agg")
 
 
 # Singleton instances

--- a/src/gispulse/persistence/sql_dialect.py
+++ b/src/gispulse/persistence/sql_dialect.py
@@ -326,6 +326,31 @@ class SQLDialect(ABC):
         """Boolean — whether a geometry is empty."""
         return f"ST_IsEmpty({geom})"
 
+    def st_difference(self, a: str, b: str) -> str:
+        """Geometric difference ``a - b``."""
+        return f"ST_Difference({a}, {b})"
+
+    def st_simplify_preserve_topology(self, geom: str, tolerance: float) -> str:
+        """Topology-preserving Douglas-Peucker simplification."""
+        return f"ST_SimplifyPreserveTopology({geom}, {float(tolerance)})"
+
+    def st_union_agg(self, geom_col: str) -> str:
+        """Aggregate union of a geometry column.
+
+        Base spelling is the PostGIS aggregate ``ST_Union``;
+        :class:`DuckDBDialect` overrides with ``ST_Union_Agg``.
+        """
+        return f"ST_Union({geom_col})"
+
+    def st_sym_difference(self, a: str, b: str) -> str:
+        """Symmetric difference ``a XOR b``.
+
+        Base spelling is the PostGIS native ``ST_SymDifference``;
+        :class:`DuckDBDialect` — which lacks it — overrides with the
+        equivalent ``(a - b) UNION (b - a)``.
+        """
+        return f"ST_SymDifference({a}, {b})"
+
 
 class PostGISDialect(SQLDialect):
     """PostgreSQL/PostGIS spatial SQL dialect."""
@@ -481,6 +506,15 @@ class DuckDBDialect(SQLDialect):
             f"{star} REPLACE ({geom_expr} AS {self.geom_column})",
             self.geom_column,
         )
+
+    def st_union_agg(self, geom_col: str) -> str:
+        # DuckDB-spatial spells the aggregate union ST_Union_Agg.
+        return f"ST_Union_Agg({geom_col})"
+
+    def st_sym_difference(self, a: str, b: str) -> str:
+        # DuckDB-spatial has no ST_SymDifference — compose it from the
+        # two one-sided differences: (a - b) unioned with (b - a).
+        return f"ST_Union(ST_Difference({a}, {b}), ST_Difference({b}, {a}))"
 
 
 class SpatiaLiteDialect(SQLDialect):
@@ -657,6 +691,18 @@ class GeoPackageDialect(SQLDialect):
 
     def st_is_empty(self, geom: str) -> str:
         return self._spatial_not_supported("ST_IsEmpty")
+
+    def st_difference(self, a: str, b: str) -> str:
+        return self._spatial_not_supported("ST_Difference")
+
+    def st_simplify_preserve_topology(self, geom: str, tolerance: float) -> str:
+        return self._spatial_not_supported("ST_SimplifyPreserveTopology")
+
+    def st_union_agg(self, geom_col: str) -> str:
+        return self._spatial_not_supported("ST_Union")
+
+    def st_sym_difference(self, a: str, b: str) -> str:
+        return self._spatial_not_supported("ST_SymDifference")
 
 
 # Singleton instances

--- a/src/gispulse/persistence/sql_dialect.py
+++ b/src/gispulse/persistence/sql_dialect.py
@@ -13,10 +13,115 @@ Usage::
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+from gispulse.core.sql_safety import validate_identifier
+
+
+class UnsupportedInDialect(NotImplementedError):
+    """A spatial SQL feature has no equivalent in the target dialect.
+
+    Subclasses :class:`NotImplementedError` so existing callers that
+    catch the broad type keep working, while new code can catch this
+    precise type — e.g. a styled buffer or the KNN operator routed
+    through DuckDB — and fall back to the Python strategy.
+    """
+
+    def __init__(self, feature: str, dialect: str) -> None:
+        super().__init__(
+            f"{feature!r} is not supported by the {dialect!r} SQL dialect"
+        )
+        self.feature = feature
+        self.dialect = dialect
+
+
+# ---------------------------------------------------------------------------
+# Buffer style (ELT Lot 1 — divergence #2)
+# ---------------------------------------------------------------------------
+
+_CAP_STYLES: frozenset[str] = frozenset({"round", "flat", "square"})
+_JOIN_STYLES: frozenset[str] = frozenset({"round", "mitre", "bevel"})
+
+
+@dataclass(frozen=True)
+class BufferStyle:
+    """Validated styling parameters for ``ST_Buffer``.
+
+    The default instance (``BufferStyle()``) is the only style DuckDB
+    can honour. Anything else has :attr:`is_default` ``False`` and only
+    PostGIS can express it as SQL — see :meth:`SQLDialect.st_buffer_styled`.
+    """
+
+    quad_segs: int = 8
+    cap_style: str = "round"
+    join_style: str = "round"
+    mitre_limit: float = 5.0
+    single_sided: bool = False
+
+    def __post_init__(self) -> None:
+        if self.cap_style not in _CAP_STYLES:
+            raise ValueError(
+                f"Invalid cap_style {self.cap_style!r}. Expected one of "
+                f"{sorted(_CAP_STYLES)}."
+            )
+        if self.join_style not in _JOIN_STYLES:
+            raise ValueError(
+                f"Invalid join_style {self.join_style!r}. Expected one of "
+                f"{sorted(_JOIN_STYLES)}."
+            )
+        if self.quad_segs < 1:
+            raise ValueError("quad_segs must be >= 1.")
+
+    @property
+    def is_default(self) -> bool:
+        """True when the style is the round/8-seg/two-sided default."""
+        return (
+            self.quad_segs == 8
+            and self.cap_style == "round"
+            and self.join_style == "round"
+            and float(self.mitre_limit) == 5.0
+            and not self.single_sided
+        )
+
+    def to_postgis_style(self) -> str:
+        """Render the PostGIS ``ST_Buffer`` style-string third argument.
+
+        Built from enum-constrained, validated fields, so it is safe to
+        inline into SQL.
+        """
+        side = "left" if self.single_sided else "both"
+        return (
+            f"quad_segs={int(self.quad_segs)} endcap={self.cap_style} "
+            f"join={self.join_style} mitre_limit={float(self.mitre_limit):.3f} "
+            f"side={side}"
+        )
+
+
+def _fmt_number(value: float) -> str:
+    """Format a numeric SQL literal (buffer distances may be negative)."""
+    return repr(float(value))
+
+
+def _qualified(column: str, table: str | None) -> str:
+    """Return a validated ``table.column`` (or bare ``column``)."""
+    validate_identifier(column, "geometry column")
+    if table is None:
+        return column
+    validate_identifier(table, "table alias")
+    return f"{table}.{column}"
 
 
 class SQLDialect(ABC):
     """Abstract base for spatial SQL dialect adapters."""
+
+    #: Column a registered GeoDataFrame's geometry lands in for this backend.
+    geom_column: str = "geometry"
+    #: Whether ``ST_Buffer`` accepts a non-default :class:`BufferStyle`.
+    supports_styled_buffer: bool = False
+    #: Whether the KNN ``<->`` distance operator is available.
+    supports_knn: bool = False
+    #: Whether ``ST_Coverage*`` topological functions are available.
+    supports_coverage: bool = False
 
     @property
     @abstractmethod
@@ -87,6 +192,101 @@ class SQLDialect(ABC):
         """SQL expression for crosses test."""
         return f"ST_Crosses({a}, {b})"
 
+    # ------------------------------------------------------------------
+    # ELT Lot 1 (#244) — the five audited DuckDB/PostGIS divergences
+    # ------------------------------------------------------------------
+
+    def geom_ref(self, column: str | None = None, *, table: str | None = None) -> str:
+        """Return a GEOMETRY-typed expression for a *registered* column.
+
+        Divergence #1 — DuckDB registers a GeoDataFrame as a ``__wkb``
+        BLOB and must lift it with ``ST_GeomFromWKB``; engines with a
+        native geometry column just reference it. Base behaviour is the
+        native reference; :class:`DuckDBDialect` overrides.
+        """
+        return _qualified(column or self.geom_column, table)
+
+    def st_intersection(self, a: str, b: str) -> str:
+        """SQL expression for the geometric intersection (overlay) of *a*, *b*."""
+        return f"ST_Intersection({a}, {b})"
+
+    def st_buffer_styled(
+        self,
+        geom_expr: str,
+        distance: float,
+        style: BufferStyle | None = None,
+    ) -> str:
+        """Planar ``ST_Buffer`` with an optional :class:`BufferStyle`.
+
+        Divergence #2 — distinct from :meth:`st_buffer`, which buffers in
+        ``geography`` space. Here the caller has already reprojected to a
+        metric CRS, so the buffer is planar. Base behaviour honours only
+        the default style; :class:`PostGISDialect` overrides to emit the
+        style string.
+
+        Raises:
+            UnsupportedInDialect: when *style* is non-default and the
+                dialect cannot express it.
+        """
+        if style is not None and not style.is_default:
+            raise UnsupportedInDialect("styled ST_Buffer", self.name)
+        return f"ST_Buffer({geom_expr}, {_fmt_number(distance)})"
+
+    def st_transform(
+        self, geom_expr: str, *, src_srid: int, dst_srid: int
+    ) -> str:
+        """Reproject a geometry between SRIDs.
+
+        Divergence #4 — base behaviour is the 2-arg ``(geom, target)``
+        form; :class:`DuckDBDialect` overrides with the 4-arg form that
+        pins axis order via ``always_xy``.
+        """
+        return f"ST_Transform({geom_expr}, {int(dst_srid)})"
+
+    def st_knn_distance(self, a: str, b: str) -> str:
+        """KNN ``<->`` index-backed nearest-neighbour distance operator.
+
+        Divergence #3 — PostGIS-only.
+
+        Raises:
+            UnsupportedInDialect: on every dialect but PostGIS.
+        """
+        raise UnsupportedInDialect("KNN <-> operator", self.name)
+
+    def project_with_geometry(
+        self,
+        table_alias: str | None,
+        geom_expr: str,
+        *,
+        result_suffix: str = "out",
+    ) -> tuple[str, str]:
+        """Build a ``SELECT`` projection that derives a new geometry column.
+
+        Returns ``(projection, result_geom_column)`` — the text placed
+        after ``SELECT`` and the name the derived geometry lands under.
+
+        *table_alias* qualifies the star (``i.*``); pass ``None`` for an
+        unqualified ``*`` (single-table queries).
+
+        Base behaviour appends *geom_expr* as a new
+        ``<geom_column>_<result_suffix>`` column next to the star.
+        :class:`DuckDBDialect` overrides this to use the ``* REPLACE``
+        projection so the geometry keeps its canonical ``__wkb`` name —
+        the DuckDB result decoder keys on that name.
+        """
+        star = self._star(table_alias)
+        result_col = f"{self.geom_column}_{result_suffix}"
+        validate_identifier(result_col, "result geometry column")
+        return f"{star}, {geom_expr} AS {result_col}", result_col
+
+    @staticmethod
+    def _star(table_alias: str | None) -> str:
+        """Return ``*`` or a validated ``<alias>.*``."""
+        if not table_alias:
+            return "*"
+        validate_identifier(table_alias, "table alias")
+        return f"{table_alias}.*"
+
 
 class PostGISDialect(SQLDialect):
     """PostgreSQL/PostGIS spatial SQL dialect."""
@@ -130,6 +330,38 @@ class PostGISDialect(SQLDialect):
     def string_agg(self, col: str, sep: str = ", ") -> str:
         return f"STRING_AGG({col}::TEXT, '{sep}')"
 
+    # -- ELT Lot 1 divergences ----------------------------------------
+
+    geom_column = "geometry"
+    supports_styled_buffer = True
+    supports_knn = True
+    supports_coverage = True
+
+    def geom_ref(self, column: str | None = None, *, table: str | None = None) -> str:
+        # `register` writes a native `geometry` column; the explicit cast
+        # is a harmless no-op that keeps the SQL symmetric with DuckDB.
+        return f"{_qualified(column or self.geom_column, table)}::geometry"
+
+    def st_buffer_styled(
+        self,
+        geom_expr: str,
+        distance: float,
+        style: BufferStyle | None = None,
+    ) -> str:
+        # A supplied BufferStyle is always rendered as the explicit style
+        # string — including a default one — so the emitted SQL is
+        # byte-stable regardless of the style's values. ``style=None``
+        # gives the bare two-argument form.
+        if style is None:
+            return f"ST_Buffer({geom_expr}, {_fmt_number(distance)})"
+        return (
+            f"ST_Buffer({geom_expr}, {_fmt_number(distance)}, "
+            f"'{style.to_postgis_style()}')"
+        )
+
+    def st_knn_distance(self, a: str, b: str) -> str:
+        return f"({a} <-> {b})"
+
 
 class DuckDBDialect(SQLDialect):
     """DuckDB spatial extension SQL dialect."""
@@ -172,6 +404,44 @@ class DuckDBDialect(SQLDialect):
 
     def string_agg(self, col: str, sep: str = ", ") -> str:
         return f"STRING_AGG({col}::VARCHAR, '{sep}')"
+
+    # -- ELT Lot 1 divergences ----------------------------------------
+    # DuckDB is the ADR 0001 contract dialect. Styled buffers and the
+    # KNN operator inherit the base behaviour (raise UnsupportedInDialect)
+    # — there is no DuckDB-spatial equivalent.
+
+    geom_column = "__wkb"
+
+    def geom_ref(self, column: str | None = None, *, table: str | None = None) -> str:
+        # `register_gdf` stores geometry as a `__wkb` BLOB column; it must
+        # be parsed back to GEOMETRY before any spatial function.
+        return f"ST_GeomFromWKB({_qualified(column or self.geom_column, table)})"
+
+    def st_transform(
+        self, geom_expr: str, *, src_srid: int, dst_srid: int
+    ) -> str:
+        # 4-arg form: always_xy := true pins lon/lat axis order so a
+        # geographic source CRS is not silently transposed.
+        return (
+            f"ST_Transform({geom_expr}, 'EPSG:{int(src_srid)}', "
+            f"'EPSG:{int(dst_srid)}', always_xy := true)"
+        )
+
+    def project_with_geometry(
+        self,
+        table_alias: str | None,
+        geom_expr: str,
+        *,
+        result_suffix: str = "out",
+    ) -> tuple[str, str]:
+        # `* REPLACE (expr AS col)` is a DuckDB extension: it swaps a
+        # column in place, so the derived geometry keeps the canonical
+        # __wkb name the result decoder expects. result_suffix is unused.
+        star = self._star(table_alias)
+        return (
+            f"{star} REPLACE ({geom_expr} AS {self.geom_column})",
+            self.geom_column,
+        )
 
 
 class SpatiaLiteDialect(SQLDialect):
@@ -221,6 +491,27 @@ class SpatiaLiteDialect(SQLDialect):
 
     def st_crosses(self, a: str, b: str) -> str:
         return f"Crosses({a}, {b})"
+
+    # -- ELT Lot 1 divergences ----------------------------------------
+    # SpatiaLite drops the ST_ prefix and has no styled buffer.
+
+    def st_intersection(self, a: str, b: str) -> str:
+        return f"Intersection({a}, {b})"
+
+    def st_buffer_styled(
+        self,
+        geom_expr: str,
+        distance: float,
+        style: BufferStyle | None = None,
+    ) -> str:
+        if style is not None and not style.is_default:
+            raise UnsupportedInDialect("styled ST_Buffer", self.name)
+        return f"Buffer({geom_expr}, {_fmt_number(distance)})"
+
+    def st_transform(
+        self, geom_expr: str, *, src_srid: int, dst_srid: int
+    ) -> str:
+        return f"Transform({geom_expr}, {int(dst_srid)})"
 
 
 class GeoPackageDialect(SQLDialect):
@@ -281,6 +572,29 @@ class GeoPackageDialect(SQLDialect):
 
     def st_crosses(self, a: str, b: str) -> str:
         return self._spatial_not_supported("ST_Crosses")
+
+    # -- ELT Lot 1 divergences ----------------------------------------
+    # GPKG has no SQL-level spatial functions — every spatial primitive
+    # below raises, as the existing st_* methods do.
+
+    def geom_ref(self, column: str | None = None, *, table: str | None = None) -> str:
+        return self._spatial_not_supported("geom_ref")
+
+    def st_intersection(self, a: str, b: str) -> str:
+        return self._spatial_not_supported("ST_Intersection")
+
+    def st_buffer_styled(
+        self,
+        geom_expr: str,
+        distance: float,
+        style: BufferStyle | None = None,
+    ) -> str:
+        return self._spatial_not_supported("ST_Buffer")
+
+    def st_transform(
+        self, geom_expr: str, *, src_srid: int, dst_srid: int
+    ) -> str:
+        return self._spatial_not_supported("ST_Transform")
 
 
 # Singleton instances

--- a/src/gispulse/persistence/sql_dialect.py
+++ b/src/gispulse/persistence/sql_dialect.py
@@ -360,6 +360,10 @@ class SQLDialect(ABC):
         """
         return f"(array_agg({col}))[1]"
 
+    def st_geometry_type(self, geom: str) -> str:
+        """String name of a geometry's type — ``ST_GeometryType``."""
+        return f"ST_GeometryType({geom})"
+
 
 class PostGISDialect(SQLDialect):
     """PostgreSQL/PostGIS spatial SQL dialect."""
@@ -719,6 +723,9 @@ class GeoPackageDialect(SQLDialect):
 
     def first_agg(self, col: str) -> str:
         return self._spatial_not_supported("first_agg")
+
+    def st_geometry_type(self, geom: str) -> str:
+        return self._spatial_not_supported("ST_GeometryType")
 
 
 # Singleton instances

--- a/tests/integration/test_attribute_pushdown.py
+++ b/tests/integration/test_attribute_pushdown.py
@@ -1,0 +1,206 @@
+"""Result-for-result harness for the attribute SQL push-down (ELT Lot 2, #245).
+
+For each of the 12 ``schema`` / ``selection`` capabilities equipped with
+DuckDB/PostGIS strategies, this verifies that the SQL push-down path
+produces the *same result* as the proven Python/GeoPandas implementation.
+
+- DuckDB vs Python — runs unconditionally.
+- DuckDB vs PostGIS — runs only when ``GISPULSE_TEST_DSN`` is set.
+
+It also checks the opportunistic fallback: an untranslatable expression
+and a non-SQL engine both fall back to Python silently.
+"""
+
+from __future__ import annotations
+
+import os
+
+import geopandas as gpd
+import pandas as pd
+import pytest
+from shapely.geometry import Point
+
+from gispulse.capabilities.schema import (
+    AddFieldCapability,
+    AttributeJoinCapability,
+    CaseWhenCapability,
+    CastFieldCapability,
+    CoalesceFieldsCapability,
+    DropFieldCapability,
+    RenameFieldCapability,
+    SelectColumnsCapability,
+)
+from gispulse.capabilities.selection import (
+    DeduplicateCapability,
+    SortCapability,
+    TopNCapability,
+)
+from gispulse.capabilities.strategy import ExecutionContext
+from gispulse.capabilities.vector.calculate import CalculateCapability
+from gispulse.persistence.duckdb_engine import DuckDBSession
+
+TEST_DSN: str | None = os.environ.get("GISPULSE_TEST_DSN")
+_requires_postgis = pytest.mark.skipif(
+    TEST_DSN is None,
+    reason="GISPULSE_TEST_DSN not set — skipping the DuckDB↔PostGIS cross-check",
+)
+
+
+# ---------------------------------------------------------------------------
+# Inputs
+# ---------------------------------------------------------------------------
+
+
+def _layer() -> gpd.GeoDataFrame:
+    return gpd.GeoDataFrame(
+        {
+            "id": [3, 1, 2, 4],
+            "name": ["c", "a", "b", "d"],
+            "pop": [30, 10, 20, 40],
+            "grp": ["x", "x", "y", "y"],
+        },
+        geometry=[Point(0, 0), Point(1, 1), Point(2, 2), Point(3, 3)],
+        crs="EPSG:4326",
+    )
+
+
+# (capability, params) — every case is SQL-translatable on purpose.
+_CASES: list[tuple[object, dict]] = [
+    (SelectColumnsCapability(), {"fields": ["id", "name"]}),
+    (DropFieldCapability(), {"fields": ["grp"]}),
+    (RenameFieldCapability(), {"mapping": {"pop": "population"}}),
+    (AddFieldCapability(), {"fields": [{"name": "tag", "dtype": "string", "default": "z"}]}),
+    (CastFieldCapability(), {"casts": {"pop": "float"}}),
+    (CoalesceFieldsCapability(), {"sources": ["name", "grp"], "target_col": "label"}),
+    (
+        CaseWhenCapability(),
+        {
+            "target_col": "tier",
+            "cases": [
+                {"when": "pop > 25", "then": "big"},
+                {"when": "pop > 15", "then": "mid"},
+            ],
+            "else_": "small",
+        },
+    ),
+    (CalculateCapability(), {"expressions": {"dbl": "pop * 2", "ratio": "pop / 10"}}),
+    (SortCapability(), {"by": ["pop"], "ascending": True}),
+    (TopNCapability(), {"n": 2, "by": "pop", "ascending": False}),
+    (DeduplicateCapability(), {"keys": ["grp"], "order_by": ["pop"], "keep": "last"}),
+]
+
+
+def _ctx(engine, gdf, params):
+    return ExecutionContext(engine=engine, feature_count=len(gdf), params=dict(params))
+
+
+def _normalise(gdf: gpd.GeoDataFrame) -> pd.DataFrame:
+    """Drop geometry, coerce dtypes away, sort — for order/dtype-free compare."""
+    geom = gdf.geometry.name if hasattr(gdf, "geometry") else None
+    df = pd.DataFrame(gdf.drop(columns=[geom], errors="ignore"))
+    df = df.astype(object).where(pd.notna(df), None)
+    return df.sort_values(by=list(df.columns)).reset_index(drop=True)
+
+
+def _assert_equivalent(sql_result, py_result, label: str) -> None:
+    a, b = _normalise(sql_result), _normalise(py_result)
+    assert set(a.columns) == set(b.columns), (
+        f"{label}: column sets differ — SQL {sorted(a.columns)} vs "
+        f"Python {sorted(b.columns)}"
+    )
+    a = a[sorted(a.columns)]
+    b = b[sorted(b.columns)]
+    a = a.sort_values(by=list(a.columns)).reset_index(drop=True)
+    b = b.sort_values(by=list(b.columns)).reset_index(drop=True)
+    assert len(a) == len(b), f"{label}: row count {len(a)} != {len(b)}"
+    assert a.values.tolist() == b.values.tolist(), (
+        f"{label}: values differ\nSQL:\n{a}\nPython:\n{b}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# DuckDB vs Python — always runs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "capability, params",
+    _CASES,
+    ids=[c.name for c, _ in _CASES],
+)
+def test_duckdb_pushdown_matches_python(capability, params):
+    gdf = _layer()
+    python_result = capability.execute(gdf, **params)
+    with DuckDBSession() as eng:
+        sql_result = capability.execute_with_context(gdf, _ctx(eng, gdf, params))
+    _assert_equivalent(sql_result, python_result, f"{capability.name} duckdb")
+
+
+def test_attribute_join_duckdb_matches_python():
+    gdf = _layer()
+    ref = pd.DataFrame({"id": [1, 2, 3, 4], "region": ["A", "B", "C", "D"]})
+    params = {"ref_gdf": ref, "left_on": "id", "columns": ["region"]}
+    python_result = AttributeJoinCapability().execute(gdf, **params)
+    with DuckDBSession() as eng:
+        sql_result = AttributeJoinCapability().execute_with_context(
+            gdf, _ctx(eng, gdf, params)
+        )
+    _assert_equivalent(sql_result, python_result, "attribute_join duckdb")
+
+
+# ---------------------------------------------------------------------------
+# Opportunistic fallback to Python
+# ---------------------------------------------------------------------------
+
+
+def test_untranslatable_expression_falls_back_to_python():
+    """A calculate expression outside the SQL subset still produces the
+    correct result via the Python strategy."""
+    gdf = _layer()
+    # `.clip()` is a method call — not SQL-translatable.
+    params = {"expressions": {"capped": "pop.clip(upper=25)"}}
+    with DuckDBSession() as eng:
+        result = CalculateCapability().execute_with_context(
+            gdf, _ctx(eng, gdf, params)
+        )
+    assert result["capped"].tolist() == [25, 10, 20, 25]
+
+
+def test_non_sql_engine_uses_python(monkeypatch):
+    """A capability on a non-DuckDB/PostGIS engine runs the Python path."""
+
+    class _FakeEngine:
+        backend_name = "gpkg"
+
+    gdf = _layer()
+    ctx = ExecutionContext(
+        engine=_FakeEngine(), feature_count=len(gdf), params={"fields": ["id"]}
+    )
+    result = SelectColumnsCapability().execute_with_context(gdf, ctx)
+    assert set(result.columns) == {"id", "geometry"}
+
+
+# ---------------------------------------------------------------------------
+# DuckDB vs PostGIS — requires GISPULSE_TEST_DSN
+# ---------------------------------------------------------------------------
+
+
+@_requires_postgis
+@pytest.mark.parametrize(
+    "capability, params",
+    _CASES,
+    ids=[c.name for c, _ in _CASES],
+)
+def test_postgis_pushdown_matches_duckdb(capability, params):
+    from gispulse.persistence.postgis import PostGISConnection
+
+    gdf = _layer()
+    with DuckDBSession() as duck:
+        duck_result = capability.execute_with_context(gdf, _ctx(duck, gdf, params))
+    pg = PostGISConnection(dsn=TEST_DSN)
+    pg.open()
+    try:
+        pg_result = capability.execute_with_context(gdf, _ctx(pg, gdf, params))
+    finally:
+        pg.close()
+    _assert_equivalent(duck_result, pg_result, f"{capability.name} x-engine")

--- a/tests/integration/test_geometry_pushdown.py
+++ b/tests/integration/test_geometry_pushdown.py
@@ -486,3 +486,123 @@ def test_nearest_neighbor_postgis_matches_python():
         pg.close()
     assert set(sql.columns) == set(py.columns)
     assert len(sql) == len(py)
+
+
+# ===========================================================================
+# Lot 3e — temporal_filter + temporal_join (exact strategy)
+# ===========================================================================
+
+
+import pandas as pd  # noqa: E402
+
+from gispulse.capabilities.temporal import (  # noqa: E402
+    TemporalFilterCapability,
+    TemporalJoinCapability,
+)
+
+
+def _temporal_layer() -> gpd.GeoDataFrame:
+    return gpd.GeoDataFrame(
+        {
+            "id": [1, 2, 3, 4],
+            "ts": pd.to_datetime(
+                ["2025-01-01", "2025-06-01", "2025-12-01", "2026-03-01"]
+            ),
+            "name": ["a", "b", "c", "d"],
+        },
+        geometry=[Point(i, i) for i in range(4)],
+        crs="EPSG:4326",
+    )
+
+
+def _temporal_ref() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "ts": pd.to_datetime(["2025-06-01", "2026-03-01"]),
+            "id": [10, 20],
+            "weather": ["sunny", "rainy"],
+        }
+    )
+
+
+def test_temporal_filter_window_duckdb_matches_python():
+    gdf = _temporal_layer()
+    params = {"time_col": "ts", "start": "2025-06-01", "end": "2025-12-31"}
+    py = TemporalFilterCapability().execute(gdf.copy(), **params)
+    with DuckDBSession() as eng:
+        sql = TemporalFilterCapability().execute_with_context(
+            gdf, _ctx(eng, gdf, params)
+        )
+    assert set(sql.columns) == set(py.columns)
+    assert sorted(sql["id"].tolist()) == sorted(py["id"].tolist())
+
+
+def test_temporal_filter_invert_drops_nulls_like_python():
+    gdf = _temporal_layer()
+    params = {
+        "time_col": "ts",
+        "start": "2025-06-01",
+        "end": "2025-12-31",
+        "invert": True,
+    }
+    py = TemporalFilterCapability().execute(gdf.copy(), **params)
+    with DuckDBSession() as eng:
+        sql = TemporalFilterCapability().execute_with_context(
+            gdf, _ctx(eng, gdf, params)
+        )
+    assert sorted(sql["id"].tolist()) == sorted(py["id"].tolist())
+
+
+def test_temporal_filter_open_end_pushed():
+    gdf = _temporal_layer()
+    params = {"time_col": "ts", "start": "2025-06-01"}
+    py = TemporalFilterCapability().execute(gdf.copy(), **params)
+    with DuckDBSession() as eng:
+        sql = TemporalFilterCapability().execute_with_context(
+            gdf, _ctx(eng, gdf, params)
+        )
+    assert sorted(sql["id"].tolist()) == sorted(py["id"].tolist())
+
+
+def test_temporal_join_exact_duckdb_matches_python():
+    gdf = _temporal_layer()
+    ref = _temporal_ref()
+    params = {
+        "ref_gdf": ref,
+        "left_on": "ts",
+        "right_on": "ts",
+        "strategy": "exact",
+    }
+    py = TemporalJoinCapability().execute(gdf.copy(), **params)
+    with DuckDBSession() as eng:
+        sql = TemporalJoinCapability().execute_with_context(
+            gdf, _ctx(eng, gdf, params)
+        )
+    assert set(sql.columns) == set(py.columns)
+    assert len(sql) == len(py)
+    sql_pairs = sorted(
+        zip(sql["id"], sql["weather"].fillna("-")), key=lambda t: t[0]
+    )
+    py_pairs = sorted(
+        zip(py["id"], py["weather"].fillna("-")), key=lambda t: t[0]
+    )
+    assert sql_pairs == py_pairs
+
+
+def test_temporal_join_asof_falls_back_to_python():
+    """Asof strategies (backward / forward / nearest) stay on Python."""
+    gdf = _temporal_layer()
+    ref = _temporal_ref()
+    params = {
+        "ref_gdf": ref,
+        "left_on": "ts",
+        "right_on": "ts",
+        "strategy": "backward",
+    }
+    py = TemporalJoinCapability().execute(gdf.copy(), **params)
+    with DuckDBSession() as eng:
+        sql = TemporalJoinCapability().execute_with_context(
+            gdf, _ctx(eng, gdf, params)
+        )
+    assert set(sql.columns) == set(py.columns)
+    assert len(sql) == len(py)

--- a/tests/integration/test_geometry_pushdown.py
+++ b/tests/integration/test_geometry_pushdown.py
@@ -253,3 +253,125 @@ def test_simplify_non_dp_falls_back_to_python():
     # The vw path is Python-only; behaviour must equal the plain execute.
     expected = SimplifyCapability().execute(gdf.copy(), **params)
     assert len(result) == len(expected)
+
+
+# ===========================================================================
+# Lot 3c — dissolve + spatial_join
+# ===========================================================================
+
+
+from shapely.geometry import Point  # noqa: E402
+
+from gispulse.capabilities.vector.dissolve import DissolveCapability  # noqa: E402
+from gispulse.capabilities.vector.spatial_join import (  # noqa: E402
+    SpatialJoinCapability,
+)
+
+
+def _group_layer() -> gpd.GeoDataFrame:
+    return gpd.GeoDataFrame(
+        {
+            "id": [1, 2, 3, 4],
+            "name": ["a", "b", "c", "d"],
+            "pop": [10, 20, 30, 40],
+            "grp": ["x", "x", "y", "y"],
+        },
+        geometry=[Point(0, 0), Point(1, 1), Point(5, 5), Point(6, 6)],
+        crs="EPSG:2154",
+    )
+
+
+def _zone_layer() -> gpd.GeoDataFrame:
+    from shapely.geometry import Polygon as _P
+
+    return gpd.GeoDataFrame(
+        {"id": [10, 20], "region": ["XX", "YY"]},
+        geometry=[
+            _P([(-1, -1), (3, -1), (3, 3), (-1, 3)]),
+            _P([(4, 4), (8, 4), (8, 8), (4, 8)]),
+        ],
+        crs="EPSG:2154",
+    )
+
+
+def test_dissolve_by_group_duckdb_matches_python():
+    gdf = _group_layer()
+    params = {"by": "grp"}
+    py = DissolveCapability().execute(gdf.copy(), **params)
+    with DuckDBSession() as eng:
+        sql = DissolveCapability().execute_with_context(
+            gdf, _ctx(eng, gdf, params)
+        )
+    assert set(sql.columns) == set(py.columns)
+    assert sorted(sql["grp"].tolist()) == sorted(py["grp"].tolist())
+    # Each unioned geometry covers the same envelope.
+    py_b = dict(zip(py["grp"], py.geometry))
+    sql_b = dict(zip(sql["grp"], sql.geometry))
+    for grp, geom in py_b.items():
+        a = sql_b[grp]
+        ref = max(geom.envelope.area, 1e-9)
+        sym = geom.symmetric_difference(a).area
+        assert sym / ref <= 1e-6, f"dissolve grp={grp}: geometries diverge"
+
+
+def test_dissolve_no_by_falls_back_to_python():
+    """by=None pushes through Python (avoids the .reset_index() 'index' col)."""
+    gdf = _group_layer()
+    with DuckDBSession() as eng:
+        sql = DissolveCapability().execute_with_context(
+            gdf, _ctx(eng, gdf, {})
+        )
+    py = DissolveCapability().execute(gdf.copy())
+    assert len(sql) == len(py) == 1
+    assert set(sql.columns) == set(py.columns)
+
+
+def test_spatial_join_duckdb_matches_python():
+    gdf = _group_layer()
+    ref = _zone_layer()
+    params = {"ref_gdf": ref, "predicate": "intersects"}
+    py = SpatialJoinCapability().execute(gdf.copy(), **params)
+    with DuckDBSession() as eng:
+        sql = SpatialJoinCapability().execute_with_context(
+            gdf, _ctx(eng, gdf, params)
+        )
+    assert set(sql.columns) == set(py.columns), (
+        f"spatial_join columns differ — sql {sorted(sql.columns)} vs "
+        f"py {sorted(py.columns)}"
+    )
+    assert len(sql) == len(py)
+    # Compare rows by (id_left, id_right) pairs — order-independent.
+    pairs_sql = sorted(zip(sql["id_left"], sql["id_right"]))
+    pairs_py = sorted(zip(py["id_left"], py["id_right"]))
+    assert pairs_sql == pairs_py
+
+
+def test_spatial_join_crs_mismatch_falls_back_to_python():
+    """SQL declines when the two layers don't share a CRS — Python reprojects."""
+    gdf = _group_layer()
+    ref = _zone_layer().to_crs("EPSG:4326")
+    params = {"ref_gdf": ref, "predicate": "intersects"}
+    py = SpatialJoinCapability().execute(gdf.copy(), **params)
+    with DuckDBSession() as eng:
+        sql = SpatialJoinCapability().execute_with_context(
+            gdf, _ctx(eng, gdf, params)
+        )
+    assert set(sql.columns) == set(py.columns)
+    assert len(sql) == len(py)
+
+
+def test_spatial_join_ref_filter_translates():
+    gdf = _group_layer()
+    ref = _zone_layer()
+    params = {
+        "ref_gdf": ref,
+        "predicate": "intersects",
+        "ref_filter": "region == 'XX'",
+    }
+    py = SpatialJoinCapability().execute(gdf.copy(), **params)
+    with DuckDBSession() as eng:
+        sql = SpatialJoinCapability().execute_with_context(
+            gdf, _ctx(eng, gdf, params)
+        )
+    assert len(sql) == len(py)
+    assert set(sql["region"].dropna().unique()) == {"XX"}

--- a/tests/integration/test_geometry_pushdown.py
+++ b/tests/integration/test_geometry_pushdown.py
@@ -161,3 +161,95 @@ def test_postgis_geometry_pushdown_matches_duckdb(capability, params, layer, rel
     _assert_geom_equivalent(
         duck_result, pg_result, rel_tol=rel_tol, label=f"{capability.name} x-engine"
     )
+
+
+# ===========================================================================
+# Lot 3b — aggregating / two-layer / CRS caps
+# ===========================================================================
+
+
+from shapely.geometry import LineString  # noqa: E402
+
+from gispulse.capabilities.vector.diff import SymmetricDifferenceCapability  # noqa: E402
+from gispulse.capabilities.vector.reproject import ReprojectCapability  # noqa: E402
+from gispulse.capabilities.vector.simplify import SimplifyCapability  # noqa: E402
+from gispulse.capabilities.vector.union import UnionCapability  # noqa: E402
+
+
+def _ref_layer() -> gpd.GeoDataFrame:
+    from shapely.geometry import Polygon as _P
+
+    return gpd.GeoDataFrame(
+        {"id": [9]},
+        geometry=[_P([(3, 3), (8, 3), (8, 8), (3, 8)])],
+        crs="EPSG:2154",
+    )
+
+
+def _line_layer() -> gpd.GeoDataFrame:
+    return gpd.GeoDataFrame(
+        {"id": [1]},
+        geometry=[
+            LineString([(0, 0), (1, 0.1), (2, -0.1), (3, 0.05), (4, 0)]),
+        ],
+        crs="EPSG:2154",
+    )
+
+
+def test_union_duckdb_matches_python():
+    gdf = _polys()
+    py = UnionCapability().execute(gdf.copy())
+    with DuckDBSession() as eng:
+        sql = UnionCapability().execute_with_context(gdf, _ctx(eng, gdf, {}))
+    assert len(sql) == len(py) == 1
+    a, b = sql.geometry.iloc[0], py.geometry.iloc[0]
+    assert abs(a.area - b.area) <= 1e-6 * max(b.area, 1.0)
+
+
+def test_reproject_duckdb_matches_python():
+    gdf = _polys()
+    params = {"target_crs": "EPSG:4326"}
+    py = ReprojectCapability().execute(gdf.copy(), **params)
+    with DuckDBSession() as eng:
+        sql = ReprojectCapability().execute_with_context(gdf, _ctx(eng, gdf, params))
+    assert str(sql.crs) == str(py.crs) == "EPSG:4326"
+    for a, b in zip(sorted(sql.geometry, key=lambda g: g.centroid.x),
+                    sorted(py.geometry, key=lambda g: g.centroid.x)):
+        assert abs(a.centroid.x - b.centroid.x) <= 1e-6
+        assert abs(a.centroid.y - b.centroid.y) <= 1e-6
+
+
+def test_symmetric_difference_duckdb_matches_python():
+    gdf, ref = _polys(), _ref_layer()
+    params = {"ref_gdf": ref}
+    py = SymmetricDifferenceCapability().execute(gdf.copy(), **params)
+    with DuckDBSession() as eng:
+        sql = SymmetricDifferenceCapability().execute_with_context(
+            gdf, _ctx(eng, gdf, params)
+        )
+    _assert_geom_equivalent(sql, py, rel_tol=1e-6, label="symmetric_difference duckdb")
+
+
+def test_simplify_duckdb_matches_python():
+    gdf = _line_layer()
+    params = {"tolerance": 0.5}
+    py = SimplifyCapability().execute(gdf.copy(), **params)
+    with DuckDBSession() as eng:
+        sql = SimplifyCapability().execute_with_context(gdf, _ctx(eng, gdf, params))
+    # GEOS TopologyPreservingSimplifier in both — vertex counts must match.
+    assert len(sql) == len(py) == 1
+    assert (
+        len(sql.geometry.iloc[0].coords) == len(py.geometry.iloc[0].coords)
+    )
+
+
+def test_simplify_non_dp_falls_back_to_python():
+    gdf = _line_layer()
+    params = {"tolerance": 0.5, "algorithm": "vw"}
+    with DuckDBSession() as eng:
+        result = SimplifyCapability().execute_with_context(
+            gdf, _ctx(eng, gdf, params)
+        )
+    # The vw path is Python-only; behaviour must equal the plain execute.
+    expected = SimplifyCapability().execute(gdf.copy(), **params)
+    assert len(result) == len(expected)

--- a/tests/integration/test_geometry_pushdown.py
+++ b/tests/integration/test_geometry_pushdown.py
@@ -375,3 +375,114 @@ def test_spatial_join_ref_filter_translates():
         )
     assert len(sql) == len(py)
     assert set(sql["region"].dropna().unique()) == {"XX"}
+
+
+# ===========================================================================
+# Lot 3d — nearest_neighbor + overlay (intersection, erase)
+# ===========================================================================
+
+
+from gispulse.capabilities.overlay import (  # noqa: E402
+    EraseCapability,
+    OverlayIntersectionCapability,
+)
+from gispulse.capabilities.vector.nearest import (  # noqa: E402
+    NearestNeighborCapability,
+)
+
+
+def _overlay_a() -> gpd.GeoDataFrame:
+    from shapely.geometry import Polygon as _P
+
+    return gpd.GeoDataFrame(
+        {"id": [1, 2], "name": ["A", "B"]},
+        geometry=[
+            _P([(0, 0), (10, 0), (10, 10), (0, 10)]),
+            _P([(15, 0), (25, 0), (25, 10), (15, 10)]),
+        ],
+        crs="EPSG:2154",
+    )
+
+
+def _overlay_b() -> gpd.GeoDataFrame:
+    from shapely.geometry import Polygon as _P
+
+    return gpd.GeoDataFrame(
+        {"id": [1, 2], "region": ["X", "Y"]},
+        geometry=[
+            _P([(5, -5), (20, -5), (20, 15), (5, 15)]),
+            _P([(8, 2), (12, 2), (12, 8), (8, 8)]),
+        ],
+        crs="EPSG:2154",
+    )
+
+
+def test_overlay_intersection_duckdb_matches_python():
+    a, b = _overlay_a(), _overlay_b()
+    params = {"ref_gdf": b}
+    py = OverlayIntersectionCapability().execute(a.copy(), **params)
+    with DuckDBSession() as eng:
+        sql = OverlayIntersectionCapability().execute_with_context(
+            a, _ctx(eng, a, params)
+        )
+    assert set(sql.columns) == set(py.columns)
+    assert len(sql) == len(py)
+    assert sorted(round(g.area, 6) for g in sql.geometry) == sorted(
+        round(g.area, 6) for g in py.geometry
+    )
+
+
+def test_overlay_intersection_non_default_suffix_falls_back():
+    a, b = _overlay_a(), _overlay_b()
+    params = {"ref_gdf": b, "suffix_left": "_a", "suffix_right": "_b"}
+    py = OverlayIntersectionCapability().execute(a.copy(), **params)
+    with DuckDBSession() as eng:
+        sql = OverlayIntersectionCapability().execute_with_context(
+            a, _ctx(eng, a, params)
+        )
+    assert set(sql.columns) == set(py.columns)
+
+
+def test_erase_duckdb_matches_python():
+    a, b = _overlay_a(), _overlay_b()
+    params = {"ref_gdf": b}
+    py = EraseCapability().execute(a.copy(), **params)
+    with DuckDBSession() as eng:
+        sql = EraseCapability().execute_with_context(a, _ctx(eng, a, params))
+    assert set(sql.columns) == set(py.columns)
+    assert len(sql) == len(py)
+    assert sorted(round(g.area, 6) for g in sql.geometry) == sorted(
+        round(g.area, 6) for g in py.geometry
+    )
+
+
+def test_nearest_neighbor_duckdb_falls_back_to_python():
+    """DuckDB has no <-> operator — the strategy declines, Python runs."""
+    a, b = _overlay_a(), _overlay_b()
+    params = {"ref_gdf": b, "k": 1}
+    py = NearestNeighborCapability().execute(a.copy(), **params)
+    with DuckDBSession() as eng:
+        sql = NearestNeighborCapability().execute_with_context(
+            a, _ctx(eng, a, params)
+        )
+    assert set(sql.columns) == set(py.columns)
+    assert len(sql) == len(py)
+
+
+@_requires_postgis
+def test_nearest_neighbor_postgis_matches_python():
+    from gispulse.persistence.postgis import PostGISConnection
+
+    a, b = _overlay_a(), _overlay_b()
+    params = {"ref_gdf": b, "k": 1}
+    py = NearestNeighborCapability().execute(a.copy(), **params)
+    pg = PostGISConnection(dsn=TEST_DSN)
+    pg.open()
+    try:
+        sql = NearestNeighborCapability().execute_with_context(
+            a, _ctx(pg, a, params)
+        )
+    finally:
+        pg.close()
+    assert set(sql.columns) == set(py.columns)
+    assert len(sql) == len(py)

--- a/tests/integration/test_geometry_pushdown.py
+++ b/tests/integration/test_geometry_pushdown.py
@@ -1,0 +1,163 @@
+"""Result-for-result harness for the geometry SQL push-down (ELT Lot 3, #246).
+
+For each Tier-1 single-layer 1:1 geometry capability equipped with
+DuckDB/PostGIS strategies, this verifies the SQL push-down produces the
+same result as the Python/GeoPandas implementation.
+
+- DuckDB vs Python — runs unconditionally.
+- DuckDB vs PostGIS — runs only when ``GISPULSE_TEST_DSN`` is set.
+
+Also checks that the non-1:1 modes (``by_group`` / ``dissolve``) and a
+non-SQL engine fall back to Python.
+"""
+
+from __future__ import annotations
+
+import os
+
+import geopandas as gpd
+import pytest
+from shapely.geometry import MultiPoint, Polygon
+
+from gispulse.capabilities.strategy import ExecutionContext
+from gispulse.capabilities.vector.boundary import BoundaryCapability
+from gispulse.capabilities.vector.centroid_area import (
+    AreaLengthCapability,
+    CentroidCapability,
+)
+from gispulse.capabilities.vector.concave_hull import ConcaveHullCapability
+from gispulse.capabilities.vector.shape_ops_basic import (
+    ConvexHullCapability,
+    EnvelopeCapability,
+    MakeValidCapability,
+)
+from gispulse.persistence.duckdb_engine import DuckDBSession
+
+TEST_DSN: str | None = os.environ.get("GISPULSE_TEST_DSN")
+_requires_postgis = pytest.mark.skipif(
+    TEST_DSN is None,
+    reason="GISPULSE_TEST_DSN not set — skipping the DuckDB↔PostGIS cross-check",
+)
+
+
+def _polys() -> gpd.GeoDataFrame:
+    return gpd.GeoDataFrame(
+        {"id": [1, 2], "grp": ["a", "b"]},
+        geometry=[
+            Polygon([(0, 0), (4, 0), (4, 4), (0, 4)]),
+            Polygon([(10, 10), (14, 10), (14, 14), (10, 14)]),
+        ],
+        crs="EPSG:2154",
+    )
+
+
+def _cloud() -> gpd.GeoDataFrame:
+    return gpd.GeoDataFrame(
+        {"id": [1]},
+        geometry=[MultiPoint([(0, 0), (4, 0), (4, 4), (0, 4), (2, 2), (1, 3)])],
+        crs="EPSG:2154",
+    )
+
+
+_GEOM_CASES = [
+    (CentroidCapability(), {}, _polys, 1e-6),
+    (BoundaryCapability(), {}, _polys, 1e-6),
+    (ConvexHullCapability(), {}, _polys, 1e-6),
+    (EnvelopeCapability(), {}, _polys, 1e-6),
+    (MakeValidCapability(), {}, _polys, 1e-6),
+    # concave hull — engine vs shapely use different internals; allow slack.
+    (ConcaveHullCapability(), {"ratio": 0.5}, _cloud, 5e-2),
+]
+
+
+def _ctx(engine, gdf, params):
+    return ExecutionContext(engine=engine, feature_count=len(gdf), params=dict(params))
+
+
+def _assert_geom_equivalent(a, b, *, rel_tol, label):
+    assert len(a) == len(b), f"{label}: row count {len(a)} != {len(b)}"
+    ga = sorted(
+        (g for g in a.geometry if g is not None),
+        key=lambda g: (round(g.centroid.x, 3), round(g.centroid.y, 3)),
+    )
+    gb = sorted(
+        (g for g in b.geometry if g is not None),
+        key=lambda g: (round(g.centroid.x, 3), round(g.centroid.y, 3)),
+    )
+    assert len(ga) == len(gb), f"{label}: non-null geometry count differs"
+    for x, y in zip(ga, gb):
+        ref = max(x.area, y.area, 1e-9)
+        sym = x.symmetric_difference(y).area
+        assert sym / ref <= rel_tol, (
+            f"{label}: geometries diverge — sym-diff ratio {sym / ref:.2e}"
+        )
+
+
+@pytest.mark.parametrize(
+    "capability, params, layer, rel_tol",
+    _GEOM_CASES,
+    ids=[c.name for c, _, _, _ in _GEOM_CASES],
+)
+def test_duckdb_geometry_pushdown_matches_python(capability, params, layer, rel_tol):
+    gdf = layer()
+    py = capability.execute(gdf.copy(), **params)
+    with DuckDBSession() as eng:
+        sql = capability.execute_with_context(gdf, _ctx(eng, gdf, params))
+    _assert_geom_equivalent(sql, py, rel_tol=rel_tol, label=f"{capability.name} duckdb")
+
+
+def test_area_length_duckdb_matches_python():
+    gdf = _polys()
+    py = AreaLengthCapability().execute(gdf.copy())
+    with DuckDBSession() as eng:
+        sql = AreaLengthCapability().execute_with_context(gdf, _ctx(eng, gdf, {}))
+    assert set(sql.columns) == set(py.columns)
+    for col in ("area_m2", "length_m"):
+        for s, p in zip(sorted(sql[col]), sorted(py[col])):
+            assert abs(s - p) <= 1e-6 * max(abs(p), 1.0), f"area_length {col} diverges"
+
+
+def test_by_group_falls_back_to_python():
+    """convex_hull with by_group is N:1 — must run the Python path."""
+    gdf = _polys()
+    with DuckDBSession() as eng:
+        result = ConvexHullCapability().execute_with_context(
+            gdf, _ctx(eng, gdf, {"by_group": "grp"})
+        )
+    # one hull per group → 2 rows, grp column retained
+    assert len(result) == 2
+    assert "grp" in result.columns
+
+
+def test_non_sql_engine_uses_python():
+    class _FakeEngine:
+        backend_name = "gpkg"
+
+    gdf = _polys()
+    ctx = ExecutionContext(engine=_FakeEngine(), feature_count=len(gdf), params={})
+    result = CentroidCapability().execute_with_context(gdf, ctx)
+    assert len(result) == 2
+    assert all(g.geom_type == "Point" for g in result.geometry)
+
+
+@_requires_postgis
+@pytest.mark.parametrize(
+    "capability, params, layer, rel_tol",
+    _GEOM_CASES,
+    ids=[c.name for c, _, _, _ in _GEOM_CASES],
+)
+def test_postgis_geometry_pushdown_matches_duckdb(capability, params, layer, rel_tol):
+    from gispulse.persistence.postgis import PostGISConnection
+
+    gdf = layer()
+    with DuckDBSession() as duck:
+        duck_result = capability.execute_with_context(gdf, _ctx(duck, gdf, params))
+    pg = PostGISConnection(dsn=TEST_DSN)
+    pg.open()
+    try:
+        pg_result = capability.execute_with_context(gdf, _ctx(pg, gdf, params))
+    finally:
+        pg.close()
+    _assert_geom_equivalent(
+        duck_result, pg_result, rel_tol=rel_tol, label=f"{capability.name} x-engine"
+    )

--- a/tests/integration/test_sql_dialect_crossengine.py
+++ b/tests/integration/test_sql_dialect_crossengine.py
@@ -1,0 +1,257 @@
+"""Cross-dialect result-for-result harness — ELT Lot 1 (#244).
+
+Verifies that the SQL emitted by ``gispulse.persistence.spatial_queries``
+produces *equal results* across engines for the three SQL-pushed
+geometry operations (``buffer`` / ``clip`` / ``intersects``).
+
+Two axes of comparison, both "result for result":
+
+1. **DuckDB SQL vs the GeoPandas/Shapely reference** — runs
+   unconditionally. This is the always-on correctness gate: it catches a
+   builder regression even when no PostGIS server is around.
+2. **DuckDB SQL vs PostGIS SQL** — runs only when ``GISPULSE_TEST_DSN``
+   points at a live PostGIS, otherwise skipped. This is the genuine
+   cross-engine check.
+
+The harness deliberately drives the engines through the *generated SQL*,
+not the capability strategies, so it tests the dialect layer in
+isolation.
+"""
+
+from __future__ import annotations
+
+import os
+
+import geopandas as gpd
+import pytest
+from shapely.geometry import Point, Polygon
+
+from gispulse.persistence.duckdb_engine import DuckDBSession
+from gispulse.persistence.sql_dialect import get_dialect
+from gispulse.persistence.spatial_queries import (
+    buffer_select,
+    clip_select,
+    intersects_select,
+)
+
+TEST_DSN: str | None = os.environ.get("GISPULSE_TEST_DSN")
+
+_requires_postgis = pytest.mark.skipif(
+    TEST_DSN is None,
+    reason="GISPULSE_TEST_DSN not set — skipping the DuckDB↔PostGIS cross-check",
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — inputs in a metric CRS (EPSG:2154) so buffers stay planar
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def points() -> gpd.GeoDataFrame:
+    return gpd.GeoDataFrame(
+        {"id": [1, 2, 3]},
+        geometry=[
+            Point(652000, 6862000),
+            Point(653000, 6863000),
+            Point(700000, 6900000),
+        ],
+        crs="EPSG:2154",
+    )
+
+
+@pytest.fixture
+def squares() -> gpd.GeoDataFrame:
+    return gpd.GeoDataFrame(
+        {"id": [1, 2]},
+        geometry=[
+            Polygon([(0, 0), (10, 0), (10, 10), (0, 10)]),
+            Polygon([(20, 0), (30, 0), (30, 10), (20, 10)]),
+        ],
+        crs="EPSG:2154",
+    )
+
+
+@pytest.fixture
+def mask() -> gpd.GeoDataFrame:
+    return gpd.GeoDataFrame(
+        geometry=[Polygon([(5, -5), (25, -5), (25, 15), (5, 15)])],
+        crs="EPSG:2154",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Comparison helper
+# ---------------------------------------------------------------------------
+
+
+def _assert_same_geometries(
+    a: gpd.GeoDataFrame,
+    b: gpd.GeoDataFrame,
+    *,
+    rel_tol: float,
+    label: str,
+) -> None:
+    """Assert two result sets hold the same geometries.
+
+    Order-independent: both sides are sorted by centroid. Each geometry
+    pair must agree to within *rel_tol* of its area, measured as the
+    symmetric-difference area ratio — robust for both exact polygon
+    overlay (clip) and faceted curves (buffer), where two engines pick
+    different but equivalent vertex sets.
+    """
+    assert len(a) == len(b), f"{label}: row count {len(a)} != {len(b)}"
+    if len(a) == 0:
+        return
+
+    def _sorted(gdf: gpd.GeoDataFrame) -> list:
+        geoms = list(gdf.geometry)
+        return sorted(geoms, key=lambda g: (round(g.centroid.x, 3), round(g.centroid.y, 3)))
+
+    for ga, gb in zip(_sorted(a), _sorted(b)):
+        ref_area = max(ga.area, gb.area, 1e-9)
+        sym = ga.symmetric_difference(gb).area
+        assert sym / ref_area <= rel_tol, (
+            f"{label}: geometries diverge — symmetric-difference ratio "
+            f"{sym / ref_area:.2e} exceeds {rel_tol:.0e}"
+        )
+
+
+def _registered_table(engine, name: str) -> str:
+    """Return the table name an engine's ``register`` actually creates."""
+    if engine.backend_name == "postgis":
+        # PostGISConnection.register writes to a `_gispulse_tmp_` table.
+        return f"_gispulse_tmp_{name}"
+    return name
+
+
+def _finish(query, gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+    """Apply the same geometry-column promotion the strategies apply."""
+    if query.geom_column in gdf.columns:
+        gdf = gdf.set_geometry(query.geom_column).rename_geometry("geometry")
+    return gdf
+
+
+# ---------------------------------------------------------------------------
+# SQL execution per engine
+# ---------------------------------------------------------------------------
+
+
+def _run_buffer(engine, gdf: gpd.GeoDataFrame, distance: float) -> gpd.GeoDataFrame:
+    engine.register("_input", gdf)
+    q = buffer_select(
+        get_dialect(engine.backend_name),
+        source_table=_registered_table(engine, "_input"),
+        distance=distance,
+    )
+    return _finish(q, engine.sql_to_gdf(q.sql))
+
+
+def _run_intersects(
+    engine, gdf: gpd.GeoDataFrame, ref: gpd.GeoDataFrame
+) -> gpd.GeoDataFrame:
+    engine.register("_is_input", gdf)
+    engine.register("_is_ref", ref)
+    q = intersects_select(
+        get_dialect(engine.backend_name),
+        source_table=_registered_table(engine, "_is_input"),
+        ref_table=_registered_table(engine, "_is_ref"),
+    )
+    return _finish(q, engine.sql_to_gdf(q.sql))
+
+
+def _run_clip(
+    engine, gdf: gpd.GeoDataFrame, mask_gdf: gpd.GeoDataFrame
+) -> gpd.GeoDataFrame:
+    engine.register("_clip_input", gdf)
+    engine.register("_clip_mask", mask_gdf)
+    q = clip_select(
+        get_dialect(engine.backend_name),
+        source_table=_registered_table(engine, "_clip_input"),
+        mask_table=_registered_table(engine, "_clip_mask"),
+    )
+    return _finish(q, engine.sql_to_gdf(q.sql))
+
+
+# ---------------------------------------------------------------------------
+# Axis 1 — DuckDB SQL vs the Shapely reference (always runs)
+# ---------------------------------------------------------------------------
+
+
+class TestDuckDBMatchesShapely:
+    """The generated DuckDB SQL must agree with the GeoPandas reference."""
+
+    def test_buffer(self, points):
+        with DuckDBSession() as eng:
+            sql_result = _run_buffer(eng, points, 100.0)
+        reference = points.copy()
+        reference["geometry"] = points.geometry.buffer(100.0)
+        # Buffer is a curved op: DuckDB and Shapely facet the circle with
+        # a different number of segments (32-gon vs 64-gon), so the tol
+        # is set at the facet-discretization level, not machine epsilon.
+        _assert_same_geometries(
+            sql_result, reference, rel_tol=2e-2, label="buffer"
+        )
+
+    def test_intersects(self, squares, mask):
+        with DuckDBSession() as eng:
+            sql_result = _run_intersects(eng, squares, mask)
+        ref_geom = mask.geometry.union_all()
+        reference = squares[squares.geometry.intersects(ref_geom)]
+        _assert_same_geometries(
+            sql_result, reference, rel_tol=1e-6, label="intersects"
+        )
+
+    def test_clip(self, squares, mask):
+        with DuckDBSession() as eng:
+            sql_result = _run_clip(eng, squares, mask)
+        reference = gpd.clip(squares, mask)
+        _assert_same_geometries(
+            sql_result, reference, rel_tol=1e-6, label="clip"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Axis 2 — DuckDB SQL vs PostGIS SQL (requires GISPULSE_TEST_DSN)
+# ---------------------------------------------------------------------------
+
+
+@_requires_postgis
+class TestDuckDBMatchesPostGIS:
+    """The same builder, run on both SQL engines, must agree result-for-result."""
+
+    @pytest.fixture
+    def postgis(self):
+        from gispulse.persistence.postgis import PostGISConnection
+
+        engine = PostGISConnection(dsn=TEST_DSN)
+        engine.open()
+        try:
+            yield engine
+        finally:
+            engine.close()
+
+    def test_buffer(self, points, postgis):
+        with DuckDBSession() as duck:
+            duck_result = _run_buffer(duck, points, 100.0)
+        pg_result = _run_buffer(postgis, points, 100.0)
+        # Facet-discretization tolerance — see TestDuckDBMatchesShapely.
+        _assert_same_geometries(
+            duck_result, pg_result, rel_tol=2e-2, label="buffer x-engine"
+        )
+
+    def test_intersects(self, squares, mask, postgis):
+        with DuckDBSession() as duck:
+            duck_result = _run_intersects(duck, squares, mask)
+        pg_result = _run_intersects(postgis, squares, mask)
+        _assert_same_geometries(
+            duck_result, pg_result, rel_tol=1e-6, label="intersects x-engine"
+        )
+
+    def test_clip(self, squares, mask, postgis):
+        with DuckDBSession() as duck:
+            duck_result = _run_clip(duck, squares, mask)
+        pg_result = _run_clip(postgis, squares, mask)
+        _assert_same_geometries(
+            duck_result, pg_result, rel_tol=1e-6, label="clip x-engine"
+        )

--- a/tests/unit/test_sql_dialect.py
+++ b/tests/unit/test_sql_dialect.py
@@ -4,10 +4,17 @@ from __future__ import annotations
 import pytest
 
 from gispulse.persistence.sql_dialect import (
+    BufferStyle,
     DuckDBDialect,
     PostGISDialect,
     SpatiaLiteDialect,
+    UnsupportedInDialect,
     get_dialect,
+)
+from gispulse.persistence.spatial_queries import (
+    buffer_select,
+    clip_select,
+    intersects_select,
 )
 
 
@@ -138,3 +145,217 @@ class TestCrossBackendConsistency:
     def test_name_is_string(self, d):
         assert isinstance(d.name, str)
         assert d.name in ("postgis", "duckdb", "spatialite")
+
+
+# ===========================================================================
+# ELT Lot 1 (#244) — the five audited DuckDB/PostGIS divergences
+# ===========================================================================
+
+
+class TestDivergence1WkbVsNative:
+    """Divergence #1 — registered geometry: WKB blob vs native column."""
+
+    def test_duckdb_lifts_wkb_blob(self):
+        d = DuckDBDialect()
+        assert d.geom_column == "__wkb"
+        assert d.geom_ref() == "ST_GeomFromWKB(__wkb)"
+        assert d.geom_ref(table="i") == "ST_GeomFromWKB(i.__wkb)"
+
+    def test_postgis_casts_native_column(self):
+        d = PostGISDialect()
+        assert d.geom_column == "geometry"
+        assert d.geom_ref() == "geometry::geometry"
+        assert d.geom_ref(table="m") == "m.geometry::geometry"
+
+    def test_geom_ref_rejects_hostile_identifier(self):
+        with pytest.raises(ValueError):
+            DuckDBDialect().geom_ref("__wkb); DROP TABLE x --")
+        with pytest.raises(ValueError):
+            PostGISDialect().geom_ref(table='i" UNION SELECT')
+
+
+class TestDivergence2StyledBuffer:
+    """Divergence #2 — styled ST_Buffer: PostGIS only."""
+
+    def test_default_style_both_dialects(self):
+        assert DuckDBDialect().st_buffer_styled("g", 100.0) == "ST_Buffer(g, 100.0)"
+        assert PostGISDialect().st_buffer_styled("g", 100.0) == "ST_Buffer(g, 100.0)"
+
+    def test_negative_distance_is_erosion(self):
+        assert DuckDBDialect().st_buffer_styled("g", -25.0) == "ST_Buffer(g, -25.0)"
+
+    def test_styled_postgis_emits_style_string(self):
+        style = BufferStyle(quad_segs=16, cap_style="flat", join_style="mitre")
+        assert PostGISDialect().st_buffer_styled("g", 5.0, style) == (
+            "ST_Buffer(g, 5.0, 'quad_segs=16 endcap=flat join=mitre "
+            "mitre_limit=5.000 side=both')"
+        )
+
+    def test_styled_duckdb_raises(self):
+        with pytest.raises(UnsupportedInDialect):
+            DuckDBDialect().st_buffer_styled("g", 5.0, BufferStyle(quad_segs=16))
+
+    def test_unsupported_is_a_notimplementederror(self):
+        # New callers catch the precise type; legacy callers catching the
+        # broad NotImplementedError keep working.
+        assert issubclass(UnsupportedInDialect, NotImplementedError)
+
+    def test_default_style_object_accepted_by_duckdb(self):
+        assert DuckDBDialect().st_buffer_styled("g", 5.0, BufferStyle()) == (
+            "ST_Buffer(g, 5.0)"
+        )
+
+    def test_capability_flag(self):
+        assert PostGISDialect().supports_styled_buffer is True
+        assert DuckDBDialect().supports_styled_buffer is False
+
+
+class TestBufferStyle:
+    def test_single_sided_renders_left(self):
+        assert "side=left" in BufferStyle(single_sided=True).to_postgis_style()
+        assert "side=both" in BufferStyle().to_postgis_style()
+
+    def test_validates_enums(self):
+        with pytest.raises(ValueError):
+            BufferStyle(cap_style="pointy")
+        with pytest.raises(ValueError):
+            BufferStyle(join_style="weird")
+        with pytest.raises(ValueError):
+            BufferStyle(quad_segs=0)
+
+    def test_is_default_flag(self):
+        assert BufferStyle().is_default is True
+        assert BufferStyle(quad_segs=16).is_default is False
+        assert BufferStyle(single_sided=True).is_default is False
+
+
+class TestDivergence3Knn:
+    """Divergence #3 — KNN <-> operator: PostGIS only."""
+
+    def test_postgis_emits_operator(self):
+        assert PostGISDialect().supports_knn is True
+        assert PostGISDialect().st_knn_distance("a.geom", "b.geom") == (
+            "(a.geom <-> b.geom)"
+        )
+
+    def test_duckdb_raises(self):
+        assert DuckDBDialect().supports_knn is False
+        with pytest.raises(UnsupportedInDialect):
+            DuckDBDialect().st_knn_distance("a", "b")
+
+
+class TestDivergence4Transform:
+    """Divergence #4 — ST_Transform arity / axis order."""
+
+    def test_duckdb_uses_four_arg_always_xy(self):
+        assert DuckDBDialect().st_transform(
+            "g", src_srid=4326, dst_srid=2154
+        ) == "ST_Transform(g, 'EPSG:4326', 'EPSG:2154', always_xy := true)"
+
+    def test_postgis_uses_two_arg_target_srid(self):
+        assert PostGISDialect().st_transform(
+            "g", src_srid=4326, dst_srid=2154
+        ) == "ST_Transform(g, 2154)"
+
+
+class TestDivergence5Coverage:
+    """Divergence #5 — topological coverage capability flag."""
+
+    def test_coverage_flags(self):
+        assert PostGISDialect().supports_coverage is True
+        assert DuckDBDialect().supports_coverage is False
+
+
+@pytest.mark.parametrize("dialect", [DuckDBDialect(), PostGISDialect()])
+def test_intersection_portable_across_sql_engines(dialect):
+    assert dialect.st_intersection("a", "b") == "ST_Intersection(a, b)"
+
+
+# ===========================================================================
+# ELT Lot 1 — statement builders (spatial_queries) — golden SQL
+# ===========================================================================
+
+
+class TestBufferSelect:
+    def test_duckdb_golden(self):
+        # DuckDB derives the geometry via `* REPLACE` so the result keeps
+        # the canonical __wkb name the result decoder keys on.
+        q = buffer_select(DuckDBDialect(), source_table="_input", distance=100.0)
+        assert q.sql == (
+            "SELECT * REPLACE (ST_Buffer(ST_GeomFromWKB(__wkb), 100.0) AS __wkb) "
+            "FROM _input"
+        )
+        assert q.geom_column == "__wkb"
+
+    def test_postgis_golden_with_style(self):
+        q = buffer_select(
+            PostGISDialect(),
+            source_table="_input",
+            distance=100.0,
+            style=BufferStyle(),
+        )
+        assert q.sql == (
+            "SELECT *, ST_Buffer(geometry::geometry, 100.0, "
+            "'quad_segs=8 endcap=round join=round mitre_limit=5.000 side=both') "
+            "AS geometry_buf FROM _input"
+        )
+        assert q.geom_column == "geometry_buf"
+
+
+class TestClipSelect:
+    def test_duckdb_uses_replace_projection(self):
+        q = clip_select(
+            DuckDBDialect(), source_table="_clip_input", mask_table="_clip_mask"
+        )
+        assert q.sql == (
+            "SELECT i.* REPLACE (ST_Intersection(ST_GeomFromWKB(i.__wkb), "
+            "ST_GeomFromWKB(m.__wkb)) AS __wkb) "
+            "FROM _clip_input i, _clip_mask m "
+            "WHERE ST_Intersects(ST_GeomFromWKB(i.__wkb), ST_GeomFromWKB(m.__wkb))"
+        )
+        assert q.geom_column == "__wkb"
+
+    def test_postgis_appends_geometry_clip(self):
+        q = clip_select(
+            PostGISDialect(), source_table="_clip_input", mask_table="_clip_mask"
+        )
+        assert q.sql == (
+            "SELECT i.*, ST_Intersection(i.geometry::geometry, "
+            "m.geometry::geometry) AS geometry_clip "
+            "FROM _clip_input i, _clip_mask m "
+            "WHERE ST_Intersects(i.geometry::geometry, m.geometry::geometry)"
+        )
+        assert q.geom_column == "geometry_clip"
+
+
+class TestIntersectsSelect:
+    def test_duckdb_golden(self):
+        q = intersects_select(
+            DuckDBDialect(), source_table="_is_input", ref_table="_is_ref"
+        )
+        assert q.sql == (
+            "SELECT i.* FROM _is_input i, _is_ref r "
+            "WHERE ST_Intersects(ST_GeomFromWKB(i.__wkb), ST_GeomFromWKB(r.__wkb))"
+        )
+        assert q.geom_column == "__wkb"
+
+    def test_postgis_golden(self):
+        q = intersects_select(
+            PostGISDialect(), source_table="_is_input", ref_table="_is_ref"
+        )
+        assert q.sql == (
+            "SELECT i.* FROM _is_input i, _is_ref r "
+            "WHERE ST_Intersects(i.geometry::geometry, r.geometry::geometry)"
+        )
+        assert q.geom_column == "geometry"
+
+
+@pytest.mark.parametrize("backend", ["duckdb", "postgis"])
+def test_builders_reject_hostile_table_names(backend):
+    d = get_dialect(backend)
+    with pytest.raises(ValueError):
+        buffer_select(d, source_table="x; DROP TABLE t", distance=1.0)
+    with pytest.raises(ValueError):
+        clip_select(d, source_table="ok", mask_table='m"--')
+    with pytest.raises(ValueError):
+        intersects_select(d, source_table="ok", ref_table="r;SELECT")

--- a/tests/unit/test_sql_dialect.py
+++ b/tests/unit/test_sql_dialect.py
@@ -399,3 +399,45 @@ def test_geometry_functions_raise_on_gpkg():
     ):
         with pytest.raises(NotImplementedError):
             call()
+
+
+# ===========================================================================
+# ELT Lot 3b (#246) — aggregating / two-layer / topology divergences
+# ===========================================================================
+
+
+def test_st_difference_and_topology_simplify_spelled_identically():
+    for d in (DuckDBDialect(), PostGISDialect()):
+        assert d.st_difference("a", "b") == "ST_Difference(a, b)"
+        assert d.st_simplify_preserve_topology("g", 0.5) == (
+            "ST_SimplifyPreserveTopology(g, 0.5)"
+        )
+
+
+def test_st_union_agg_diverges_between_dialects():
+    # PostGIS spells the aggregate ST_Union(col); DuckDB needs ST_Union_Agg.
+    assert PostGISDialect().st_union_agg("geom") == "ST_Union(geom)"
+    assert DuckDBDialect().st_union_agg("geom") == "ST_Union_Agg(geom)"
+
+
+def test_st_sym_difference_emulated_on_duckdb():
+    # PostGIS has native ST_SymDifference; DuckDB composes it from
+    # the two one-sided differences via ST_Union.
+    assert PostGISDialect().st_sym_difference("a", "b") == "ST_SymDifference(a, b)"
+    assert DuckDBDialect().st_sym_difference("a", "b") == (
+        "ST_Union(ST_Difference(a, b), ST_Difference(b, a))"
+    )
+
+
+def test_lot3b_methods_raise_on_gpkg():
+    from gispulse.persistence.sql_dialect import get_dialect
+
+    gpkg = get_dialect("gpkg")
+    for call in (
+        lambda: gpkg.st_difference("a", "b"),
+        lambda: gpkg.st_simplify_preserve_topology("g", 1.0),
+        lambda: gpkg.st_union_agg("g"),
+        lambda: gpkg.st_sym_difference("a", "b"),
+    ):
+        with pytest.raises(NotImplementedError):
+            call()

--- a/tests/unit/test_sql_dialect.py
+++ b/tests/unit/test_sql_dialect.py
@@ -359,3 +359,43 @@ def test_builders_reject_hostile_table_names(backend):
         clip_select(d, source_table="ok", mask_table='m"--')
     with pytest.raises(ValueError):
         intersects_select(d, source_table="ok", ref_table="r;SELECT")
+
+
+# ===========================================================================
+# ELT Lot 3 (#246) — single-layer geometry transform spellings
+# ===========================================================================
+
+
+@pytest.mark.parametrize("dialect", [DuckDBDialect(), PostGISDialect()])
+def test_lot3_geometry_functions_spelled_identically(dialect):
+    # DuckDB-spatial and PostGIS share the ST_* spelling for these.
+    assert dialect.st_boundary("g") == "ST_Boundary(g)"
+    assert dialect.st_envelope("g") == "ST_Envelope(g)"
+    assert dialect.st_convex_hull("g") == "ST_ConvexHull(g)"
+    assert dialect.st_make_valid("g") == "ST_MakeValid(g)"
+    assert dialect.st_simplify("g", 0.5) == "ST_Simplify(g, 0.5)"
+    assert dialect.st_is_empty("g") == "ST_IsEmpty(g)"
+
+
+@pytest.mark.parametrize("dialect", [DuckDBDialect(), PostGISDialect()])
+def test_concave_hull_uses_three_arg_form(dialect):
+    # The 2-arg form is rejected by DuckDB-spatial — always emit 3 args.
+    assert dialect.st_concave_hull("g", 0.5) == "ST_ConcaveHull(g, 0.5, false)"
+    assert (
+        dialect.st_concave_hull("g", 0.3, allow_holes=True)
+        == "ST_ConcaveHull(g, 0.3, true)"
+    )
+
+
+def test_geometry_functions_raise_on_gpkg():
+    from gispulse.persistence.sql_dialect import get_dialect
+
+    gpkg = get_dialect("gpkg")
+    for call in (
+        lambda: gpkg.st_boundary("g"),
+        lambda: gpkg.st_convex_hull("g"),
+        lambda: gpkg.st_make_valid("g"),
+        lambda: gpkg.st_simplify("g", 1.0),
+    ):
+        with pytest.raises(NotImplementedError):
+            call()

--- a/tests/unit/test_sql_pushdown.py
+++ b/tests/unit/test_sql_pushdown.py
@@ -1,0 +1,107 @@
+"""Unit tests for the SQL push-down infrastructure (ELT Lot 2, #245).
+
+Covers the pure helpers of ``gispulse.capabilities.sql_pushdown`` —
+identifier quoting, SQL-literal rendering, and the pandas-expression →
+SQL translator, including its rejection of everything outside the
+SQL-pure subset.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+
+from gispulse.capabilities.sql_pushdown import (
+    Untranslatable,
+    qi,
+    sql_literal,
+    translate_expression,
+)
+
+
+# --- qi ---------------------------------------------------------------------
+
+
+def test_qi_quotes_identifier():
+    assert qi("population") == '"population"'
+    assert qi("code_insee") == '"code_insee"'
+    assert qi("__wkb") == '"__wkb"'
+
+
+def test_qi_rejects_embedded_quote_and_empty():
+    with pytest.raises(ValueError):
+        qi('evil" OR 1=1 --')
+    with pytest.raises(ValueError):
+        qi("")
+
+
+# --- sql_literal ------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, "NULL"),
+        (True, "TRUE"),
+        (False, "FALSE"),
+        (42, "42"),
+        (3.5, "3.5"),
+        ("hello", "'hello'"),
+        ("O'Brien", "'O''Brien'"),
+        (dt.date(2026, 5, 19), "'2026-05-19'"),
+    ],
+)
+def test_sql_literal(value, expected):
+    assert sql_literal(value) == expected
+
+
+def test_sql_literal_rejects_unsupported():
+    with pytest.raises(Untranslatable):
+        sql_literal(["a", "b"])
+    with pytest.raises(Untranslatable):
+        sql_literal({"k": "v"})
+
+
+# --- translate_expression — accepted ---------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("expr", "expected"),
+    [
+        ("pop > 100", '"pop" > 100'),
+        ("name == 'Paris'", '"name" = \'Paris\''),
+        ("a != 5", '"a" <> 5'),
+        ("pop / area * 100", '"pop" / "area" * 100'),
+        ("price * 1.5", '"price" * 1.5'),
+        ("a > 1 and b < 2", '"a" > 1 AND "b" < 2'),
+        ("not active", 'NOT "active"'),
+        ("x == true", '"x" = TRUE'),
+        ("(a + b) * 2", '("a" + "b") * 2'),
+        ('label == "x"', '"label" = \'x\''),
+    ],
+)
+def test_translate_expression_accepted(expr, expected):
+    assert translate_expression(expr) == expected
+
+
+# --- translate_expression — rejected ---------------------------------------
+
+
+@pytest.mark.parametrize(
+    "expr",
+    [
+        "name.str.contains('a')",  # attribute access / method call
+        "@threshold > 1",          # injected variable
+        "pop ** 2",                # exponent — not portable
+        "total // 3",              # floor division
+        "col[0]",                  # indexing
+        "abs(value)",              # function call
+        "pop > 1; DROP TABLE t",   # statement break
+        "",                        # empty
+        "`weird col` > 1",         # backtick
+    ],
+)
+def test_translate_expression_rejects(expr):
+    with pytest.raises(Untranslatable):
+        translate_expression(expr)


### PR DESCRIPTION
ELT Lot 3 batch 5 — push-down de `temporal_filter` et `temporal_join` (`strategy='exact'` uniquement).

### Builders
- **temporal_filter** — `WHERE CAST(col AS TIMESTAMP) [>=/>/<=/<] CAST('...' AS TIMESTAMP)`. `invert=True` mirroite la sémantique Python `~mask & times.notna()` (les NULL restent exclus dans les deux sens). Le `CAST` permet de gérer une colonne stockée en VARCHAR (GPKG/CSV non auto-parsés).
- **temporal_join exact** — `LEFT JOIN` sur `CAST(l.left_on AS TIMESTAMP) = CAST(r.right_key AS TIMESTAMP)`. Suffixe `_ref` collision-aware sur les colonnes côté droit. La clé de jointure côté droit est exclue de la projection (Python la `drop` après merge).

### Non livrés
- **temporal_join strategy=backward/forward/nearest** : asof avec `tolerance` (`Timedelta` → INTERVAL SQL) + `by` groupes — divergences DuckDB/PostGIS sur l'arithmétique d'intervalle, parsing de `Timedelta("1h")` → INTERVAL. Reste sur Python.
- **overlay_union** : 3-régions NaN non portablement exprimables (déjà acté Lot 3d).
- **vector_diff** : ETL-strict (Hausdorff row-by-row).

### Tests
5 nouveaux : window, invert NULL-safe, open-end (start seul), join exact, join asof fallback Python.

### Validation
`ruff` clean · 138 tests Lot 1+2+3 verts · 813 tests vector sans régression.

### Bilan #246
**Push-down scope effectivement clos** : 18 capabilities géométriques poussées (Lot 3a-e) + 12 attributaires (Lot 2) = **30 stratégies SQL push-down livrées**. Restent `overlay_union` et `vector_diff` qui restent Python par conception (chacune pour une raison documentée).

PR empilée : main ← #264 ← #279 ← #282 ← #285 ← cette PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)