### PR TITLE
feat(data-pack): regulatory-zoning content type + entry schema — T3

### DIFF
--- a/src/gispulse/core/plugin_model.py
+++ b/src/gispulse/core/plugin_model.py
@@ -215,8 +215,16 @@ class PluginManifest:
 
 # Recognised data-pack content types. Open set — a new content type is a
 # new value and needs no contract change, mirroring the SourceDomain axiom.
+# ``regulatory-zoning`` (T3, #270) ships urban-planning zonage manifests
+# consumed by the data-pack regulatory pack (gispulse-data-regulatory).
 DATA_PACK_CONTENTS: frozenset[str] = frozenset(
-    {"template-pack", "source-catalog", "basemap-pack", "projection-pack"}
+    {
+        "template-pack",
+        "source-catalog",
+        "basemap-pack",
+        "projection-pack",
+        "regulatory-zoning",
+    }
 )
 
 

--- a/src/gispulse/core/regulatory_zoning_entry.py
+++ b/src/gispulse/core/regulatory_zoning_entry.py
@@ -1,0 +1,198 @@
+"""Story T3 (#270) — declarative format for a `regulatory-zoning` data-pack entry.
+
+A ``regulatory-zoning`` ``DataPackManifest`` ships one entry per (country,
+plan-source) combination. The OSS engine validates the shape; the
+country-specific *content* (which endpoint, which typename, which mapping)
+lives in the data-pack itself (``gispulse-data-regulatory``).
+
+Schema (one entry):
+
+::
+
+    - name:            slug, unique within the pack
+      source_country:  ISO-3166-1 alpha-2 (e.g. "FR")
+      protocol:        "wfs" | "ogc_api_features"
+      endpoint:        base URL of the service
+      typename:        collection / typeName
+      crs:             explicit EPSG identifier ("EPSG:4326")
+      mapping:
+        fields:        { zone_code|zone_label|plan_id|plan_date|regulation_ref: source_key }
+        hilucs:        optional { source_value: hilucs_string }
+        hilucs_key:    optional, default "zone_code"
+      bbox:            optional [minx, miny, maxx, maxy]
+      max_features:    optional int
+      regulation:      optional free-form documentation (description, license, refresh)
+
+Only the engine-meaningful fields are validated; ``regulation`` is opaque
+documentation that ships with the pack but is not consumed at fetch time.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+__all__ = [
+    "ZONING_ENTRY_REQUIRED_FIELDS",
+    "ZONING_ENTRY_OPTIONAL_FIELDS",
+    "ZONING_MAPPING_FIELD_TARGETS",
+    "ZONING_VALID_PROTOCOLS",
+    "RegulatoryZoningEntryError",
+    "RegulatoryZoningEntry",
+]
+
+
+ZONING_ENTRY_REQUIRED_FIELDS: tuple[str, ...] = (
+    "name",
+    "source_country",
+    "protocol",
+    "endpoint",
+    "typename",
+    "crs",
+    "mapping",
+)
+
+ZONING_ENTRY_OPTIONAL_FIELDS: tuple[str, ...] = (
+    "bbox",
+    "max_features",
+    "regulation",
+    "auth",
+    "version",
+    "query",
+)
+
+ZONING_VALID_PROTOCOLS: frozenset[str] = frozenset({"wfs", "ogc_api_features"})
+
+# These are the only *fields* a mapping may rename — kept in lockstep with
+# the engine's :data:`gispulse.core.zoning_normalizer.ZONING_ELEMENT_FIELDS`
+# minus the three fields that are not renames (geometry / hilucs_class /
+# source_country). Duplicated here on purpose to keep T3 free of a T2
+# import — the two stories can land independently.
+ZONING_MAPPING_FIELD_TARGETS: frozenset[str] = frozenset(
+    {
+        "zone_code",
+        "zone_label",
+        "plan_id",
+        "plan_date",
+        "regulation_ref",
+    }
+)
+
+
+class RegulatoryZoningEntryError(ValueError):
+    """Raised on a malformed regulatory-zoning entry."""
+
+
+@dataclass(frozen=True)
+class RegulatoryZoningEntry:
+    """One entry of a ``regulatory-zoning`` data pack.
+
+    Frozen + flat: the engine only needs to read it, never mutate it. The
+    ``mapping`` is kept as a plain dict so the data-pack can ship country
+    quirks without the OSS engine releasing a new class shape.
+    """
+
+    name: str
+    source_country: str
+    protocol: str
+    endpoint: str
+    typename: str
+    crs: str
+    mapping: Mapping[str, Any]
+    bbox: tuple[float, float, float, float] | None = None
+    max_features: int | None = None
+    regulation: Mapping[str, Any] = field(default_factory=dict)
+    auth: dict[str, str] | None = None
+    version: str = "2.0.0"
+    query: Mapping[str, str] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> "RegulatoryZoningEntry":
+        """Validate and parse one entry dict from a pack manifest."""
+        if not isinstance(raw, Mapping):
+            raise RegulatoryZoningEntryError(
+                "regulatory-zoning entry must be a mapping, got "
+                f"{type(raw).__name__}"
+            )
+        missing = [k for k in ZONING_ENTRY_REQUIRED_FIELDS if not raw.get(k)]
+        if missing:
+            raise RegulatoryZoningEntryError(
+                f"regulatory-zoning entry missing required fields: {missing}"
+            )
+        unknown = set(raw) - set(
+            ZONING_ENTRY_REQUIRED_FIELDS + ZONING_ENTRY_OPTIONAL_FIELDS
+        )
+        if unknown:
+            raise RegulatoryZoningEntryError(
+                f"regulatory-zoning entry has unknown fields: {sorted(unknown)}"
+            )
+        country = str(raw["source_country"])
+        if len(country) != 2:
+            raise RegulatoryZoningEntryError(
+                f"source_country must be ISO-3166-1 alpha-2, got {country!r}"
+            )
+        protocol = str(raw["protocol"]).lower()
+        if protocol not in ZONING_VALID_PROTOCOLS:
+            raise RegulatoryZoningEntryError(
+                f"protocol must be one of {sorted(ZONING_VALID_PROTOCOLS)}, "
+                f"got {protocol!r}"
+            )
+        crs = str(raw["crs"])
+        if ":" not in crs:
+            raise RegulatoryZoningEntryError(
+                "crs must be an explicit identifier like 'EPSG:4326', "
+                f"got {crs!r}"
+            )
+        mapping = raw["mapping"]
+        if not isinstance(mapping, Mapping):
+            raise RegulatoryZoningEntryError(
+                "mapping must be a mapping, got " f"{type(mapping).__name__}"
+            )
+        fields_ = mapping.get("fields", {})
+        if not isinstance(fields_, Mapping):
+            raise RegulatoryZoningEntryError(
+                "mapping.fields must be a mapping"
+            )
+        bad_targets = set(fields_) - ZONING_MAPPING_FIELD_TARGETS
+        if bad_targets:
+            raise RegulatoryZoningEntryError(
+                f"mapping.fields keys must be ZoningElement targets — got "
+                f"unknown {sorted(bad_targets)}"
+            )
+
+        bbox_raw = raw.get("bbox")
+        bbox: tuple[float, float, float, float] | None = None
+        if bbox_raw is not None:
+            try:
+                pts = tuple(float(x) for x in bbox_raw)
+            except (TypeError, ValueError) as exc:
+                raise RegulatoryZoningEntryError(
+                    f"bbox must be 4 numbers, got {bbox_raw!r}"
+                ) from exc
+            if len(pts) != 4:
+                raise RegulatoryZoningEntryError(
+                    f"bbox must have 4 numbers, got {len(pts)}"
+                )
+            bbox = pts  # type: ignore[assignment]
+
+        max_features = raw.get("max_features")
+        if max_features is not None and not isinstance(max_features, int):
+            raise RegulatoryZoningEntryError(
+                "max_features must be an integer when present"
+            )
+
+        return cls(
+            name=str(raw["name"]),
+            source_country=country.upper(),
+            protocol=protocol,
+            endpoint=str(raw["endpoint"]),
+            typename=str(raw["typename"]),
+            crs=crs,
+            mapping=dict(mapping),
+            bbox=bbox,
+            max_features=max_features,
+            regulation=dict(raw.get("regulation", {}) or {}),
+            auth=raw.get("auth"),
+            version=str(raw.get("version", "2.0.0")),
+            query=dict(raw.get("query", {}) or {}),
+        )

--- a/tests/unit/test_regulatory_zoning_entry.py
+++ b/tests/unit/test_regulatory_zoning_entry.py
@@ -1,0 +1,249 @@
+"""Tests for the regulatory-zoning entry format (story T3, issue #270)."""
+
+from __future__ import annotations
+
+from pathlib import Path  # noqa: F401 — used in type hint of tmp_path
+
+import pytest
+
+from gispulse.core.plugin_model import (
+    DATA_PACK_CONTENTS,
+    DataPackManifest,
+)
+from gispulse.core.regulatory_zoning_entry import (
+    ZONING_ENTRY_REQUIRED_FIELDS,
+    ZONING_VALID_PROTOCOLS,
+    RegulatoryZoningEntry,
+    RegulatoryZoningEntryError,
+)
+
+
+# ---------------------------------------------------------------------------
+# Content type is recognised
+# ---------------------------------------------------------------------------
+
+
+def test_regulatory_zoning_is_a_recognised_content_type() -> None:
+    assert "regulatory-zoning" in DATA_PACK_CONTENTS
+
+
+def test_manifest_with_regulatory_zoning_loads() -> None:
+    raw = {
+        "name": "regulatory-zoning-eu-nw",
+        "content": "regulatory-zoning",
+        "version": "1.0.0",
+        "tier": "pro",
+        "entries": [],
+    }
+    m = DataPackManifest.from_dict(raw)
+    assert m.content == "regulatory-zoning"
+    assert m.tier.value == "pro"
+
+
+# ---------------------------------------------------------------------------
+# Happy path — full FR entry
+# ---------------------------------------------------------------------------
+
+
+def _fr_entry() -> dict:
+    return {
+        "name": "gpu-zone-urba",
+        "source_country": "FR",
+        "protocol": "wfs",
+        "endpoint": "https://data.geopf.fr/wfs/ows",
+        "typename": "wfs_du:zone_urba",
+        "crs": "EPSG:4326",
+        "mapping": {
+            "fields": {
+                "zone_code": "libelle",
+                "zone_label": "libelong",
+                "plan_id": "idurba",
+                "plan_date": "dateappro",
+                "regulation_ref": "nomfic",
+            },
+            "hilucs_key": "zone_code",
+            "hilucs": {
+                "U": "1_PrimaryProduction_Residential",
+                "AU": "1_PrimaryProduction_Residential",
+                "A": "1_PrimaryProduction_Agriculture",
+                "N": "4_OtherUses_NaturalAreas",
+            },
+        },
+        "max_features": 1000,
+        "regulation": {
+            "description": "Plan Local d'Urbanisme",
+            "license": "Etalab 2.0",
+            "refresh_freq": "monthly",
+        },
+    }
+
+
+def test_full_fr_entry_roundtrips() -> None:
+    entry = RegulatoryZoningEntry.from_dict(_fr_entry())
+    assert entry.name == "gpu-zone-urba"
+    assert entry.source_country == "FR"
+    assert entry.protocol == "wfs"
+    assert entry.endpoint == "https://data.geopf.fr/wfs/ows"
+    assert entry.typename == "wfs_du:zone_urba"
+    assert entry.crs == "EPSG:4326"
+    assert entry.mapping["fields"]["zone_code"] == "libelle"
+    assert entry.max_features == 1000
+    assert entry.regulation["license"] == "Etalab 2.0"
+    assert entry.bbox is None  # not provided
+
+
+def test_lowercase_country_is_normalised_to_uppercase() -> None:
+    raw = _fr_entry()
+    raw["source_country"] = "fr"
+    entry = RegulatoryZoningEntry.from_dict(raw)
+    assert entry.source_country == "FR"
+
+
+def test_bbox_accepted_when_4_numbers() -> None:
+    raw = _fr_entry()
+    raw["bbox"] = [2.0, 48.5, 2.6, 49.0]
+    entry = RegulatoryZoningEntry.from_dict(raw)
+    assert entry.bbox == (2.0, 48.5, 2.6, 49.0)
+
+
+# ---------------------------------------------------------------------------
+# Required-field validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("missing", list(ZONING_ENTRY_REQUIRED_FIELDS))
+def test_missing_required_field_rejected(missing: str) -> None:
+    raw = _fr_entry()
+    del raw[missing]
+    with pytest.raises(RegulatoryZoningEntryError, match="required fields"):
+        RegulatoryZoningEntry.from_dict(raw)
+
+
+def test_unknown_field_rejected() -> None:
+    raw = _fr_entry()
+    raw["totally_made_up"] = True
+    with pytest.raises(RegulatoryZoningEntryError, match="unknown fields"):
+        RegulatoryZoningEntry.from_dict(raw)
+
+
+# ---------------------------------------------------------------------------
+# Type validation
+# ---------------------------------------------------------------------------
+
+
+def test_non_mapping_input_rejected() -> None:
+    with pytest.raises(RegulatoryZoningEntryError, match="must be a mapping"):
+        RegulatoryZoningEntry.from_dict(["not", "a", "mapping"])  # type: ignore[arg-type]
+
+
+def test_invalid_country_code_rejected() -> None:
+    raw = _fr_entry()
+    raw["source_country"] = "FRA"
+    with pytest.raises(RegulatoryZoningEntryError, match="alpha-2"):
+        RegulatoryZoningEntry.from_dict(raw)
+
+
+@pytest.mark.parametrize("protocol", ["", "rest", "ogc", "wms"])
+def test_invalid_protocol_rejected(protocol: str) -> None:
+    raw = _fr_entry()
+    raw["protocol"] = protocol
+    with pytest.raises(RegulatoryZoningEntryError, match="protocol"):
+        RegulatoryZoningEntry.from_dict(raw)
+
+
+def test_protocol_is_case_insensitive() -> None:
+    raw = _fr_entry()
+    raw["protocol"] = "WFS"
+    entry = RegulatoryZoningEntry.from_dict(raw)
+    assert entry.protocol == "wfs"
+
+
+def test_crs_must_be_explicit_identifier() -> None:
+    raw = _fr_entry()
+    raw["crs"] = "4326"  # no 'EPSG:' prefix
+    with pytest.raises(RegulatoryZoningEntryError, match="EPSG"):
+        RegulatoryZoningEntry.from_dict(raw)
+
+
+# ---------------------------------------------------------------------------
+# Mapping validation
+# ---------------------------------------------------------------------------
+
+
+def test_mapping_must_be_a_dict() -> None:
+    raw = _fr_entry()
+    raw["mapping"] = "not-a-dict"
+    with pytest.raises(RegulatoryZoningEntryError, match="mapping must be"):
+        RegulatoryZoningEntry.from_dict(raw)
+
+
+def test_mapping_fields_unknown_target_rejected() -> None:
+    raw = _fr_entry()
+    raw["mapping"]["fields"]["geometry"] = "geom"  # not a renameable target
+    with pytest.raises(
+        RegulatoryZoningEntryError, match="ZoningElement targets"
+    ):
+        RegulatoryZoningEntry.from_dict(raw)
+
+
+def test_mapping_can_be_minimal_with_just_fields() -> None:
+    raw = _fr_entry()
+    raw["mapping"] = {"fields": {"zone_code": "code"}}
+    entry = RegulatoryZoningEntry.from_dict(raw)
+    assert entry.mapping["fields"] == {"zone_code": "code"}
+
+
+# ---------------------------------------------------------------------------
+# bbox + max_features tolerance
+# ---------------------------------------------------------------------------
+
+
+def test_bbox_with_3_numbers_rejected() -> None:
+    raw = _fr_entry()
+    raw["bbox"] = [1, 2, 3]
+    with pytest.raises(RegulatoryZoningEntryError, match="4 numbers"):
+        RegulatoryZoningEntry.from_dict(raw)
+
+
+def test_bbox_with_garbage_rejected() -> None:
+    raw = _fr_entry()
+    raw["bbox"] = ["one", "two", "three", "four"]
+    with pytest.raises(RegulatoryZoningEntryError, match="bbox"):
+        RegulatoryZoningEntry.from_dict(raw)
+
+
+def test_max_features_must_be_int_when_present() -> None:
+    raw = _fr_entry()
+    raw["max_features"] = "1000"
+    with pytest.raises(RegulatoryZoningEntryError, match="max_features"):
+        RegulatoryZoningEntry.from_dict(raw)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end via DataPackManifest — a real pack manifest validates entry-by-entry
+# ---------------------------------------------------------------------------
+
+
+def test_pack_manifest_with_entries_keeps_them_as_raw_dicts(tmp_path: Path) -> None:
+    """T3 contract: DataPackManifest holds entries as opaque dicts; the
+    data-pack consumer validates entries via RegulatoryZoningEntry.from_dict
+    on demand. This decouples pack format evolution from manifest loading."""
+    raw = {
+        "name": "regulatory-zoning-eu-nw",
+        "content": "regulatory-zoning",
+        "version": "1.0.0",
+        "tier": "pro",
+        "entries": [_fr_entry()],
+    }
+    m = DataPackManifest.from_dict(raw)
+    assert len(m.entries) == 1
+    # opaque on the manifest side
+    assert m.entries[0]["typename"] == "wfs_du:zone_urba"
+    # validates cleanly on demand
+    entry = RegulatoryZoningEntry.from_dict(m.entries[0])
+    assert entry.source_country == "FR"
+
+
+def test_protocols_list_is_two_only() -> None:
+    """Defensive: keep the protocol surface small until a real need appears."""
+    assert ZONING_VALID_PROTOCOLS == {"wfs", "ogc_api_features"}


### PR DESCRIPTION
Implements story **T3** of EPIC #265 (Regulatory data-packs, M1) — the
declarative format the regulatory data-pack uses to describe one zoning
source per (country, plan-source).

## What

Two pieces:

- `DATA_PACK_CONTENTS` learns `"regulatory-zoning"` so a manifest of
  that content type is recognised by ExtensionHub's discovery and the
  G1a (#271) signature gate without any further change;
- `gispulse.core.regulatory_zoning_entry`:
  - `RegulatoryZoningEntry` frozen dataclass;
  - `RegulatoryZoningEntry.from_dict(raw)` validates required fields,
    rejects unknown fields (typo-safe), enforces ISO-3166-1 alpha-2 for
    `source_country`, normalises country to upper-case, requires explicit
    `EPSG:` CRS, only allows ZoningElement targets in `mapping.fields`,
    requires `bbox` to be exactly 4 numbers, requires `max_features` to
    be int.

## Entry shape (example FR)

```yaml
- name: gpu-zone-urba
  source_country: FR
  protocol: wfs
  endpoint: https://data.geopf.fr/wfs/ows
  typename: wfs_du:zone_urba
  crs: EPSG:4326
  mapping:
    fields:
      zone_code: libelle
      zone_label: libelong
      plan_id: idurba
      plan_date: dateappro
      regulation_ref: nomfic
    hilucs_key: zone_code
    hilucs:
      U: 1_PrimaryProduction_Residential
      AU: 1_PrimaryProduction_Residential
      A: 1_PrimaryProduction_Agriculture
      N: 4_OtherUses_NaturalAreas
  max_features: 1000
  regulation:
    description: "Plan Local d'Urbanisme"
    license: "Etalab 2.0"
    refresh_freq: monthly
```

## Design

`DataPackManifest.entries` stays a list of *opaque* dicts on the
manifest side; entries are validated **on demand** via
`RegulatoryZoningEntry.from_dict`. The pack format can evolve without
changing the manifest loader.

T3 deliberately keeps the small list of valid mapping targets local to
this module (duplicated from `zoning_normalizer.ZONING_ELEMENT_FIELDS`)
so T2 (#268) and T3 can land in any order. A follow-up consolidates
once both are on `main`.

## Acceptance criteria (from #270)

- [x] `regulatory-zoning` is a recognised data-pack content type.
- [x] An entry has a stable validated shape with explicit failures
      pointing at the missing/unknown field.
- [x] The OSS engine validates the shape; the data-pack ships the
      country-specific *content* (which mapping, which HILUCS table).

## Tests

21 new unit cases in `tests/unit/test_regulatory_zoning_entry.py`.
Existing `test_data_pack_regime` (13) stays green. Local run: 42 passed.

## Out of scope

- Country mapping tables (live in `gispulse-data-regulatory`, stories
  P-FR / P-DK / P-NL).
- `worldwide_catalog.yml` entry that surfaces regulatory packs in the
  worldwide aggregator — clean follow-up, the engine surface is settled
  in this PR.
- Helper that turns an entry into a fetch call — composes T1 (#267) +
  T2 (#268) and lives naturally in the data-pack itself.

Refs: #265 (EPIC), #270 (story), #275 (REL-J5).

Signed-off-by: Marco <simon.ducournau@gmail.com>