### PR TITLE
docs(release): 2.0.0 CHANGELOG entry + 1.x → 2.0 migration guide — REL-NOTES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,124 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0]
+
+The first **major** release. Numerically it's a jump from `1.6.2`, but in
+practice the API surface is the same as `1.7.0` / `1.8.0` / `1.9.0` —
+features that accumulated on `main` without ever being published to
+PyPI. We promote the whole stack in one tag and reset the public version
+to match the product story.
+
+Three threads converge here:
+
+1. **Foundations** (was tagged internally `v1.8.0`) — `gispulse.*`
+   mono-package, `ExtensionHub` replacing `PluginHub`, `GISPulseApp`
+   façade, full MCP server, data-pack regime, CLI / HTTP / template
+   routers.
+2. **Worldwide aggregator** (was tagged internally `v1.9.0`) — lazy
+   DuckDB-backed fetcher network covering 4 protocol families
+   (`GeoParquetS3`, `OGCFeatures`, `STAC`, `HttpFile`) and a curated
+   `worldwide_catalog.yml` listing France / EU / world data sources.
+3. **Data-pack rails** — the first *third-party* data-packs can now ship
+   on PyPI: a discovery channel via the `gispulse.data_packs` entry-point,
+   an Ed25519 signature gate on EXTERNAL manifests, and a shared licence
+   payload format that also covers the future SaaS tenant licence.
+
+The full migration path is in [`MIGRATION-2.0.md`](MIGRATION-2.0.md). The
+short version: **no application code change is strictly required** — the
+`_compat.py` meta-path shim absorbs the import-path move and the
+`PluginHub` rename keeps a working alias until 2.1.
+
+### Added
+
+- **Data-pack regime — PyPI discovery channel (T5).** A third channel
+  alongside the bundled OSS manifests and `GISPULSE_DATA_PACKS_DIR`: a
+  Python entry-point group `gispulse.data_packs` lets a third-party
+  package register its manifests at install time. One bad pack never
+  locks out the others (every failure path is isolated and logged).
+  (#269)
+- **Data-pack regime — Ed25519 signature gate (G1a).** `DataPackManifest`
+  gains an optional `signature` field. An EXTERNAL manifest carrying a
+  signature is verified against the public key in
+  `GISPULSE_DATA_PACK_PUBLIC_KEY` before being registered; tampered or
+  foreign-signed manifests are dropped with explicit log events
+  (`data_pack_signature_invalid`,
+  `data_pack_signature_no_public_key`). INTERNAL (bundled) manifests
+  are exempt — the OSS tree is the source of truth. Unsigned EXTERNAL
+  packs are admitted by default (rollout-friendly); set
+  `GISPULSE_DATA_PACK_REQUIRE_SIGNATURE=true` to refuse them. (#271)
+- **Unified Ed25519 licence payload format (L0).** New
+  `gispulse.core.licence_format` defines the single payload schema
+  shared by the per-machine licence key (Mode A), the future SaaS
+  tenant licence (Mode B) and the data-pack manifest signature.
+  Versioned via `schema_version`, forward-compat (unknown fields land
+  in `LicencePayload.extra`, never crash an older verifier),
+  canonicalised JSON (sort-keys, compact, UTF-8) so bytes-to-sign are
+  stable across runs and Python versions. (#266)
+- **High-level OGC client for data packs (T1).** New
+  `gispulse.core.fetchers.ogc_client.fetch_features(...)` — a one-liner
+  any data-pack can use without building an `AccessSpec`. Thin layer
+  over the consolidated transport: argument normalisation, WFS vs OGC
+  API Features dispatch, **typed network-error surface**
+  (`OGCEndpointUnreachable`, `OGCClientError`) so callers don't depend
+  on httpx classes. (#267)
+- **Declarative ZoningElement normaliser (T2).** New
+  `gispulse.core.zoning_normalizer` maps heterogeneous source records
+  into a common 8-field schema (`geometry, zone_code, zone_label,
+  hilucs_class, plan_id, plan_date, regulation_ref, source_country`)
+  inspired by INSPIRE PlannedLandUse. `ZoningMapping` is a flat
+  declarative `{target -> source_key}` table plus an optional
+  best-effort HILUCS lookup. CRS is mandatory and must be explicit
+  (`EPSG:XXXX`). HILUCS misses leave the column `None`, never crash
+  the batch. (#268)
+- **`regulatory-zoning` data-pack content type (T3).** New value in
+  `DATA_PACK_CONTENTS` so a manifest of that type is recognised by the
+  discovery and signature gate. New `RegulatoryZoningEntry` dataclass
+  + `from_dict()` validator: required-field set, no unknown fields,
+  ISO-3166-1 alpha-2 country, known protocol, explicit `EPSG:` CRS,
+  bbox 4-numbers. `DataPackManifest.entries` stays a list of opaque
+  dicts — entries are validated on demand so the pack format can
+  evolve without changing the manifest loader. (#270)
+
+### Changed
+
+- **`PluginHub` renamed to `ExtensionHub`.** The class lives in the
+  same module (`gispulse.core.plugin_hub`); a `PluginHub = ExtensionHub`
+  alias preserves existing imports. The alias is scheduled for removal
+  in **2.1.0**. The data-pack regime (`_discover_data_packs`) is wired
+  into both bundled discovery and the new PyPI channel.
+- **`gispulse.core.plugin_contracts` public surface frozen via
+  `__all__`.** The 8 symbols actually exported by the 1.6.2 wheel are
+  gelled with an explicit `__all__` and an anti-regression test. The
+  types that moved to `plugin_model.py` during the consolidation
+  (`Tier`, `PluginManifest`, `DataPackManifest`, …) were never in
+  `plugin_contracts` in 1.6.2 — no compat shim is needed.
+- **`_compat.py` deprecation horizon corrected.** The docstring and
+  `DeprecationWarning` message had carried over a stale "removed in
+  1.9.0" line; both now correctly point at **2.1.0**, in step with
+  the release plan.
+
+### Fixed
+
+- **`security-audit` job — silence two disputed upstream advisories.**
+  `pip-audit` was failing on `joblib` PYSEC-2024-277 (disputed by
+  upstream, only triggered when loading untrusted cache content) and
+  `pyjwt` PYSEC-2025-183 (disputed by upstream, the key length is
+  chosen by the application, not the library). Both are added to the
+  `--ignore-vuln` allowlist with a re-evaluation note. No code change.
+
+### Migration
+
+See [`MIGRATION-2.0.md`](MIGRATION-2.0.md). TL;DR:
+
+- imports under top-level `core.*`, `capabilities.*`, `rules.*`,
+  `orchestration.*`, `persistence.*`, `catalog.*` continue to work via
+  the `_compat.py` meta-path shim with a one-time `DeprecationWarning`;
+- `PluginHub` continues to work via the `PluginHub = ExtensionHub`
+  alias;
+- both will be removed in **2.1.0** — migrate to `gispulse.*` /
+  `ExtensionHub` at your leisure.
+
 ## [1.7.0]
 
 The "Wiring the ETL platform" release. EPIC #175 (PR #189) landed the unified plugin model as a *skeleton*; v1.7.0 makes it work end to end — a data source can be declared, fetched over the network through a protocol registry, and watched for freshness so an external revision fires a trigger. GISPulse gains an "Extract" stage alongside its existing local-CDC triggers.

--- a/MIGRATION-2.0.md
+++ b/MIGRATION-2.0.md
@@ -1,0 +1,128 @@
+# Migration guide — `gispulse` 1.x → 2.0
+
+`gispulse 2.0.0` is the first major release since `1.6.2`. The version
+bump packages three threads that accumulated on `main` without ever
+hitting PyPI (`Foundations` v1.8.0, `worldwide aggregator` v1.9.0, and
+the new data-pack rails); see [`CHANGELOG.md`](CHANGELOG.md) for the
+full list. This document focuses on **what callers need to know to
+upgrade**.
+
+## TL;DR — almost nothing
+
+The two real API changes (`gispulse.*` package layout and
+`PluginHub → ExtensionHub` rename) are both **shimmed**, so a working
+1.x project will keep working under 2.0 without any code change. You
+will see one `DeprecationWarning` per stale import root the first time
+the process imports from it.
+
+Both shims are scheduled for removal in **2.1.0**.
+
+## What changed (and what didn't)
+
+| Change | Severity | Shim until 2.1.0 | Action |
+|---|---|---|---|
+| Imports `core.*`, `capabilities.*`, `rules.*`, `orchestration.*`, `persistence.*`, `catalog.*` moved under `gispulse.*` | **soft** | ✅ meta-path redirect + one `DeprecationWarning` | optional — rename imports at your leisure |
+| `core.plugin_hub.PluginHub` renamed to `ExtensionHub` | **soft** | ✅ `PluginHub = ExtensionHub` alias | optional — rename at your leisure |
+| Top-level `viewer/` package removed | cosmetic | n/a (the package was empty in 1.6.2) | none |
+| `PROTOCOL_VERSION` bumped `"1.0"` → `"1.1"` | non-breaking | n/a | none — `_check_protocol_version` is warn-only since #182 |
+| `gispulse.core.plugin_contracts` symbols (`Tier`, `PluginManifest`, …) | non-breaking | n/a | none — these were **never** in `plugin_contracts` in 1.6.2, they live in `plugin_model` |
+
+The CLI, the HTTP routers, `triggers.yaml`, and every published
+dependency bound are **unchanged** between 1.6.2 and 2.0.0 (verified
+against the published wheel).
+
+## Renaming imports — when you're ready
+
+```diff
+- from core.plugin_hub import PluginHub
++ from gispulse.core.plugin_hub import ExtensionHub
+```
+
+```diff
+- from capabilities.vector import calculate
++ from gispulse.capabilities.vector import calculate
+```
+
+```diff
+- from rules.evaluator import evaluate
++ from gispulse.rules.evaluator import evaluate
+```
+
+Any qualified import under the legacy top-level packages (`core`,
+`capabilities`, `rules`, `orchestration`, `persistence`, `catalog`) is
+covered by the meta-path shim in `gispulse/_compat.py`. The shim emits
+`DeprecationWarning` once per root the first time the process touches
+it, so you can `grep` your test logs for `_compat` to find what's still
+on the old name.
+
+## Data-pack ecosystem — new and opt-in
+
+`gispulse 2.0.0` opens the door to third-party data packs distributed
+via PyPI. Three pieces matter for integrators:
+
+### `gispulse.data_packs` entry-point
+
+Third-party packages register their manifests through an entry-point
+group:
+
+```toml
+# pyproject.toml of a data-pack package
+[project.entry-points."gispulse.data_packs"]
+my_pack = "my_pack._gispulse_entry:manifest_paths"
+```
+
+```python
+# my_pack/_gispulse_entry.py
+from importlib.resources import files
+
+
+def manifest_paths():
+    return [files("my_pack") / "manifests" / "zoning.yml"]
+```
+
+The callable may return either a single path-like or an iterable of
+path-likes (`str` is **not** iterated char-by-char). One bad pack never
+locks out the others.
+
+### Manifest signature (Ed25519)
+
+A pack manifest may carry a `signature` field — the base64-URL Ed25519
+signature of the canonical JSON of the manifest **without** that field.
+Verification key configuration:
+
+```bash
+# Base64 DER of the Ed25519 public key.
+export GISPULSE_DATA_PACK_PUBLIC_KEY="MCowBQYD..."
+# Optional strict mode — refuse unsigned EXTERNAL manifests.
+export GISPULSE_DATA_PACK_REQUIRE_SIGNATURE=true
+```
+
+The bundled OSS manifests (`Origin.INTERNAL`) are exempt — the OSS
+tree is the source of truth. By default unsigned EXTERNAL manifests
+are admitted (rollout-friendly).
+
+### `regulatory-zoning` content type
+
+A new value in `DATA_PACK_CONTENTS` (`"regulatory-zoning"`) describes
+urban-planning zoning sources. See `RegulatoryZoningEntry` for the
+declarative shape and the country-by-country entries shipped by
+`gispulse-data-regulatory`.
+
+## Numbering note — why `2.0.0` and not `1.10.0`
+
+By strict semver the changes above could fit in a `1.10.0`. The
+`2.0.0` bump is a **product-level milestone** for: the consolidated
+package layout, the worldwide aggregator, and the data-pack rails.
+The migration cost stays minimal thanks to the shims listed above.
+
+The shims (`_compat.py` meta-path redirect and the `PluginHub` alias)
+will be removed in **2.1.0**. Renaming your imports any time before
+then is safe.
+
+## Reporting issues
+
+Any unexpected import error, missing symbol, or behaviour change after
+upgrading — please open an issue against
+[`imagodata/gispulse`](https://github.com/imagodata/gispulse/issues)
+with the import path you used in 1.x and the version of `gispulse`
+you're now running.


### PR DESCRIPTION
Implements story **REL-NOTES** of EPIC #265 (Regulatory data-packs, M1).

Frames the upcoming 2.0.0 release as a *major-but-shimmed* bump and
documents the migration path.

## Why this story

The audit found the *real* breaking surface for 2.0.0 is contained to
two changes that are both already shimmed (`gispulse.*` package layout
and `PluginHub → ExtensionHub` rename). The 2.0.0 jump itself is a
product-level milestone — Foundations + worldwide aggregator + data-pack
rails in one tag.

The CHANGELOG and migration guide make that explicit so OSGeo, plugin
authors, and existing CLI users don't read "2.0.0" and assume a 1.x app
will break.

## CHANGELOG additions

- **Added** — L0 (#266), T1 (#267), T2 (#268), T3 (#270), T5 (#269),
  G1a (#271). One paragraph each.
- **Changed** — `PluginHub` rename + alias, `plugin_contracts` `__all__`
  freeze, `_compat.py` docstring fix.
- **Fixed** — disputed `pip-audit` advisories silenced (PR #263).
- **Migration** — TL;DR pointing at the new guide.

## `MIGRATION-2.0.md`

Stand-alone guide. Per-change severity table, what to rename and when,
data-pack ecosystem overview (entry-point, signature env, content
type), the numbering rationale.

## Out of scope

- Updating the release tag itself — story REL-J5 (#275).
- Any further behaviour change beyond what already landed in the
  M1 stack.

Refs: #265 (EPIC), #273 (story), #275 (REL-J5).

Signed-off-by: Marco <simon.ducournau@gmail.com>