### PR TITLE
feat(elt): manifest runner + view/table materialization (Lot 4C, partial #249)

### DIFF
--- a/src/gispulse/capabilities/_attribute_sql.py
+++ b/src/gispulse/capabilities/_attribute_sql.py
@@ -1,0 +1,379 @@
+"""SQL builders for the attribute-only capabilities (ELT Lot 2, #245).
+
+One builder per ``schema`` / ``selection`` capability. Each turns
+``(dialect, gdf, params, tables)`` into a ``SELECT`` statement, or raises
+:class:`~gispulse.capabilities.sql_pushdown.Untranslatable` to defer to
+the Python implementation.
+
+Wiring lives at the bottom of ``schema.py`` / ``selection.py`` /
+``vector/calculate.py`` via :func:`attach_sql_pushdown` — kept out of
+those files so the capability modules stay readable.
+"""
+
+from __future__ import annotations
+
+import geopandas as gpd
+
+from gispulse.capabilities.sql_pushdown import (
+    Untranslatable,
+    attr_columns,
+    qi,
+    sql_literal,
+    translate_expression,
+)
+from gispulse.persistence.sql_dialect import SQLDialect
+
+# --- dtype → SQL type -------------------------------------------------------
+
+# Maps a pandas dtype (as resolved by schema._resolve_dtype) to the SQL
+# column type for each engine.
+_SQL_TYPES: dict[str, dict[str, str]] = {
+    "duckdb": {
+        "int": "BIGINT",
+        "float": "DOUBLE",
+        "string": "VARCHAR",
+        "boolean": "BOOLEAN",
+        "datetime": "TIMESTAMP",
+    },
+    "postgis": {
+        "int": "BIGINT",
+        "float": "DOUBLE PRECISION",
+        "string": "TEXT",
+        "boolean": "BOOLEAN",
+        "datetime": "TIMESTAMP",
+    },
+}
+
+
+def _type_family(resolved_dtype: str) -> str:
+    """Collapse a resolved pandas dtype to a SQL type family."""
+    d = resolved_dtype.lower()
+    if d.startswith("int"):
+        return "int"
+    if d.startswith("float"):
+        return "float"
+    if d in ("string", "object", "str"):
+        return "string"
+    if d in ("boolean", "bool"):
+        return "boolean"
+    if d.startswith("datetime"):
+        return "datetime"
+    raise Untranslatable(f"dtype {resolved_dtype!r} has no SQL type mapping")
+
+
+def _sql_type(dialect: SQLDialect, resolved_dtype: str) -> str:
+    return _SQL_TYPES[dialect.name][_type_family(resolved_dtype)]
+
+
+# --- projection helpers -----------------------------------------------------
+
+
+def _geom_reg(dialect: SQLDialect, gdf: gpd.GeoDataFrame) -> str:
+    """Name of the geometry column in the *registered* table."""
+    if dialect.name == "duckdb":
+        return dialect.geom_column  # always __wkb
+    return gdf.geometry.name  # PostGIS keeps the GeoDataFrame's name
+
+
+def _ordered_projection(
+    dialect: SQLDialect,
+    gdf: gpd.GeoDataFrame,
+    *,
+    rename: dict[str, str] | None = None,
+    drop: set[str] | None = None,
+    keep: set[str] | None = None,
+) -> str:
+    """Build a column projection that preserves the input column order.
+
+    The geometry column is always kept (under its registered name).
+    *rename* / *drop* / *keep* act on attribute columns only.
+    """
+    rename = rename or {}
+    drop = drop or set()
+    geom_name = gdf.geometry.name
+    geom_reg = _geom_reg(dialect, gdf)
+    parts: list[str] = []
+    for col in gdf.columns:
+        if col == geom_name:
+            parts.append(qi(geom_reg))
+            continue
+        if col in drop:
+            continue
+        if keep is not None and col not in keep:
+            continue
+        if col in rename:
+            parts.append(f"{qi(col)} AS {qi(rename[col])}")
+        else:
+            parts.append(qi(col))
+    return ", ".join(parts)
+
+
+# ===========================================================================
+# schema.py builders
+# ===========================================================================
+
+
+def build_select_columns(dialect, gdf, params, tables) -> str:
+    fields = [c for c in (params.get("fields") or []) if c in attr_columns(gdf)]
+    proj = _ordered_projection(dialect, gdf, keep=set(fields))
+    return f"SELECT {proj} FROM {tables['input']}"
+
+
+def build_drop_field(dialect, gdf, params, tables) -> str:
+    geom_name = gdf.geometry.name
+    drop: set[str] = set()
+    for col in params.get("fields") or []:
+        if col == geom_name:
+            raise Untranslatable("drop_field cannot drop the geometry column")
+        if col in attr_columns(gdf):
+            drop.add(col)
+    proj = _ordered_projection(dialect, gdf, drop=drop)
+    return f"SELECT {proj} FROM {tables['input']}"
+
+
+def build_rename_field(dialect, gdf, params, tables) -> str:
+    mapping = params.get("mapping") or {}
+    geom_name = gdf.geometry.name
+    cols = set(attr_columns(gdf))
+    valid: dict[str, str] = {}
+    for old, new in mapping.items():
+        if old == geom_name or new == geom_name:
+            raise Untranslatable("rename_field cannot touch the geometry column")
+        if old not in cols:
+            continue  # ignore_missing default — Python handles errors=raise
+        if new in cols and new != old:
+            raise Untranslatable(f"rename target {new!r} collides")
+        valid[old] = new
+    proj = _ordered_projection(dialect, gdf, rename=valid)
+    return f"SELECT {proj} FROM {tables['input']}"
+
+
+def build_add_field(dialect, gdf, params, tables) -> str:
+    from gispulse.capabilities.schema import _resolve_dtype
+
+    fields = params.get("fields") or []
+    existing = set(gdf.columns)
+    geom_name = gdf.geometry.name
+    additions: list[str] = []
+    for spec in fields:
+        name = spec.get("name", "")
+        if name == geom_name:
+            raise Untranslatable("add_field cannot overwrite the geometry column")
+        if name in existing:
+            # overwrite / skip semantics — leave to Python.
+            raise Untranslatable(f"add_field target {name!r} already exists")
+        sql_type = _sql_type(dialect, _resolve_dtype(spec.get("dtype", "string")))
+        lit = sql_literal(spec.get("default"))
+        additions.append(f"CAST({lit} AS {sql_type}) AS {qi(name)}")
+    if not additions:
+        raise Untranslatable("add_field has no new columns")
+    return f"SELECT *, {', '.join(additions)} FROM {tables['input']}"
+
+
+def build_cast_field(dialect, gdf, params, tables) -> str:
+    from gispulse.capabilities.schema import _resolve_dtype
+
+    casts = params.get("casts") or {}
+    errors = params.get("errors", "raise")
+    if errors == "ignore":
+        raise Untranslatable("cast_field errors='ignore' is not SQL-expressible")
+    if errors == "coerce" and dialect.name != "duckdb":
+        raise Untranslatable("cast_field errors='coerce' needs DuckDB TRY_CAST")
+    cast_fn = "TRY_CAST" if errors == "coerce" else "CAST"
+    geom_name = gdf.geometry.name
+    cols = set(attr_columns(gdf))
+    cast_map: dict[str, str] = {}
+    for col, dtype_spec in casts.items():
+        if col == geom_name:
+            raise Untranslatable("cast_field cannot cast the geometry column")
+        if col not in cols:
+            raise Untranslatable(f"cast_field column {col!r} absent")
+        cast_map[col] = _sql_type(dialect, _resolve_dtype(dtype_spec))
+    parts: list[str] = []
+    for col in gdf.columns:
+        if col == geom_name:
+            parts.append(qi(_geom_reg(dialect, gdf)))
+        elif col in cast_map:
+            parts.append(f"{cast_fn}({qi(col)} AS {cast_map[col]}) AS {qi(col)}")
+        else:
+            parts.append(qi(col))
+    return f"SELECT {', '.join(parts)} FROM {tables['input']}"
+
+
+def build_coalesce_fields(dialect, gdf, params, tables) -> str:
+    sources = params.get("sources") or []
+    target = params.get("target_col", "")
+    cols = set(attr_columns(gdf))
+    for c in sources:
+        if c not in cols:
+            raise Untranslatable(f"coalesce source {c!r} absent")
+    if target in gdf.columns:
+        raise Untranslatable(f"coalesce target {target!r} already exists")
+    coalesced = "COALESCE(" + ", ".join(qi(c) for c in sources) + ")"
+    return f"SELECT *, {coalesced} AS {qi(target)} FROM {tables['input']}"
+
+
+def build_case_when(dialect, gdf, params, tables) -> str:
+    target = params.get("target_col", "")
+    cases = params.get("cases") or []
+    if target in gdf.columns:
+        raise Untranslatable(f"case_when target {target!r} already exists")
+    whens: list[str] = []
+    for case in cases:
+        when = case.get("when", "")
+        if not when:
+            raise Untranslatable("case_when: empty 'when'")
+        cond = translate_expression(when)
+        then = sql_literal(case.get("then"))
+        whens.append(f"WHEN ({cond}) THEN {then}")
+    else_sql = sql_literal(params.get("else_"))
+    case_expr = "CASE " + " ".join(whens) + f" ELSE {else_sql} END"
+    return f"SELECT *, {case_expr} AS {qi(target)} FROM {tables['input']}"
+
+
+def build_attribute_join(dialect, gdf, params, tables) -> str:
+    left_on = params.get("left_on", "")
+    right_on = params.get("right_on") or left_on
+    how = params.get("how", "left")
+    columns = params.get("columns")
+    prefix = params.get("prefix", "")
+    suffix = params.get("suffix", "")
+    ref = params.get("ref_gdf")
+    if ref is None or not left_on:
+        raise Untranslatable("attribute_join missing ref/left_on")
+    if left_on not in gdf.columns:
+        raise Untranslatable(f"attribute_join left_on {left_on!r} absent")
+    if right_on not in getattr(ref, "columns", []):
+        raise Untranslatable(f"attribute_join right_on {right_on!r} absent")
+    if prefix or suffix:
+        for ch in (prefix, suffix):
+            if ch and not all(c.isalnum() or c == "_" for c in ch):
+                raise Untranslatable("attribute_join prefix/suffix not identifier-safe")
+    _JOIN_SQL = {
+        "left": "LEFT JOIN",
+        "right": "RIGHT JOIN",
+        "inner": "INNER JOIN",
+        "outer": "FULL OUTER JOIN",
+    }
+    if how not in _JOIN_SQL:
+        raise Untranslatable(f"attribute_join how={how!r} unsupported")
+
+    ref_attr = [c for c in attr_columns(ref) if c != right_on]
+    if columns:
+        ref_attr = [c for c in ref_attr if c in columns]
+    imported: list[str] = []
+    for c in ref_attr:
+        alias = f"{prefix}{c}{suffix}"
+        if alias in gdf.columns:
+            raise Untranslatable(f"attribute_join column {alias!r} collides")
+        imported.append(f"r.{qi(c)} AS {qi(alias)}")
+    proj = "i.*" + ("" if not imported else ", " + ", ".join(imported))
+    on = f"i.{qi(left_on)} = r.{qi(right_on)}"
+    return (
+        f"SELECT {proj} FROM {tables['input']} i "
+        f"{_JOIN_SQL[how]} {tables['ref']} r ON {on}"
+    )
+
+
+# ===========================================================================
+# selection.py builders
+# ===========================================================================
+
+
+def _order_by_clause(by, ascending, na_position="last") -> str:
+    cols = [by] if isinstance(by, str) else list(by)
+    if isinstance(ascending, bool):
+        asc = [ascending] * len(cols)
+    else:
+        asc = list(ascending)
+        if len(asc) != len(cols):
+            raise Untranslatable("ascending length mismatch")
+    if na_position not in ("first", "last"):
+        raise Untranslatable(f"na_position {na_position!r} invalid")
+    nulls = "NULLS FIRST" if na_position == "first" else "NULLS LAST"
+    terms = [
+        f"{qi(c)} {'ASC' if a else 'DESC'} {nulls}"
+        for c, a in zip(cols, asc)
+    ]
+    return ", ".join(terms)
+
+
+def build_sort(dialect, gdf, params, tables) -> str:
+    by = params.get("by")
+    if not by:
+        raise Untranslatable("sort without 'by' is a no-op")
+    order = _order_by_clause(
+        by, params.get("ascending", True), params.get("na_position", "last")
+    )
+    return f"SELECT * FROM {tables['input']} ORDER BY {order}"
+
+
+def build_top_n(dialect, gdf, params, tables) -> str:
+    n = params.get("n", 10)
+    by = params.get("by")
+    if n is None or n < 0:
+        raise Untranslatable("top_n needs n >= 0")
+    if not by:
+        # head(n) = input order; SQL has no stable input order — defer.
+        raise Untranslatable("top_n without 'by' relies on input order")
+    order = _order_by_clause(by, params.get("ascending", False))
+    return f"SELECT * FROM {tables['input']} ORDER BY {order} LIMIT {int(n)}"
+
+
+def build_deduplicate(dialect, gdf, params, tables) -> str:
+    keys = params.get("keys")
+    keep = params.get("keep", "first")
+    order_by = params.get("order_by")
+    if not keys:
+        raise Untranslatable("deduplicate needs 'keys'")
+    if not order_by:
+        # 'first'/'last' without order_by means input order — not stable in SQL.
+        raise Untranslatable("deduplicate push-down requires 'order_by'")
+    if keep not in ("first", "last"):
+        raise Untranslatable(f"deduplicate keep={keep!r} invalid")
+    key_cols = [keys] if isinstance(keys, str) else list(keys)
+    for c in key_cols:
+        if c not in gdf.columns:
+            raise Untranslatable(f"deduplicate key {c!r} absent")
+    # keep='last' ⇔ reverse the order so row 1 is the last per group.
+    asc = params.get("ascending", True)
+    if keep == "last":
+        if isinstance(asc, bool):
+            asc = not asc
+        else:
+            asc = [not a for a in asc]
+    order = _order_by_clause(order_by, asc)
+    partition = ", ".join(qi(c) for c in key_cols)
+    geom_name = gdf.geometry.name
+    cols = ", ".join(
+        qi(_geom_reg(dialect, gdf)) if c == geom_name else qi(c)
+        for c in gdf.columns
+    )
+    return (
+        f"SELECT {cols} FROM ("
+        f"SELECT *, ROW_NUMBER() OVER (PARTITION BY {partition} "
+        f"ORDER BY {order}) AS _gp_rn FROM {tables['input']}"
+        f") _gp_sub WHERE _gp_rn = 1"
+    )
+
+
+# ===========================================================================
+# vector/calculate.py builder
+# ===========================================================================
+
+
+def build_calculate(dialect, gdf, params, tables) -> str:
+    expressions = params.get("expressions") or {}
+    geom_name = gdf.geometry.name
+    additions: list[str] = []
+    for col_name, expr in expressions.items():
+        if col_name == geom_name:
+            raise Untranslatable("calculate cannot write the geometry column")
+        if col_name in gdf.columns:
+            # Overwriting an existing column would duplicate it under
+            # `SELECT *` — leave that case to the Python implementation.
+            raise Untranslatable(f"calculate target {col_name!r} already exists")
+        additions.append(f"({translate_expression(expr)}) AS {qi(col_name)}")
+    if not additions:
+        raise Untranslatable("calculate has no expressions")
+    return f"SELECT *, {', '.join(additions)} FROM {tables['input']}"

--- a/src/gispulse/capabilities/_geometry_sql.py
+++ b/src/gispulse/capabilities/_geometry_sql.py
@@ -24,6 +24,7 @@ import geopandas as gpd
 from gispulse.capabilities.sql_pushdown import (
     Untranslatable,
     qi,
+    sql_literal,
     translate_expression,
 )
 from gispulse.persistence.sql_dialect import SQLDialect
@@ -487,4 +488,111 @@ def build_erase(dialect, gdf, params, tables) -> str:
         f"SELECT {projection} FROM {tables['input']} "
         f"WHERE {erased} IS NOT NULL "
         f"AND NOT {dialect.st_is_empty(erased)}"
+    )
+
+
+# ===========================================================================
+# ELT Lot 3e (#246) — temporal_filter + temporal_join (exact strategy)
+# ===========================================================================
+
+
+def build_temporal_filter(dialect, gdf, params, tables) -> str:
+    """``temporal_filter`` — WHERE clause on a datetime column.
+
+    The column is cast to ``TIMESTAMP`` so string-typed time columns
+    (common when GPKG / CSV inputs are not auto-parsed) work too.
+    ``invert=True`` flips the keep-window into an exclude-window while
+    still dropping NULL timestamps — matching the Python ``~mask &
+    times.notna()`` semantics.
+    """
+    time_col = params.get("time_col", "")
+    if not time_col:
+        raise Untranslatable("temporal_filter missing time_col")
+    start = params.get("start")
+    end = params.get("end")
+    if start is None and end is None:
+        raise Untranslatable("temporal_filter needs at least start or end")
+    if time_col not in gdf.columns:
+        raise Untranslatable(f"temporal_filter time_col {time_col!r} absent")
+
+    include_start = params.get("include_start", True)
+    include_end = params.get("include_end", True)
+    col_expr = f"CAST({qi(time_col)} AS TIMESTAMP)"
+    clauses: list[str] = []
+    if start is not None:
+        op = ">=" if include_start else ">"
+        clauses.append(
+            f"{col_expr} {op} CAST({sql_literal(str(start))} AS TIMESTAMP)"
+        )
+    if end is not None:
+        op = "<=" if include_end else "<"
+        clauses.append(
+            f"{col_expr} {op} CAST({sql_literal(str(end))} AS TIMESTAMP)"
+        )
+    window = " AND ".join(clauses)
+
+    if params.get("invert", False):
+        # Mirror the Python ``~mask & times.notna()`` — NULL timestamps
+        # are excluded regardless of inversion.
+        where = f"{qi(time_col)} IS NOT NULL AND NOT ({window})"
+    else:
+        where = window
+    return f"SELECT * FROM {tables['input']} WHERE {where}"
+
+
+def build_temporal_join_exact(dialect, gdf, params, tables) -> str:
+    """``temporal_join`` strategy=``exact`` — equality join on a time key.
+
+    Asof strategies (``backward`` / ``forward`` / ``nearest``) defer to
+    Python: they need LATERAL + tolerance INTERVAL arithmetic with
+    enough dialect divergences (tolerance string parsing, ``by`` groups)
+    that the SQL push-down's risk/reward is poor for now.
+    """
+    strategy = params.get("strategy", "backward")
+    if strategy != "exact":
+        raise Untranslatable(
+            f"temporal_join push-down handles strategy='exact' only (got {strategy!r})"
+        )
+    ref = params.get("ref_gdf")
+    left_on = params.get("left_on", "")
+    if ref is None or not left_on:
+        raise Untranslatable("temporal_join missing ref_gdf / left_on")
+    right_on = params.get("right_on") or left_on
+    if left_on not in gdf.columns:
+        raise Untranslatable(f"temporal_join left_on {left_on!r} absent")
+    if right_on not in getattr(ref, "columns", []):
+        raise Untranslatable(f"temporal_join right_on {right_on!r} absent")
+
+    left_geom = gdf.geometry.name
+    left_attrs = [c for c in gdf.columns if c != left_geom]
+    right_geom = (
+        ref.geometry.name if hasattr(ref, "geometry") else None
+    )
+    # The right key is merged into the left's column — Python drops the
+    # right-side copy unconditionally — so we exclude it from the ref
+    # projection in both `same key name` and `different key name` cases.
+    right_attrs = [
+        c for c in ref.columns
+        if c != right_geom and c != right_on
+    ]
+    columns = params.get("columns")
+    if columns is not None:
+        right_attrs = [c for c in right_attrs if c in columns]
+    collisions = set(left_attrs) & set(right_attrs)
+
+    geom_reg = _geom_reg(dialect, gdf)
+    parts: list[str] = [f"l.{qi(c)} AS {qi(c)}" for c in left_attrs]
+    parts.append(f"l.{qi(geom_reg)} AS {qi(geom_reg)}")
+    for col in right_attrs:
+        alias = f"{col}_ref" if col in collisions else col
+        parts.append(f"r.{qi(col)} AS {qi(alias)}")
+
+    on_clause = (
+        f"CAST(l.{qi(left_on)} AS TIMESTAMP) = "
+        f"CAST(r.{qi(right_on)} AS TIMESTAMP)"
+    )
+    return (
+        f"SELECT {', '.join(parts)} "
+        f"FROM {tables['input']} l "
+        f"LEFT JOIN {tables['ref']} r ON {on_clause}"
     )

--- a/src/gispulse/capabilities/_geometry_sql.py
+++ b/src/gispulse/capabilities/_geometry_sql.py
@@ -21,7 +21,11 @@ from __future__ import annotations
 
 import geopandas as gpd
 
-from gispulse.capabilities.sql_pushdown import Untranslatable, qi
+from gispulse.capabilities.sql_pushdown import (
+    Untranslatable,
+    qi,
+    translate_expression,
+)
 from gispulse.persistence.sql_dialect import SQLDialect
 
 
@@ -215,3 +219,111 @@ def build_simplify(dialect, gdf, params, tables) -> str:
     if src is not None:
         geom = dialect.st_transform(geom, src_srid=meters, dst_srid=src)
     return f"SELECT {_replace_geom_projection(dialect, gdf, geom)} FROM {tables['input']}"
+
+
+# ===========================================================================
+# ELT Lot 3c (#246) — dissolve + spatial_join (group-by / two-layer predicate)
+# ===========================================================================
+
+
+def build_dissolve(dialect, gdf, params, tables) -> str:
+    """``dissolve`` — group-by union with ``first`` on the other columns.
+
+    With ``by=col`` the result has one row per distinct ``col`` value; the
+    geometry of each group is ``ST_Union``-aggregated, every other column
+    keeps an arbitrary value via the dialect's ``first_agg``. With
+    ``by=None`` the whole layer collapses into a single row.
+    """
+    by = params.get("by")
+    geom_name = gdf.geometry.name
+    geom_reg = _geom_reg(dialect, gdf)
+    attrs = [c for c in gdf.columns if c != geom_name]
+    union_expr = dialect.st_union_agg(dialect.geom_ref())
+
+    if by:
+        if by not in attrs:
+            raise Untranslatable(f"dissolve by={by!r} absent from layer")
+        others = [c for c in attrs if c != by]
+        selects = [qi(by), f"{union_expr} AS {qi(geom_reg)}"]
+        for col in others:
+            selects.append(f"{dialect.first_agg(qi(col))} AS {qi(col)}")
+        return (
+            f"SELECT {', '.join(selects)} FROM {tables['input']} "
+            f"GROUP BY {qi(by)}"
+        )
+    # Whole-layer dissolve — one row, no GROUP BY.
+    selects = [f"{union_expr} AS {qi(geom_reg)}"]
+    for col in attrs:
+        selects.append(f"{dialect.first_agg(qi(col))} AS {qi(col)}")
+    return f"SELECT {', '.join(selects)} FROM {tables['input']}"
+
+
+_SJOIN_HOWS = {"inner": "INNER JOIN", "left": "LEFT JOIN", "right": "RIGHT JOIN"}
+_SJOIN_PREDICATES = {
+    "intersects": "st_intersects",
+    "within": "st_within",
+    "contains": "st_contains",
+}
+
+
+def build_spatial_join(dialect, gdf, params, tables) -> str:
+    """``spatial_join`` — keep left attrs+geom, attach right attrs on predicate.
+
+    Reproduces GeoPandas ``sjoin`` column naming: collisions on attribute
+    names get the ``_left`` / ``_right`` suffix; the geometry stays from
+    the left side. ``columns`` restricts which right-side attributes are
+    imported, ``ref_filter`` is translated to a ``WHERE`` clause via the
+    Lot 2 expression translator (declines to Python if non-translatable).
+    """
+    ref = params.get("ref_gdf")
+    if ref is None:
+        raise Untranslatable("spatial_join missing ref_gdf")
+    if gdf.crs is not None and ref.crs is not None and gdf.crs != ref.crs:
+        raise Untranslatable(
+            "spatial_join: CRS mismatch — Python reprojects, SQL does not"
+        )
+    how = params.get("how", "inner")
+    if how not in _SJOIN_HOWS:
+        raise Untranslatable(f"spatial_join how={how!r} unsupported")
+    predicate = params.get("predicate", "intersects")
+    if predicate not in _SJOIN_PREDICATES:
+        raise Untranslatable(f"spatial_join predicate={predicate!r} unsupported")
+
+    left_geom = gdf.geometry.name
+    left_attrs = [c for c in gdf.columns if c != left_geom]
+    right_geom = ref.geometry.name
+    right_attrs = [c for c in ref.columns if c != right_geom]
+    columns = params.get("columns")
+    if columns is not None:
+        right_attrs = [c for c in right_attrs if c in columns]
+    collisions = set(left_attrs) & set(right_attrs)
+
+    geom_reg = _geom_reg(dialect, gdf)
+    parts: list[str] = []
+    for col in left_attrs:
+        alias = f"{col}_left" if col in collisions else col
+        parts.append(f"l.{qi(col)} AS {qi(alias)}")
+    parts.append(f"l.{qi(geom_reg)} AS {qi(geom_reg)}")
+    for col in right_attrs:
+        alias = f"{col}_right" if col in collisions else col
+        parts.append(f"r.{qi(col)} AS {qi(alias)}")
+
+    pred_method = getattr(dialect, _SJOIN_PREDICATES[predicate])
+    on_clause = pred_method(
+        dialect.geom_ref(table="l"), dialect.geom_ref(table="r")
+    )
+
+    ref_filter = params.get("ref_filter")
+    if ref_filter:
+        # translate_expression raises Untranslatable for anything outside
+        # the SQL-pure subset → caller falls back to Python.
+        filter_sql = translate_expression(ref_filter)
+        ref_source = f"(SELECT * FROM {tables['ref']} WHERE {filter_sql}) r"
+    else:
+        ref_source = f"{tables['ref']} r"
+
+    return (
+        f"SELECT {', '.join(parts)} "
+        f"FROM {tables['input']} l "
+        f"{_SJOIN_HOWS[how]} {ref_source} ON {on_clause}"
+    )

--- a/src/gispulse/capabilities/_geometry_sql.py
+++ b/src/gispulse/capabilities/_geometry_sql.py
@@ -1,0 +1,149 @@
+"""SQL builders for the single-layer 1:1 geometry capabilities (ELT Lot 3, #246).
+
+One builder per Tier-1 geometry capability whose operation is a pure
+*per-feature* geometry transform — ``centroid``, ``boundary``,
+``make_valid``, ``convex_hull``, ``envelope``, ``concave_hull`` — plus
+``area_length`` (geometry untouched, two metric columns added).
+
+Each builder produces a ``SELECT`` that rewrites the geometry column
+in place (under its registered name — ``__wkb`` on DuckDB, ``geometry``
+on PostGIS) so no result post-processing is needed: the engine's own
+decoder rebuilds the GeoDataFrame. Builders raise
+:class:`~gispulse.capabilities.sql_pushdown.Untranslatable` to defer the
+non-1:1 modes (``by_group`` / ``dissolve``) and unsupported options to
+the Python implementation.
+
+Wiring lives at the bottom of the capability modules via
+:func:`attach_sql_pushdown`.
+"""
+
+from __future__ import annotations
+
+import geopandas as gpd
+
+from gispulse.capabilities.sql_pushdown import Untranslatable, qi
+from gispulse.persistence.sql_dialect import SQLDialect
+
+
+def _geom_reg(dialect: SQLDialect, gdf: gpd.GeoDataFrame) -> str:
+    """Name of the geometry column in the *registered* table."""
+    return dialect.geom_column if dialect.name == "duckdb" else gdf.geometry.name
+
+
+def _replace_geom_projection(
+    dialect: SQLDialect, gdf: gpd.GeoDataFrame, geom_expr: str
+) -> str:
+    """Projection that rewrites the geometry column in place, order-preserving.
+
+    Every attribute column is passed through; the geometry slot is
+    replaced by *geom_expr* aliased back to the registered geometry
+    column name — uniform across DuckDB and PostGIS, no ``* REPLACE``.
+    """
+    geom_name = gdf.geometry.name
+    reg = _geom_reg(dialect, gdf)
+    parts: list[str] = []
+    for col in gdf.columns:
+        if col == geom_name:
+            parts.append(f"{geom_expr} AS {qi(reg)}")
+        else:
+            parts.append(qi(col))
+    return ", ".join(parts)
+
+
+def _epsg(crs_spec: str) -> int:
+    """Parse an ``EPSG:nnnn`` string to its integer code."""
+    s = str(crs_spec).strip().upper()
+    if s.startswith("EPSG:"):
+        s = s[5:]
+    try:
+        return int(s)
+    except ValueError:
+        raise Untranslatable(f"crs {crs_spec!r} is not an EPSG code") from None
+
+
+# ===========================================================================
+# Pure 1:1 geometry transforms
+# ===========================================================================
+
+
+def build_centroid(dialect, gdf, params, tables) -> str:
+    expr = dialect.st_centroid(dialect.geom_ref())
+    return f"SELECT {_replace_geom_projection(dialect, gdf, expr)} FROM {tables['input']}"
+
+
+def build_boundary(dialect, gdf, params, tables) -> str:
+    expr = dialect.st_boundary(dialect.geom_ref())
+    sql = f"SELECT {_replace_geom_projection(dialect, gdf, expr)} FROM {tables['input']}"
+    if params.get("drop_empty", True):
+        # A point's boundary is empty — drop those rows like the Python path.
+        sql += f" WHERE {expr} IS NOT NULL AND {dialect.st_is_empty(expr)} = FALSE"
+    return sql
+
+
+def build_make_valid(dialect, gdf, params, tables) -> str:
+    if params.get("keep_geom_type", False):
+        raise Untranslatable("make_valid keep_geom_type is not SQL-expressible")
+    expr = dialect.st_make_valid(dialect.geom_ref())
+    sql = f"SELECT {_replace_geom_projection(dialect, gdf, expr)} FROM {tables['input']}"
+    if params.get("drop_empty", True):
+        sql += f" WHERE {expr} IS NOT NULL AND {dialect.st_is_empty(expr)} = FALSE"
+    return sql
+
+
+def build_convex_hull(dialect, gdf, params, tables) -> str:
+    expr = dialect.st_convex_hull(dialect.geom_ref())
+    return f"SELECT {_replace_geom_projection(dialect, gdf, expr)} FROM {tables['input']}"
+
+
+def build_envelope(dialect, gdf, params, tables) -> str:
+    expr = dialect.st_envelope(dialect.geom_ref())
+    return f"SELECT {_replace_geom_projection(dialect, gdf, expr)} FROM {tables['input']}"
+
+
+def build_concave_hull(dialect, gdf, params, tables) -> str:
+    ratio = params.get("ratio", 0.3)
+    if not (0.0 <= float(ratio) <= 1.0):
+        raise Untranslatable("concave_hull ratio outside [0, 1]")
+    expr = dialect.st_concave_hull(
+        dialect.geom_ref(), ratio, allow_holes=bool(params.get("allow_holes", False))
+    )
+    return f"SELECT {_replace_geom_projection(dialect, gdf, expr)} FROM {tables['input']}"
+
+
+# ===========================================================================
+# area_length — metric columns, geometry untouched
+# ===========================================================================
+
+
+def build_area_length(dialect, gdf, params, tables) -> str:
+    area_col = params.get("area_col", "area_m2")
+    length_col = params.get("length_col", "length_m")
+    compute_area = params.get("compute_area", True)
+    compute_length = params.get("compute_length", True)
+    if not compute_area and not compute_length:
+        raise Untranslatable("area_length computes neither area nor length")
+    if compute_area and area_col in gdf.columns:
+        raise Untranslatable(f"area_length area_col {area_col!r} already exists")
+    if compute_length and length_col in gdf.columns:
+        raise Untranslatable(f"area_length length_col {length_col!r} already exists")
+
+    geom = dialect.geom_ref()
+    if gdf.crs is not None:
+        src = gdf.crs.to_epsg()
+        if src is None:
+            raise Untranslatable("area_length: source CRS has no EPSG code")
+        geom = dialect.st_transform(
+            geom, src_srid=src, dst_srid=_epsg(params.get("crs_meters", "EPSG:3857"))
+        )
+    adds: list[str] = []
+    if compute_area:
+        adds.append(f"ST_Area({geom}) AS {qi(area_col)}")
+    if compute_length:
+        # GeoPandas `.length` is the total 1-D measure: a polygon's
+        # perimeter, a line's length. ST_Length alone returns 0 for
+        # areal geometries, so add ST_Perimeter — the two are mutually
+        # exclusive per geometry, so the sum reproduces `.length`.
+        adds.append(
+            f"(ST_Length({geom}) + ST_Perimeter({geom})) AS {qi(length_col)}"
+        )
+    return f"SELECT *, {', '.join(adds)} FROM {tables['input']}"

--- a/src/gispulse/capabilities/_geometry_sql.py
+++ b/src/gispulse/capabilities/_geometry_sql.py
@@ -147,3 +147,71 @@ def build_area_length(dialect, gdf, params, tables) -> str:
             f"(ST_Length({geom}) + ST_Perimeter({geom})) AS {qi(length_col)}"
         )
     return f"SELECT *, {', '.join(adds)} FROM {tables['input']}"
+
+
+# ===========================================================================
+# ELT Lot 3b (#246) — aggregating / two-layer / CRS geometry capabilities
+# ===========================================================================
+
+
+def build_union(dialect, gdf, params, tables) -> str:
+    """``union`` — dissolve every feature into one geometry (attrs dropped)."""
+    reg = _geom_reg(dialect, gdf)
+    agg = dialect.st_union_agg(dialect.geom_ref())
+    return f"SELECT {agg} AS {qi(reg)} FROM {tables['input']}"
+
+
+def build_reproject(dialect, gdf, params, tables) -> str:
+    """``reproject`` — ST_Transform to a target CRS (CRS re-stamped post-hoc)."""
+    if gdf.crs is None:
+        raise Untranslatable("reproject: source layer has no CRS")
+    src = gdf.crs.to_epsg()
+    if src is None:
+        raise Untranslatable("reproject: source CRS has no EPSG code")
+    dst = _epsg(params.get("target_crs", "EPSG:4326"))
+    expr = dialect.st_transform(dialect.geom_ref(), src_srid=src, dst_srid=dst)
+    return f"SELECT {_replace_geom_projection(dialect, gdf, expr)} FROM {tables['input']}"
+
+
+def reproject_post(result, params):
+    """Stamp the target CRS — the result decoder infers the *source* CRS."""
+    return result.set_crs(params.get("target_crs", "EPSG:4326"), allow_override=True)
+
+
+def build_symmetric_difference(dialect, gdf, params, tables) -> str:
+    """``symmetric_difference`` — A XOR (unioned reference layer), per feature."""
+    ref_union = (
+        f"(SELECT {dialect.st_union_agg(dialect.geom_ref())} FROM {tables['ref']})"
+    )
+    geom = dialect.geom_ref()
+    xor = dialect.st_sym_difference(geom, ref_union)
+    # Empty / null geometries are passed through unchanged, as in Python.
+    expr = (
+        f"CASE WHEN {geom} IS NULL OR {dialect.st_is_empty(geom)} "
+        f"THEN {geom} ELSE {xor} END"
+    )
+    return f"SELECT {_replace_geom_projection(dialect, gdf, expr)} FROM {tables['input']}"
+
+
+def build_simplify(dialect, gdf, params, tables) -> str:
+    """``simplify`` — Douglas-Peucker, in a metric CRS, round-tripped back."""
+    algorithm = params.get("algorithm", "dp")
+    if algorithm != "dp":
+        raise Untranslatable(f"simplify algorithm {algorithm!r} is not SQL-pushable")
+    tol = params.get("tolerance", 1.0)
+    if tol is None or float(tol) <= 0:
+        raise Untranslatable("simplify requires tolerance > 0")
+    geom = dialect.geom_ref()
+    src = gdf.crs.to_epsg() if gdf.crs is not None else None
+    if gdf.crs is not None and src is None:
+        raise Untranslatable("simplify: source CRS has no EPSG code")
+    if src is not None:
+        meters = _epsg(params.get("crs_meters", "EPSG:3857"))
+        geom = dialect.st_transform(geom, src_srid=src, dst_srid=meters)
+    if params.get("preserve_topology", True):
+        geom = dialect.st_simplify_preserve_topology(geom, tol)
+    else:
+        geom = dialect.st_simplify(geom, tol)
+    if src is not None:
+        geom = dialect.st_transform(geom, src_srid=meters, dst_srid=src)
+    return f"SELECT {_replace_geom_projection(dialect, gdf, geom)} FROM {tables['input']}"

--- a/src/gispulse/capabilities/_geometry_sql.py
+++ b/src/gispulse/capabilities/_geometry_sql.py
@@ -327,3 +327,164 @@ def build_spatial_join(dialect, gdf, params, tables) -> str:
         f"FROM {tables['input']} l "
         f"{_SJOIN_HOWS[how]} {ref_source} ON {on_clause}"
     )
+
+
+# ===========================================================================
+# ELT Lot 3d (#246) — nearest_neighbor + overlay (intersection / erase)
+# ===========================================================================
+
+
+def _two_layer_collision_projection(
+    dialect: SQLDialect,
+    left_gdf: gpd.GeoDataFrame,
+    right_gdf: gpd.GeoDataFrame,
+    *,
+    columns: list[str] | None = None,
+    suffix_left: str = "_left",
+    suffix_right: str = "_right",
+    include_left_geom: bool = True,
+) -> tuple[list[str], set[str]]:
+    """Return collision-aware ``l.col AS …`` / ``r.col AS …`` projections.
+
+    Used by ``spatial_join`` / ``nearest_neighbor`` / ``overlay_*``.
+    Returns ``(parts, collisions)`` — *parts* in order: left attrs,
+    optionally left geometry, then right attrs. Geometry of the right
+    side is never included.
+    """
+    left_geom_name = left_gdf.geometry.name
+    right_geom_name = right_gdf.geometry.name
+    left_attrs = [c for c in left_gdf.columns if c != left_geom_name]
+    right_attrs = [c for c in right_gdf.columns if c != right_geom_name]
+    if columns is not None:
+        right_attrs = [c for c in right_attrs if c in columns]
+    collisions = set(left_attrs) & set(right_attrs)
+    geom_reg = _geom_reg(dialect, left_gdf)
+    parts: list[str] = []
+    for col in left_attrs:
+        alias = f"{col}{suffix_left}" if col in collisions else col
+        parts.append(f"l.{qi(col)} AS {qi(alias)}")
+    if include_left_geom:
+        parts.append(f"l.{qi(geom_reg)} AS {qi(geom_reg)}")
+    for col in right_attrs:
+        alias = f"{col}{suffix_right}" if col in collisions else col
+        parts.append(f"r.{qi(col)} AS {qi(alias)}")
+    return parts, collisions
+
+
+def build_nearest_neighbor(dialect, gdf, params, tables) -> str:
+    """``nearest_neighbor`` — 1-NN via PostGIS's ``<->`` operator.
+
+    Push-down restricted to PostGIS (DuckDB has no KNN operator) and the
+    simple case: ``k=1``, no ``max_distance``, both layers in the *same
+    projected CRS*. Everything else defers to Python.
+    """
+    if dialect.name != "postgis":
+        raise Untranslatable("nearest_neighbor push-down needs PostGIS (<-> operator)")
+    ref = params.get("ref_gdf")
+    if ref is None:
+        raise Untranslatable("nearest_neighbor missing ref_gdf")
+    if int(params.get("k", 1)) != 1:
+        raise Untranslatable("nearest_neighbor push-down handles k=1 only")
+    if params.get("max_distance") is not None:
+        raise Untranslatable("nearest_neighbor max_distance not pushable")
+    if gdf.crs is None or ref.crs is None or str(gdf.crs) != str(ref.crs):
+        raise Untranslatable("nearest_neighbor: layers must share a CRS")
+    if getattr(gdf.crs, "is_geographic", False):
+        raise Untranslatable("nearest_neighbor needs a projected CRS for distance")
+
+    distance_col = params.get("distance_col", "nn_distance")
+    parts, _ = _two_layer_collision_projection(
+        dialect, gdf, ref, columns=params.get("columns")
+    )
+    geom_reg = _geom_reg(dialect, gdf)
+    parts.append(
+        f"ST_Distance(l.{qi(geom_reg)}::geometry, r.{qi(geom_reg)}::geometry) "
+        f"AS {qi(distance_col)}"
+    )
+    return (
+        f"SELECT {', '.join(parts)} "
+        f"FROM {tables['input']} l "
+        f"CROSS JOIN LATERAL ("
+        f"SELECT * FROM {tables['ref']} _r "
+        f"ORDER BY l.{qi(geom_reg)}::geometry <-> _r.{qi(geom_reg)}::geometry "
+        f"LIMIT 1"
+        f") r"
+    )
+
+
+def _overlay_collision_parts(
+    dialect: SQLDialect,
+    gdf: gpd.GeoDataFrame,
+    ref: gpd.GeoDataFrame,
+    *,
+    suffix_left: str = "_1",
+    suffix_right: str = "_2",
+) -> list[str]:
+    """Per-pair attribute projection for ``overlay_intersection``.
+
+    Geometry is emitted separately by the caller (overlay rewrites it via
+    ``ST_Intersection``). Only attribute columns are produced here, with
+    GeoPandas's ``_1`` / ``_2`` suffixes on collision.
+    """
+    parts, _ = _two_layer_collision_projection(
+        dialect, gdf, ref,
+        suffix_left=suffix_left,
+        suffix_right=suffix_right,
+        include_left_geom=False,
+    )
+    return parts
+
+
+def build_overlay_intersection(dialect, gdf, params, tables) -> str:
+    """``overlay_intersection`` — pair-wise ``ST_Intersection`` + attr inheritance."""
+    ref = params.get("ref_gdf")
+    if ref is None or len(ref) == 0:
+        raise Untranslatable("overlay_intersection requires a non-empty ref")
+    if params.get("suffix_left", "_1") != "_1" or params.get("suffix_right", "_2") != "_2":
+        raise Untranslatable("overlay_intersection push-down keeps the GeoPandas default suffixes")
+    if gdf.crs is not None and ref.crs is not None and str(gdf.crs) != str(ref.crs):
+        raise Untranslatable("overlay_intersection: CRS mismatch")
+    keep_geom_type = params.get("keep_geom_type", True)
+
+    geom_reg = _geom_reg(dialect, gdf)
+    left_geom = dialect.geom_ref(table="l")
+    right_geom = dialect.geom_ref(table="r")
+    intersection = dialect.st_intersection(left_geom, right_geom)
+    parts = _overlay_collision_parts(dialect, gdf, ref)
+    parts.append(f"{intersection} AS {qi(geom_reg)}")
+
+    where = [dialect.st_intersects(left_geom, right_geom)]
+    where.append(f"NOT {dialect.st_is_empty(intersection)}")
+    if keep_geom_type:
+        # GeoPandas drops fragments whose geometry type differs from the
+        # primary layer's — e.g. a line dropping out of two edge-touching
+        # polygons. Replicate at the row level.
+        where.append(
+            f"{dialect.st_geometry_type(intersection)} = "
+            f"{dialect.st_geometry_type(left_geom)}"
+        )
+    return (
+        f"SELECT {', '.join(parts)} "
+        f"FROM {tables['input']} l, {tables['ref']} r "
+        f"WHERE {' AND '.join(where)}"
+    )
+
+
+def build_erase(dialect, gdf, params, tables) -> str:
+    """``erase`` — left geometry minus the unioned reference geometry."""
+    ref = params.get("ref_gdf")
+    if ref is None or len(ref) == 0:
+        raise Untranslatable("erase requires a non-empty ref")
+    if gdf.crs is not None and ref.crs is not None and str(gdf.crs) != str(ref.crs):
+        raise Untranslatable("erase: CRS mismatch")
+
+    ref_union = (
+        f"(SELECT {dialect.st_union_agg(dialect.geom_ref())} FROM {tables['ref']})"
+    )
+    erased = dialect.st_difference(dialect.geom_ref(), ref_union)
+    projection = _replace_geom_projection(dialect, gdf, erased)
+    return (
+        f"SELECT {projection} FROM {tables['input']} "
+        f"WHERE {erased} IS NOT NULL "
+        f"AND NOT {dialect.st_is_empty(erased)}"
+    )

--- a/src/gispulse/capabilities/overlay.py
+++ b/src/gispulse/capabilities/overlay.py
@@ -244,3 +244,26 @@ def _overlay_schema() -> dict:
             },
         },
     }
+
+
+# ---------------------------------------------------------------------------
+# ELT Lot 3 (#246) — DuckDB / PostGIS SQL push-down strategies
+# ---------------------------------------------------------------------------
+# overlay_intersection and erase push down cleanly; overlay_union stays on
+# Python — its three-region NaN-attribute semantics is not SQL-portable.
+
+from gispulse.capabilities import _geometry_sql as _gsql  # noqa: E402
+from gispulse.capabilities.sql_pushdown import attach_sql_pushdown  # noqa: E402
+
+attach_sql_pushdown(
+    OverlayIntersectionCapability,
+    _gsql.build_overlay_intersection,
+    gate=lambda p: p.get("ref_gdf") is not None,
+    extra_inputs={"ref": "ref_gdf"},
+)
+attach_sql_pushdown(
+    EraseCapability,
+    _gsql.build_erase,
+    gate=lambda p: p.get("ref_gdf") is not None,
+    extra_inputs={"ref": "ref_gdf"},
+)

--- a/src/gispulse/capabilities/schema.py
+++ b/src/gispulse/capabilities/schema.py
@@ -1116,3 +1116,53 @@ def _jsonable(value):
     if isinstance(value, (pd.Timestamp,)):
         return value.isoformat()
     return str(value)
+
+
+# ---------------------------------------------------------------------------
+# ELT Lot 2 (#245) — DuckDB / PostGIS SQL push-down strategies
+# ---------------------------------------------------------------------------
+
+from gispulse.capabilities import _attribute_sql as _asql  # noqa: E402
+from gispulse.capabilities.sql_pushdown import attach_sql_pushdown  # noqa: E402
+
+attach_sql_pushdown(
+    SelectColumnsCapability,
+    _asql.build_select_columns,
+    gate=lambda p: bool(p.get("fields")),
+)
+attach_sql_pushdown(
+    DropFieldCapability,
+    _asql.build_drop_field,
+    gate=lambda p: bool(p.get("fields")),
+)
+attach_sql_pushdown(
+    RenameFieldCapability,
+    _asql.build_rename_field,
+    gate=lambda p: bool(p.get("mapping")),
+)
+attach_sql_pushdown(
+    AddFieldCapability,
+    _asql.build_add_field,
+    gate=lambda p: bool(p.get("fields")),
+)
+attach_sql_pushdown(
+    CastFieldCapability,
+    _asql.build_cast_field,
+    gate=lambda p: bool(p.get("casts")),
+)
+attach_sql_pushdown(
+    CoalesceFieldsCapability,
+    _asql.build_coalesce_fields,
+    gate=lambda p: bool(p.get("sources")) and bool(p.get("target_col")),
+)
+attach_sql_pushdown(
+    CaseWhenCapability,
+    _asql.build_case_when,
+    gate=lambda p: bool(p.get("target_col")) and bool(p.get("cases")),
+)
+attach_sql_pushdown(
+    AttributeJoinCapability,
+    _asql.build_attribute_join,
+    gate=lambda p: p.get("ref_gdf") is not None and bool(p.get("left_on")),
+    extra_inputs={"ref": "ref_gdf"},
+)

--- a/src/gispulse/capabilities/selection.py
+++ b/src/gispulse/capabilities/selection.py
@@ -311,3 +311,27 @@ class TopNCapability(Capability):
             },
             "required": ["n"],
         }
+
+
+# ---------------------------------------------------------------------------
+# ELT Lot 2 (#245) — DuckDB / PostGIS SQL push-down strategies
+# ---------------------------------------------------------------------------
+
+from gispulse.capabilities import _attribute_sql as _asql  # noqa: E402
+from gispulse.capabilities.sql_pushdown import attach_sql_pushdown  # noqa: E402
+
+attach_sql_pushdown(
+    SortCapability,
+    _asql.build_sort,
+    gate=lambda p: bool(p.get("by")),
+)
+attach_sql_pushdown(
+    TopNCapability,
+    _asql.build_top_n,
+    gate=lambda p: bool(p.get("by")),
+)
+attach_sql_pushdown(
+    DeduplicateCapability,
+    _asql.build_deduplicate,
+    gate=lambda p: bool(p.get("keys")) and bool(p.get("order_by")),
+)

--- a/src/gispulse/capabilities/sql_pushdown.py
+++ b/src/gispulse/capabilities/sql_pushdown.py
@@ -231,6 +231,8 @@ def translate_expression(expr: str) -> str:
 SqlBuilder = Callable[[SQLDialect, gpd.GeoDataFrame, dict, dict], str]
 # An optional eligibility gate evaluated on params alone (no frame).
 SqlGate = Callable[[dict], bool]
+# An optional (result, params) -> result hook run on the decoded result.
+SqlPost = Callable[[gpd.GeoDataFrame, dict], gpd.GeoDataFrame]
 
 
 class _SqlPushdownStrategy(ExecutionStrategy):
@@ -244,12 +246,14 @@ class _SqlPushdownStrategy(ExecutionStrategy):
         *,
         gate: SqlGate | None,
         extra_inputs: dict[str, str],
+        post: "SqlPost | None" = None,
     ):
         self._backend = backend
         self._capability = capability
         self._build = build
         self._gate = gate
         self._extra_inputs = extra_inputs  # logical name -> param key
+        self._post = post
         self.mode = _MODE[backend]
 
     def can_execute(self, ctx: ExecutionContext) -> bool:
@@ -276,7 +280,10 @@ class _SqlPushdownStrategy(ExecutionStrategy):
         except Untranslatable as exc:
             log.debug("sql_pushdown_declined", backend=self._backend, reason=str(exc))
             return self._python_fallback(gdf, ctx.params)
-        return engine.sql_to_gdf(sql)
+        result = engine.sql_to_gdf(sql)
+        if self._post is not None:
+            result = self._post(result, ctx.params)
+        return result
 
     def _python_fallback(self, gdf: gpd.GeoDataFrame, params: dict) -> gpd.GeoDataFrame:
         from gispulse.capabilities.base import safe_execute
@@ -295,6 +302,7 @@ def attach_sql_pushdown(
     *,
     gate: SqlGate | None = None,
     extra_inputs: dict[str, str] | None = None,
+    post: "SqlPost | None" = None,
 ) -> None:
     """Wire DuckDB + PostGIS push-down strategies onto a capability class.
 
@@ -309,14 +317,17 @@ def attach_sql_pushdown(
             ``False`` to defer to Python (e.g. required params absent).
         extra_inputs:   Logical-name → param-key map of additional
             GeoDataFrame inputs to register (e.g. ``{"ref": "ref_gdf"}``).
+        post:           Optional ``(result, params) -> result`` hook run on
+            the decoded GeoDataFrame — e.g. ``reproject`` re-stamps the
+            target CRS, which the engine's result decoder cannot infer.
     """
     instance = capability_cls()
     extras = extra_inputs or {}
     capability_cls._strategies = [
         _SqlPushdownStrategy(
-            "postgis", instance, build, gate=gate, extra_inputs=extras
+            "postgis", instance, build, gate=gate, extra_inputs=extras, post=post
         ),
         _SqlPushdownStrategy(
-            "duckdb", instance, build, gate=gate, extra_inputs=extras
+            "duckdb", instance, build, gate=gate, extra_inputs=extras, post=post
         ),
     ]

--- a/src/gispulse/capabilities/sql_pushdown.py
+++ b/src/gispulse/capabilities/sql_pushdown.py
@@ -1,0 +1,322 @@
+"""Shared SQL push-down infrastructure for non-geometric capabilities.
+
+ELT Lot 2 (issue #245, ADR 0005). The ~12 ``schema`` / ``selection``
+capabilities are *attribute-only* — pure ``SELECT`` / ``CAST`` / ``CASE``
+/ ``ORDER BY`` / ``DISTINCT`` / ``LIMIT``, no geometry maths. This module
+gives them a single, generic DuckDB/PostGIS execution strategy so each
+capability only describes *how to build its SELECT*, not how to register
+data, dispatch, or decode the result.
+
+Design — the push-down is **opportunistic**. A strategy declines (and
+the proven Python/GeoPandas implementation runs) when:
+
+- the active engine is neither DuckDB nor PostGIS;
+- a capability-supplied ``gate`` rejects the params (missing required
+  keys, an empty no-op call — handled by Python so the original
+  ``ValueError`` / passthrough semantics are preserved);
+- the builder raises :class:`Untranslatable` (e.g. a ``calculate``
+  expression that leaves the SQL-pure subset).
+
+Correctness never depends on the SQL path. The geometry column is
+carried through untouched — every generated query keeps the dialect's
+registered geometry column (``__wkb`` on DuckDB, ``geometry`` on PostGIS)
+so the engine's own result decoder rebuilds the GeoDataFrame.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+from typing import Callable
+
+import geopandas as gpd
+
+from gispulse.capabilities.strategy import (
+    ExecutionContext,
+    ExecutionStrategy,
+    StrategyMode,
+)
+from gispulse.core.logging import get_logger
+from gispulse.persistence.sql_dialect import SQLDialect, get_dialect
+
+log = get_logger(__name__)
+
+# PostGIS `register` writes to a prefixed temp table — keep in sync with
+# gispulse.persistence.postgis._TMP_PREFIX.
+_POSTGIS_TMP_PREFIX = "_gispulse_tmp_"
+
+_PRIORITY = {"postgis": 100, "duckdb": 80}
+_MODE = {"postgis": StrategyMode.POSTGIS, "duckdb": StrategyMode.DUCKDB}
+
+__all__ = [
+    "Untranslatable",
+    "qi",
+    "attr_columns",
+    "sql_literal",
+    "translate_expression",
+    "attach_sql_pushdown",
+]
+
+
+class Untranslatable(Exception):
+    """Raised by a builder when the operation cannot be expressed in SQL.
+
+    Not an error: :class:`_SqlPushdownStrategy` catches it and runs the
+    capability's Python implementation instead.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Identifier / literal helpers
+# ---------------------------------------------------------------------------
+
+
+def _registered_table(engine, name: str) -> str:
+    """Return the table name an engine's ``register`` actually creates."""
+    if getattr(engine, "backend_name", "") == "postgis":
+        return f"{_POSTGIS_TMP_PREFIX}{name}"
+    return name
+
+
+def qi(identifier: str) -> str:
+    """Quote a SQL identifier (column / table) with double quotes.
+
+    The capability layer constrains identifiers to
+    ``[A-Za-z_][A-Za-z0-9_]{0,62}``; quoting on top neutralises reserved
+    words. A stray double quote is rejected outright.
+    """
+    if not isinstance(identifier, str) or not identifier or '"' in identifier:
+        raise ValueError(f"Unsafe SQL identifier: {identifier!r}")
+    return f'"{identifier}"'
+
+
+def attr_columns(gdf: gpd.GeoDataFrame) -> list[str]:
+    """Return *gdf*'s column names with the active geometry column removed."""
+    geom = gdf.geometry.name if hasattr(gdf, "geometry") else None
+    return [c for c in gdf.columns if c != geom]
+
+
+def _as_registerable(frame) -> gpd.GeoDataFrame:
+    """Coerce a join reference into something the engines can ``register``.
+
+    A non-spatial reference table (``attribute_join`` accepts a plain
+    ``DataFrame``) is wrapped with a throw-away null-geometry column so
+    ``register`` — which assumes a GeoDataFrame — succeeds. The dummy
+    column is never referenced by the generated JOIN.
+    """
+    if isinstance(frame, gpd.GeoDataFrame):
+        return frame
+    return gpd.GeoDataFrame(
+        frame.copy(),
+        geometry=gpd.GeoSeries([None] * len(frame), crs=None),
+    )
+
+
+def sql_literal(value: object) -> str:
+    """Render a Python scalar as a SQL literal.
+
+    Raises :class:`Untranslatable` for anything that cannot be safely
+    inlined (lists, dicts, geometries, …).
+    """
+    if value is None:
+        return "NULL"
+    if isinstance(value, bool):
+        return "TRUE" if value else "FALSE"
+    if isinstance(value, (int, float)):
+        return repr(value)
+    if isinstance(value, str):
+        return "'" + value.replace("'", "''") + "'"
+    if isinstance(value, (_dt.date, _dt.datetime)):
+        return "'" + value.isoformat() + "'"
+    raise Untranslatable(f"value {value!r} has no safe SQL literal form")
+
+
+# ---------------------------------------------------------------------------
+# pandas-query / eval expression → SQL
+# ---------------------------------------------------------------------------
+
+# Substrings that mean the expression leaves the SQL-pure subset.
+_EXPR_REJECT = ("@", "`", "[", "]", "{", "}", ";", "--", "/*", "**", "~", "//")
+
+
+def translate_expression(expr: str) -> str:
+    """Translate a pandas ``query``/``eval`` expression to portable SQL.
+
+    Handles the SQL-pure subset only — column names, numeric/string
+    literals, arithmetic (``+ - * / %``), comparisons and the boolean
+    connectives ``and`` / ``or`` / ``not``. Anything outside it (method
+    calls, ``@`` variables, indexing, ``**`` / ``//``) raises
+    :class:`Untranslatable`, so the caller falls back to Python.
+
+    ``ST_*`` and other function calls are intentionally *not* supported —
+    ``calculate`` / ``case_when`` push-down covers plain attribute maths.
+    """
+    raw = expr.strip()
+    if not raw:
+        raise Untranslatable("empty expression")
+    for bad in _EXPR_REJECT:
+        if bad in raw:
+            raise Untranslatable(f"expression uses unsupported token {bad!r}")
+
+    out: list[str] = []
+    i, n = 0, len(raw)
+    while i < n:
+        ch = raw[i]
+        if ch in ("'", '"'):  # string literal — re-quote to SQL single quotes
+            j = i + 1
+            while j < n and raw[j] != ch:
+                j += 1
+            if j >= n:
+                raise Untranslatable("unterminated string literal")
+            out.append("'" + raw[i + 1 : j].replace("'", "''") + "'")
+            i = j + 1
+            continue
+        if ch == ".":  # legal only between digits (decimal literal)
+            prev = raw[i - 1] if i > 0 else ""
+            nxt = raw[i + 1] if i + 1 < n else ""
+            if not (prev.isdigit() and nxt.isdigit()):
+                raise Untranslatable("attribute access is not SQL-translatable")
+            out.append(ch)
+            i += 1
+            continue
+        if ch == "=" and i + 1 < n and raw[i + 1] == "=":
+            out.append("=")
+            i += 2
+            continue
+        if ch == "!" and i + 1 < n and raw[i + 1] == "=":
+            out.append("<>")
+            i += 2
+            continue
+        if ch == "(":  # a function call — `name(` — is out of scope
+            if out and out[-1] not in ("(", "AND", "OR", "NOT", "", "+", "-", "*", "/", "%", "=", "<", ">", "<>", "<=", ">="):
+                raise Untranslatable("function calls are not SQL-translatable")
+            out.append(ch)
+            i += 1
+            continue
+        if ch.isalpha() or ch == "_":
+            j = i
+            while j < n and (raw[j].isalnum() or raw[j] == "_"):
+                j += 1
+            word, lowered = raw[i:j], raw[i:j].lower()
+            if lowered in ("and", "or", "not"):
+                out.append(lowered.upper())
+            elif lowered == "true":
+                out.append("TRUE")
+            elif lowered == "false":
+                out.append("FALSE")
+            elif lowered in ("none", "null"):
+                out.append("NULL")
+            else:
+                out.append(qi(word))
+            i = j
+            continue
+        if ch in "0123456789+-*/%)<> \t":
+            out.append(ch)
+            i += 1
+            continue
+        raise Untranslatable(f"unsupported character {ch!r} in expression")
+
+    sql = "".join(out).strip()
+    if not sql:
+        raise Untranslatable("expression translated to empty SQL")
+    return sql
+
+
+# ---------------------------------------------------------------------------
+# Generic strategy
+# ---------------------------------------------------------------------------
+
+# A builder turns (dialect, gdf, params, tables) into a SQL string. It may
+# raise Untranslatable to decline. `tables` maps a logical name ("input",
+# plus any declared extras) to the registered table name.
+SqlBuilder = Callable[[SQLDialect, gpd.GeoDataFrame, dict, dict], str]
+# An optional eligibility gate evaluated on params alone (no frame).
+SqlGate = Callable[[dict], bool]
+
+
+class _SqlPushdownStrategy(ExecutionStrategy):
+    """Generic DuckDB/PostGIS strategy for one attribute-only capability."""
+
+    def __init__(
+        self,
+        backend: str,
+        capability,
+        build: SqlBuilder,
+        *,
+        gate: SqlGate | None,
+        extra_inputs: dict[str, str],
+    ):
+        self._backend = backend
+        self._capability = capability
+        self._build = build
+        self._gate = gate
+        self._extra_inputs = extra_inputs  # logical name -> param key
+        self.mode = _MODE[backend]
+
+    def can_execute(self, ctx: ExecutionContext) -> bool:
+        if getattr(ctx.engine, "backend_name", "") != self._backend:
+            return False
+        if self._gate is not None and not self._gate(ctx.params):
+            return False
+        return True
+
+    def execute(self, gdf: gpd.GeoDataFrame, ctx: ExecutionContext) -> gpd.GeoDataFrame:
+        dialect = get_dialect(self._backend)
+        engine = ctx.engine
+        try:
+            engine.register("_sqlin", gdf)
+            tables = {"input": _registered_table(engine, "_sqlin")}
+            for logical, param_key in self._extra_inputs.items():
+                extra = ctx.params.get(param_key)
+                if extra is None:
+                    raise Untranslatable(f"missing extra input {param_key!r}")
+                reg = f"_sql_{logical}"
+                engine.register(reg, _as_registerable(extra))
+                tables[logical] = _registered_table(engine, reg)
+            sql = self._build(dialect, gdf, ctx.params, tables)
+        except Untranslatable as exc:
+            log.debug("sql_pushdown_declined", backend=self._backend, reason=str(exc))
+            return self._python_fallback(gdf, ctx.params)
+        return engine.sql_to_gdf(sql)
+
+    def _python_fallback(self, gdf: gpd.GeoDataFrame, params: dict) -> gpd.GeoDataFrame:
+        from gispulse.capabilities.base import safe_execute
+
+        clean = {k: v for k, v in params.items() if not k.startswith("_")}
+        return safe_execute(self._capability, gdf, **clean)
+
+    @property
+    def priority(self) -> int:
+        return _PRIORITY[self._backend]
+
+
+def attach_sql_pushdown(
+    capability_cls: type,
+    build: SqlBuilder,
+    *,
+    gate: SqlGate | None = None,
+    extra_inputs: dict[str, str] | None = None,
+) -> None:
+    """Wire DuckDB + PostGIS push-down strategies onto a capability class.
+
+    Call once, just after the class body. Builds a single capability
+    instance shared by both strategies as the Python fallback target.
+
+    Args:
+        capability_cls: The :class:`~gispulse.capabilities.base.Capability`
+            subclass to equip.
+        build:          The SQL builder for this capability.
+        gate:           Optional params-only eligibility predicate. Return
+            ``False`` to defer to Python (e.g. required params absent).
+        extra_inputs:   Logical-name → param-key map of additional
+            GeoDataFrame inputs to register (e.g. ``{"ref": "ref_gdf"}``).
+    """
+    instance = capability_cls()
+    extras = extra_inputs or {}
+    capability_cls._strategies = [
+        _SqlPushdownStrategy(
+            "postgis", instance, build, gate=gate, extra_inputs=extras
+        ),
+        _SqlPushdownStrategy(
+            "duckdb", instance, build, gate=gate, extra_inputs=extras
+        ),
+    ]

--- a/src/gispulse/capabilities/temporal.py
+++ b/src/gispulse/capabilities/temporal.py
@@ -266,3 +266,34 @@ class TemporalJoinCapability(Capability):
             },
             "required": ["left_on"],
         }
+
+
+# ---------------------------------------------------------------------------
+# ELT Lot 3 (#246) — DuckDB / PostGIS SQL push-down strategies
+# ---------------------------------------------------------------------------
+# temporal_filter pushes its time window down as a WHERE clause.
+# temporal_join push-down handles `strategy='exact'` only — the asof
+# strategies (backward / forward / nearest), `tolerance` and `by` groups
+# stay on Python (LATERAL + INTERVAL arithmetic, with dialect quirks).
+
+from gispulse.capabilities import _geometry_sql as _gsql  # noqa: E402
+from gispulse.capabilities.sql_pushdown import attach_sql_pushdown  # noqa: E402
+
+attach_sql_pushdown(
+    TemporalFilterCapability,
+    _gsql.build_temporal_filter,
+    gate=lambda p: (
+        bool(p.get("time_col"))
+        and (p.get("start") is not None or p.get("end") is not None)
+    ),
+)
+attach_sql_pushdown(
+    TemporalJoinCapability,
+    _gsql.build_temporal_join_exact,
+    gate=lambda p: (
+        p.get("strategy", "backward") == "exact"
+        and p.get("ref_gdf") is not None
+        and bool(p.get("left_on"))
+    ),
+    extra_inputs={"ref": "ref_gdf"},
+)

--- a/src/gispulse/capabilities/vector/__init__.py
+++ b/src/gispulse/capabilities/vector/__init__.py
@@ -38,7 +38,6 @@ from gispulse.capabilities.vector.buffer import (  # noqa: F401
     BufferCapability,
     _buffer_kwargs,
     _buffer_params_are_default,
-    _buffer_style_sql,
 )
 
 # Union / Reproject ----------------------------------------------------------

--- a/src/gispulse/capabilities/vector/boundary.py
+++ b/src/gispulse/capabilities/vector/boundary.py
@@ -44,3 +44,13 @@ class BoundaryCapability(Capability):
             },
         }
 
+
+# ---------------------------------------------------------------------------
+# ELT Lot 3 (#246) — DuckDB / PostGIS SQL push-down strategy
+# ---------------------------------------------------------------------------
+
+from gispulse.capabilities import _geometry_sql as _gsql  # noqa: E402
+from gispulse.capabilities.sql_pushdown import attach_sql_pushdown  # noqa: E402
+
+attach_sql_pushdown(BoundaryCapability, _gsql.build_boundary)
+

--- a/src/gispulse/capabilities/vector/buffer.py
+++ b/src/gispulse/capabilities/vector/buffer.py
@@ -6,6 +6,8 @@ import geopandas as gpd
 from gispulse.capabilities.base import Capability
 from gispulse.capabilities.registry import register
 from gispulse.capabilities.strategy import ExecutionContext, ExecutionStrategy, StrategyMode
+from gispulse.persistence.sql_dialect import BufferStyle, get_dialect
+from gispulse.persistence.spatial_queries import buffer_select
 
 
 # ---------------------------------------------------------------------------
@@ -45,23 +47,6 @@ def _buffer_kwargs(
         join_style=_BUFFER_JOIN_STYLES[join_style],
         mitre_limit=float(mitre_limit),
         single_sided=bool(single_sided),
-    )
-
-
-def _buffer_style_sql(
-    quad_segs: int,
-    cap_style: str,
-    join_style: str,
-    mitre_limit: float,
-    single_sided: bool,
-) -> str:
-    """Build the PostGIS/DuckDB ST_Buffer style string."""
-    side = "left" if single_sided else "both"
-    # DuckDB spatial implements ST_Buffer(geom, dist) — no style string yet.
-    # For PostGIS this returns the 3rd parameter.
-    return (
-        f"quad_segs={int(quad_segs)} endcap={cap_style} "
-        f"join={join_style} mitre_limit={float(mitre_limit):.3f} side={side}"
     )
 
 
@@ -156,16 +141,17 @@ class _BufferDuckDBStrategy(ExecutionStrategy):
             gdf = gdf.to_crs(crs_meters)
 
         ctx.engine.register("_input", gdf)
-        # register_gdf stores geometry as __wkb binary column;
-        # convert back to GEOMETRY via ST_GeomFromWKB before ST_Buffer
-        result = ctx.engine.sql_to_gdf(
-            f"SELECT *, ST_Buffer(ST_GeomFromWKB(__wkb), {distance}) AS __wkb_buf "
-            f"FROM _input"
-        )
-        # Replace geometry column with the buffered one
-        if "__wkb_buf" in result.columns:
-            result = result.set_geometry("__wkb_buf").drop(
-                columns=["__wkb"], errors="ignore"
+        # SQL generation is delegated to the dialect-aware layer
+        # (persistence.sql_dialect / spatial_queries) — ELT Lot 1,
+        # ADR 0005. A default-style buffer is the only kind DuckDB can
+        # express; can_execute() already deferred styled buffers to the
+        # Python strategy.
+        dialect = get_dialect(ctx.engine.backend_name)
+        query = buffer_select(dialect, source_table="_input", distance=distance)
+        result = ctx.engine.sql_to_gdf(query.sql)
+        if query.geom_column in result.columns:
+            result = result.set_geometry(query.geom_column).drop(
+                columns=[dialect.geom_column], errors="ignore"
             )
             result = result.rename_geometry("geometry")
 
@@ -189,12 +175,12 @@ class _BufferPostGISStrategy(ExecutionStrategy):
     def execute(self, gdf: gpd.GeoDataFrame, ctx: ExecutionContext) -> gpd.GeoDataFrame:
         distance = float(ctx.params.get("distance", 0.0))
         crs_meters: str = ctx.params.get("crs_meters", "EPSG:3857")
-        style = _buffer_style_sql(
-            int(ctx.params.get("quad_segs", 8)),
-            ctx.params.get("cap_style", "round"),
-            ctx.params.get("join_style", "round"),
-            float(ctx.params.get("mitre_limit", 5.0)),
-            bool(ctx.params.get("single_sided", False)),
+        style = BufferStyle(
+            quad_segs=int(ctx.params.get("quad_segs", 8)),
+            cap_style=ctx.params.get("cap_style", "round"),
+            join_style=ctx.params.get("join_style", "round"),
+            mitre_limit=float(ctx.params.get("mitre_limit", 5.0)),
+            single_sided=bool(ctx.params.get("single_sided", False)),
         )
 
         original_crs = gdf.crs
@@ -202,15 +188,17 @@ class _BufferPostGISStrategy(ExecutionStrategy):
             gdf = gdf.to_crs(crs_meters)
 
         ctx.engine.register("_input", gdf)
-        # Style string is built from validated params (enum-constrained),
-        # safe to inline. Distance is a numeric literal.
-        result = ctx.engine.sql_to_gdf(
-            f"SELECT *, ST_Buffer(geometry::geometry, {distance}, '{style}') "
-            f"AS geometry_buf FROM _input"
+        # Dialect-aware SQL (persistence.sql_dialect / spatial_queries) —
+        # ELT Lot 1, ADR 0005. PostGIS expresses the full ST_Buffer style
+        # string; the style is built from enum-constrained, validated params.
+        dialect = get_dialect(ctx.engine.backend_name)
+        query = buffer_select(
+            dialect, source_table="_input", distance=distance, style=style
         )
-        if "geometry_buf" in result.columns:
-            result = result.set_geometry("geometry_buf").drop(
-                columns=["geometry"], errors="ignore"
+        result = ctx.engine.sql_to_gdf(query.sql)
+        if query.geom_column in result.columns:
+            result = result.set_geometry(query.geom_column).drop(
+                columns=[dialect.geom_column], errors="ignore"
             )
             result = result.rename_geometry("geometry")
 

--- a/src/gispulse/capabilities/vector/calculate.py
+++ b/src/gispulse/capabilities/vector/calculate.py
@@ -200,3 +200,17 @@ class CalculateCapability(Capability):
             },
             "required": ["expressions"],
         }
+
+
+# ---------------------------------------------------------------------------
+# ELT Lot 2 (#245) — DuckDB / PostGIS SQL push-down strategy
+# ---------------------------------------------------------------------------
+
+from gispulse.capabilities import _attribute_sql as _asql  # noqa: E402
+from gispulse.capabilities.sql_pushdown import attach_sql_pushdown  # noqa: E402
+
+attach_sql_pushdown(
+    CalculateCapability,
+    _asql.build_calculate,
+    gate=lambda p: bool(p.get("expressions")),
+)

--- a/src/gispulse/capabilities/vector/centroid_area.py
+++ b/src/gispulse/capabilities/vector/centroid_area.py
@@ -100,3 +100,14 @@ class AreaLengthCapability(Capability):
             },
         }
 
+
+# ---------------------------------------------------------------------------
+# ELT Lot 3 (#246) — DuckDB / PostGIS SQL push-down strategies
+# ---------------------------------------------------------------------------
+
+from gispulse.capabilities import _geometry_sql as _gsql  # noqa: E402
+from gispulse.capabilities.sql_pushdown import attach_sql_pushdown  # noqa: E402
+
+attach_sql_pushdown(CentroidCapability, _gsql.build_centroid)
+attach_sql_pushdown(AreaLengthCapability, _gsql.build_area_length)
+

--- a/src/gispulse/capabilities/vector/clip.py
+++ b/src/gispulse/capabilities/vector/clip.py
@@ -6,6 +6,8 @@ import geopandas as gpd
 from gispulse.capabilities.base import Capability
 from gispulse.capabilities.registry import register
 from gispulse.capabilities.strategy import ExecutionContext, ExecutionStrategy, StrategyMode
+from gispulse.persistence.sql_dialect import get_dialect
+from gispulse.persistence.spatial_queries import clip_select
 
 
 # ---------------------------------------------------------------------------
@@ -78,14 +80,14 @@ class _ClipDuckDBStrategy(ExecutionStrategy):
 
         ctx.engine.register("_clip_input", gdf)
         ctx.engine.register("_clip_mask", mask_gdf)
-        result = ctx.engine.sql_to_gdf(
-            "SELECT i.* REPLACE ("
-            "  ST_Intersection(ST_GeomFromWKB(i.__wkb), ST_GeomFromWKB(m.__wkb)) "
-            "  AS __wkb"
-            ") "
-            "FROM _clip_input i, _clip_mask m "
-            "WHERE ST_Intersects(ST_GeomFromWKB(i.__wkb), ST_GeomFromWKB(m.__wkb))"
+        # Dialect-aware SQL (persistence.sql_dialect / spatial_queries) —
+        # ELT Lot 1, ADR 0005.
+        query = clip_select(
+            get_dialect(ctx.engine.backend_name),
+            source_table="_clip_input",
+            mask_table="_clip_mask",
         )
+        result = ctx.engine.sql_to_gdf(query.sql)
         return result.reset_index(drop=True)
 
     @property
@@ -114,15 +116,16 @@ class _ClipPostGISStrategy(ExecutionStrategy):
 
         ctx.engine.register("_clip_input", gdf)
         ctx.engine.register("_clip_mask", mask_gdf)
-        result = ctx.engine.sql_to_gdf(
-            "SELECT i.*, ST_Intersection(i.geometry::geometry, m.geometry::geometry) "
-            "AS geometry_clip "
-            "FROM _clip_input i, _clip_mask m "
-            "WHERE ST_Intersects(i.geometry::geometry, m.geometry::geometry)"
+        # Dialect-aware SQL (persistence.sql_dialect / spatial_queries) —
+        # ELT Lot 1, ADR 0005.
+        dialect = get_dialect(ctx.engine.backend_name)
+        query = clip_select(
+            dialect, source_table="_clip_input", mask_table="_clip_mask"
         )
-        if "geometry_clip" in result.columns:
-            result = result.set_geometry("geometry_clip").drop(
-                columns=["geometry"], errors="ignore"
+        result = ctx.engine.sql_to_gdf(query.sql)
+        if query.geom_column in result.columns:
+            result = result.set_geometry(query.geom_column).drop(
+                columns=[dialect.geom_column], errors="ignore"
             ).rename_geometry("geometry")
         return result.reset_index(drop=True)
 

--- a/src/gispulse/capabilities/vector/concave_hull.py
+++ b/src/gispulse/capabilities/vector/concave_hull.py
@@ -92,3 +92,17 @@ class ConcaveHullCapability(Capability):
         }
 
 
+# ---------------------------------------------------------------------------
+# ELT Lot 3 (#246) — DuckDB / PostGIS SQL push-down strategy
+# ---------------------------------------------------------------------------
+
+from gispulse.capabilities import _geometry_sql as _gsql  # noqa: E402
+from gispulse.capabilities.sql_pushdown import attach_sql_pushdown  # noqa: E402
+
+attach_sql_pushdown(
+    ConcaveHullCapability,
+    _gsql.build_concave_hull,
+    gate=lambda p: not p.get("by_group") and not p.get("dissolve"),
+)
+
+

--- a/src/gispulse/capabilities/vector/diff.py
+++ b/src/gispulse/capabilities/vector/diff.py
@@ -220,3 +220,22 @@ class VectorDiffCapability(Capability):
         }
 
 
+# ---------------------------------------------------------------------------
+# ELT Lot 3 (#246) — DuckDB / PostGIS SQL push-down strategy
+# ---------------------------------------------------------------------------
+# Only symmetric_difference pushes down — it is a clean per-feature XOR
+# against the unioned reference. vector_diff stays on Python: its
+# row-by-row added/removed/modified diff with Hausdorff tolerance is not
+# a SQL-pure operation.
+
+from gispulse.capabilities import _geometry_sql as _gsql  # noqa: E402
+from gispulse.capabilities.sql_pushdown import attach_sql_pushdown  # noqa: E402
+
+attach_sql_pushdown(
+    SymmetricDifferenceCapability,
+    _gsql.build_symmetric_difference,
+    gate=lambda p: p.get("ref_gdf") is not None,
+    extra_inputs={"ref": "ref_gdf"},
+)
+
+

--- a/src/gispulse/capabilities/vector/dissolve.py
+++ b/src/gispulse/capabilities/vector/dissolve.py
@@ -44,3 +44,20 @@ class DissolveCapability(Capability):
             },
         }
 
+
+# ---------------------------------------------------------------------------
+# ELT Lot 3 (#246) — DuckDB / PostGIS SQL push-down strategy
+# ---------------------------------------------------------------------------
+
+from gispulse.capabilities import _geometry_sql as _gsql  # noqa: E402
+from gispulse.capabilities.sql_pushdown import attach_sql_pushdown  # noqa: E402
+
+attach_sql_pushdown(
+    DissolveCapability,
+    _gsql.build_dissolve,
+    # by=None falls back to Python because gpd.dissolve().reset_index()
+    # then appends a spurious 'index' column from the default RangeIndex —
+    # not a meaningful difference, but reproducing it in SQL has no value.
+    gate=lambda p: bool(p.get("by")),
+)
+

--- a/src/gispulse/capabilities/vector/intersects.py
+++ b/src/gispulse/capabilities/vector/intersects.py
@@ -6,6 +6,8 @@ import geopandas as gpd
 from gispulse.capabilities.base import Capability
 from gispulse.capabilities.registry import register
 from gispulse.capabilities.strategy import ExecutionContext, ExecutionStrategy, StrategyMode
+from gispulse.persistence.sql_dialect import get_dialect
+from gispulse.persistence.spatial_queries import intersects_select
 
 
 # ---------------------------------------------------------------------------
@@ -80,10 +82,14 @@ class _IntersectsDuckDBStrategy(ExecutionStrategy):
         ref_gdf = gpd.GeoDataFrame(geometry=[ref_geom], crs=gdf.crs)
         ctx.engine.register("_is_input", gdf)
         ctx.engine.register("_is_ref", ref_gdf)
-        return ctx.engine.sql_to_gdf(
-            "SELECT i.* FROM _is_input i, _is_ref r "
-            "WHERE ST_Intersects(ST_GeomFromWKB(i.__wkb), ST_GeomFromWKB(r.__wkb))"
-        ).reset_index(drop=True)
+        # Dialect-aware SQL (persistence.sql_dialect / spatial_queries) —
+        # ELT Lot 1, ADR 0005.
+        query = intersects_select(
+            get_dialect(ctx.engine.backend_name),
+            source_table="_is_input",
+            ref_table="_is_ref",
+        )
+        return ctx.engine.sql_to_gdf(query.sql).reset_index(drop=True)
 
     @property
     def priority(self) -> int:
@@ -112,10 +118,14 @@ class _IntersectsPostGISStrategy(ExecutionStrategy):
         ref_gdf = gpd.GeoDataFrame(geometry=[ref_geom], crs=gdf.crs)
         ctx.engine.register("_is_input", gdf)
         ctx.engine.register("_is_ref", ref_gdf)
-        return ctx.engine.sql_to_gdf(
-            "SELECT i.* FROM _is_input i, _is_ref r "
-            "WHERE ST_Intersects(i.geometry::geometry, r.geometry::geometry)"
-        ).reset_index(drop=True)
+        # Dialect-aware SQL (persistence.sql_dialect / spatial_queries) —
+        # ELT Lot 1, ADR 0005.
+        query = intersects_select(
+            get_dialect(ctx.engine.backend_name),
+            source_table="_is_input",
+            ref_table="_is_ref",
+        )
+        return ctx.engine.sql_to_gdf(query.sql).reset_index(drop=True)
 
     @property
     def priority(self) -> int:

--- a/src/gispulse/capabilities/vector/nearest.py
+++ b/src/gispulse/capabilities/vector/nearest.py
@@ -189,5 +189,20 @@ class NearestNeighborCapability(Capability):
 
 
 # ---------------------------------------------------------------------------
+# ELT Lot 3 (#246) — PostGIS-only push-down (DuckDB lacks the <-> operator)
+# ---------------------------------------------------------------------------
+
+from gispulse.capabilities import _geometry_sql as _gsql  # noqa: E402
+from gispulse.capabilities.sql_pushdown import attach_sql_pushdown  # noqa: E402
+
+attach_sql_pushdown(
+    NearestNeighborCapability,
+    _gsql.build_nearest_neighbor,
+    gate=lambda p: p.get("ref_gdf") is not None,
+    extra_inputs={"ref": "ref_gdf"},
+)
+
+
+# ---------------------------------------------------------------------------
 # Advanced geometry constructions
 # ---------------------------------------------------------------------------

--- a/src/gispulse/capabilities/vector/reproject.py
+++ b/src/gispulse/capabilities/vector/reproject.py
@@ -41,3 +41,15 @@ class ReprojectCapability(Capability):
         }
 
 
+# ---------------------------------------------------------------------------
+# ELT Lot 3 (#246) — DuckDB / PostGIS SQL push-down strategy
+# ---------------------------------------------------------------------------
+
+from gispulse.capabilities import _geometry_sql as _gsql  # noqa: E402
+from gispulse.capabilities.sql_pushdown import attach_sql_pushdown  # noqa: E402
+
+attach_sql_pushdown(
+    ReprojectCapability, _gsql.build_reproject, post=_gsql.reproject_post
+)
+
+

--- a/src/gispulse/capabilities/vector/shape_ops_basic.py
+++ b/src/gispulse/capabilities/vector/shape_ops_basic.py
@@ -200,3 +200,18 @@ class EnvelopeCapability(Capability):
                 },
             },
         }
+
+
+# ---------------------------------------------------------------------------
+# ELT Lot 3 (#246) — DuckDB / PostGIS SQL push-down strategies
+# ---------------------------------------------------------------------------
+
+from gispulse.capabilities import _geometry_sql as _gsql  # noqa: E402
+from gispulse.capabilities.sql_pushdown import attach_sql_pushdown  # noqa: E402
+
+# by_group / dissolve are N:1 aggregations — not 1:1 — and stay on Python.
+_per_feature = lambda p: not p.get("by_group") and not p.get("dissolve")  # noqa: E731
+
+attach_sql_pushdown(MakeValidCapability, _gsql.build_make_valid)
+attach_sql_pushdown(ConvexHullCapability, _gsql.build_convex_hull, gate=_per_feature)
+attach_sql_pushdown(EnvelopeCapability, _gsql.build_envelope, gate=_per_feature)

--- a/src/gispulse/capabilities/vector/simplify.py
+++ b/src/gispulse/capabilities/vector/simplify.py
@@ -124,3 +124,17 @@ class SimplifyCapability(Capability):
             },
             "required": ["tolerance"],
         }
+
+
+# ---------------------------------------------------------------------------
+# ELT Lot 3 (#246) — DuckDB / PostGIS SQL push-down strategy (dp algorithm)
+# ---------------------------------------------------------------------------
+
+from gispulse.capabilities import _geometry_sql as _gsql  # noqa: E402
+from gispulse.capabilities.sql_pushdown import attach_sql_pushdown  # noqa: E402
+
+attach_sql_pushdown(
+    SimplifyCapability,
+    _gsql.build_simplify,
+    gate=lambda p: p.get("algorithm", "dp") == "dp",
+)

--- a/src/gispulse/capabilities/vector/spatial_join.py
+++ b/src/gispulse/capabilities/vector/spatial_join.py
@@ -102,3 +102,18 @@ class SpatialJoinCapability(Capability):
             # when ``ref_gdf`` is None, which preserves the contract.
         }
 
+
+# ---------------------------------------------------------------------------
+# ELT Lot 3 (#246) — DuckDB / PostGIS SQL push-down strategy
+# ---------------------------------------------------------------------------
+
+from gispulse.capabilities import _geometry_sql as _gsql  # noqa: E402
+from gispulse.capabilities.sql_pushdown import attach_sql_pushdown  # noqa: E402
+
+attach_sql_pushdown(
+    SpatialJoinCapability,
+    _gsql.build_spatial_join,
+    gate=lambda p: p.get("ref_gdf") is not None,
+    extra_inputs={"ref": "ref_gdf"},
+)
+

--- a/src/gispulse/capabilities/vector/union.py
+++ b/src/gispulse/capabilities/vector/union.py
@@ -29,3 +29,13 @@ class UnionCapability(Capability):
         return {"type": "object", "properties": {}}
 
 
+# ---------------------------------------------------------------------------
+# ELT Lot 3 (#246) — DuckDB / PostGIS SQL push-down strategy
+# ---------------------------------------------------------------------------
+
+from gispulse.capabilities import _geometry_sql as _gsql  # noqa: E402
+from gispulse.capabilities.sql_pushdown import attach_sql_pushdown  # noqa: E402
+
+attach_sql_pushdown(UnionCapability, _gsql.build_union)
+
+

--- a/src/gispulse/cli.py
+++ b/src/gispulse/cli.py
@@ -1548,6 +1548,83 @@ from gispulse.cli_mcp import cmd_mcp  # noqa: E402
 app.command(name="mcp")(cmd_mcp)
 
 
+# ---------------------------------------------------------------------------
+# migrate — rewrite a v1/v2 pipeline file as a v3 manifest (ADR 0005)
+# ---------------------------------------------------------------------------
+
+
+@app.command()
+def migrate(
+    input_file: Path = typer.Argument(
+        ..., help="Source pipeline file (v1 array or v2 PipelineSpec JSON/YAML)."
+    ),
+    output_file: Path | None = typer.Option(
+        None, "--output", "-o",
+        help="Destination .yaml/.json. When omitted, prints to stdout.",
+    ),
+    fmt: str = typer.Option(
+        "yaml", "--format", "-f",
+        help="Output format when writing to stdout: 'yaml' (default) or 'json'.",
+    ),
+) -> None:
+    """Rewrite a v1/v2 pipeline as a v3 manifest (ADR 0005).
+
+    The compiled v3 file is validated against ``SCHEMA_V3`` before
+    emission; a primary input source (``<primary_input>`` placeholder)
+    is added so the manifest is structurally self-contained.
+    """
+    import json as _json
+
+    from gispulse.core.manifest_v3 import migrate_to_v3
+    from gispulse.core.pipeline_schema import validate_pipeline_json
+
+    if not input_file.exists():
+        typer.echo(f"Error: input file not found: {input_file}", err=True)
+        raise typer.Exit(1)
+
+    text = input_file.read_text(encoding="utf-8")
+    if input_file.suffix.lower() in (".yaml", ".yml"):
+        import yaml as _yaml
+
+        raw = _yaml.safe_load(text)
+    else:
+        raw = _json.loads(text)
+
+    try:
+        v3 = migrate_to_v3(raw)
+    except Exception as exc:
+        typer.echo(f"Error: migration failed — {exc}", err=True)
+        raise typer.Exit(1)
+
+    errors = validate_pipeline_json(v3)
+    if errors:
+        typer.echo("Warning: migrated manifest fails v3 validation:", err=True)
+        for err in errors[:10]:
+            typer.echo(f"  - {err}", err=True)
+
+    if output_file is not None:
+        if output_file.suffix.lower() in (".yaml", ".yml"):
+            import yaml as _yaml
+
+            output_file.write_text(
+                _yaml.safe_dump(v3, sort_keys=False, allow_unicode=True),
+                encoding="utf-8",
+            )
+        else:
+            output_file.write_text(
+                _json.dumps(v3, indent=2, ensure_ascii=False),
+                encoding="utf-8",
+            )
+        typer.echo(f"Wrote v3 manifest to {output_file}")
+    else:
+        if fmt == "json":
+            typer.echo(_json.dumps(v3, indent=2, ensure_ascii=False))
+        else:
+            import yaml as _yaml
+
+            typer.echo(_yaml.safe_dump(v3, sort_keys=False, allow_unicode=True))
+
+
 def main() -> None:
     from gispulse._pyogrio_warnings import silence_gispulse_extension_warnings
 

--- a/src/gispulse/core/dag.py
+++ b/src/gispulse/core/dag.py
@@ -1,0 +1,91 @@
+"""Shared DAG utilities — Kahn topological sort + cycle reporting.
+
+ELT Lot 4B (issue #248, ADR 0005). The Kahn topological-sort algorithm
+already lives inside :class:`gispulse.orchestration.graph_executor.GraphExecutor`
+where it runs *at execution time* over the pipeline's
+:class:`~gispulse.core.graph.NodeDef` / :class:`~gispulse.core.graph.EdgeDef`
+graph. ADR 0005 calls for the same check at **load time** on the v3
+manifest's inter-model dependency graph — same algorithm, different
+node-type, called earlier.
+
+This module extracts the algorithm into a reusable utility keyed on
+opaque node-id strings, so:
+
+- :class:`GraphExecutor` reuses it at run time (no change in behaviour).
+- :func:`gispulse.core.manifest_v3.validate_manifest` reuses it at load
+  time over the model→model dependency graph.
+
+Anything that fails the sort raises :class:`CycleError` — a
+:class:`ValueError` subtype carrying the precise cycle members so
+callers can surface them in messages.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict, deque
+from collections.abc import Iterable
+
+__all__ = ["CycleError", "topological_sort"]
+
+
+class CycleError(ValueError):
+    """The graph has at least one cycle.
+
+    Attributes:
+        cycle: Set of node ids that participate in some cycle — the
+            nodes Kahn's algorithm could not reach.
+    """
+
+    def __init__(self, cycle: set[str], message: str | None = None) -> None:
+        self.cycle = cycle
+        super().__init__(
+            message
+            or f"Cycle detected; unreachable nodes: {sorted(cycle)!r}"
+        )
+
+
+def topological_sort(
+    nodes: Iterable[str],
+    edges: Iterable[tuple[str, str]],
+) -> list[str]:
+    """Return *nodes* in a topological order (Kahn's algorithm).
+
+    Args:
+        nodes: Iterable of node ids. Order seeds the deterministic
+            stable-tie behaviour — nodes are visited in input order
+            when they share an in-degree of zero.
+        edges: Iterable of ``(source, target)`` pairs. ``source`` and
+            ``target`` must be ids from *nodes*; unknown targets land in
+            ``in_degree`` with a zero base, matching the legacy
+            ``GraphExecutor`` behaviour.
+
+    Returns:
+        The node ids in a stable topological order.
+
+    Raises:
+        CycleError: When a cycle prevents ordering all nodes. The
+            exception's ``cycle`` attribute carries the participating
+            node ids.
+    """
+    node_ids = list(nodes)
+    adj: dict[str, list[str]] = defaultdict(list)
+    in_degree: dict[str, int] = {nid: 0 for nid in node_ids}
+    for src, dst in edges:
+        adj[src].append(dst)
+        in_degree.setdefault(dst, 0)
+        in_degree[dst] += 1
+
+    queue: deque[str] = deque(nid for nid in node_ids if in_degree.get(nid, 0) == 0)
+    order: list[str] = []
+    deg = dict(in_degree)
+    while queue:
+        nid = queue.popleft()
+        order.append(nid)
+        for child in adj.get(nid, []):
+            deg[child] -= 1
+            if deg[child] == 0:
+                queue.append(child)
+    if len(order) != len(node_ids):
+        unreachable = {nid for nid in node_ids if nid not in order}
+        raise CycleError(unreachable)
+    return order

--- a/src/gispulse/core/manifest_v3.py
+++ b/src/gispulse/core/manifest_v3.py
@@ -1,0 +1,592 @@
+"""Unified GISPulse manifest version 3 — ADR 0005 / EPIC #243 / issue #247.
+
+The v3 manifest unifies the three legacy configuration surfaces
+(``triggers.yaml`` v1, pipeline JSON v2, bare rule lists) into one
+declarative schema with ``sources`` / ``staging`` / ``models`` /
+``triggers`` / ``security`` / ``runtime`` sections.
+
+This module is the **declarative surface**: typed dataclasses + a
+loader + a compiler that turns the authored ``models:`` form into the
+existing :class:`~gispulse.core.pipeline.PipelineSpec` —
+*no new DAG engine, no new dispatcher*. ``models:`` syntax compiles
+directly to ``StepSpec.input`` edges; the rest of the engine
+(``GraphExecutor`` + the strategy dispatch + the capability layer)
+runs the pipeline as before.
+
+Public surface:
+
+- :class:`ManifestV3` (with :class:`SourceSpec`, :class:`StagingSpec`,
+  :class:`ModelSpec`, :class:`V3TriggerSpec`).
+- :func:`load_manifest_v3` — parse a YAML / JSON file, validate against
+  :data:`gispulse.core.pipeline_schema.SCHEMA_V3`, return ManifestV3.
+- :func:`compile_to_pipeline` — turn the manifest's models into a
+  :class:`PipelineSpec`. Sources are surfaced as ``ref_layers``;
+  each model's transforms become a chain of StepSpecs linked through
+  ``StepSpec.input``.
+- :func:`migrate_to_v3` — convert a v1 (flat rule list) or v2
+  (PipelineSpec dict) raw payload into a v3 dict.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from gispulse.core.pipeline import (
+    PipelineSpec,
+    StepSpec,
+    TriggerSpec,
+)
+from gispulse.core.pipeline_schema import validate_pipeline_json
+
+__all__ = [
+    "SourceSpec",
+    "StagingSpec",
+    "ModelSpec",
+    "V3TriggerSpec",
+    "ManifestV3",
+    "load_manifest_v3",
+    "compile_to_pipeline",
+    "migrate_to_v3",
+    "manifest_to_dict",
+]
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SourceSpec:
+    """A declared input source — ``sources: { <name>: … }``."""
+
+    name: str
+    uri: str
+    layer: str | None = None
+    geometry: str | None = None
+    crs: str | None = None
+    format: str | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class StagingSpec:
+    """Optional ``staging:`` facade — engine / attach / cdc knobs."""
+
+    engine: str | None = None
+    attach: bool = True
+    cdc: str = "off"  # off | snapshot | incremental
+
+
+@dataclass
+class ModelSpec:
+    """A derived model — a node in the manifest DAG.
+
+    Attributes:
+        name:        Model name (the key under ``models:``). Also the
+                     terminal step id after compilation.
+        select:      Upstream layer reference — a source name or
+                     another model.
+        transform:   List of ``{capability: params}`` shorthand items.
+                     Compiles to a chain of :class:`StepSpec`.
+        materialize: ``view`` (default), ``table``, ``incremental``.
+        refresh:     ``manual`` (default), ``on_change``, ``schedule``.
+    """
+
+    name: str
+    select: str
+    transform: list[dict[str, Any]] = field(default_factory=list)
+    materialize: str = "view"
+    refresh: str = "manual"
+
+
+@dataclass
+class V3TriggerSpec:
+    """Reactive trigger declared at the manifest top level."""
+
+    name: str
+    on: str | list[str]
+    table: str = ""
+    when: list[Any] | dict[str, Any] | None = None
+    actions: list[dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass
+class ManifestV3:
+    """Parsed v3 manifest — the in-memory shape after loading."""
+
+    name: str = ""
+    description: str = ""
+    sources: dict[str, SourceSpec] = field(default_factory=dict)
+    staging: StagingSpec = field(default_factory=StagingSpec)
+    models: dict[str, ModelSpec] = field(default_factory=dict)
+    triggers: list[V3TriggerSpec] = field(default_factory=list)
+    security: dict[str, Any] = field(default_factory=dict)
+    runtime: dict[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Parse / load
+# ---------------------------------------------------------------------------
+
+
+def _parse_sources(raw: dict[str, Any]) -> dict[str, SourceSpec]:
+    out: dict[str, SourceSpec] = {}
+    for name, spec in (raw or {}).items():
+        known = {"uri", "layer", "geometry", "crs", "format"}
+        extras = {k: v for k, v in spec.items() if k not in known}
+        out[name] = SourceSpec(
+            name=name,
+            uri=spec["uri"],
+            layer=spec.get("layer"),
+            geometry=spec.get("geometry"),
+            crs=spec.get("crs"),
+            format=spec.get("format"),
+            extra=extras,
+        )
+    return out
+
+
+def _parse_staging(raw: dict[str, Any] | None) -> StagingSpec:
+    if not raw:
+        return StagingSpec()
+    return StagingSpec(
+        engine=raw.get("engine"),
+        attach=bool(raw.get("attach", True)),
+        cdc=raw.get("cdc", "off"),
+    )
+
+
+def _parse_models(raw: dict[str, Any]) -> dict[str, ModelSpec]:
+    out: dict[str, ModelSpec] = {}
+    for name, spec in (raw or {}).items():
+        out[name] = ModelSpec(
+            name=name,
+            select=spec["select"],
+            transform=list(spec.get("transform") or []),
+            materialize=spec.get("materialize", "view"),
+            refresh=spec.get("refresh", "manual"),
+        )
+    return out
+
+
+def _parse_v3_triggers(raw: list[Any]) -> list[V3TriggerSpec]:
+    out: list[V3TriggerSpec] = []
+    for spec in raw or []:
+        out.append(
+            V3TriggerSpec(
+                name=spec["name"],
+                on=spec["on"],
+                table=spec.get("table", ""),
+                when=spec.get("when"),
+                actions=list(spec.get("actions") or []),
+            )
+        )
+    return out
+
+
+def _load_raw(path: Path) -> Any:
+    suffix = path.suffix.lower()
+    text = path.read_text(encoding="utf-8")
+    if suffix in (".yaml", ".yml"):
+        import yaml  # type: ignore[import-untyped]
+
+        return yaml.safe_load(text)
+    return json.loads(text)
+
+
+def load_manifest_v3(path: str | Path, *, validate: bool = True) -> ManifestV3:
+    """Load and parse a v3 manifest from YAML / JSON.
+
+    Args:
+        path:     File path (``.yaml`` / ``.yml`` / ``.json``).
+        validate: When ``True`` (default), validate against ``SCHEMA_V3``
+            before parsing. Validation errors are raised as ValueError.
+
+    Returns:
+        Typed :class:`ManifestV3`.
+    """
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"Manifest file not found: {p}")
+    raw = _load_raw(p)
+    if not isinstance(raw, dict):
+        raise ValueError(
+            f"v3 manifest must be a YAML/JSON object, got {type(raw).__name__}"
+        )
+    if raw.get("version") != 3:
+        raise ValueError(
+            f"Expected version: 3 manifest, got version={raw.get('version')!r}"
+        )
+
+    if validate:
+        errors = validate_pipeline_json(raw)
+        if errors:
+            msg = f"Manifest v3 schema validation failed for {p.name}:\n"
+            msg += "\n".join(f"  - {e}" for e in errors[:20])
+            if len(errors) > 20:
+                msg += f"\n  ... and {len(errors) - 20} more errors"
+            raise ValueError(msg)
+
+    return ManifestV3(
+        name=raw.get("name", ""),
+        description=raw.get("description", ""),
+        sources=_parse_sources(raw.get("sources", {})),
+        staging=_parse_staging(raw.get("staging")),
+        models=_parse_models(raw.get("models", {})),
+        triggers=_parse_v3_triggers(raw.get("triggers", [])),
+        security=dict(raw.get("security") or {}),
+        runtime=dict(raw.get("runtime") or {}),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Compile: ManifestV3 → PipelineSpec
+# ---------------------------------------------------------------------------
+
+
+def _resolve_ref(
+    ref: str, sources: dict[str, SourceSpec], model_names: set[str]
+) -> tuple[str, bool]:
+    """Resolve a ``select:`` reference.
+
+    Returns ``(resolved, is_model_ref)``:
+
+    - For a *source* reference → ``(source_name, False)`` — the compiler
+      registers it under ``PipelineSpec.ref_layers``.
+    - For a *model* reference → ``(model_name, True)`` — used as the
+      upstream step id in the generated DAG.
+    """
+    if ref in sources:
+        return ref, False
+    if ref in model_names:
+        return ref, True
+    raise ValueError(
+        f"Unknown select target {ref!r} — not a declared source or model"
+    )
+
+
+def _split_transform(item: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+    """Pull the ``{capability_name: params}`` pair out of a transform item."""
+    if len(item) != 1:
+        raise ValueError(
+            f"transform step must have exactly one key, got {list(item)!r}"
+        )
+    (cap_name, params), = item.items()
+    return cap_name, dict(params or {})
+
+
+def _compile_model_steps(
+    model: ModelSpec,
+    sources: dict[str, SourceSpec],
+    model_names: set[str],
+) -> list[StepSpec]:
+    """Turn one ModelSpec into a chain of StepSpecs.
+
+    The terminal step's id is the model name (so cross-model
+    ``select: other_model`` resolves to the right upstream node). Each
+    intermediate step is named ``<model>__t<index>``. A transform's
+    ``with: <ref>`` is converted into a multi-input edge plus a
+    ``ref_layer`` capability param for the legacy ref-layer plumbing.
+    """
+    primary, primary_is_model = _resolve_ref(model.select, sources, model_names)
+    prev_input: str | list[str] | None
+    prev_input = primary if primary_is_model else None
+    # For a source-rooted model, no upstream step exists; the first step
+    # reads the primary input set by the executor (the source registered
+    # in ref_layers).
+
+    transforms = model.transform
+    if not transforms:
+        # Passthrough — an identity model. Compile to a single
+        # filter-no-op step that simply forwards the input.
+        return [
+            StepSpec(
+                id=model.name,
+                type="capability",
+                capability="filter",  # no params → identity
+                params={},
+                input=prev_input,
+                order=0,
+            )
+        ]
+
+    steps: list[StepSpec] = []
+    n = len(transforms)
+    for i, item in enumerate(transforms):
+        cap_name, params = _split_transform(item)
+        # `with: <ref>` ⇒ multi-input edge + ref_layer capability param.
+        extra_ref = params.pop("with", None)
+        inputs: str | list[str] | None = prev_input
+        if extra_ref is not None:
+            resolved, is_model = _resolve_ref(
+                extra_ref, sources, model_names
+            )
+            # ref_layer carries the secondary input for the existing
+            # ref-layer plumbing (spatial_join, attribute_join, …).
+            params.setdefault("ref_layer", resolved)
+            # When the primary input is itself an upstream *step* AND the
+            # with-ref names another *model*, surface the dep as a
+            # multi-input edge so the DAG executor wires both branches.
+            # When the primary is a *source* (prev_input is None), the
+            # secondary stays on ref_layer alone — adding it to step.input
+            # would silently swap the primary with the secondary.
+            if is_model and prev_input is not None:
+                base = (
+                    [prev_input]
+                    if isinstance(prev_input, str)
+                    else list(prev_input)
+                )
+                inputs = base + [resolved]
+        step_id = model.name if i == n - 1 else f"{model.name}__t{i}"
+        steps.append(
+            StepSpec(
+                id=step_id,
+                type="capability",
+                capability=cap_name,
+                params=params,
+                input=inputs,
+                order=i,
+            )
+        )
+        prev_input = step_id
+    return steps
+
+
+def _topo_models(models: dict[str, ModelSpec]) -> list[str]:
+    """Stable topological order over the inter-model select edges.
+
+    Models that ``select`` a *source* (no model dep) come first; models
+    that ``select`` another model wait for that one. The result drives
+    the order in which model step-chains are appended to the compiled
+    :class:`PipelineSpec` — useful for the readability of the emitted
+    pipeline. (The cycle-detection / DAG-execution semantics belong to
+    the engine, not the compiler — see #248 for the load-time cycle
+    check planned alongside this lot.)
+    """
+    remaining = dict(models)
+    ordered: list[str] = []
+    progress = True
+    while remaining and progress:
+        progress = False
+        for name in list(remaining):
+            ref = remaining[name].select
+            if ref not in remaining:
+                ordered.append(name)
+                del remaining[name]
+                progress = True
+    # Any leftover models are part of a cycle — append in declaration
+    # order so the compiler still emits something deterministic.
+    ordered.extend(remaining)
+    return ordered
+
+
+def compile_to_pipeline(manifest: ManifestV3) -> PipelineSpec:
+    """Compile a v3 manifest's ``models:`` into a runnable PipelineSpec.
+
+    The DAG is the union of every model's step chain, linked through
+    ``StepSpec.input``. Sources land in ``PipelineSpec.ref_layers``.
+    Manifest-level v3 triggers are not represented on PipelineSpec —
+    they are reactive and live next to the pipeline, not inside it.
+    """
+    model_names = set(manifest.models)
+    ref_layers = {name: src.uri for name, src in manifest.sources.items()}
+
+    steps: list[StepSpec] = []
+    order = 0
+    for model_name in _topo_models(manifest.models):
+        model_steps = _compile_model_steps(
+            manifest.models[model_name],
+            manifest.sources,
+            model_names,
+        )
+        for step in model_steps:
+            step.order = order
+            order += 1
+            steps.append(step)
+
+    return PipelineSpec(
+        version=2,  # compiled output — the runtime sees v2 DAG semantics.
+        name=manifest.name,
+        description=manifest.description,
+        steps=steps,
+        triggers=[],
+        ref_layers=ref_layers,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Migration: v1 / v2 → v3
+# ---------------------------------------------------------------------------
+
+
+def _v2_to_v3(raw: dict[str, Any]) -> dict[str, Any]:
+    """Compile a v2 PipelineSpec dict to an equivalent v3 manifest dict.
+
+    Each v2 step becomes a single-transform model whose select points at
+    the upstream step's id (or at the primary input, surfaced as the
+    pseudo source ``input``).
+    """
+    out: dict[str, Any] = {
+        "version": 3,
+        "name": raw.get("name", ""),
+        "description": raw.get("description", ""),
+    }
+    sources: dict[str, dict[str, Any]] = {}
+    for alias, uri in (raw.get("ref_layers") or {}).items():
+        sources[alias] = {"uri": uri}
+    # The primary input is unknown to v2 statically; surface it as a
+    # placeholder source so the v3 file is self-contained.
+    sources.setdefault("input", {"uri": "<primary_input>"})
+    out["sources"] = sources
+
+    models: dict[str, dict[str, Any]] = {}
+    for step in raw.get("steps") or []:
+        if not step.get("enabled", True):
+            continue
+        sid = step.get("id") or step.get("name") or f"step_{len(models)}"
+        cap = step.get("capability") or step.get("type") or "filter"
+        params = dict(step.get("params") or step.get("config") or {})
+        upstream = step.get("input")
+        select: str
+        if isinstance(upstream, list):
+            select = upstream[0] if upstream else "input"
+            # Carry the remaining inputs through the legacy ``ref_layer`` arg.
+            if len(upstream) > 1 and "ref_layer" not in params:
+                params["ref_layer"] = upstream[1]
+        elif isinstance(upstream, str) and upstream:
+            select = upstream
+        else:
+            select = "input"
+        models[sid] = {
+            "select": select,
+            "transform": [{cap: params}] if cap else [],
+        }
+    out["models"] = models
+
+    triggers_in = raw.get("triggers") or []
+    if triggers_in:
+        out["triggers"] = [
+            {
+                "name": t.get("name", f"trigger_{i}"),
+                "on": t.get("on", "manual"),
+                "table": t.get("table", ""),
+                "actions": t.get("then_config", {}).get("actions", [])
+                or [{"type": t.get("then", "log_event"), **t.get("then_config", {})}],
+            }
+            for i, t in enumerate(triggers_in)
+        ]
+    return out
+
+
+def _v1_to_v3(raw: list[dict[str, Any]]) -> dict[str, Any]:
+    """Compile a v1 flat rule list to a v3 manifest dict — a linear chain."""
+    sources = {"input": {"uri": "<primary_input>"}}
+    models: dict[str, dict[str, Any]] = {}
+    prev_id: str | None = None
+    for i, entry in enumerate(raw):
+        rid = entry.get("name") or f"step_{i}"
+        cap = entry.get("capability", "filter")
+        params = dict(entry.get("config") or {})
+        params.pop("order", None)
+        select = prev_id or "input"
+        models[rid] = {
+            "select": select,
+            "transform": [{cap: params}],
+        }
+        prev_id = rid
+    return {"version": 3, "sources": sources, "models": models}
+
+
+def migrate_to_v3(raw: Any) -> dict[str, Any]:
+    """Convert a v1 (list) or v2 (dict) raw payload to a v3 manifest dict."""
+    if isinstance(raw, list):
+        return _v1_to_v3(raw)
+    if isinstance(raw, dict):
+        version = raw.get("version")
+        if version == 3:
+            return raw  # already v3
+        if version == 2:
+            return _v2_to_v3(raw)
+        raise ValueError(
+            f"migrate_to_v3: unsupported pipeline dict (version={version!r})"
+        )
+    raise TypeError(
+        f"migrate_to_v3: expected dict or list, got {type(raw).__name__}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Round-trip
+# ---------------------------------------------------------------------------
+
+
+def manifest_to_dict(manifest: ManifestV3) -> dict[str, Any]:
+    """Render a :class:`ManifestV3` back to a canonical v3 dict.
+
+    Useful for ``gispulse migrate`` (write the migrated manifest out) and
+    for golden tests on the loader.
+    """
+    out: dict[str, Any] = {"version": 3}
+    if manifest.name:
+        out["name"] = manifest.name
+    if manifest.description:
+        out["description"] = manifest.description
+    if manifest.sources:
+        out["sources"] = {
+            name: {
+                k: v
+                for k, v in {
+                    "uri": src.uri,
+                    "layer": src.layer,
+                    "geometry": src.geometry,
+                    "crs": src.crs,
+                    "format": src.format,
+                    **src.extra,
+                }.items()
+                if v is not None
+            }
+            for name, src in manifest.sources.items()
+        }
+    if manifest.staging.engine or manifest.staging.cdc != "off":
+        st: dict[str, Any] = {}
+        if manifest.staging.engine:
+            st["engine"] = manifest.staging.engine
+        if not manifest.staging.attach:
+            st["attach"] = False
+        if manifest.staging.cdc != "off":
+            st["cdc"] = manifest.staging.cdc
+        out["staging"] = st
+    if manifest.models:
+        out["models"] = {
+            name: {
+                "select": m.select,
+                **({"transform": m.transform} if m.transform else {}),
+                **({"materialize": m.materialize} if m.materialize != "view" else {}),
+                **({"refresh": m.refresh} if m.refresh != "manual" else {}),
+            }
+            for name, m in manifest.models.items()
+        }
+    if manifest.triggers:
+        out["triggers"] = [
+            {
+                "name": t.name,
+                "on": t.on,
+                **({"table": t.table} if t.table else {}),
+                **({"when": t.when} if t.when is not None else {}),
+                **({"actions": t.actions} if t.actions else {}),
+            }
+            for t in manifest.triggers
+        ]
+    if manifest.security:
+        out["security"] = manifest.security
+    if manifest.runtime:
+        out["runtime"] = manifest.runtime
+    return out
+
+
+# Silence the unused-import warning when TYPE_CHECKING is False.
+_ = TriggerSpec

--- a/src/gispulse/core/manifest_v3.py
+++ b/src/gispulse/core/manifest_v3.py
@@ -39,6 +39,7 @@ from gispulse.core.pipeline import (
     StepSpec,
     TriggerSpec,
 )
+from gispulse.core.dag import CycleError, topological_sort
 from gispulse.core.pipeline_schema import validate_pipeline_json
 
 __all__ = [
@@ -47,6 +48,8 @@ __all__ = [
     "ModelSpec",
     "V3TriggerSpec",
     "ManifestV3",
+    "ManifestValidationError",
+    "validate_manifest",
     "load_manifest_v3",
     "compile_to_pipeline",
     "migrate_to_v3",
@@ -204,11 +207,17 @@ def load_manifest_v3(path: str | Path, *, validate: bool = True) -> ManifestV3:
     Args:
         path:     File path (``.yaml`` / ``.yml`` / ``.json``).
         validate: When ``True`` (default), validate against ``SCHEMA_V3``
-            before parsing. Validation errors are raised as ValueError.
+            **and** run the load-time graph check
+            (:func:`validate_manifest`) — unresolved ``select:``/``with:``
+            references and inter-model cycles raise
+            :class:`ManifestValidationError`. Orphan-model warnings are
+            logged through :mod:`gispulse.core.logging`.
 
     Returns:
         Typed :class:`ManifestV3`.
     """
+    from gispulse.core.logging import get_logger
+
     p = Path(path)
     if not p.exists():
         raise FileNotFoundError(f"Manifest file not found: {p}")
@@ -231,7 +240,7 @@ def load_manifest_v3(path: str | Path, *, validate: bool = True) -> ManifestV3:
                 msg += f"\n  ... and {len(errors) - 20} more errors"
             raise ValueError(msg)
 
-    return ManifestV3(
+    manifest = ManifestV3(
         name=raw.get("name", ""),
         description=raw.get("description", ""),
         sources=_parse_sources(raw.get("sources", {})),
@@ -241,6 +250,15 @@ def load_manifest_v3(path: str | Path, *, validate: bool = True) -> ManifestV3:
         security=dict(raw.get("security") or {}),
         runtime=dict(raw.get("runtime") or {}),
     )
+
+    if validate:
+        # Load-time graph check — raises ManifestValidationError on
+        # unresolved refs / cycles, logs orphan warnings.
+        log = get_logger(__name__)
+        for warning in validate_manifest(manifest):
+            log.warning("manifest_v3_warning", manifest=p.name, message=warning)
+
+    return manifest
 
 
 # ---------------------------------------------------------------------------
@@ -590,3 +608,118 @@ def manifest_to_dict(manifest: ManifestV3) -> dict[str, Any]:
 
 # Silence the unused-import warning when TYPE_CHECKING is False.
 _ = TriggerSpec
+
+
+# ---------------------------------------------------------------------------
+# Load-time validation (ELT Lot 4B — issue #248)
+# ---------------------------------------------------------------------------
+
+
+class ManifestValidationError(ValueError):
+    """One or more load-time problems in a v3 manifest.
+
+    Attributes:
+        errors: Human-readable error lines (unresolved refs, cycles).
+    """
+
+    def __init__(self, errors: list[str]) -> None:
+        self.errors = list(errors)
+        super().__init__(
+            "v3 manifest validation failed:\n  - "
+            + "\n  - ".join(errors)
+        )
+
+
+def _extract_with_ref(params: object) -> str | None:
+    if isinstance(params, dict):
+        ref = params.get("with")
+        if isinstance(ref, str):
+            return ref
+    return None
+
+
+def validate_manifest(manifest: ManifestV3) -> list[str]:
+    """Validate a v3 manifest at load-time.
+
+    Catches the three load-time concerns ADR 0005 / #248 calls for:
+
+    - Unresolved ``select:`` and transform-level ``with:`` references —
+      a ``ModelSpec`` selecting a name that is neither a declared source
+      nor another model. Error (blocking).
+    - Cycles in the inter-model dependency graph, detected by
+      :func:`~gispulse.core.dag.topological_sort` (Kahn's algorithm,
+      shared with :class:`GraphExecutor`). Error (blocking).
+    - Orphan models — models nobody else selects. They are often the
+      pipeline's terminal outputs (perfectly legitimate), so this is
+      surfaced as a warning, not an error.
+
+    Returns the list of *warnings*. Errors raise
+    :class:`ManifestValidationError`.
+    """
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    sources = set(manifest.sources)
+    models = set(manifest.models)
+    known = sources | models
+
+    referenced_models: set[str] = set()
+    inter_model_edges: list[tuple[str, str]] = []
+
+    for name, model in manifest.models.items():
+        if not isinstance(model.select, str) or not model.select:
+            errors.append(
+                f"models.{name}: missing or empty 'select' reference"
+            )
+        elif model.select not in known:
+            errors.append(
+                f"models.{name}: select={model.select!r} is not a "
+                "declared source or model"
+            )
+        elif model.select in models:
+            inter_model_edges.append((model.select, name))
+            referenced_models.add(model.select)
+
+        for i, step in enumerate(model.transform or []):
+            if not isinstance(step, dict) or len(step) != 1:
+                errors.append(
+                    f"models.{name}.transform[{i}]: must be a single-key "
+                    "{capability: params} object"
+                )
+                continue
+            (cap, params), = step.items()
+            with_ref = _extract_with_ref(params)
+            if with_ref is None:
+                continue
+            if with_ref not in known:
+                errors.append(
+                    f"models.{name}.transform[{i}].{cap}: with={with_ref!r} "
+                    "is not a declared source or model"
+                )
+            elif with_ref in models:
+                inter_model_edges.append((with_ref, name))
+                referenced_models.add(with_ref)
+
+    if errors:
+        raise ManifestValidationError(errors)
+
+    # Inter-model cycle detection (shared utility — same Kahn's algorithm
+    # GraphExecutor uses at execution time).
+    try:
+        topological_sort(list(models), inter_model_edges)
+    except CycleError as exc:
+        raise ManifestValidationError(
+            [
+                "model-dependency cycle involving: "
+                + ", ".join(repr(n) for n in sorted(exc.cycle))
+            ]
+        ) from exc
+
+    # Orphan models: nobody selects them. Often a pipeline's terminal
+    # outputs — emit as a warning so the user can confirm.
+    for name in sorted(models - referenced_models):
+        warnings.append(
+            f"models.{name}: nobody selects this model "
+            "(terminal output, or dead code?)"
+        )
+    return warnings

--- a/src/gispulse/core/pipeline_schema.py
+++ b/src/gispulse/core/pipeline_schema.py
@@ -211,6 +211,156 @@ SCHEMA_V2: dict[str, Any] = {
 
 
 # ---------------------------------------------------------------------------
+# Schema v3 — ADR 0005 unified manifest (sources / models / triggers)
+# ---------------------------------------------------------------------------
+
+SCHEMA_V3: dict[str, Any] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://gispulse.dev/schemas/manifest-v3.json",
+    "title": "GISPulse Manifest v3",
+    "description": (
+        "Unified ADR 0005 manifest: declared sources, an optional "
+        "staging facade, a `models:` DAG that compiles to PipelineSpec, "
+        "reactive triggers, plus security/runtime sections."
+    ),
+    "type": "object",
+    "required": ["version"],
+    "properties": {
+        "version": {"const": 3},
+        "name": {"type": "string"},
+        "description": {"type": "string"},
+        "sources": {
+            "type": "object",
+            "description": "Declared input sources, alias → spec.",
+            "additionalProperties": {"$ref": "#/$defs/source"},
+        },
+        "staging": {"$ref": "#/$defs/staging"},
+        "models": {
+            "type": "object",
+            "description": "DAG of derived models — compiled to PipelineSpec.steps.",
+            "additionalProperties": {"$ref": "#/$defs/model"},
+        },
+        "triggers": {
+            "type": "array",
+            "items": {"$ref": "#/$defs/v3_trigger"},
+        },
+        "security": {"type": "object"},
+        "runtime": {"type": "object"},
+    },
+    "additionalProperties": False,
+    "$defs": {
+        "source": {
+            "type": "object",
+            "required": ["uri"],
+            "properties": {
+                "uri": {
+                    "type": "string",
+                    "description": "URI of the source — local path, http(s), s3, virtual:…",
+                },
+                "layer": {
+                    "type": ["string", "null"],
+                    "description": "Layer name inside multi-layer sources (GPKG, GeoParquet…).",
+                },
+                "geometry": {
+                    "type": ["string", "null"],
+                    "description": "Logical geometry column name (Q3 — geometry-agnostic).",
+                },
+                "crs": {
+                    "type": ["string", "null"],
+                    "description": "Logical CRS — never the physical encoding.",
+                },
+                "format": {
+                    "type": ["string", "null"],
+                    "description": "Optional explicit format hint (gpkg, parquet, …).",
+                },
+            },
+            "additionalProperties": True,
+        },
+        "staging": {
+            "type": "object",
+            "properties": {
+                "engine": {
+                    "type": "string",
+                    "enum": ["duckdb", "postgis", "gpkg", "spatialite"],
+                    "description": "GISPulseConfig.engine — global, not per-model.",
+                },
+                "attach": {"type": "boolean", "default": True},
+                "cdc": {
+                    "type": "string",
+                    "enum": ["off", "snapshot", "incremental"],
+                    "default": "off",
+                },
+            },
+            "additionalProperties": False,
+        },
+        "model": {
+            "type": "object",
+            "required": ["select"],
+            "properties": {
+                "select": {
+                    "type": "string",
+                    "description": "Upstream layer reference — a source name or another model.",
+                },
+                "transform": {
+                    "type": "array",
+                    "items": {"$ref": "#/$defs/transform_step"},
+                    "default": [],
+                },
+                "materialize": {
+                    "type": "string",
+                    "enum": ["view", "table", "incremental"],
+                    "default": "view",
+                },
+                "refresh": {
+                    "type": "string",
+                    "enum": ["on_change", "manual", "schedule"],
+                    "default": "manual",
+                },
+            },
+            "additionalProperties": False,
+        },
+        "transform_step": {
+            "type": "object",
+            "description": (
+                "Single transform — exactly one key (the capability name) "
+                "mapping to its params object. e.g. `{filter: {where: ...}}`."
+            ),
+            "minProperties": 1,
+            "maxProperties": 1,
+            "additionalProperties": {"type": "object"},
+        },
+        "v3_trigger": {
+            "type": "object",
+            "required": ["name", "on"],
+            "properties": {
+                "name": {"type": "string", "minLength": 1},
+                "on": {
+                    "oneOf": [
+                        {"type": "string"},
+                        {"type": "array", "items": {"type": "string"}},
+                    ],
+                    "description": "Event(s): INSERT, UPDATE, DELETE, schedule, manual.",
+                },
+                "table": {"type": "string"},
+                "when": {
+                    "oneOf": [
+                        {"type": "array"},
+                        {"type": "object"},
+                        {"type": "null"},
+                    ],
+                },
+                "actions": {
+                    "type": "array",
+                    "items": {"type": "object"},
+                },
+            },
+            "additionalProperties": True,
+        },
+    },
+}
+
+
+# ---------------------------------------------------------------------------
 # Validation
 # ---------------------------------------------------------------------------
 
@@ -243,10 +393,17 @@ def validate_pipeline_json(raw: Any) -> list[str]:
 
 
 def _pick_schema(raw: Any) -> dict[str, Any] | None:
-    """Select schema based on data type and version field."""
+    """Select schema based on data type and version field.
+
+    A dict with ``version: 3`` (ADR 0005 unified manifest) routes to
+    :data:`SCHEMA_V3`; otherwise ``version: 2`` is the default for any
+    dict. A list is the legacy v1 flat rule format.
+    """
     if isinstance(raw, list):
         return SCHEMA_V1
     if isinstance(raw, dict):
+        if raw.get("version") == 3:
+            return SCHEMA_V3
         return SCHEMA_V2
     return None
 
@@ -267,32 +424,97 @@ def _validate_basic(raw: Any, schema: dict[str, Any]) -> list[str]:
                 errors.append(f"[{i}]: missing required field 'capability'")
 
     elif isinstance(raw, dict):
-        # V2: pipeline object
-        if "version" not in raw:
-            errors.append("(root): missing required field 'version'")
-        elif raw["version"] != 2:
-            errors.append(f"(root): version must be 2, got {raw['version']}")
-        if "steps" not in raw:
-            errors.append("(root): missing required field 'steps'")
-        elif not isinstance(raw["steps"], list):
-            errors.append("(root): 'steps' must be an array")
-        elif len(raw["steps"]) == 0:
-            errors.append("(root): 'steps' must contain at least one step")
+        if raw.get("version") == 3:
+            errors.extend(_validate_v3_basic(raw))
         else:
-            for i, step in enumerate(raw["steps"]):
-                if not isinstance(step, dict):
-                    errors.append(f"steps[{i}]: must be an object")
-                    continue
-                if "id" not in step and "name" not in step:
-                    errors.append(f"steps[{i}]: missing required field 'id'")
+            errors.extend(_validate_v2_basic(raw))
 
-        for i, trigger in enumerate(raw.get("triggers", [])):
-            if not isinstance(trigger, dict):
-                errors.append(f"triggers[{i}]: must be an object")
+    return errors
+
+
+def _validate_v2_basic(raw: dict[str, Any]) -> list[str]:
+    """Structural check for a v2 PipelineSpec dict (no jsonschema)."""
+    errors: list[str] = []
+    if "version" not in raw:
+        errors.append("(root): missing required field 'version'")
+    elif raw["version"] != 2:
+        errors.append(f"(root): version must be 2, got {raw['version']}")
+    if "steps" not in raw:
+        errors.append("(root): missing required field 'steps'")
+    elif not isinstance(raw["steps"], list):
+        errors.append("(root): 'steps' must be an array")
+    elif len(raw["steps"]) == 0:
+        errors.append("(root): 'steps' must contain at least one step")
+    else:
+        for i, step in enumerate(raw["steps"]):
+            if not isinstance(step, dict):
+                errors.append(f"steps[{i}]: must be an object")
                 continue
-            if "on" not in trigger:
-                errors.append(f"triggers[{i}]: missing required field 'on'")
-            if "then" not in trigger:
-                errors.append(f"triggers[{i}]: missing required field 'then'")
+            if "id" not in step and "name" not in step:
+                errors.append(f"steps[{i}]: missing required field 'id'")
 
+    for i, trigger in enumerate(raw.get("triggers", [])):
+        if not isinstance(trigger, dict):
+            errors.append(f"triggers[{i}]: must be an object")
+            continue
+        if "on" not in trigger:
+            errors.append(f"triggers[{i}]: missing required field 'on'")
+        if "then" not in trigger:
+            errors.append(f"triggers[{i}]: missing required field 'then'")
+    return errors
+
+
+def _validate_v3_basic(raw: dict[str, Any]) -> list[str]:
+    """Structural check for a v3 manifest dict (no jsonschema).
+
+    Mirrors the rules in :data:`SCHEMA_V3` enough to catch the obvious
+    mistakes — missing ``uri`` on a source, missing ``select`` on a
+    model, a transform step with the wrong number of keys, a trigger
+    missing ``name`` / ``on``. Falls back here when ``jsonschema`` is
+    not installed; the full schema check still happens when it is.
+    """
+    errors: list[str] = []
+    sources = raw.get("sources", {})
+    if not isinstance(sources, dict):
+        errors.append("sources: must be an object (alias -> source spec)")
+        sources = {}
+    for name, spec in sources.items():
+        if not isinstance(spec, dict):
+            errors.append(f"sources.{name}: must be an object")
+            continue
+        if "uri" not in spec:
+            errors.append(f"sources.{name}: missing required field 'uri'")
+
+    models = raw.get("models", {})
+    if not isinstance(models, dict):
+        errors.append("models: must be an object (name -> model spec)")
+        models = {}
+    for name, model in models.items():
+        if not isinstance(model, dict):
+            errors.append(f"models.{name}: must be an object")
+            continue
+        if "select" not in model:
+            errors.append(f"models.{name}: missing required field 'select'")
+        transform = model.get("transform")
+        if transform is not None:
+            if not isinstance(transform, list):
+                errors.append(
+                    f"models.{name}.transform: must be an array of "
+                    "single-key {capability: params} objects"
+                )
+                continue
+            for i, step in enumerate(transform):
+                if not isinstance(step, dict) or len(step) != 1:
+                    errors.append(
+                        f"models.{name}.transform[{i}]: must have exactly "
+                        "one key (capability name)"
+                    )
+
+    for i, trigger in enumerate(raw.get("triggers", []) or []):
+        if not isinstance(trigger, dict):
+            errors.append(f"triggers[{i}]: must be an object")
+            continue
+        for required in ("name", "on"):
+            if required not in trigger:
+                errors.append(f"triggers[{i}]: missing required field {required!r}")
     return errors

--- a/src/gispulse/orchestration/graph_executor.py
+++ b/src/gispulse/orchestration/graph_executor.py
@@ -7,7 +7,7 @@ loop/branch/parallel composite nodes, and dataset/artifact endpoints.
 
 from __future__ import annotations
 
-from collections import defaultdict, deque
+from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Callable
 
@@ -338,24 +338,26 @@ class GraphExecutor:
         adj: dict[str, list[str]],
         in_degree: dict[str, int],
     ) -> list[str]:
-        """Kahn's algorithm for topological ordering."""
-        q: deque[str] = deque()
-        for n in nodes:
-            if in_degree.get(n.id, 0) == 0:
-                q.append(n.id)
-        order: list[str] = []
-        deg = dict(in_degree)
-        while q:
-            nid = q.popleft()
-            order.append(nid)
-            for child in adj.get(nid, []):
-                deg[child] -= 1
-                if deg[child] == 0:
-                    q.append(child)
-        if len(order) != len(nodes):
-            missing = {n.id for n in nodes} - set(order)
-            raise ValueError(f"Cycle detected in graph, unreachable nodes: {missing}")
-        return order
+        """Kahn's algorithm for topological ordering.
+
+        Thin wrapper over :func:`gispulse.core.dag.topological_sort` —
+        the algorithm now lives in :mod:`gispulse.core.dag` so the v3
+        manifest loader can reuse it for load-time cycle detection
+        (ELT Lot 4B / #248). The ``in_degree`` argument is accepted for
+        signature back-compat but recomputed from *adj* inside the
+        utility.
+        """
+        from gispulse.core.dag import CycleError, topological_sort
+
+        edges = [(src, dst) for src, targets in adj.items() for dst in targets]
+        try:
+            return topological_sort([n.id for n in nodes], edges)
+        except CycleError as exc:
+            # Preserve the legacy ValueError text so existing callers
+            # and tests keep matching.
+            raise ValueError(
+                f"Cycle detected in graph, unreachable nodes: {exc.cycle}"
+            ) from exc
 
     @staticmethod
     def _build_edge_index(edges: list[EdgeDef]) -> dict[str, list[EdgeDef]]:

--- a/src/gispulse/persistence/spatial_queries.py
+++ b/src/gispulse/persistence/spatial_queries.py
@@ -1,0 +1,133 @@
+"""Statement builders for the SQL-pushed geometry capabilities.
+
+ELT Lot 1 (issue #244, ADR 0005). One builder per capability that used
+to emit inline SQL — ``buffer`` / ``clip`` / ``intersects``. Each is
+parameterised by a :class:`~gispulse.persistence.sql_dialect.SQLDialect`
+and reproduces, statement for statement, the SQL the capability
+strategies emitted as hand-written f-strings — so pointing a strategy at
+a builder is a behaviour-preserving refactor.
+
+This sits one layer above :mod:`gispulse.persistence.sql_dialect`: the
+dialect spells *expressions* (a buffer, an intersection, a geometry
+reference), the builders here assemble whole ``SELECT`` *statements*.
+
+All table names go through :func:`validate_identifier`; geometry columns
+and aliases are validated inside the dialect. No value is inlined raw.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from gispulse.core.sql_safety import validate_identifier
+from gispulse.persistence.sql_dialect import BufferStyle, SQLDialect
+
+__all__ = [
+    "GeneratedQuery",
+    "buffer_select",
+    "clip_select",
+    "intersects_select",
+]
+
+
+@dataclass(frozen=True)
+class GeneratedQuery:
+    """A generated SQL statement plus the result's geometry column.
+
+    Attributes:
+        sql:         SQL statement ready to hand to ``sql_to_gdf``.
+        geom_column: Name of the geometry column in the result set — the
+            column a strategy should ``set_geometry`` on. For queries
+            that only filter rows (``intersects``) this is the dialect's
+            pass-through geometry column.
+    """
+
+    sql: str
+    geom_column: str
+
+
+def buffer_select(
+    dialect: SQLDialect,
+    *,
+    source_table: str,
+    distance: float,
+    style: BufferStyle | None = None,
+) -> GeneratedQuery:
+    """Build the ``buffer`` push-down query.
+
+    Emits ``SELECT <projection> FROM <source_table>`` where the buffered
+    geometry is derived via :meth:`SQLDialect.project_with_geometry` —
+    ``* REPLACE`` on DuckDB (so the result decoder finds the canonical
+    ``__wkb`` column), an appended ``geometry_buf`` column on PostGIS.
+
+    Raises:
+        UnsupportedInDialect: when *style* is non-default and the dialect
+            cannot express a styled buffer (DuckDB) — the caller falls
+            back to the Python strategy.
+    """
+    validate_identifier(source_table, "source table")
+    buffered = dialect.st_buffer_styled(dialect.geom_ref(), distance, style)
+    projection, geom_col = dialect.project_with_geometry(
+        None, buffered, result_suffix="buf"
+    )
+    sql = f"SELECT {projection} FROM {source_table}"
+    return GeneratedQuery(sql=sql, geom_column=geom_col)
+
+
+def clip_select(
+    dialect: SQLDialect,
+    *,
+    source_table: str,
+    mask_table: str,
+    source_alias: str = "i",
+    mask_alias: str = "m",
+) -> GeneratedQuery:
+    """Build the ``clip`` push-down query.
+
+    Emits an ``ST_Intersection`` of every source feature against the
+    (already unioned) mask, keeping only features that actually
+    intersect. The derived geometry is projected via
+    :meth:`SQLDialect.project_with_geometry` — ``* REPLACE`` on DuckDB so
+    the result keeps the canonical ``__wkb`` name, an appended
+    ``geometry_clip`` column on PostGIS.
+    """
+    validate_identifier(source_table, "source table")
+    validate_identifier(mask_table, "mask table")
+    src = dialect.geom_ref(table=source_alias)
+    msk = dialect.geom_ref(table=mask_alias)
+    projection, geom_col = dialect.project_with_geometry(
+        source_alias, dialect.st_intersection(src, msk), result_suffix="clip"
+    )
+    sql = (
+        f"SELECT {projection} "
+        f"FROM {source_table} {source_alias}, {mask_table} {mask_alias} "
+        f"WHERE {dialect.st_intersects(src, msk)}"
+    )
+    return GeneratedQuery(sql=sql, geom_column=geom_col)
+
+
+def intersects_select(
+    dialect: SQLDialect,
+    *,
+    source_table: str,
+    ref_table: str,
+    source_alias: str = "i",
+    ref_alias: str = "r",
+) -> GeneratedQuery:
+    """Build the ``intersects`` push-down query.
+
+    Emits ``SELECT <src>.* FROM <source> <src>, <ref> <ref> WHERE
+    ST_Intersects(...)`` — a row filter that keeps source features
+    intersecting the reference geometry. No geometry is derived, so the
+    result geometry column is the dialect's pass-through column.
+    """
+    validate_identifier(source_table, "source table")
+    validate_identifier(ref_table, "reference table")
+    src = dialect.geom_ref(table=source_alias)
+    ref = dialect.geom_ref(table=ref_alias)
+    sql = (
+        f"SELECT {source_alias}.* "
+        f"FROM {source_table} {source_alias}, {ref_table} {ref_alias} "
+        f"WHERE {dialect.st_intersects(src, ref)}"
+    )
+    return GeneratedQuery(sql=sql, geom_column=dialect.geom_column)

--- a/src/gispulse/persistence/sql_dialect.py
+++ b/src/gispulse/persistence/sql_dialect.py
@@ -287,6 +287,45 @@ class SQLDialect(ABC):
         validate_identifier(table_alias, "table alias")
         return f"{table_alias}.*"
 
+    # ------------------------------------------------------------------
+    # ELT Lot 3 (#246) — single-layer 1:1 geometry transforms
+    # ------------------------------------------------------------------
+    # DuckDB-spatial and PostGIS spell these identically (``ST_*``); they
+    # are concrete here. :class:`GeoPackageDialect` overrides them to
+    # raise. They are only ever invoked through the DuckDB/PostGIS
+    # push-down strategies, so the SpatiaLite spelling is not specialised.
+
+    def st_boundary(self, geom: str) -> str:
+        """Topological boundary of a geometry."""
+        return f"ST_Boundary({geom})"
+
+    def st_envelope(self, geom: str) -> str:
+        """Axis-aligned bounding-box envelope of a geometry."""
+        return f"ST_Envelope({geom})"
+
+    def st_convex_hull(self, geom: str) -> str:
+        """Convex hull of a geometry."""
+        return f"ST_ConvexHull({geom})"
+
+    def st_concave_hull(
+        self, geom: str, ratio: float, *, allow_holes: bool = False
+    ) -> str:
+        """Concave hull — three-arg form, the one DuckDB-spatial accepts."""
+        holes = "true" if allow_holes else "false"
+        return f"ST_ConcaveHull({geom}, {float(ratio)}, {holes})"
+
+    def st_make_valid(self, geom: str) -> str:
+        """Repaired (validity-corrected) geometry."""
+        return f"ST_MakeValid({geom})"
+
+    def st_simplify(self, geom: str, tolerance: float) -> str:
+        """Douglas-Peucker simplified geometry."""
+        return f"ST_Simplify({geom}, {float(tolerance)})"
+
+    def st_is_empty(self, geom: str) -> str:
+        """Boolean — whether a geometry is empty."""
+        return f"ST_IsEmpty({geom})"
+
 
 class PostGISDialect(SQLDialect):
     """PostgreSQL/PostGIS spatial SQL dialect."""
@@ -595,6 +634,29 @@ class GeoPackageDialect(SQLDialect):
         self, geom_expr: str, *, src_srid: int, dst_srid: int
     ) -> str:
         return self._spatial_not_supported("ST_Transform")
+
+    def st_boundary(self, geom: str) -> str:
+        return self._spatial_not_supported("ST_Boundary")
+
+    def st_envelope(self, geom: str) -> str:
+        return self._spatial_not_supported("ST_Envelope")
+
+    def st_convex_hull(self, geom: str) -> str:
+        return self._spatial_not_supported("ST_ConvexHull")
+
+    def st_concave_hull(
+        self, geom: str, ratio: float, *, allow_holes: bool = False
+    ) -> str:
+        return self._spatial_not_supported("ST_ConcaveHull")
+
+    def st_make_valid(self, geom: str) -> str:
+        return self._spatial_not_supported("ST_MakeValid")
+
+    def st_simplify(self, geom: str, tolerance: float) -> str:
+        return self._spatial_not_supported("ST_Simplify")
+
+    def st_is_empty(self, geom: str) -> str:
+        return self._spatial_not_supported("ST_IsEmpty")
 
 
 # Singleton instances

--- a/src/gispulse/persistence/sql_dialect.py
+++ b/src/gispulse/persistence/sql_dialect.py
@@ -351,6 +351,15 @@ class SQLDialect(ABC):
         """
         return f"ST_SymDifference({a}, {b})"
 
+    def first_agg(self, col: str) -> str:
+        """Pick one value per group — the GeoPandas ``dissolve`` aggfunc.
+
+        PostgreSQL has no ``first`` aggregate; the base spelling picks
+        the first element of ``array_agg``. :class:`DuckDBDialect`
+        overrides with the native ``first()`` aggregate.
+        """
+        return f"(array_agg({col}))[1]"
+
 
 class PostGISDialect(SQLDialect):
     """PostgreSQL/PostGIS spatial SQL dialect."""
@@ -515,6 +524,10 @@ class DuckDBDialect(SQLDialect):
         # DuckDB-spatial has no ST_SymDifference — compose it from the
         # two one-sided differences: (a - b) unioned with (b - a).
         return f"ST_Union(ST_Difference({a}, {b}), ST_Difference({b}, {a}))"
+
+    def first_agg(self, col: str) -> str:
+        # DuckDB has a native first() aggregate — pick one element per group.
+        return f"first({col})"
 
 
 class SpatiaLiteDialect(SQLDialect):
@@ -703,6 +716,9 @@ class GeoPackageDialect(SQLDialect):
 
     def st_sym_difference(self, a: str, b: str) -> str:
         return self._spatial_not_supported("ST_SymDifference")
+
+    def first_agg(self, col: str) -> str:
+        return self._spatial_not_supported("first_agg")
 
 
 # Singleton instances

--- a/src/gispulse/persistence/sql_dialect.py
+++ b/src/gispulse/persistence/sql_dialect.py
@@ -326,6 +326,31 @@ class SQLDialect(ABC):
         """Boolean — whether a geometry is empty."""
         return f"ST_IsEmpty({geom})"
 
+    def st_difference(self, a: str, b: str) -> str:
+        """Geometric difference ``a - b``."""
+        return f"ST_Difference({a}, {b})"
+
+    def st_simplify_preserve_topology(self, geom: str, tolerance: float) -> str:
+        """Topology-preserving Douglas-Peucker simplification."""
+        return f"ST_SimplifyPreserveTopology({geom}, {float(tolerance)})"
+
+    def st_union_agg(self, geom_col: str) -> str:
+        """Aggregate union of a geometry column.
+
+        Base spelling is the PostGIS aggregate ``ST_Union``;
+        :class:`DuckDBDialect` overrides with ``ST_Union_Agg``.
+        """
+        return f"ST_Union({geom_col})"
+
+    def st_sym_difference(self, a: str, b: str) -> str:
+        """Symmetric difference ``a XOR b``.
+
+        Base spelling is the PostGIS native ``ST_SymDifference``;
+        :class:`DuckDBDialect` — which lacks it — overrides with the
+        equivalent ``(a - b) UNION (b - a)``.
+        """
+        return f"ST_SymDifference({a}, {b})"
+
 
 class PostGISDialect(SQLDialect):
     """PostgreSQL/PostGIS spatial SQL dialect."""
@@ -481,6 +506,15 @@ class DuckDBDialect(SQLDialect):
             f"{star} REPLACE ({geom_expr} AS {self.geom_column})",
             self.geom_column,
         )
+
+    def st_union_agg(self, geom_col: str) -> str:
+        # DuckDB-spatial spells the aggregate union ST_Union_Agg.
+        return f"ST_Union_Agg({geom_col})"
+
+    def st_sym_difference(self, a: str, b: str) -> str:
+        # DuckDB-spatial has no ST_SymDifference — compose it from the
+        # two one-sided differences: (a - b) unioned with (b - a).
+        return f"ST_Union(ST_Difference({a}, {b}), ST_Difference({b}, {a}))"
 
 
 class SpatiaLiteDialect(SQLDialect):
@@ -657,6 +691,18 @@ class GeoPackageDialect(SQLDialect):
 
     def st_is_empty(self, geom: str) -> str:
         return self._spatial_not_supported("ST_IsEmpty")
+
+    def st_difference(self, a: str, b: str) -> str:
+        return self._spatial_not_supported("ST_Difference")
+
+    def st_simplify_preserve_topology(self, geom: str, tolerance: float) -> str:
+        return self._spatial_not_supported("ST_SimplifyPreserveTopology")
+
+    def st_union_agg(self, geom_col: str) -> str:
+        return self._spatial_not_supported("ST_Union")
+
+    def st_sym_difference(self, a: str, b: str) -> str:
+        return self._spatial_not_supported("ST_SymDifference")
 
 
 # Singleton instances

--- a/src/gispulse/persistence/sql_dialect.py
+++ b/src/gispulse/persistence/sql_dialect.py
@@ -13,10 +13,115 @@ Usage::
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+from gispulse.core.sql_safety import validate_identifier
+
+
+class UnsupportedInDialect(NotImplementedError):
+    """A spatial SQL feature has no equivalent in the target dialect.
+
+    Subclasses :class:`NotImplementedError` so existing callers that
+    catch the broad type keep working, while new code can catch this
+    precise type — e.g. a styled buffer or the KNN operator routed
+    through DuckDB — and fall back to the Python strategy.
+    """
+
+    def __init__(self, feature: str, dialect: str) -> None:
+        super().__init__(
+            f"{feature!r} is not supported by the {dialect!r} SQL dialect"
+        )
+        self.feature = feature
+        self.dialect = dialect
+
+
+# ---------------------------------------------------------------------------
+# Buffer style (ELT Lot 1 — divergence #2)
+# ---------------------------------------------------------------------------
+
+_CAP_STYLES: frozenset[str] = frozenset({"round", "flat", "square"})
+_JOIN_STYLES: frozenset[str] = frozenset({"round", "mitre", "bevel"})
+
+
+@dataclass(frozen=True)
+class BufferStyle:
+    """Validated styling parameters for ``ST_Buffer``.
+
+    The default instance (``BufferStyle()``) is the only style DuckDB
+    can honour. Anything else has :attr:`is_default` ``False`` and only
+    PostGIS can express it as SQL — see :meth:`SQLDialect.st_buffer_styled`.
+    """
+
+    quad_segs: int = 8
+    cap_style: str = "round"
+    join_style: str = "round"
+    mitre_limit: float = 5.0
+    single_sided: bool = False
+
+    def __post_init__(self) -> None:
+        if self.cap_style not in _CAP_STYLES:
+            raise ValueError(
+                f"Invalid cap_style {self.cap_style!r}. Expected one of "
+                f"{sorted(_CAP_STYLES)}."
+            )
+        if self.join_style not in _JOIN_STYLES:
+            raise ValueError(
+                f"Invalid join_style {self.join_style!r}. Expected one of "
+                f"{sorted(_JOIN_STYLES)}."
+            )
+        if self.quad_segs < 1:
+            raise ValueError("quad_segs must be >= 1.")
+
+    @property
+    def is_default(self) -> bool:
+        """True when the style is the round/8-seg/two-sided default."""
+        return (
+            self.quad_segs == 8
+            and self.cap_style == "round"
+            and self.join_style == "round"
+            and float(self.mitre_limit) == 5.0
+            and not self.single_sided
+        )
+
+    def to_postgis_style(self) -> str:
+        """Render the PostGIS ``ST_Buffer`` style-string third argument.
+
+        Built from enum-constrained, validated fields, so it is safe to
+        inline into SQL.
+        """
+        side = "left" if self.single_sided else "both"
+        return (
+            f"quad_segs={int(self.quad_segs)} endcap={self.cap_style} "
+            f"join={self.join_style} mitre_limit={float(self.mitre_limit):.3f} "
+            f"side={side}"
+        )
+
+
+def _fmt_number(value: float) -> str:
+    """Format a numeric SQL literal (buffer distances may be negative)."""
+    return repr(float(value))
+
+
+def _qualified(column: str, table: str | None) -> str:
+    """Return a validated ``table.column`` (or bare ``column``)."""
+    validate_identifier(column, "geometry column")
+    if table is None:
+        return column
+    validate_identifier(table, "table alias")
+    return f"{table}.{column}"
 
 
 class SQLDialect(ABC):
     """Abstract base for spatial SQL dialect adapters."""
+
+    #: Column a registered GeoDataFrame's geometry lands in for this backend.
+    geom_column: str = "geometry"
+    #: Whether ``ST_Buffer`` accepts a non-default :class:`BufferStyle`.
+    supports_styled_buffer: bool = False
+    #: Whether the KNN ``<->`` distance operator is available.
+    supports_knn: bool = False
+    #: Whether ``ST_Coverage*`` topological functions are available.
+    supports_coverage: bool = False
 
     @property
     @abstractmethod
@@ -87,6 +192,101 @@ class SQLDialect(ABC):
         """SQL expression for crosses test."""
         return f"ST_Crosses({a}, {b})"
 
+    # ------------------------------------------------------------------
+    # ELT Lot 1 (#244) — the five audited DuckDB/PostGIS divergences
+    # ------------------------------------------------------------------
+
+    def geom_ref(self, column: str | None = None, *, table: str | None = None) -> str:
+        """Return a GEOMETRY-typed expression for a *registered* column.
+
+        Divergence #1 — DuckDB registers a GeoDataFrame as a ``__wkb``
+        BLOB and must lift it with ``ST_GeomFromWKB``; engines with a
+        native geometry column just reference it. Base behaviour is the
+        native reference; :class:`DuckDBDialect` overrides.
+        """
+        return _qualified(column or self.geom_column, table)
+
+    def st_intersection(self, a: str, b: str) -> str:
+        """SQL expression for the geometric intersection (overlay) of *a*, *b*."""
+        return f"ST_Intersection({a}, {b})"
+
+    def st_buffer_styled(
+        self,
+        geom_expr: str,
+        distance: float,
+        style: BufferStyle | None = None,
+    ) -> str:
+        """Planar ``ST_Buffer`` with an optional :class:`BufferStyle`.
+
+        Divergence #2 — distinct from :meth:`st_buffer`, which buffers in
+        ``geography`` space. Here the caller has already reprojected to a
+        metric CRS, so the buffer is planar. Base behaviour honours only
+        the default style; :class:`PostGISDialect` overrides to emit the
+        style string.
+
+        Raises:
+            UnsupportedInDialect: when *style* is non-default and the
+                dialect cannot express it.
+        """
+        if style is not None and not style.is_default:
+            raise UnsupportedInDialect("styled ST_Buffer", self.name)
+        return f"ST_Buffer({geom_expr}, {_fmt_number(distance)})"
+
+    def st_transform(
+        self, geom_expr: str, *, src_srid: int, dst_srid: int
+    ) -> str:
+        """Reproject a geometry between SRIDs.
+
+        Divergence #4 — base behaviour is the 2-arg ``(geom, target)``
+        form; :class:`DuckDBDialect` overrides with the 4-arg form that
+        pins axis order via ``always_xy``.
+        """
+        return f"ST_Transform({geom_expr}, {int(dst_srid)})"
+
+    def st_knn_distance(self, a: str, b: str) -> str:
+        """KNN ``<->`` index-backed nearest-neighbour distance operator.
+
+        Divergence #3 — PostGIS-only.
+
+        Raises:
+            UnsupportedInDialect: on every dialect but PostGIS.
+        """
+        raise UnsupportedInDialect("KNN <-> operator", self.name)
+
+    def project_with_geometry(
+        self,
+        table_alias: str | None,
+        geom_expr: str,
+        *,
+        result_suffix: str = "out",
+    ) -> tuple[str, str]:
+        """Build a ``SELECT`` projection that derives a new geometry column.
+
+        Returns ``(projection, result_geom_column)`` — the text placed
+        after ``SELECT`` and the name the derived geometry lands under.
+
+        *table_alias* qualifies the star (``i.*``); pass ``None`` for an
+        unqualified ``*`` (single-table queries).
+
+        Base behaviour appends *geom_expr* as a new
+        ``<geom_column>_<result_suffix>`` column next to the star.
+        :class:`DuckDBDialect` overrides this to use the ``* REPLACE``
+        projection so the geometry keeps its canonical ``__wkb`` name —
+        the DuckDB result decoder keys on that name.
+        """
+        star = self._star(table_alias)
+        result_col = f"{self.geom_column}_{result_suffix}"
+        validate_identifier(result_col, "result geometry column")
+        return f"{star}, {geom_expr} AS {result_col}", result_col
+
+    @staticmethod
+    def _star(table_alias: str | None) -> str:
+        """Return ``*`` or a validated ``<alias>.*``."""
+        if not table_alias:
+            return "*"
+        validate_identifier(table_alias, "table alias")
+        return f"{table_alias}.*"
+
 
 class PostGISDialect(SQLDialect):
     """PostgreSQL/PostGIS spatial SQL dialect."""
@@ -130,6 +330,38 @@ class PostGISDialect(SQLDialect):
     def string_agg(self, col: str, sep: str = ", ") -> str:
         return f"STRING_AGG({col}::TEXT, '{sep}')"
 
+    # -- ELT Lot 1 divergences ----------------------------------------
+
+    geom_column = "geometry"
+    supports_styled_buffer = True
+    supports_knn = True
+    supports_coverage = True
+
+    def geom_ref(self, column: str | None = None, *, table: str | None = None) -> str:
+        # `register` writes a native `geometry` column; the explicit cast
+        # is a harmless no-op that keeps the SQL symmetric with DuckDB.
+        return f"{_qualified(column or self.geom_column, table)}::geometry"
+
+    def st_buffer_styled(
+        self,
+        geom_expr: str,
+        distance: float,
+        style: BufferStyle | None = None,
+    ) -> str:
+        # A supplied BufferStyle is always rendered as the explicit style
+        # string — including a default one — so the emitted SQL is
+        # byte-stable regardless of the style's values. ``style=None``
+        # gives the bare two-argument form.
+        if style is None:
+            return f"ST_Buffer({geom_expr}, {_fmt_number(distance)})"
+        return (
+            f"ST_Buffer({geom_expr}, {_fmt_number(distance)}, "
+            f"'{style.to_postgis_style()}')"
+        )
+
+    def st_knn_distance(self, a: str, b: str) -> str:
+        return f"({a} <-> {b})"
+
 
 class DuckDBDialect(SQLDialect):
     """DuckDB spatial extension SQL dialect."""
@@ -172,6 +404,44 @@ class DuckDBDialect(SQLDialect):
 
     def string_agg(self, col: str, sep: str = ", ") -> str:
         return f"STRING_AGG({col}::VARCHAR, '{sep}')"
+
+    # -- ELT Lot 1 divergences ----------------------------------------
+    # DuckDB is the ADR 0001 contract dialect. Styled buffers and the
+    # KNN operator inherit the base behaviour (raise UnsupportedInDialect)
+    # — there is no DuckDB-spatial equivalent.
+
+    geom_column = "__wkb"
+
+    def geom_ref(self, column: str | None = None, *, table: str | None = None) -> str:
+        # `register_gdf` stores geometry as a `__wkb` BLOB column; it must
+        # be parsed back to GEOMETRY before any spatial function.
+        return f"ST_GeomFromWKB({_qualified(column or self.geom_column, table)})"
+
+    def st_transform(
+        self, geom_expr: str, *, src_srid: int, dst_srid: int
+    ) -> str:
+        # 4-arg form: always_xy := true pins lon/lat axis order so a
+        # geographic source CRS is not silently transposed.
+        return (
+            f"ST_Transform({geom_expr}, 'EPSG:{int(src_srid)}', "
+            f"'EPSG:{int(dst_srid)}', always_xy := true)"
+        )
+
+    def project_with_geometry(
+        self,
+        table_alias: str | None,
+        geom_expr: str,
+        *,
+        result_suffix: str = "out",
+    ) -> tuple[str, str]:
+        # `* REPLACE (expr AS col)` is a DuckDB extension: it swaps a
+        # column in place, so the derived geometry keeps the canonical
+        # __wkb name the result decoder expects. result_suffix is unused.
+        star = self._star(table_alias)
+        return (
+            f"{star} REPLACE ({geom_expr} AS {self.geom_column})",
+            self.geom_column,
+        )
 
 
 class SpatiaLiteDialect(SQLDialect):
@@ -221,6 +491,27 @@ class SpatiaLiteDialect(SQLDialect):
 
     def st_crosses(self, a: str, b: str) -> str:
         return f"Crosses({a}, {b})"
+
+    # -- ELT Lot 1 divergences ----------------------------------------
+    # SpatiaLite drops the ST_ prefix and has no styled buffer.
+
+    def st_intersection(self, a: str, b: str) -> str:
+        return f"Intersection({a}, {b})"
+
+    def st_buffer_styled(
+        self,
+        geom_expr: str,
+        distance: float,
+        style: BufferStyle | None = None,
+    ) -> str:
+        if style is not None and not style.is_default:
+            raise UnsupportedInDialect("styled ST_Buffer", self.name)
+        return f"Buffer({geom_expr}, {_fmt_number(distance)})"
+
+    def st_transform(
+        self, geom_expr: str, *, src_srid: int, dst_srid: int
+    ) -> str:
+        return f"Transform({geom_expr}, {int(dst_srid)})"
 
 
 class GeoPackageDialect(SQLDialect):
@@ -281,6 +572,29 @@ class GeoPackageDialect(SQLDialect):
 
     def st_crosses(self, a: str, b: str) -> str:
         return self._spatial_not_supported("ST_Crosses")
+
+    # -- ELT Lot 1 divergences ----------------------------------------
+    # GPKG has no SQL-level spatial functions — every spatial primitive
+    # below raises, as the existing st_* methods do.
+
+    def geom_ref(self, column: str | None = None, *, table: str | None = None) -> str:
+        return self._spatial_not_supported("geom_ref")
+
+    def st_intersection(self, a: str, b: str) -> str:
+        return self._spatial_not_supported("ST_Intersection")
+
+    def st_buffer_styled(
+        self,
+        geom_expr: str,
+        distance: float,
+        style: BufferStyle | None = None,
+    ) -> str:
+        return self._spatial_not_supported("ST_Buffer")
+
+    def st_transform(
+        self, geom_expr: str, *, src_srid: int, dst_srid: int
+    ) -> str:
+        return self._spatial_not_supported("ST_Transform")
 
 
 # Singleton instances

--- a/src/gispulse/persistence/sql_dialect.py
+++ b/src/gispulse/persistence/sql_dialect.py
@@ -360,6 +360,10 @@ class SQLDialect(ABC):
         """
         return f"(array_agg({col}))[1]"
 
+    def st_geometry_type(self, geom: str) -> str:
+        """String name of a geometry's type — ``ST_GeometryType``."""
+        return f"ST_GeometryType({geom})"
+
 
 class PostGISDialect(SQLDialect):
     """PostgreSQL/PostGIS spatial SQL dialect."""
@@ -719,6 +723,9 @@ class GeoPackageDialect(SQLDialect):
 
     def first_agg(self, col: str) -> str:
         return self._spatial_not_supported("first_agg")
+
+    def st_geometry_type(self, geom: str) -> str:
+        return self._spatial_not_supported("ST_GeometryType")
 
 
 # Singleton instances

--- a/src/gispulse/runtime/manifest_runner.py
+++ b/src/gispulse/runtime/manifest_runner.py
@@ -1,0 +1,340 @@
+"""End-to-end execution of a v3 manifest — materialization layer.
+
+ELT Lot 4C (issue #249, ADR 0005 / EPIC #243). Re-scoped per ADR 0005:
+``models:`` already compiles to ``PipelineSpec`` (Lot 4A / #247) and
+the inter-model DAG is validated at load time (Lot 4B / #248). This
+module wires the two together with the materialization rules ADR 0005
+defines:
+
+- ``materialize: view`` (default) — keep the result as an in-memory
+  GeoDataFrame; downstream models read it via the materializer cache.
+- ``materialize: table`` — same in-memory cache *and* register the
+  result on the active engine, so the Lot 1-3 SQL push-down strategies
+  can JOIN against it.
+- ``materialize: incremental`` — requires ``staging.cdc: incremental``
+  and an increment key. Not wired here: this batch covers the view /
+  table path and the full end-to-end runner that the EPIC needs. The
+  incremental path raises a clear :class:`NotImplementedError` for now.
+
+Refresh modes (``manual`` / ``on_change`` / ``schedule``) are surfaced
+on the materialized model but the runner treats every call as a fresh
+recompute — schedule-driven refresh and on-change short-circuit go
+with #249's continuation alongside the CDC bridge.
+
+DELETE cascade across descendant models (ADR 0002 bounded fixed-point)
+is also a follow-up: this batch establishes the runner and the
+materialization plumbing; the cascade reuses the existing
+:class:`gispulse.persistence.change_log_watcher` plumbing once the
+incremental path lands.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+import geopandas as gpd
+
+from gispulse.core.dag import topological_sort
+from gispulse.core.manifest_v3 import (
+    ManifestV3,
+    ModelSpec,
+    SourceSpec,
+    _compile_model_steps,
+    validate_manifest,
+)
+from gispulse.core.pipeline import PipelineSpec, StepSpec
+from gispulse.core.logging import get_logger
+from gispulse.orchestration.pipeline_executor import PipelineExecutor
+
+log = get_logger(__name__)
+
+__all__ = [
+    "MaterializationMode",
+    "RefreshMode",
+    "MaterializedModel",
+    "Materializer",
+    "ManifestRunResult",
+    "run_manifest",
+]
+
+
+class MaterializationMode(str, Enum):
+    """ADR 0005 materialization modes."""
+
+    VIEW = "view"
+    TABLE = "table"
+    INCREMENTAL = "incremental"
+
+
+class RefreshMode(str, Enum):
+    """ADR 0005 refresh strategies for a materialized model."""
+
+    MANUAL = "manual"
+    ON_CHANGE = "on_change"
+    SCHEDULE = "schedule"
+
+
+@dataclass
+class MaterializedModel:
+    """A model after materialization."""
+
+    name: str
+    mode: MaterializationMode
+    refresh: RefreshMode
+    result: gpd.GeoDataFrame
+    #: Engine table name when ``mode == TABLE`` — ``None`` otherwise.
+    table_ref: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Materializer
+# ---------------------------------------------------------------------------
+
+
+class Materializer:
+    """Caches materialized models and applies the per-mode persistence.
+
+    Keeping the cache out of :func:`run_manifest` lets the caller share
+    one across multiple runs (incremental refresh, partial reruns).
+    """
+
+    def __init__(self, engine: Any | None = None, *, table_prefix: str = "elt_"):
+        self._engine = engine
+        self._table_prefix = table_prefix
+        self._models: dict[str, MaterializedModel] = {}
+
+    @property
+    def models(self) -> dict[str, MaterializedModel]:
+        """The cache keyed by model name."""
+        return self._models
+
+    def get(self, name: str) -> MaterializedModel | None:
+        return self._models.get(name)
+
+    def materialize(
+        self,
+        name: str,
+        gdf: gpd.GeoDataFrame,
+        mode: MaterializationMode,
+        refresh: RefreshMode = RefreshMode.MANUAL,
+    ) -> MaterializedModel:
+        """Apply per-mode persistence and cache the result.
+
+        Raises:
+            NotImplementedError: ``mode == INCREMENTAL`` (follow-up).
+            RuntimeError: ``mode == TABLE`` with no engine attached.
+        """
+        if mode == MaterializationMode.INCREMENTAL:
+            raise NotImplementedError(
+                "incremental materialization requires staging.cdc: incremental "
+                "and an increment key — wiring lands in the #249 continuation."
+            )
+        table_ref: str | None = None
+        if mode == MaterializationMode.TABLE:
+            if self._engine is None:
+                raise RuntimeError(
+                    "TABLE materialization requires an engine attached to the "
+                    "Materializer (register-as-table is engine-mediated)."
+                )
+            table_ref = f"{self._table_prefix}{name}"
+            # Register the gdf on the engine so the Lot 1-3 push-down
+            # strategies can JOIN against it from downstream models.
+            self._engine.register(table_ref, gdf)
+        materialized = MaterializedModel(
+            name=name,
+            mode=mode,
+            refresh=refresh,
+            result=gdf,
+            table_ref=table_ref,
+        )
+        self._models[name] = materialized
+        return materialized
+
+
+# ---------------------------------------------------------------------------
+# Run a v3 manifest
+# ---------------------------------------------------------------------------
+
+#: Signature of a source-loader. Defaults to ``engine.load_layer(uri, layer)``.
+SourceLoader = Callable[[SourceSpec], gpd.GeoDataFrame]
+
+
+@dataclass
+class ManifestRunResult:
+    """Outcome of one :func:`run_manifest` call."""
+
+    materialized: dict[str, MaterializedModel] = field(default_factory=dict)
+    #: Topological order in which the models were executed.
+    execution_order: list[str] = field(default_factory=list)
+
+
+def _inter_model_edges(manifest: ManifestV3) -> list[tuple[str, str]]:
+    """Inter-model dependency edges, used to order execution."""
+    model_names = set(manifest.models)
+    edges: list[tuple[str, str]] = []
+    for name, model in manifest.models.items():
+        if model.select in model_names:
+            edges.append((model.select, name))
+        for step in model.transform or []:
+            if not isinstance(step, dict) or len(step) != 1:
+                continue
+            (_cap, params), = step.items()
+            ref = params.get("with") if isinstance(params, dict) else None
+            if isinstance(ref, str) and ref in model_names:
+                edges.append((ref, name))
+    return edges
+
+
+def _build_sub_pipeline(
+    model: ModelSpec, sources: dict[str, SourceSpec], model_names: set[str]
+) -> PipelineSpec:
+    """Per-model PipelineSpec — the chain of transforms isolated."""
+    raw_steps = _compile_model_steps(model, sources, model_names)
+    # Inside the sub-pipeline every step that referenced an upstream model
+    # collapses to ``input=None`` — the upstream is resolved into the
+    # ``inputs`` dict the runner hands to PipelineExecutor.
+    own_ids = {s.id for s in raw_steps}
+    sub_steps: list[StepSpec] = []
+    for s in raw_steps:
+        inp: str | list[str] | None = s.input
+        if isinstance(inp, str):
+            inp = inp if inp in own_ids else None
+        elif isinstance(inp, list):
+            inp = [x for x in inp if x in own_ids] or None
+        sub_steps.append(
+            StepSpec(
+                id=s.id,
+                type=s.type,
+                capability=s.capability,
+                params=dict(s.params),
+                input=inp,
+                when=s.when,
+                enabled=s.enabled,
+                order=s.order,
+            )
+        )
+    return PipelineSpec(version=2, name=model.name, steps=sub_steps)
+
+
+def run_manifest(
+    manifest: ManifestV3,
+    *,
+    engine: Any | None = None,
+    source_loader: SourceLoader | None = None,
+    materializer: Materializer | None = None,
+) -> ManifestRunResult:
+    """Execute a v3 manifest end-to-end.
+
+    Walks the models in topological order and, for each one, resolves
+    its ``select`` and any transform-level ``with:`` references into
+    real GeoDataFrames (from declared sources or from previously
+    materialized models), compiles the model's transforms into a tiny
+    :class:`PipelineSpec`, runs it through :class:`PipelineExecutor`,
+    and hands the result to the :class:`Materializer` for per-mode
+    persistence.
+
+    Args:
+        manifest:      The parsed v3 manifest. The runner re-validates
+            it through :func:`validate_manifest` so refs / cycles are
+            caught even when callers skip the loader's check.
+        engine:        Optional :class:`SpatialEngine`. Required when
+            *source_loader* is omitted (the default loader calls
+            ``engine.load_layer``) or when any model picks ``materialize:
+            table`` (register-as-table goes through the engine).
+        source_loader: Override for source loading — useful for tests or
+            for in-memory inputs that don't sit behind ``load_layer``.
+        materializer:  Reuse an existing materializer to share its cache
+            across multiple runs. A fresh one is created when omitted.
+
+    Returns:
+        :class:`ManifestRunResult` carrying the materialized models and
+        the execution order. The same data also lives on the supplied
+        materializer's ``models`` dict.
+    """
+    validate_manifest(manifest)  # raises on cycles / unresolved refs
+
+    if source_loader is None:
+        if engine is None:
+            raise RuntimeError(
+                "run_manifest requires either an engine (uses engine.load_layer) "
+                "or a source_loader callable"
+            )
+
+        def source_loader(src: SourceSpec) -> gpd.GeoDataFrame:
+            return engine.load_layer(src.uri, layer=src.layer or "")
+
+    if materializer is None:
+        materializer = Materializer(engine=engine)
+
+    model_names = set(manifest.models)
+    order = topological_sort(list(model_names), _inter_model_edges(manifest))
+    log.info(
+        "manifest_run_start",
+        manifest=manifest.name or "(unnamed)",
+        n_models=len(model_names),
+        order=order,
+    )
+
+    source_cache: dict[str, gpd.GeoDataFrame] = {}
+
+    def _resolve(ref: str) -> gpd.GeoDataFrame:
+        if ref in manifest.sources:
+            if ref not in source_cache:
+                source_cache[ref] = source_loader(manifest.sources[ref])
+            return source_cache[ref]
+        cached = materializer.get(ref)
+        if cached is not None:
+            return cached.result
+        raise KeyError(
+            f"run_manifest: reference {ref!r} resolves to neither a declared "
+            "source nor a previously materialized model"
+        )
+
+    executor = PipelineExecutor(execution_context=None)
+
+    for model_name in order:
+        model = manifest.models[model_name]
+        primary = _resolve(model.select)
+        sub_spec = _build_sub_pipeline(model, manifest.sources, model_names)
+
+        # Inputs: primary GDF first (PipelineExecutor's linear path keys
+        # off the first value); any `with: <ref>` resolves into a named
+        # entry that the existing ``ref_layer`` plumbing picks up.
+        inputs: dict[str, gpd.GeoDataFrame] = {model.select: primary}
+        for step in sub_spec.steps:
+            alias = step.params.get("ref_layer")
+            if isinstance(alias, str) and alias not in inputs:
+                inputs[alias] = _resolve(alias)
+
+        results = executor.execute(sub_spec, inputs)
+
+        # The model's output is the last step's result — fall back to
+        # any single produced output, then to the primary, so a
+        # transform-less passthrough still materializes something.
+        if model_name in results:
+            terminal = results[model_name]
+        elif results:
+            terminal = list(results.values())[-1]
+        else:
+            terminal = primary
+
+        materializer.materialize(
+            model_name,
+            terminal,
+            MaterializationMode(model.materialize),
+            RefreshMode(model.refresh),
+        )
+        log.debug(
+            "manifest_model_materialized",
+            model=model_name,
+            mode=model.materialize,
+            rows=len(terminal),
+        )
+
+    return ManifestRunResult(
+        materialized=dict(materializer.models),
+        execution_order=order,
+    )

--- a/tests/integration/test_attribute_pushdown.py
+++ b/tests/integration/test_attribute_pushdown.py
@@ -1,0 +1,206 @@
+"""Result-for-result harness for the attribute SQL push-down (ELT Lot 2, #245).
+
+For each of the 12 ``schema`` / ``selection`` capabilities equipped with
+DuckDB/PostGIS strategies, this verifies that the SQL push-down path
+produces the *same result* as the proven Python/GeoPandas implementation.
+
+- DuckDB vs Python — runs unconditionally.
+- DuckDB vs PostGIS — runs only when ``GISPULSE_TEST_DSN`` is set.
+
+It also checks the opportunistic fallback: an untranslatable expression
+and a non-SQL engine both fall back to Python silently.
+"""
+
+from __future__ import annotations
+
+import os
+
+import geopandas as gpd
+import pandas as pd
+import pytest
+from shapely.geometry import Point
+
+from gispulse.capabilities.schema import (
+    AddFieldCapability,
+    AttributeJoinCapability,
+    CaseWhenCapability,
+    CastFieldCapability,
+    CoalesceFieldsCapability,
+    DropFieldCapability,
+    RenameFieldCapability,
+    SelectColumnsCapability,
+)
+from gispulse.capabilities.selection import (
+    DeduplicateCapability,
+    SortCapability,
+    TopNCapability,
+)
+from gispulse.capabilities.strategy import ExecutionContext
+from gispulse.capabilities.vector.calculate import CalculateCapability
+from gispulse.persistence.duckdb_engine import DuckDBSession
+
+TEST_DSN: str | None = os.environ.get("GISPULSE_TEST_DSN")
+_requires_postgis = pytest.mark.skipif(
+    TEST_DSN is None,
+    reason="GISPULSE_TEST_DSN not set — skipping the DuckDB↔PostGIS cross-check",
+)
+
+
+# ---------------------------------------------------------------------------
+# Inputs
+# ---------------------------------------------------------------------------
+
+
+def _layer() -> gpd.GeoDataFrame:
+    return gpd.GeoDataFrame(
+        {
+            "id": [3, 1, 2, 4],
+            "name": ["c", "a", "b", "d"],
+            "pop": [30, 10, 20, 40],
+            "grp": ["x", "x", "y", "y"],
+        },
+        geometry=[Point(0, 0), Point(1, 1), Point(2, 2), Point(3, 3)],
+        crs="EPSG:4326",
+    )
+
+
+# (capability, params) — every case is SQL-translatable on purpose.
+_CASES: list[tuple[object, dict]] = [
+    (SelectColumnsCapability(), {"fields": ["id", "name"]}),
+    (DropFieldCapability(), {"fields": ["grp"]}),
+    (RenameFieldCapability(), {"mapping": {"pop": "population"}}),
+    (AddFieldCapability(), {"fields": [{"name": "tag", "dtype": "string", "default": "z"}]}),
+    (CastFieldCapability(), {"casts": {"pop": "float"}}),
+    (CoalesceFieldsCapability(), {"sources": ["name", "grp"], "target_col": "label"}),
+    (
+        CaseWhenCapability(),
+        {
+            "target_col": "tier",
+            "cases": [
+                {"when": "pop > 25", "then": "big"},
+                {"when": "pop > 15", "then": "mid"},
+            ],
+            "else_": "small",
+        },
+    ),
+    (CalculateCapability(), {"expressions": {"dbl": "pop * 2", "ratio": "pop / 10"}}),
+    (SortCapability(), {"by": ["pop"], "ascending": True}),
+    (TopNCapability(), {"n": 2, "by": "pop", "ascending": False}),
+    (DeduplicateCapability(), {"keys": ["grp"], "order_by": ["pop"], "keep": "last"}),
+]
+
+
+def _ctx(engine, gdf, params):
+    return ExecutionContext(engine=engine, feature_count=len(gdf), params=dict(params))
+
+
+def _normalise(gdf: gpd.GeoDataFrame) -> pd.DataFrame:
+    """Drop geometry, coerce dtypes away, sort — for order/dtype-free compare."""
+    geom = gdf.geometry.name if hasattr(gdf, "geometry") else None
+    df = pd.DataFrame(gdf.drop(columns=[geom], errors="ignore"))
+    df = df.astype(object).where(pd.notna(df), None)
+    return df.sort_values(by=list(df.columns)).reset_index(drop=True)
+
+
+def _assert_equivalent(sql_result, py_result, label: str) -> None:
+    a, b = _normalise(sql_result), _normalise(py_result)
+    assert set(a.columns) == set(b.columns), (
+        f"{label}: column sets differ — SQL {sorted(a.columns)} vs "
+        f"Python {sorted(b.columns)}"
+    )
+    a = a[sorted(a.columns)]
+    b = b[sorted(b.columns)]
+    a = a.sort_values(by=list(a.columns)).reset_index(drop=True)
+    b = b.sort_values(by=list(b.columns)).reset_index(drop=True)
+    assert len(a) == len(b), f"{label}: row count {len(a)} != {len(b)}"
+    assert a.values.tolist() == b.values.tolist(), (
+        f"{label}: values differ\nSQL:\n{a}\nPython:\n{b}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# DuckDB vs Python — always runs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "capability, params",
+    _CASES,
+    ids=[c.name for c, _ in _CASES],
+)
+def test_duckdb_pushdown_matches_python(capability, params):
+    gdf = _layer()
+    python_result = capability.execute(gdf, **params)
+    with DuckDBSession() as eng:
+        sql_result = capability.execute_with_context(gdf, _ctx(eng, gdf, params))
+    _assert_equivalent(sql_result, python_result, f"{capability.name} duckdb")
+
+
+def test_attribute_join_duckdb_matches_python():
+    gdf = _layer()
+    ref = pd.DataFrame({"id": [1, 2, 3, 4], "region": ["A", "B", "C", "D"]})
+    params = {"ref_gdf": ref, "left_on": "id", "columns": ["region"]}
+    python_result = AttributeJoinCapability().execute(gdf, **params)
+    with DuckDBSession() as eng:
+        sql_result = AttributeJoinCapability().execute_with_context(
+            gdf, _ctx(eng, gdf, params)
+        )
+    _assert_equivalent(sql_result, python_result, "attribute_join duckdb")
+
+
+# ---------------------------------------------------------------------------
+# Opportunistic fallback to Python
+# ---------------------------------------------------------------------------
+
+
+def test_untranslatable_expression_falls_back_to_python():
+    """A calculate expression outside the SQL subset still produces the
+    correct result via the Python strategy."""
+    gdf = _layer()
+    # `.clip()` is a method call — not SQL-translatable.
+    params = {"expressions": {"capped": "pop.clip(upper=25)"}}
+    with DuckDBSession() as eng:
+        result = CalculateCapability().execute_with_context(
+            gdf, _ctx(eng, gdf, params)
+        )
+    assert result["capped"].tolist() == [25, 10, 20, 25]
+
+
+def test_non_sql_engine_uses_python(monkeypatch):
+    """A capability on a non-DuckDB/PostGIS engine runs the Python path."""
+
+    class _FakeEngine:
+        backend_name = "gpkg"
+
+    gdf = _layer()
+    ctx = ExecutionContext(
+        engine=_FakeEngine(), feature_count=len(gdf), params={"fields": ["id"]}
+    )
+    result = SelectColumnsCapability().execute_with_context(gdf, ctx)
+    assert set(result.columns) == {"id", "geometry"}
+
+
+# ---------------------------------------------------------------------------
+# DuckDB vs PostGIS — requires GISPULSE_TEST_DSN
+# ---------------------------------------------------------------------------
+
+
+@_requires_postgis
+@pytest.mark.parametrize(
+    "capability, params",
+    _CASES,
+    ids=[c.name for c, _ in _CASES],
+)
+def test_postgis_pushdown_matches_duckdb(capability, params):
+    from gispulse.persistence.postgis import PostGISConnection
+
+    gdf = _layer()
+    with DuckDBSession() as duck:
+        duck_result = capability.execute_with_context(gdf, _ctx(duck, gdf, params))
+    pg = PostGISConnection(dsn=TEST_DSN)
+    pg.open()
+    try:
+        pg_result = capability.execute_with_context(gdf, _ctx(pg, gdf, params))
+    finally:
+        pg.close()
+    _assert_equivalent(duck_result, pg_result, f"{capability.name} x-engine")

--- a/tests/integration/test_geometry_pushdown.py
+++ b/tests/integration/test_geometry_pushdown.py
@@ -486,3 +486,123 @@ def test_nearest_neighbor_postgis_matches_python():
         pg.close()
     assert set(sql.columns) == set(py.columns)
     assert len(sql) == len(py)
+
+
+# ===========================================================================
+# Lot 3e — temporal_filter + temporal_join (exact strategy)
+# ===========================================================================
+
+
+import pandas as pd  # noqa: E402
+
+from gispulse.capabilities.temporal import (  # noqa: E402
+    TemporalFilterCapability,
+    TemporalJoinCapability,
+)
+
+
+def _temporal_layer() -> gpd.GeoDataFrame:
+    return gpd.GeoDataFrame(
+        {
+            "id": [1, 2, 3, 4],
+            "ts": pd.to_datetime(
+                ["2025-01-01", "2025-06-01", "2025-12-01", "2026-03-01"]
+            ),
+            "name": ["a", "b", "c", "d"],
+        },
+        geometry=[Point(i, i) for i in range(4)],
+        crs="EPSG:4326",
+    )
+
+
+def _temporal_ref() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "ts": pd.to_datetime(["2025-06-01", "2026-03-01"]),
+            "id": [10, 20],
+            "weather": ["sunny", "rainy"],
+        }
+    )
+
+
+def test_temporal_filter_window_duckdb_matches_python():
+    gdf = _temporal_layer()
+    params = {"time_col": "ts", "start": "2025-06-01", "end": "2025-12-31"}
+    py = TemporalFilterCapability().execute(gdf.copy(), **params)
+    with DuckDBSession() as eng:
+        sql = TemporalFilterCapability().execute_with_context(
+            gdf, _ctx(eng, gdf, params)
+        )
+    assert set(sql.columns) == set(py.columns)
+    assert sorted(sql["id"].tolist()) == sorted(py["id"].tolist())
+
+
+def test_temporal_filter_invert_drops_nulls_like_python():
+    gdf = _temporal_layer()
+    params = {
+        "time_col": "ts",
+        "start": "2025-06-01",
+        "end": "2025-12-31",
+        "invert": True,
+    }
+    py = TemporalFilterCapability().execute(gdf.copy(), **params)
+    with DuckDBSession() as eng:
+        sql = TemporalFilterCapability().execute_with_context(
+            gdf, _ctx(eng, gdf, params)
+        )
+    assert sorted(sql["id"].tolist()) == sorted(py["id"].tolist())
+
+
+def test_temporal_filter_open_end_pushed():
+    gdf = _temporal_layer()
+    params = {"time_col": "ts", "start": "2025-06-01"}
+    py = TemporalFilterCapability().execute(gdf.copy(), **params)
+    with DuckDBSession() as eng:
+        sql = TemporalFilterCapability().execute_with_context(
+            gdf, _ctx(eng, gdf, params)
+        )
+    assert sorted(sql["id"].tolist()) == sorted(py["id"].tolist())
+
+
+def test_temporal_join_exact_duckdb_matches_python():
+    gdf = _temporal_layer()
+    ref = _temporal_ref()
+    params = {
+        "ref_gdf": ref,
+        "left_on": "ts",
+        "right_on": "ts",
+        "strategy": "exact",
+    }
+    py = TemporalJoinCapability().execute(gdf.copy(), **params)
+    with DuckDBSession() as eng:
+        sql = TemporalJoinCapability().execute_with_context(
+            gdf, _ctx(eng, gdf, params)
+        )
+    assert set(sql.columns) == set(py.columns)
+    assert len(sql) == len(py)
+    sql_pairs = sorted(
+        zip(sql["id"], sql["weather"].fillna("-")), key=lambda t: t[0]
+    )
+    py_pairs = sorted(
+        zip(py["id"], py["weather"].fillna("-")), key=lambda t: t[0]
+    )
+    assert sql_pairs == py_pairs
+
+
+def test_temporal_join_asof_falls_back_to_python():
+    """Asof strategies (backward / forward / nearest) stay on Python."""
+    gdf = _temporal_layer()
+    ref = _temporal_ref()
+    params = {
+        "ref_gdf": ref,
+        "left_on": "ts",
+        "right_on": "ts",
+        "strategy": "backward",
+    }
+    py = TemporalJoinCapability().execute(gdf.copy(), **params)
+    with DuckDBSession() as eng:
+        sql = TemporalJoinCapability().execute_with_context(
+            gdf, _ctx(eng, gdf, params)
+        )
+    assert set(sql.columns) == set(py.columns)
+    assert len(sql) == len(py)

--- a/tests/integration/test_geometry_pushdown.py
+++ b/tests/integration/test_geometry_pushdown.py
@@ -253,3 +253,125 @@ def test_simplify_non_dp_falls_back_to_python():
     # The vw path is Python-only; behaviour must equal the plain execute.
     expected = SimplifyCapability().execute(gdf.copy(), **params)
     assert len(result) == len(expected)
+
+
+# ===========================================================================
+# Lot 3c — dissolve + spatial_join
+# ===========================================================================
+
+
+from shapely.geometry import Point  # noqa: E402
+
+from gispulse.capabilities.vector.dissolve import DissolveCapability  # noqa: E402
+from gispulse.capabilities.vector.spatial_join import (  # noqa: E402
+    SpatialJoinCapability,
+)
+
+
+def _group_layer() -> gpd.GeoDataFrame:
+    return gpd.GeoDataFrame(
+        {
+            "id": [1, 2, 3, 4],
+            "name": ["a", "b", "c", "d"],
+            "pop": [10, 20, 30, 40],
+            "grp": ["x", "x", "y", "y"],
+        },
+        geometry=[Point(0, 0), Point(1, 1), Point(5, 5), Point(6, 6)],
+        crs="EPSG:2154",
+    )
+
+
+def _zone_layer() -> gpd.GeoDataFrame:
+    from shapely.geometry import Polygon as _P
+
+    return gpd.GeoDataFrame(
+        {"id": [10, 20], "region": ["XX", "YY"]},
+        geometry=[
+            _P([(-1, -1), (3, -1), (3, 3), (-1, 3)]),
+            _P([(4, 4), (8, 4), (8, 8), (4, 8)]),
+        ],
+        crs="EPSG:2154",
+    )
+
+
+def test_dissolve_by_group_duckdb_matches_python():
+    gdf = _group_layer()
+    params = {"by": "grp"}
+    py = DissolveCapability().execute(gdf.copy(), **params)
+    with DuckDBSession() as eng:
+        sql = DissolveCapability().execute_with_context(
+            gdf, _ctx(eng, gdf, params)
+        )
+    assert set(sql.columns) == set(py.columns)
+    assert sorted(sql["grp"].tolist()) == sorted(py["grp"].tolist())
+    # Each unioned geometry covers the same envelope.
+    py_b = dict(zip(py["grp"], py.geometry))
+    sql_b = dict(zip(sql["grp"], sql.geometry))
+    for grp, geom in py_b.items():
+        a = sql_b[grp]
+        ref = max(geom.envelope.area, 1e-9)
+        sym = geom.symmetric_difference(a).area
+        assert sym / ref <= 1e-6, f"dissolve grp={grp}: geometries diverge"
+
+
+def test_dissolve_no_by_falls_back_to_python():
+    """by=None pushes through Python (avoids the .reset_index() 'index' col)."""
+    gdf = _group_layer()
+    with DuckDBSession() as eng:
+        sql = DissolveCapability().execute_with_context(
+            gdf, _ctx(eng, gdf, {})
+        )
+    py = DissolveCapability().execute(gdf.copy())
+    assert len(sql) == len(py) == 1
+    assert set(sql.columns) == set(py.columns)
+
+
+def test_spatial_join_duckdb_matches_python():
+    gdf = _group_layer()
+    ref = _zone_layer()
+    params = {"ref_gdf": ref, "predicate": "intersects"}
+    py = SpatialJoinCapability().execute(gdf.copy(), **params)
+    with DuckDBSession() as eng:
+        sql = SpatialJoinCapability().execute_with_context(
+            gdf, _ctx(eng, gdf, params)
+        )
+    assert set(sql.columns) == set(py.columns), (
+        f"spatial_join columns differ — sql {sorted(sql.columns)} vs "
+        f"py {sorted(py.columns)}"
+    )
+    assert len(sql) == len(py)
+    # Compare rows by (id_left, id_right) pairs — order-independent.
+    pairs_sql = sorted(zip(sql["id_left"], sql["id_right"]))
+    pairs_py = sorted(zip(py["id_left"], py["id_right"]))
+    assert pairs_sql == pairs_py
+
+
+def test_spatial_join_crs_mismatch_falls_back_to_python():
+    """SQL declines when the two layers don't share a CRS — Python reprojects."""
+    gdf = _group_layer()
+    ref = _zone_layer().to_crs("EPSG:4326")
+    params = {"ref_gdf": ref, "predicate": "intersects"}
+    py = SpatialJoinCapability().execute(gdf.copy(), **params)
+    with DuckDBSession() as eng:
+        sql = SpatialJoinCapability().execute_with_context(
+            gdf, _ctx(eng, gdf, params)
+        )
+    assert set(sql.columns) == set(py.columns)
+    assert len(sql) == len(py)
+
+
+def test_spatial_join_ref_filter_translates():
+    gdf = _group_layer()
+    ref = _zone_layer()
+    params = {
+        "ref_gdf": ref,
+        "predicate": "intersects",
+        "ref_filter": "region == 'XX'",
+    }
+    py = SpatialJoinCapability().execute(gdf.copy(), **params)
+    with DuckDBSession() as eng:
+        sql = SpatialJoinCapability().execute_with_context(
+            gdf, _ctx(eng, gdf, params)
+        )
+    assert len(sql) == len(py)
+    assert set(sql["region"].dropna().unique()) == {"XX"}

--- a/tests/integration/test_geometry_pushdown.py
+++ b/tests/integration/test_geometry_pushdown.py
@@ -161,3 +161,95 @@ def test_postgis_geometry_pushdown_matches_duckdb(capability, params, layer, rel
     _assert_geom_equivalent(
         duck_result, pg_result, rel_tol=rel_tol, label=f"{capability.name} x-engine"
     )
+
+
+# ===========================================================================
+# Lot 3b — aggregating / two-layer / CRS caps
+# ===========================================================================
+
+
+from shapely.geometry import LineString  # noqa: E402
+
+from gispulse.capabilities.vector.diff import SymmetricDifferenceCapability  # noqa: E402
+from gispulse.capabilities.vector.reproject import ReprojectCapability  # noqa: E402
+from gispulse.capabilities.vector.simplify import SimplifyCapability  # noqa: E402
+from gispulse.capabilities.vector.union import UnionCapability  # noqa: E402
+
+
+def _ref_layer() -> gpd.GeoDataFrame:
+    from shapely.geometry import Polygon as _P
+
+    return gpd.GeoDataFrame(
+        {"id": [9]},
+        geometry=[_P([(3, 3), (8, 3), (8, 8), (3, 8)])],
+        crs="EPSG:2154",
+    )
+
+
+def _line_layer() -> gpd.GeoDataFrame:
+    return gpd.GeoDataFrame(
+        {"id": [1]},
+        geometry=[
+            LineString([(0, 0), (1, 0.1), (2, -0.1), (3, 0.05), (4, 0)]),
+        ],
+        crs="EPSG:2154",
+    )
+
+
+def test_union_duckdb_matches_python():
+    gdf = _polys()
+    py = UnionCapability().execute(gdf.copy())
+    with DuckDBSession() as eng:
+        sql = UnionCapability().execute_with_context(gdf, _ctx(eng, gdf, {}))
+    assert len(sql) == len(py) == 1
+    a, b = sql.geometry.iloc[0], py.geometry.iloc[0]
+    assert abs(a.area - b.area) <= 1e-6 * max(b.area, 1.0)
+
+
+def test_reproject_duckdb_matches_python():
+    gdf = _polys()
+    params = {"target_crs": "EPSG:4326"}
+    py = ReprojectCapability().execute(gdf.copy(), **params)
+    with DuckDBSession() as eng:
+        sql = ReprojectCapability().execute_with_context(gdf, _ctx(eng, gdf, params))
+    assert str(sql.crs) == str(py.crs) == "EPSG:4326"
+    for a, b in zip(sorted(sql.geometry, key=lambda g: g.centroid.x),
+                    sorted(py.geometry, key=lambda g: g.centroid.x)):
+        assert abs(a.centroid.x - b.centroid.x) <= 1e-6
+        assert abs(a.centroid.y - b.centroid.y) <= 1e-6
+
+
+def test_symmetric_difference_duckdb_matches_python():
+    gdf, ref = _polys(), _ref_layer()
+    params = {"ref_gdf": ref}
+    py = SymmetricDifferenceCapability().execute(gdf.copy(), **params)
+    with DuckDBSession() as eng:
+        sql = SymmetricDifferenceCapability().execute_with_context(
+            gdf, _ctx(eng, gdf, params)
+        )
+    _assert_geom_equivalent(sql, py, rel_tol=1e-6, label="symmetric_difference duckdb")
+
+
+def test_simplify_duckdb_matches_python():
+    gdf = _line_layer()
+    params = {"tolerance": 0.5}
+    py = SimplifyCapability().execute(gdf.copy(), **params)
+    with DuckDBSession() as eng:
+        sql = SimplifyCapability().execute_with_context(gdf, _ctx(eng, gdf, params))
+    # GEOS TopologyPreservingSimplifier in both — vertex counts must match.
+    assert len(sql) == len(py) == 1
+    assert (
+        len(sql.geometry.iloc[0].coords) == len(py.geometry.iloc[0].coords)
+    )
+
+
+def test_simplify_non_dp_falls_back_to_python():
+    gdf = _line_layer()
+    params = {"tolerance": 0.5, "algorithm": "vw"}
+    with DuckDBSession() as eng:
+        result = SimplifyCapability().execute_with_context(
+            gdf, _ctx(eng, gdf, params)
+        )
+    # The vw path is Python-only; behaviour must equal the plain execute.
+    expected = SimplifyCapability().execute(gdf.copy(), **params)
+    assert len(result) == len(expected)

--- a/tests/integration/test_geometry_pushdown.py
+++ b/tests/integration/test_geometry_pushdown.py
@@ -375,3 +375,114 @@ def test_spatial_join_ref_filter_translates():
         )
     assert len(sql) == len(py)
     assert set(sql["region"].dropna().unique()) == {"XX"}
+
+
+# ===========================================================================
+# Lot 3d — nearest_neighbor + overlay (intersection, erase)
+# ===========================================================================
+
+
+from gispulse.capabilities.overlay import (  # noqa: E402
+    EraseCapability,
+    OverlayIntersectionCapability,
+)
+from gispulse.capabilities.vector.nearest import (  # noqa: E402
+    NearestNeighborCapability,
+)
+
+
+def _overlay_a() -> gpd.GeoDataFrame:
+    from shapely.geometry import Polygon as _P
+
+    return gpd.GeoDataFrame(
+        {"id": [1, 2], "name": ["A", "B"]},
+        geometry=[
+            _P([(0, 0), (10, 0), (10, 10), (0, 10)]),
+            _P([(15, 0), (25, 0), (25, 10), (15, 10)]),
+        ],
+        crs="EPSG:2154",
+    )
+
+
+def _overlay_b() -> gpd.GeoDataFrame:
+    from shapely.geometry import Polygon as _P
+
+    return gpd.GeoDataFrame(
+        {"id": [1, 2], "region": ["X", "Y"]},
+        geometry=[
+            _P([(5, -5), (20, -5), (20, 15), (5, 15)]),
+            _P([(8, 2), (12, 2), (12, 8), (8, 8)]),
+        ],
+        crs="EPSG:2154",
+    )
+
+
+def test_overlay_intersection_duckdb_matches_python():
+    a, b = _overlay_a(), _overlay_b()
+    params = {"ref_gdf": b}
+    py = OverlayIntersectionCapability().execute(a.copy(), **params)
+    with DuckDBSession() as eng:
+        sql = OverlayIntersectionCapability().execute_with_context(
+            a, _ctx(eng, a, params)
+        )
+    assert set(sql.columns) == set(py.columns)
+    assert len(sql) == len(py)
+    assert sorted(round(g.area, 6) for g in sql.geometry) == sorted(
+        round(g.area, 6) for g in py.geometry
+    )
+
+
+def test_overlay_intersection_non_default_suffix_falls_back():
+    a, b = _overlay_a(), _overlay_b()
+    params = {"ref_gdf": b, "suffix_left": "_a", "suffix_right": "_b"}
+    py = OverlayIntersectionCapability().execute(a.copy(), **params)
+    with DuckDBSession() as eng:
+        sql = OverlayIntersectionCapability().execute_with_context(
+            a, _ctx(eng, a, params)
+        )
+    assert set(sql.columns) == set(py.columns)
+
+
+def test_erase_duckdb_matches_python():
+    a, b = _overlay_a(), _overlay_b()
+    params = {"ref_gdf": b}
+    py = EraseCapability().execute(a.copy(), **params)
+    with DuckDBSession() as eng:
+        sql = EraseCapability().execute_with_context(a, _ctx(eng, a, params))
+    assert set(sql.columns) == set(py.columns)
+    assert len(sql) == len(py)
+    assert sorted(round(g.area, 6) for g in sql.geometry) == sorted(
+        round(g.area, 6) for g in py.geometry
+    )
+
+
+def test_nearest_neighbor_duckdb_falls_back_to_python():
+    """DuckDB has no <-> operator — the strategy declines, Python runs."""
+    a, b = _overlay_a(), _overlay_b()
+    params = {"ref_gdf": b, "k": 1}
+    py = NearestNeighborCapability().execute(a.copy(), **params)
+    with DuckDBSession() as eng:
+        sql = NearestNeighborCapability().execute_with_context(
+            a, _ctx(eng, a, params)
+        )
+    assert set(sql.columns) == set(py.columns)
+    assert len(sql) == len(py)
+
+
+@_requires_postgis
+def test_nearest_neighbor_postgis_matches_python():
+    from gispulse.persistence.postgis import PostGISConnection
+
+    a, b = _overlay_a(), _overlay_b()
+    params = {"ref_gdf": b, "k": 1}
+    py = NearestNeighborCapability().execute(a.copy(), **params)
+    pg = PostGISConnection(dsn=TEST_DSN)
+    pg.open()
+    try:
+        sql = NearestNeighborCapability().execute_with_context(
+            a, _ctx(pg, a, params)
+        )
+    finally:
+        pg.close()
+    assert set(sql.columns) == set(py.columns)
+    assert len(sql) == len(py)

--- a/tests/integration/test_geometry_pushdown.py
+++ b/tests/integration/test_geometry_pushdown.py
@@ -1,0 +1,163 @@
+"""Result-for-result harness for the geometry SQL push-down (ELT Lot 3, #246).
+
+For each Tier-1 single-layer 1:1 geometry capability equipped with
+DuckDB/PostGIS strategies, this verifies the SQL push-down produces the
+same result as the Python/GeoPandas implementation.
+
+- DuckDB vs Python — runs unconditionally.
+- DuckDB vs PostGIS — runs only when ``GISPULSE_TEST_DSN`` is set.
+
+Also checks that the non-1:1 modes (``by_group`` / ``dissolve``) and a
+non-SQL engine fall back to Python.
+"""
+
+from __future__ import annotations
+
+import os
+
+import geopandas as gpd
+import pytest
+from shapely.geometry import MultiPoint, Polygon
+
+from gispulse.capabilities.strategy import ExecutionContext
+from gispulse.capabilities.vector.boundary import BoundaryCapability
+from gispulse.capabilities.vector.centroid_area import (
+    AreaLengthCapability,
+    CentroidCapability,
+)
+from gispulse.capabilities.vector.concave_hull import ConcaveHullCapability
+from gispulse.capabilities.vector.shape_ops_basic import (
+    ConvexHullCapability,
+    EnvelopeCapability,
+    MakeValidCapability,
+)
+from gispulse.persistence.duckdb_engine import DuckDBSession
+
+TEST_DSN: str | None = os.environ.get("GISPULSE_TEST_DSN")
+_requires_postgis = pytest.mark.skipif(
+    TEST_DSN is None,
+    reason="GISPULSE_TEST_DSN not set — skipping the DuckDB↔PostGIS cross-check",
+)
+
+
+def _polys() -> gpd.GeoDataFrame:
+    return gpd.GeoDataFrame(
+        {"id": [1, 2], "grp": ["a", "b"]},
+        geometry=[
+            Polygon([(0, 0), (4, 0), (4, 4), (0, 4)]),
+            Polygon([(10, 10), (14, 10), (14, 14), (10, 14)]),
+        ],
+        crs="EPSG:2154",
+    )
+
+
+def _cloud() -> gpd.GeoDataFrame:
+    return gpd.GeoDataFrame(
+        {"id": [1]},
+        geometry=[MultiPoint([(0, 0), (4, 0), (4, 4), (0, 4), (2, 2), (1, 3)])],
+        crs="EPSG:2154",
+    )
+
+
+_GEOM_CASES = [
+    (CentroidCapability(), {}, _polys, 1e-6),
+    (BoundaryCapability(), {}, _polys, 1e-6),
+    (ConvexHullCapability(), {}, _polys, 1e-6),
+    (EnvelopeCapability(), {}, _polys, 1e-6),
+    (MakeValidCapability(), {}, _polys, 1e-6),
+    # concave hull — engine vs shapely use different internals; allow slack.
+    (ConcaveHullCapability(), {"ratio": 0.5}, _cloud, 5e-2),
+]
+
+
+def _ctx(engine, gdf, params):
+    return ExecutionContext(engine=engine, feature_count=len(gdf), params=dict(params))
+
+
+def _assert_geom_equivalent(a, b, *, rel_tol, label):
+    assert len(a) == len(b), f"{label}: row count {len(a)} != {len(b)}"
+    ga = sorted(
+        (g for g in a.geometry if g is not None),
+        key=lambda g: (round(g.centroid.x, 3), round(g.centroid.y, 3)),
+    )
+    gb = sorted(
+        (g for g in b.geometry if g is not None),
+        key=lambda g: (round(g.centroid.x, 3), round(g.centroid.y, 3)),
+    )
+    assert len(ga) == len(gb), f"{label}: non-null geometry count differs"
+    for x, y in zip(ga, gb):
+        ref = max(x.area, y.area, 1e-9)
+        sym = x.symmetric_difference(y).area
+        assert sym / ref <= rel_tol, (
+            f"{label}: geometries diverge — sym-diff ratio {sym / ref:.2e}"
+        )
+
+
+@pytest.mark.parametrize(
+    "capability, params, layer, rel_tol",
+    _GEOM_CASES,
+    ids=[c.name for c, _, _, _ in _GEOM_CASES],
+)
+def test_duckdb_geometry_pushdown_matches_python(capability, params, layer, rel_tol):
+    gdf = layer()
+    py = capability.execute(gdf.copy(), **params)
+    with DuckDBSession() as eng:
+        sql = capability.execute_with_context(gdf, _ctx(eng, gdf, params))
+    _assert_geom_equivalent(sql, py, rel_tol=rel_tol, label=f"{capability.name} duckdb")
+
+
+def test_area_length_duckdb_matches_python():
+    gdf = _polys()
+    py = AreaLengthCapability().execute(gdf.copy())
+    with DuckDBSession() as eng:
+        sql = AreaLengthCapability().execute_with_context(gdf, _ctx(eng, gdf, {}))
+    assert set(sql.columns) == set(py.columns)
+    for col in ("area_m2", "length_m"):
+        for s, p in zip(sorted(sql[col]), sorted(py[col])):
+            assert abs(s - p) <= 1e-6 * max(abs(p), 1.0), f"area_length {col} diverges"
+
+
+def test_by_group_falls_back_to_python():
+    """convex_hull with by_group is N:1 — must run the Python path."""
+    gdf = _polys()
+    with DuckDBSession() as eng:
+        result = ConvexHullCapability().execute_with_context(
+            gdf, _ctx(eng, gdf, {"by_group": "grp"})
+        )
+    # one hull per group → 2 rows, grp column retained
+    assert len(result) == 2
+    assert "grp" in result.columns
+
+
+def test_non_sql_engine_uses_python():
+    class _FakeEngine:
+        backend_name = "gpkg"
+
+    gdf = _polys()
+    ctx = ExecutionContext(engine=_FakeEngine(), feature_count=len(gdf), params={})
+    result = CentroidCapability().execute_with_context(gdf, ctx)
+    assert len(result) == 2
+    assert all(g.geom_type == "Point" for g in result.geometry)
+
+
+@_requires_postgis
+@pytest.mark.parametrize(
+    "capability, params, layer, rel_tol",
+    _GEOM_CASES,
+    ids=[c.name for c, _, _, _ in _GEOM_CASES],
+)
+def test_postgis_geometry_pushdown_matches_duckdb(capability, params, layer, rel_tol):
+    from gispulse.persistence.postgis import PostGISConnection
+
+    gdf = layer()
+    with DuckDBSession() as duck:
+        duck_result = capability.execute_with_context(gdf, _ctx(duck, gdf, params))
+    pg = PostGISConnection(dsn=TEST_DSN)
+    pg.open()
+    try:
+        pg_result = capability.execute_with_context(gdf, _ctx(pg, gdf, params))
+    finally:
+        pg.close()
+    _assert_geom_equivalent(
+        duck_result, pg_result, rel_tol=rel_tol, label=f"{capability.name} x-engine"
+    )

--- a/tests/integration/test_sql_dialect_crossengine.py
+++ b/tests/integration/test_sql_dialect_crossengine.py
@@ -1,0 +1,257 @@
+"""Cross-dialect result-for-result harness — ELT Lot 1 (#244).
+
+Verifies that the SQL emitted by ``gispulse.persistence.spatial_queries``
+produces *equal results* across engines for the three SQL-pushed
+geometry operations (``buffer`` / ``clip`` / ``intersects``).
+
+Two axes of comparison, both "result for result":
+
+1. **DuckDB SQL vs the GeoPandas/Shapely reference** — runs
+   unconditionally. This is the always-on correctness gate: it catches a
+   builder regression even when no PostGIS server is around.
+2. **DuckDB SQL vs PostGIS SQL** — runs only when ``GISPULSE_TEST_DSN``
+   points at a live PostGIS, otherwise skipped. This is the genuine
+   cross-engine check.
+
+The harness deliberately drives the engines through the *generated SQL*,
+not the capability strategies, so it tests the dialect layer in
+isolation.
+"""
+
+from __future__ import annotations
+
+import os
+
+import geopandas as gpd
+import pytest
+from shapely.geometry import Point, Polygon
+
+from gispulse.persistence.duckdb_engine import DuckDBSession
+from gispulse.persistence.sql_dialect import get_dialect
+from gispulse.persistence.spatial_queries import (
+    buffer_select,
+    clip_select,
+    intersects_select,
+)
+
+TEST_DSN: str | None = os.environ.get("GISPULSE_TEST_DSN")
+
+_requires_postgis = pytest.mark.skipif(
+    TEST_DSN is None,
+    reason="GISPULSE_TEST_DSN not set — skipping the DuckDB↔PostGIS cross-check",
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — inputs in a metric CRS (EPSG:2154) so buffers stay planar
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def points() -> gpd.GeoDataFrame:
+    return gpd.GeoDataFrame(
+        {"id": [1, 2, 3]},
+        geometry=[
+            Point(652000, 6862000),
+            Point(653000, 6863000),
+            Point(700000, 6900000),
+        ],
+        crs="EPSG:2154",
+    )
+
+
+@pytest.fixture
+def squares() -> gpd.GeoDataFrame:
+    return gpd.GeoDataFrame(
+        {"id": [1, 2]},
+        geometry=[
+            Polygon([(0, 0), (10, 0), (10, 10), (0, 10)]),
+            Polygon([(20, 0), (30, 0), (30, 10), (20, 10)]),
+        ],
+        crs="EPSG:2154",
+    )
+
+
+@pytest.fixture
+def mask() -> gpd.GeoDataFrame:
+    return gpd.GeoDataFrame(
+        geometry=[Polygon([(5, -5), (25, -5), (25, 15), (5, 15)])],
+        crs="EPSG:2154",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Comparison helper
+# ---------------------------------------------------------------------------
+
+
+def _assert_same_geometries(
+    a: gpd.GeoDataFrame,
+    b: gpd.GeoDataFrame,
+    *,
+    rel_tol: float,
+    label: str,
+) -> None:
+    """Assert two result sets hold the same geometries.
+
+    Order-independent: both sides are sorted by centroid. Each geometry
+    pair must agree to within *rel_tol* of its area, measured as the
+    symmetric-difference area ratio — robust for both exact polygon
+    overlay (clip) and faceted curves (buffer), where two engines pick
+    different but equivalent vertex sets.
+    """
+    assert len(a) == len(b), f"{label}: row count {len(a)} != {len(b)}"
+    if len(a) == 0:
+        return
+
+    def _sorted(gdf: gpd.GeoDataFrame) -> list:
+        geoms = list(gdf.geometry)
+        return sorted(geoms, key=lambda g: (round(g.centroid.x, 3), round(g.centroid.y, 3)))
+
+    for ga, gb in zip(_sorted(a), _sorted(b)):
+        ref_area = max(ga.area, gb.area, 1e-9)
+        sym = ga.symmetric_difference(gb).area
+        assert sym / ref_area <= rel_tol, (
+            f"{label}: geometries diverge — symmetric-difference ratio "
+            f"{sym / ref_area:.2e} exceeds {rel_tol:.0e}"
+        )
+
+
+def _registered_table(engine, name: str) -> str:
+    """Return the table name an engine's ``register`` actually creates."""
+    if engine.backend_name == "postgis":
+        # PostGISConnection.register writes to a `_gispulse_tmp_` table.
+        return f"_gispulse_tmp_{name}"
+    return name
+
+
+def _finish(query, gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+    """Apply the same geometry-column promotion the strategies apply."""
+    if query.geom_column in gdf.columns:
+        gdf = gdf.set_geometry(query.geom_column).rename_geometry("geometry")
+    return gdf
+
+
+# ---------------------------------------------------------------------------
+# SQL execution per engine
+# ---------------------------------------------------------------------------
+
+
+def _run_buffer(engine, gdf: gpd.GeoDataFrame, distance: float) -> gpd.GeoDataFrame:
+    engine.register("_input", gdf)
+    q = buffer_select(
+        get_dialect(engine.backend_name),
+        source_table=_registered_table(engine, "_input"),
+        distance=distance,
+    )
+    return _finish(q, engine.sql_to_gdf(q.sql))
+
+
+def _run_intersects(
+    engine, gdf: gpd.GeoDataFrame, ref: gpd.GeoDataFrame
+) -> gpd.GeoDataFrame:
+    engine.register("_is_input", gdf)
+    engine.register("_is_ref", ref)
+    q = intersects_select(
+        get_dialect(engine.backend_name),
+        source_table=_registered_table(engine, "_is_input"),
+        ref_table=_registered_table(engine, "_is_ref"),
+    )
+    return _finish(q, engine.sql_to_gdf(q.sql))
+
+
+def _run_clip(
+    engine, gdf: gpd.GeoDataFrame, mask_gdf: gpd.GeoDataFrame
+) -> gpd.GeoDataFrame:
+    engine.register("_clip_input", gdf)
+    engine.register("_clip_mask", mask_gdf)
+    q = clip_select(
+        get_dialect(engine.backend_name),
+        source_table=_registered_table(engine, "_clip_input"),
+        mask_table=_registered_table(engine, "_clip_mask"),
+    )
+    return _finish(q, engine.sql_to_gdf(q.sql))
+
+
+# ---------------------------------------------------------------------------
+# Axis 1 — DuckDB SQL vs the Shapely reference (always runs)
+# ---------------------------------------------------------------------------
+
+
+class TestDuckDBMatchesShapely:
+    """The generated DuckDB SQL must agree with the GeoPandas reference."""
+
+    def test_buffer(self, points):
+        with DuckDBSession() as eng:
+            sql_result = _run_buffer(eng, points, 100.0)
+        reference = points.copy()
+        reference["geometry"] = points.geometry.buffer(100.0)
+        # Buffer is a curved op: DuckDB and Shapely facet the circle with
+        # a different number of segments (32-gon vs 64-gon), so the tol
+        # is set at the facet-discretization level, not machine epsilon.
+        _assert_same_geometries(
+            sql_result, reference, rel_tol=2e-2, label="buffer"
+        )
+
+    def test_intersects(self, squares, mask):
+        with DuckDBSession() as eng:
+            sql_result = _run_intersects(eng, squares, mask)
+        ref_geom = mask.geometry.union_all()
+        reference = squares[squares.geometry.intersects(ref_geom)]
+        _assert_same_geometries(
+            sql_result, reference, rel_tol=1e-6, label="intersects"
+        )
+
+    def test_clip(self, squares, mask):
+        with DuckDBSession() as eng:
+            sql_result = _run_clip(eng, squares, mask)
+        reference = gpd.clip(squares, mask)
+        _assert_same_geometries(
+            sql_result, reference, rel_tol=1e-6, label="clip"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Axis 2 — DuckDB SQL vs PostGIS SQL (requires GISPULSE_TEST_DSN)
+# ---------------------------------------------------------------------------
+
+
+@_requires_postgis
+class TestDuckDBMatchesPostGIS:
+    """The same builder, run on both SQL engines, must agree result-for-result."""
+
+    @pytest.fixture
+    def postgis(self):
+        from gispulse.persistence.postgis import PostGISConnection
+
+        engine = PostGISConnection(dsn=TEST_DSN)
+        engine.open()
+        try:
+            yield engine
+        finally:
+            engine.close()
+
+    def test_buffer(self, points, postgis):
+        with DuckDBSession() as duck:
+            duck_result = _run_buffer(duck, points, 100.0)
+        pg_result = _run_buffer(postgis, points, 100.0)
+        # Facet-discretization tolerance — see TestDuckDBMatchesShapely.
+        _assert_same_geometries(
+            duck_result, pg_result, rel_tol=2e-2, label="buffer x-engine"
+        )
+
+    def test_intersects(self, squares, mask, postgis):
+        with DuckDBSession() as duck:
+            duck_result = _run_intersects(duck, squares, mask)
+        pg_result = _run_intersects(postgis, squares, mask)
+        _assert_same_geometries(
+            duck_result, pg_result, rel_tol=1e-6, label="intersects x-engine"
+        )
+
+    def test_clip(self, squares, mask, postgis):
+        with DuckDBSession() as duck:
+            duck_result = _run_clip(duck, squares, mask)
+        pg_result = _run_clip(postgis, squares, mask)
+        _assert_same_geometries(
+            duck_result, pg_result, rel_tol=1e-6, label="clip x-engine"
+        )

--- a/tests/unit/test_dag.py
+++ b/tests/unit/test_dag.py
@@ -1,0 +1,69 @@
+"""Unit tests for the shared DAG utility (ELT Lot 4B — issue #248).
+
+The Kahn topological-sort algorithm used at execution time by
+:class:`GraphExecutor` lives in :mod:`gispulse.core.dag` so the v3
+manifest loader can reuse it for *load-time* cycle detection. These
+tests pin both the happy path and the cycle-reporting contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gispulse.core.dag import CycleError, topological_sort
+
+
+def test_topological_sort_orders_a_simple_chain():
+    assert topological_sort(
+        nodes=["a", "b", "c"],
+        edges=[("a", "b"), ("b", "c")],
+    ) == ["a", "b", "c"]
+
+
+def test_topological_sort_is_stable_on_independent_nodes():
+    # Input order seeds the tie-break — three roots stay in declaration order.
+    assert topological_sort(
+        nodes=["x", "y", "z"], edges=[]
+    ) == ["x", "y", "z"]
+
+
+def test_topological_sort_handles_diamond():
+    order = topological_sort(
+        nodes=["root", "left", "right", "join"],
+        edges=[("root", "left"), ("root", "right"), ("left", "join"), ("right", "join")],
+    )
+    assert order[0] == "root"
+    assert order[-1] == "join"
+    assert set(order[1:3]) == {"left", "right"}
+
+
+def test_topological_sort_raises_cycle_error_with_members():
+    with pytest.raises(CycleError) as exc:
+        topological_sort(
+            nodes=["a", "b", "c"],
+            edges=[("a", "b"), ("b", "c"), ("c", "a")],
+        )
+    assert exc.value.cycle == {"a", "b", "c"}
+
+
+def test_cycle_error_subclasses_value_error():
+    # Existing callers catch ValueError — keep the inheritance chain.
+    err = CycleError({"x"})
+    assert isinstance(err, ValueError)
+
+
+def test_graph_executor_topo_sort_still_raises_legacy_message():
+    """The :class:`GraphExecutor` wrapper preserves its historical
+    ``Cycle detected in graph, unreachable nodes: …`` message so old
+    tests / log scrapers keep matching."""
+    from gispulse.core.graph import NodeDef, NodeType
+    from gispulse.orchestration.graph_executor import GraphExecutor
+
+    nodes = [
+        NodeDef(id="a", node_type=NodeType.CAPABILITY),
+        NodeDef(id="b", node_type=NodeType.CAPABILITY),
+    ]
+    adj = {"a": ["b"], "b": ["a"]}
+    in_degree = {"a": 1, "b": 1}
+    with pytest.raises(ValueError, match="Cycle detected in graph"):
+        GraphExecutor._topo_sort(nodes, adj, in_degree)

--- a/tests/unit/test_manifest_runner.py
+++ b/tests/unit/test_manifest_runner.py
@@ -1,0 +1,251 @@
+"""Unit tests for the v3 manifest runner (ELT Lot 4C — issue #249).
+
+Exercises :func:`run_manifest` end-to-end with in-memory inputs (no real
+engine), verifying view / table materialization, execution order, the
+incremental NotImplementedError gate, and the materializer cache.
+"""
+
+from __future__ import annotations
+
+import geopandas as gpd
+import pytest
+from shapely.geometry import Point
+
+from gispulse.core.manifest_v3 import ManifestV3, ModelSpec, SourceSpec
+from gispulse.runtime.manifest_runner import (
+    MaterializationMode,
+    Materializer,
+    RefreshMode,
+    run_manifest,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — in-memory sources via a custom source_loader
+# ---------------------------------------------------------------------------
+
+
+def _make_layer(ids, values) -> gpd.GeoDataFrame:
+    return gpd.GeoDataFrame(
+        {"id": list(ids), "val": list(values)},
+        geometry=[Point(i, i) for i in ids],
+        crs="EPSG:2154",
+    )
+
+
+def _source_loader_for(layers: dict[str, gpd.GeoDataFrame]):
+    def loader(src):
+        return layers[src.name]
+
+    return loader
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_run_manifest_view_single_model():
+    """A single VIEW model — runs its transforms, caches the result."""
+    cad = _make_layer([1, 2, 3], [10, 20, 30])
+    manifest = ManifestV3(
+        sources={"cad": SourceSpec(name="cad", uri="memory://cad")},
+        models={
+            "kept": ModelSpec(
+                name="kept",
+                select="cad",
+                transform=[{"filter": {"expression": "val >= 20"}}],
+                materialize="view",
+            ),
+        },
+    )
+    result = run_manifest(
+        manifest, source_loader=_source_loader_for({"cad": cad})
+    )
+    assert result.execution_order == ["kept"]
+    kept = result.materialized["kept"]
+    assert kept.mode == MaterializationMode.VIEW
+    assert kept.refresh == RefreshMode.MANUAL
+    assert sorted(kept.result["val"].tolist()) == [20, 30]
+    assert kept.table_ref is None
+
+
+def test_run_manifest_respects_topo_order():
+    """An A→B chain must run A before B (B reads A's materialization)."""
+    src = _make_layer([1, 2, 3], [10, 20, 30])
+    manifest = ManifestV3(
+        sources={"src": SourceSpec(name="src", uri="memory://src")},
+        models={
+            "b": ModelSpec(
+                name="b",
+                select="a",
+                transform=[{"filter": {"expression": "val >= 30"}}],
+            ),
+            "a": ModelSpec(
+                name="a",
+                select="src",
+                transform=[{"filter": {"expression": "val >= 20"}}],
+            ),
+        },
+    )
+    result = run_manifest(
+        manifest, source_loader=_source_loader_for({"src": src})
+    )
+    assert result.execution_order == ["a", "b"]
+    assert sorted(result.materialized["a"].result["val"]) == [20, 30]
+    assert result.materialized["b"].result["val"].tolist() == [30]
+
+
+def test_run_manifest_table_mode_registers_on_engine():
+    """TABLE mode hands the gdf to engine.register under the prefixed name."""
+
+    class _FakeEngine:
+        backend_name = "duckdb"
+
+        def __init__(self):
+            self.registered: dict[str, gpd.GeoDataFrame] = {}
+
+        def load_layer(self, source, *, layer=None, schema="public"):
+            raise NotImplementedError  # source_loader is supplied
+
+        def register(self, name, gdf):
+            self.registered[name] = gdf
+
+    cad = _make_layer([1, 2], [5, 9])
+    engine = _FakeEngine()
+    manifest = ManifestV3(
+        sources={"cad": SourceSpec(name="cad", uri="memory://cad")},
+        models={
+            "kept": ModelSpec(
+                name="kept",
+                select="cad",
+                transform=[{"filter": {"expression": "val > 5"}}],
+                materialize="table",
+            ),
+        },
+    )
+    result = run_manifest(
+        manifest,
+        engine=engine,
+        source_loader=_source_loader_for({"cad": cad}),
+    )
+    kept = result.materialized["kept"]
+    assert kept.mode == MaterializationMode.TABLE
+    assert kept.table_ref == "elt_kept"
+    assert "elt_kept" in engine.registered
+    assert engine.registered["elt_kept"]["val"].tolist() == [9]
+
+
+def test_run_manifest_incremental_raises_not_implemented():
+    src = _make_layer([1], [1])
+    manifest = ManifestV3(
+        sources={"src": SourceSpec(name="src", uri="memory://src")},
+        models={
+            "inc": ModelSpec(
+                name="inc",
+                select="src",
+                transform=[{"filter": {"expression": "val >= 0"}}],
+                materialize="incremental",
+            ),
+        },
+    )
+    with pytest.raises(NotImplementedError, match="incremental"):
+        run_manifest(
+            manifest, source_loader=_source_loader_for({"src": src})
+        )
+
+
+def test_run_manifest_propagates_validation_errors():
+    """Unresolved select must surface from run_manifest (not silently swallowed)."""
+    manifest = ManifestV3(
+        sources={"src": SourceSpec(name="src", uri="memory://src")},
+        models={
+            "m": ModelSpec(name="m", select="ghost", transform=[]),
+        },
+    )
+    with pytest.raises(ValueError, match="ghost"):
+        run_manifest(
+            manifest, source_loader=_source_loader_for({"src": _make_layer([1], [1])})
+        )
+
+
+def test_materializer_reuse_shares_cache_across_runs():
+    """Caller-supplied materializer accumulates results across calls."""
+    src = _make_layer([1, 2], [10, 20])
+    materializer = Materializer()
+    manifest_a = ManifestV3(
+        sources={"src": SourceSpec(name="src", uri="memory://src")},
+        models={"a": ModelSpec(name="a", select="src", transform=[])},
+    )
+    run_manifest(
+        manifest_a,
+        source_loader=_source_loader_for({"src": src}),
+        materializer=materializer,
+    )
+    assert "a" in materializer.models
+    manifest_b = ManifestV3(
+        sources={"src": SourceSpec(name="src", uri="memory://src")},
+        models={"b": ModelSpec(name="b", select="src", transform=[])},
+    )
+    run_manifest(
+        manifest_b,
+        source_loader=_source_loader_for({"src": src}),
+        materializer=materializer,
+    )
+    assert {"a", "b"} == set(materializer.models)
+
+
+def test_table_mode_requires_engine():
+    src = _make_layer([1], [1])
+    manifest = ManifestV3(
+        sources={"src": SourceSpec(name="src", uri="memory://src")},
+        models={
+            "m": ModelSpec(
+                name="m", select="src", transform=[], materialize="table"
+            ),
+        },
+    )
+    # No engine, no materializer → TABLE has no engine to register on.
+    with pytest.raises(RuntimeError, match="TABLE materialization"):
+        run_manifest(
+            manifest,
+            source_loader=_source_loader_for({"src": src}),
+        )
+
+
+def test_run_manifest_with_clause_routes_ref_layer():
+    """A model whose transform has ``with: <other_model>`` reads it via
+    the ``ref_layer`` plumbing, not as the primary input."""
+    left = _make_layer([1, 2, 3], [10, 20, 30])
+    manifest = ManifestV3(
+        sources={"src": SourceSpec(name="src", uri="memory://src")},
+        models={
+            "filtered": ModelSpec(
+                name="filtered",
+                select="src",
+                transform=[{"filter": {"expression": "val >= 20"}}],
+            ),
+            "joined": ModelSpec(
+                name="joined",
+                select="src",
+                transform=[
+                    {
+                        "attribute_join": {
+                            "with": "filtered",
+                            "left_on": "id",
+                            "right_on": "id",
+                            "how": "inner",
+                        }
+                    }
+                ],
+            ),
+        },
+    )
+    result = run_manifest(
+        manifest, source_loader=_source_loader_for({"src": left})
+    )
+    assert result.execution_order == ["filtered", "joined"]
+    joined = result.materialized["joined"].result
+    # Inner-joined with the filtered set (vals >= 20) → 2 rows kept.
+    assert len(joined) == 2
+    assert sorted(joined["id"].tolist()) == [2, 3]

--- a/tests/unit/test_manifest_v3.py
+++ b/tests/unit/test_manifest_v3.py
@@ -1,0 +1,311 @@
+"""Unit tests for the v3 manifest (ELT Lot 4A — issue #247).
+
+Covers the schema, the loader, the ``models:`` → PipelineSpec compiler
+and the v1/v2 → v3 migration helper. No engine is exercised — the tests
+assert on the structure of the parsed manifest and the compiled
+PipelineSpec.
+"""
+
+from __future__ import annotations
+
+import json
+import textwrap
+
+import pytest
+import yaml
+
+from gispulse.core.manifest_v3 import (
+    ManifestV3,
+    ModelSpec,
+    SourceSpec,
+    compile_to_pipeline,
+    load_manifest_v3,
+    manifest_to_dict,
+    migrate_to_v3,
+)
+from gispulse.core.pipeline_schema import SCHEMA_V3, validate_pipeline_json
+
+
+# ---------------------------------------------------------------------------
+# Schema validation
+# ---------------------------------------------------------------------------
+
+
+def test_schema_v3_accepts_canonical_adr0005_example():
+    raw = {
+        "version": 3,
+        "sources": {
+            "cadastre": {"uri": "./parcelles.gpkg", "crs": "EPSG:2154"},
+            "plu": {"uri": "s3://bucket/plu.parquet"},
+        },
+        "staging": {"engine": "duckdb", "cdc": "incremental"},
+        "models": {
+            "zones_u": {
+                "select": "plu",
+                "transform": [{"filter": {"expression": "zone == 'U'"}}],
+                "materialize": "view",
+            },
+            "parcelles_constructibles": {
+                "select": "cadastre",
+                "transform": [
+                    {"spatial_join": {"with": "zones_u", "predicate": "intersects"}},
+                    {"area_length": {"compute_area": True, "area_col": "surface_m2"}},
+                ],
+                "materialize": "incremental",
+            },
+        },
+        "triggers": [
+            {
+                "name": "notify",
+                "on": ["INSERT"],
+                "table": "parcelles_constructibles",
+                "actions": [{"type": "webhook", "url": "https://example.com/hook"}],
+            }
+        ],
+    }
+    assert validate_pipeline_json(raw) == []
+
+
+def test_schema_v3_rejects_wrong_version():
+    errors = validate_pipeline_json({"version": 2, "sources": {}, "models": {}})
+    assert any("version" in e.lower() or "steps" in e.lower() for e in errors)
+
+
+def test_schema_v3_rejects_transform_step_with_two_keys():
+    raw = {
+        "version": 3,
+        "sources": {"x": {"uri": "./x.gpkg"}},
+        "models": {
+            "m": {
+                "select": "x",
+                # Two-keyed transform — schema requires exactly one.
+                "transform": [{"filter": {}, "buffer": {}}],
+            }
+        },
+    }
+    errors = validate_pipeline_json(raw)
+    assert errors, "schema should reject transforms with multiple capabilities"
+
+
+def test_schema_v3_id_routes_via_version_field():
+    """The schema picker routes v3 manifests by ``version: 3``."""
+    assert SCHEMA_V3["properties"]["version"] == {"const": 3}
+
+
+# ---------------------------------------------------------------------------
+# Loader
+# ---------------------------------------------------------------------------
+
+
+_CANONICAL_YAML = textwrap.dedent(
+    """
+    version: 3
+    name: demo
+    sources:
+      cadastre:
+        uri: ./parcelles.gpkg
+        crs: EPSG:2154
+      plu:
+        uri: s3://bucket/plu.parquet
+    models:
+      zones_u:
+        select: plu
+        transform:
+          - filter: { expression: "zone == 'U'" }
+      parcelles_constructibles:
+        select: cadastre
+        transform:
+          - spatial_join: { with: zones_u, predicate: intersects }
+          - area_length: { compute_area: true }
+        materialize: incremental
+    """
+)
+
+
+def test_loader_parses_yaml(tmp_path):
+    path = tmp_path / "manifest.yaml"
+    path.write_text(_CANONICAL_YAML, encoding="utf-8")
+    m = load_manifest_v3(path)
+    assert m.name == "demo"
+    assert set(m.sources) == {"cadastre", "plu"}
+    assert m.sources["cadastre"].crs == "EPSG:2154"
+    assert set(m.models) == {"zones_u", "parcelles_constructibles"}
+    pc = m.models["parcelles_constructibles"]
+    assert pc.select == "cadastre"
+    assert pc.materialize == "incremental"
+    assert len(pc.transform) == 2
+
+
+def test_loader_parses_json(tmp_path):
+    raw = yaml.safe_load(_CANONICAL_YAML)
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(raw), encoding="utf-8")
+    m = load_manifest_v3(path)
+    assert set(m.models) == {"zones_u", "parcelles_constructibles"}
+
+
+def test_loader_rejects_wrong_version(tmp_path):
+    path = tmp_path / "m.yaml"
+    path.write_text("version: 2\nname: x\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="version"):
+        load_manifest_v3(path)
+
+
+def test_loader_missing_file_raises(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        load_manifest_v3(tmp_path / "nope.yaml")
+
+
+# ---------------------------------------------------------------------------
+# Compiler
+# ---------------------------------------------------------------------------
+
+
+def _canonical_manifest() -> ManifestV3:
+    return ManifestV3(
+        sources={
+            "cadastre": SourceSpec(name="cadastre", uri="./p.gpkg"),
+            "plu": SourceSpec(name="plu", uri="s3://b/plu.parquet"),
+        },
+        models={
+            "zones_u": ModelSpec(
+                name="zones_u",
+                select="plu",
+                transform=[{"filter": {"expression": "zone == 'U'"}}],
+            ),
+            "parcelles_constructibles": ModelSpec(
+                name="parcelles_constructibles",
+                select="cadastre",
+                transform=[
+                    {"spatial_join": {"with": "zones_u", "predicate": "intersects"}},
+                    {"area_length": {"compute_area": True}},
+                ],
+            ),
+        },
+    )
+
+
+def test_compile_produces_three_steps_with_correct_chain():
+    ps = compile_to_pipeline(_canonical_manifest())
+    assert [s.id for s in ps.steps] == [
+        "zones_u",
+        "parcelles_constructibles__t0",
+        "parcelles_constructibles",
+    ]
+    assert ps.ref_layers == {
+        "cadastre": "./p.gpkg",
+        "plu": "s3://b/plu.parquet",
+    }
+
+
+def test_compile_select_source_keeps_step_input_none():
+    """A model rooted at a *source* compiles to a first step with input=None."""
+    ps = compile_to_pipeline(_canonical_manifest())
+    by_id = {s.id: s for s in ps.steps}
+    # zones_u selects plu (a source) → input=None.
+    assert by_id["zones_u"].input is None
+    # parcelles_constructibles__t0 selects cadastre (a source); with=zones_u
+    # rides on ref_layer rather than swapping the primary input.
+    sj = by_id["parcelles_constructibles__t0"]
+    assert sj.input is None
+    assert sj.capability == "spatial_join"
+    assert sj.params["ref_layer"] == "zones_u"
+    assert sj.params["predicate"] == "intersects"
+
+
+def test_compile_chains_transforms_within_a_model():
+    ps = compile_to_pipeline(_canonical_manifest())
+    by_id = {s.id: s for s in ps.steps}
+    assert by_id["parcelles_constructibles"].input == "parcelles_constructibles__t0"
+    assert by_id["parcelles_constructibles"].capability == "area_length"
+
+
+def test_compile_select_model_routes_input_to_terminal_step():
+    """A model selecting another *model* uses that model's terminal id."""
+    m = ManifestV3(
+        sources={"x": SourceSpec(name="x", uri="./x.gpkg")},
+        models={
+            "a": ModelSpec(
+                name="a", select="x",
+                transform=[{"filter": {"expression": "1==1"}}],
+            ),
+            "b": ModelSpec(
+                name="b", select="a",
+                transform=[{"buffer": {"distance": 5}}],
+            ),
+        },
+    )
+    ps = compile_to_pipeline(m)
+    by_id = {s.id: s for s in ps.steps}
+    assert by_id["b"].input == "a"
+
+
+def test_compile_rejects_unknown_select():
+    m = ManifestV3(
+        sources={"src": SourceSpec(name="src", uri="./x.gpkg")},
+        models={"m": ModelSpec(name="m", select="nope", transform=[])},
+    )
+    with pytest.raises(ValueError, match="Unknown select target"):
+        compile_to_pipeline(m)
+
+
+def test_compile_empty_transform_yields_identity_filter():
+    m = ManifestV3(
+        sources={"src": SourceSpec(name="src", uri="./x.gpkg")},
+        models={"m": ModelSpec(name="m", select="src", transform=[])},
+    )
+    ps = compile_to_pipeline(m)
+    assert len(ps.steps) == 1
+    assert ps.steps[0].capability == "filter"
+    assert ps.steps[0].params == {}
+
+
+# ---------------------------------------------------------------------------
+# Migration v1 / v2 → v3
+# ---------------------------------------------------------------------------
+
+
+def test_migrate_v2_pipelinespec_to_v3():
+    v2 = {
+        "version": 2,
+        "name": "demo",
+        "ref_layers": {"zones": "./zones.gpkg"},
+        "steps": [
+            {"id": "s1", "capability": "filter", "params": {"expression": "pop > 100"}},
+            {"id": "s2", "capability": "buffer", "params": {"distance": 50}, "input": "s1"},
+        ],
+    }
+    v3 = migrate_to_v3(v2)
+    assert v3["version"] == 3
+    assert "zones" in v3["sources"]
+    assert "input" in v3["sources"]  # primary-input placeholder
+    assert set(v3["models"]) == {"s1", "s2"}
+    assert v3["models"]["s2"]["select"] == "s1"
+    assert validate_pipeline_json(v3) == []
+
+
+def test_migrate_v1_flat_rules_to_v3():
+    v1 = [
+        {"name": "a", "capability": "filter", "config": {"expression": "x > 1"}},
+        {"name": "b", "capability": "buffer", "config": {"distance": 10}},
+    ]
+    v3 = migrate_to_v3(v1)
+    assert v3["version"] == 3
+    # v1 is a linear chain → b selects a.
+    assert v3["models"]["b"]["select"] == "a"
+    assert validate_pipeline_json(v3) == []
+
+
+def test_migrate_already_v3_is_passthrough():
+    v3 = {"version": 3, "sources": {"x": {"uri": "./x.gpkg"}}, "models": {}}
+    assert migrate_to_v3(v3) is v3
+
+
+def test_manifest_to_dict_round_trips_canonical():
+    m = _canonical_manifest()
+    d = manifest_to_dict(m)
+    assert d["version"] == 3
+    assert d["sources"]["cadastre"]["uri"] == "./p.gpkg"
+    assert d["models"]["parcelles_constructibles"]["select"] == "cadastre"
+    # The output validates against the schema.
+    assert validate_pipeline_json(d) == []

--- a/tests/unit/test_manifest_v3.py
+++ b/tests/unit/test_manifest_v3.py
@@ -309,3 +309,132 @@ def test_manifest_to_dict_round_trips_canonical():
     assert d["models"]["parcelles_constructibles"]["select"] == "cadastre"
     # The output validates against the schema.
     assert validate_pipeline_json(d) == []
+
+
+# ===========================================================================
+# Load-time graph validation (ELT Lot 4B / #248)
+# ===========================================================================
+
+
+from gispulse.core.manifest_v3 import (  # noqa: E402
+    ManifestValidationError,
+    validate_manifest,
+)
+
+
+def test_validate_manifest_canonical_returns_no_warnings_for_used_outputs():
+    """Models that are referenced by another have no warnings; only
+    terminal/unreferenced outputs are flagged."""
+    m = _canonical_manifest()
+    warnings = validate_manifest(m)
+    # zones_u is selected by parcelles_constructibles (via `with`) so
+    # only parcelles_constructibles is a terminal/orphan output.
+    assert len(warnings) == 1
+    assert "parcelles_constructibles" in warnings[0]
+
+
+def test_validate_manifest_rejects_unresolved_select():
+    m = ManifestV3(
+        sources={"src": SourceSpec(name="src", uri="./x.gpkg")},
+        models={
+            "m": ModelSpec(name="m", select="nope", transform=[]),
+        },
+    )
+    with pytest.raises(ManifestValidationError) as exc:
+        validate_manifest(m)
+    assert any("nope" in e for e in exc.value.errors)
+
+
+def test_validate_manifest_rejects_unresolved_with_ref():
+    m = ManifestV3(
+        sources={"src": SourceSpec(name="src", uri="./x.gpkg")},
+        models={
+            "m": ModelSpec(
+                name="m",
+                select="src",
+                transform=[
+                    {"spatial_join": {"with": "ghost_model", "predicate": "intersects"}},
+                ],
+            ),
+        },
+    )
+    with pytest.raises(ManifestValidationError) as exc:
+        validate_manifest(m)
+    assert any("ghost_model" in e and "with=" in e for e in exc.value.errors)
+
+
+def test_validate_manifest_detects_inter_model_cycle():
+    """A → B → A through `select:` references must fail load."""
+    m = ManifestV3(
+        sources={"src": SourceSpec(name="src", uri="./x.gpkg")},
+        models={
+            "a": ModelSpec(
+                name="a", select="b", transform=[{"filter": {"expression": "1==1"}}]
+            ),
+            "b": ModelSpec(
+                name="b", select="a", transform=[{"filter": {"expression": "1==1"}}]
+            ),
+        },
+    )
+    with pytest.raises(ManifestValidationError, match="cycle"):
+        validate_manifest(m)
+
+
+def test_validate_manifest_detects_with_cycle():
+    """A cycle that goes through a transform-level `with:` also fails."""
+    m = ManifestV3(
+        sources={"src": SourceSpec(name="src", uri="./x.gpkg")},
+        models={
+            "a": ModelSpec(
+                name="a",
+                select="src",
+                transform=[{"spatial_join": {"with": "b", "predicate": "intersects"}}],
+            ),
+            "b": ModelSpec(
+                name="b",
+                select="src",
+                transform=[{"spatial_join": {"with": "a", "predicate": "intersects"}}],
+            ),
+        },
+    )
+    with pytest.raises(ManifestValidationError, match="cycle"):
+        validate_manifest(m)
+
+
+def test_validate_manifest_passes_on_acyclic_graph():
+    m = _canonical_manifest()
+    # No exception, and validation runs to completion (returns warnings list).
+    assert isinstance(validate_manifest(m), list)
+
+
+def test_load_manifest_v3_raises_on_cycle(tmp_path):
+    """The load entry point picks up cycle detection automatically."""
+    path = tmp_path / "cyclic.yaml"
+    path.write_text(
+        "version: 3\n"
+        "sources:\n"
+        "  src: { uri: ./x.gpkg }\n"
+        "models:\n"
+        "  a: { select: b, transform: [{ filter: { expression: \"1==1\" } }] }\n"
+        "  b: { select: a, transform: [{ filter: { expression: \"1==1\" } }] }\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ManifestValidationError, match="cycle"):
+        load_manifest_v3(path)
+
+
+def test_load_manifest_v3_passes_validate_false_through(tmp_path):
+    """``validate=False`` bypasses both schema and graph checks (escape hatch)."""
+    path = tmp_path / "broken.yaml"
+    path.write_text(
+        "version: 3\n"
+        "sources:\n"
+        "  src: { uri: ./x.gpkg }\n"
+        "models:\n"
+        "  m: { select: nope }\n",
+        encoding="utf-8",
+    )
+    # With validate=True the unresolved select would be flagged; with
+    # validate=False we get the raw ManifestV3 back.
+    m = load_manifest_v3(path, validate=False)
+    assert "m" in m.models

--- a/tests/unit/test_pipeline_schema.py
+++ b/tests/unit/test_pipeline_schema.py
@@ -128,7 +128,9 @@ class TestValidateV2:
         assert any("version" in e.lower() for e in errors)
 
     def test_v2_wrong_version_value(self):
-        data = {"version": 3, "steps": [{"id": "s1"}]}
+        # version=3 is now a valid ADR 0005 manifest, routed to SCHEMA_V3.
+        # Use a clearly-unsupported value to keep the original intent.
+        data = {"version": 99, "steps": [{"id": "s1"}]}
         errors = validate_pipeline_json(data)
         assert any("version" in e.lower() or "2" in e for e in errors)
 

--- a/tests/unit/test_sql_dialect.py
+++ b/tests/unit/test_sql_dialect.py
@@ -4,10 +4,17 @@ from __future__ import annotations
 import pytest
 
 from gispulse.persistence.sql_dialect import (
+    BufferStyle,
     DuckDBDialect,
     PostGISDialect,
     SpatiaLiteDialect,
+    UnsupportedInDialect,
     get_dialect,
+)
+from gispulse.persistence.spatial_queries import (
+    buffer_select,
+    clip_select,
+    intersects_select,
 )
 
 
@@ -138,3 +145,217 @@ class TestCrossBackendConsistency:
     def test_name_is_string(self, d):
         assert isinstance(d.name, str)
         assert d.name in ("postgis", "duckdb", "spatialite")
+
+
+# ===========================================================================
+# ELT Lot 1 (#244) — the five audited DuckDB/PostGIS divergences
+# ===========================================================================
+
+
+class TestDivergence1WkbVsNative:
+    """Divergence #1 — registered geometry: WKB blob vs native column."""
+
+    def test_duckdb_lifts_wkb_blob(self):
+        d = DuckDBDialect()
+        assert d.geom_column == "__wkb"
+        assert d.geom_ref() == "ST_GeomFromWKB(__wkb)"
+        assert d.geom_ref(table="i") == "ST_GeomFromWKB(i.__wkb)"
+
+    def test_postgis_casts_native_column(self):
+        d = PostGISDialect()
+        assert d.geom_column == "geometry"
+        assert d.geom_ref() == "geometry::geometry"
+        assert d.geom_ref(table="m") == "m.geometry::geometry"
+
+    def test_geom_ref_rejects_hostile_identifier(self):
+        with pytest.raises(ValueError):
+            DuckDBDialect().geom_ref("__wkb); DROP TABLE x --")
+        with pytest.raises(ValueError):
+            PostGISDialect().geom_ref(table='i" UNION SELECT')
+
+
+class TestDivergence2StyledBuffer:
+    """Divergence #2 — styled ST_Buffer: PostGIS only."""
+
+    def test_default_style_both_dialects(self):
+        assert DuckDBDialect().st_buffer_styled("g", 100.0) == "ST_Buffer(g, 100.0)"
+        assert PostGISDialect().st_buffer_styled("g", 100.0) == "ST_Buffer(g, 100.0)"
+
+    def test_negative_distance_is_erosion(self):
+        assert DuckDBDialect().st_buffer_styled("g", -25.0) == "ST_Buffer(g, -25.0)"
+
+    def test_styled_postgis_emits_style_string(self):
+        style = BufferStyle(quad_segs=16, cap_style="flat", join_style="mitre")
+        assert PostGISDialect().st_buffer_styled("g", 5.0, style) == (
+            "ST_Buffer(g, 5.0, 'quad_segs=16 endcap=flat join=mitre "
+            "mitre_limit=5.000 side=both')"
+        )
+
+    def test_styled_duckdb_raises(self):
+        with pytest.raises(UnsupportedInDialect):
+            DuckDBDialect().st_buffer_styled("g", 5.0, BufferStyle(quad_segs=16))
+
+    def test_unsupported_is_a_notimplementederror(self):
+        # New callers catch the precise type; legacy callers catching the
+        # broad NotImplementedError keep working.
+        assert issubclass(UnsupportedInDialect, NotImplementedError)
+
+    def test_default_style_object_accepted_by_duckdb(self):
+        assert DuckDBDialect().st_buffer_styled("g", 5.0, BufferStyle()) == (
+            "ST_Buffer(g, 5.0)"
+        )
+
+    def test_capability_flag(self):
+        assert PostGISDialect().supports_styled_buffer is True
+        assert DuckDBDialect().supports_styled_buffer is False
+
+
+class TestBufferStyle:
+    def test_single_sided_renders_left(self):
+        assert "side=left" in BufferStyle(single_sided=True).to_postgis_style()
+        assert "side=both" in BufferStyle().to_postgis_style()
+
+    def test_validates_enums(self):
+        with pytest.raises(ValueError):
+            BufferStyle(cap_style="pointy")
+        with pytest.raises(ValueError):
+            BufferStyle(join_style="weird")
+        with pytest.raises(ValueError):
+            BufferStyle(quad_segs=0)
+
+    def test_is_default_flag(self):
+        assert BufferStyle().is_default is True
+        assert BufferStyle(quad_segs=16).is_default is False
+        assert BufferStyle(single_sided=True).is_default is False
+
+
+class TestDivergence3Knn:
+    """Divergence #3 — KNN <-> operator: PostGIS only."""
+
+    def test_postgis_emits_operator(self):
+        assert PostGISDialect().supports_knn is True
+        assert PostGISDialect().st_knn_distance("a.geom", "b.geom") == (
+            "(a.geom <-> b.geom)"
+        )
+
+    def test_duckdb_raises(self):
+        assert DuckDBDialect().supports_knn is False
+        with pytest.raises(UnsupportedInDialect):
+            DuckDBDialect().st_knn_distance("a", "b")
+
+
+class TestDivergence4Transform:
+    """Divergence #4 — ST_Transform arity / axis order."""
+
+    def test_duckdb_uses_four_arg_always_xy(self):
+        assert DuckDBDialect().st_transform(
+            "g", src_srid=4326, dst_srid=2154
+        ) == "ST_Transform(g, 'EPSG:4326', 'EPSG:2154', always_xy := true)"
+
+    def test_postgis_uses_two_arg_target_srid(self):
+        assert PostGISDialect().st_transform(
+            "g", src_srid=4326, dst_srid=2154
+        ) == "ST_Transform(g, 2154)"
+
+
+class TestDivergence5Coverage:
+    """Divergence #5 — topological coverage capability flag."""
+
+    def test_coverage_flags(self):
+        assert PostGISDialect().supports_coverage is True
+        assert DuckDBDialect().supports_coverage is False
+
+
+@pytest.mark.parametrize("dialect", [DuckDBDialect(), PostGISDialect()])
+def test_intersection_portable_across_sql_engines(dialect):
+    assert dialect.st_intersection("a", "b") == "ST_Intersection(a, b)"
+
+
+# ===========================================================================
+# ELT Lot 1 — statement builders (spatial_queries) — golden SQL
+# ===========================================================================
+
+
+class TestBufferSelect:
+    def test_duckdb_golden(self):
+        # DuckDB derives the geometry via `* REPLACE` so the result keeps
+        # the canonical __wkb name the result decoder keys on.
+        q = buffer_select(DuckDBDialect(), source_table="_input", distance=100.0)
+        assert q.sql == (
+            "SELECT * REPLACE (ST_Buffer(ST_GeomFromWKB(__wkb), 100.0) AS __wkb) "
+            "FROM _input"
+        )
+        assert q.geom_column == "__wkb"
+
+    def test_postgis_golden_with_style(self):
+        q = buffer_select(
+            PostGISDialect(),
+            source_table="_input",
+            distance=100.0,
+            style=BufferStyle(),
+        )
+        assert q.sql == (
+            "SELECT *, ST_Buffer(geometry::geometry, 100.0, "
+            "'quad_segs=8 endcap=round join=round mitre_limit=5.000 side=both') "
+            "AS geometry_buf FROM _input"
+        )
+        assert q.geom_column == "geometry_buf"
+
+
+class TestClipSelect:
+    def test_duckdb_uses_replace_projection(self):
+        q = clip_select(
+            DuckDBDialect(), source_table="_clip_input", mask_table="_clip_mask"
+        )
+        assert q.sql == (
+            "SELECT i.* REPLACE (ST_Intersection(ST_GeomFromWKB(i.__wkb), "
+            "ST_GeomFromWKB(m.__wkb)) AS __wkb) "
+            "FROM _clip_input i, _clip_mask m "
+            "WHERE ST_Intersects(ST_GeomFromWKB(i.__wkb), ST_GeomFromWKB(m.__wkb))"
+        )
+        assert q.geom_column == "__wkb"
+
+    def test_postgis_appends_geometry_clip(self):
+        q = clip_select(
+            PostGISDialect(), source_table="_clip_input", mask_table="_clip_mask"
+        )
+        assert q.sql == (
+            "SELECT i.*, ST_Intersection(i.geometry::geometry, "
+            "m.geometry::geometry) AS geometry_clip "
+            "FROM _clip_input i, _clip_mask m "
+            "WHERE ST_Intersects(i.geometry::geometry, m.geometry::geometry)"
+        )
+        assert q.geom_column == "geometry_clip"
+
+
+class TestIntersectsSelect:
+    def test_duckdb_golden(self):
+        q = intersects_select(
+            DuckDBDialect(), source_table="_is_input", ref_table="_is_ref"
+        )
+        assert q.sql == (
+            "SELECT i.* FROM _is_input i, _is_ref r "
+            "WHERE ST_Intersects(ST_GeomFromWKB(i.__wkb), ST_GeomFromWKB(r.__wkb))"
+        )
+        assert q.geom_column == "__wkb"
+
+    def test_postgis_golden(self):
+        q = intersects_select(
+            PostGISDialect(), source_table="_is_input", ref_table="_is_ref"
+        )
+        assert q.sql == (
+            "SELECT i.* FROM _is_input i, _is_ref r "
+            "WHERE ST_Intersects(i.geometry::geometry, r.geometry::geometry)"
+        )
+        assert q.geom_column == "geometry"
+
+
+@pytest.mark.parametrize("backend", ["duckdb", "postgis"])
+def test_builders_reject_hostile_table_names(backend):
+    d = get_dialect(backend)
+    with pytest.raises(ValueError):
+        buffer_select(d, source_table="x; DROP TABLE t", distance=1.0)
+    with pytest.raises(ValueError):
+        clip_select(d, source_table="ok", mask_table='m"--')
+    with pytest.raises(ValueError):
+        intersects_select(d, source_table="ok", ref_table="r;SELECT")

--- a/tests/unit/test_sql_dialect.py
+++ b/tests/unit/test_sql_dialect.py
@@ -399,3 +399,45 @@ def test_geometry_functions_raise_on_gpkg():
     ):
         with pytest.raises(NotImplementedError):
             call()
+
+
+# ===========================================================================
+# ELT Lot 3b (#246) — aggregating / two-layer / topology divergences
+# ===========================================================================
+
+
+def test_st_difference_and_topology_simplify_spelled_identically():
+    for d in (DuckDBDialect(), PostGISDialect()):
+        assert d.st_difference("a", "b") == "ST_Difference(a, b)"
+        assert d.st_simplify_preserve_topology("g", 0.5) == (
+            "ST_SimplifyPreserveTopology(g, 0.5)"
+        )
+
+
+def test_st_union_agg_diverges_between_dialects():
+    # PostGIS spells the aggregate ST_Union(col); DuckDB needs ST_Union_Agg.
+    assert PostGISDialect().st_union_agg("geom") == "ST_Union(geom)"
+    assert DuckDBDialect().st_union_agg("geom") == "ST_Union_Agg(geom)"
+
+
+def test_st_sym_difference_emulated_on_duckdb():
+    # PostGIS has native ST_SymDifference; DuckDB composes it from
+    # the two one-sided differences via ST_Union.
+    assert PostGISDialect().st_sym_difference("a", "b") == "ST_SymDifference(a, b)"
+    assert DuckDBDialect().st_sym_difference("a", "b") == (
+        "ST_Union(ST_Difference(a, b), ST_Difference(b, a))"
+    )
+
+
+def test_lot3b_methods_raise_on_gpkg():
+    from gispulse.persistence.sql_dialect import get_dialect
+
+    gpkg = get_dialect("gpkg")
+    for call in (
+        lambda: gpkg.st_difference("a", "b"),
+        lambda: gpkg.st_simplify_preserve_topology("g", 1.0),
+        lambda: gpkg.st_union_agg("g"),
+        lambda: gpkg.st_sym_difference("a", "b"),
+    ):
+        with pytest.raises(NotImplementedError):
+            call()

--- a/tests/unit/test_sql_dialect.py
+++ b/tests/unit/test_sql_dialect.py
@@ -359,3 +359,43 @@ def test_builders_reject_hostile_table_names(backend):
         clip_select(d, source_table="ok", mask_table='m"--')
     with pytest.raises(ValueError):
         intersects_select(d, source_table="ok", ref_table="r;SELECT")
+
+
+# ===========================================================================
+# ELT Lot 3 (#246) — single-layer geometry transform spellings
+# ===========================================================================
+
+
+@pytest.mark.parametrize("dialect", [DuckDBDialect(), PostGISDialect()])
+def test_lot3_geometry_functions_spelled_identically(dialect):
+    # DuckDB-spatial and PostGIS share the ST_* spelling for these.
+    assert dialect.st_boundary("g") == "ST_Boundary(g)"
+    assert dialect.st_envelope("g") == "ST_Envelope(g)"
+    assert dialect.st_convex_hull("g") == "ST_ConvexHull(g)"
+    assert dialect.st_make_valid("g") == "ST_MakeValid(g)"
+    assert dialect.st_simplify("g", 0.5) == "ST_Simplify(g, 0.5)"
+    assert dialect.st_is_empty("g") == "ST_IsEmpty(g)"
+
+
+@pytest.mark.parametrize("dialect", [DuckDBDialect(), PostGISDialect()])
+def test_concave_hull_uses_three_arg_form(dialect):
+    # The 2-arg form is rejected by DuckDB-spatial — always emit 3 args.
+    assert dialect.st_concave_hull("g", 0.5) == "ST_ConcaveHull(g, 0.5, false)"
+    assert (
+        dialect.st_concave_hull("g", 0.3, allow_holes=True)
+        == "ST_ConcaveHull(g, 0.3, true)"
+    )
+
+
+def test_geometry_functions_raise_on_gpkg():
+    from gispulse.persistence.sql_dialect import get_dialect
+
+    gpkg = get_dialect("gpkg")
+    for call in (
+        lambda: gpkg.st_boundary("g"),
+        lambda: gpkg.st_convex_hull("g"),
+        lambda: gpkg.st_make_valid("g"),
+        lambda: gpkg.st_simplify("g", 1.0),
+    ):
+        with pytest.raises(NotImplementedError):
+            call()

--- a/tests/unit/test_sql_pushdown.py
+++ b/tests/unit/test_sql_pushdown.py
@@ -1,0 +1,107 @@
+"""Unit tests for the SQL push-down infrastructure (ELT Lot 2, #245).
+
+Covers the pure helpers of ``gispulse.capabilities.sql_pushdown`` —
+identifier quoting, SQL-literal rendering, and the pandas-expression →
+SQL translator, including its rejection of everything outside the
+SQL-pure subset.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+
+from gispulse.capabilities.sql_pushdown import (
+    Untranslatable,
+    qi,
+    sql_literal,
+    translate_expression,
+)
+
+
+# --- qi ---------------------------------------------------------------------
+
+
+def test_qi_quotes_identifier():
+    assert qi("population") == '"population"'
+    assert qi("code_insee") == '"code_insee"'
+    assert qi("__wkb") == '"__wkb"'
+
+
+def test_qi_rejects_embedded_quote_and_empty():
+    with pytest.raises(ValueError):
+        qi('evil" OR 1=1 --')
+    with pytest.raises(ValueError):
+        qi("")
+
+
+# --- sql_literal ------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, "NULL"),
+        (True, "TRUE"),
+        (False, "FALSE"),
+        (42, "42"),
+        (3.5, "3.5"),
+        ("hello", "'hello'"),
+        ("O'Brien", "'O''Brien'"),
+        (dt.date(2026, 5, 19), "'2026-05-19'"),
+    ],
+)
+def test_sql_literal(value, expected):
+    assert sql_literal(value) == expected
+
+
+def test_sql_literal_rejects_unsupported():
+    with pytest.raises(Untranslatable):
+        sql_literal(["a", "b"])
+    with pytest.raises(Untranslatable):
+        sql_literal({"k": "v"})
+
+
+# --- translate_expression — accepted ---------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("expr", "expected"),
+    [
+        ("pop > 100", '"pop" > 100'),
+        ("name == 'Paris'", '"name" = \'Paris\''),
+        ("a != 5", '"a" <> 5'),
+        ("pop / area * 100", '"pop" / "area" * 100'),
+        ("price * 1.5", '"price" * 1.5'),
+        ("a > 1 and b < 2", '"a" > 1 AND "b" < 2'),
+        ("not active", 'NOT "active"'),
+        ("x == true", '"x" = TRUE'),
+        ("(a + b) * 2", '("a" + "b") * 2'),
+        ('label == "x"', '"label" = \'x\''),
+    ],
+)
+def test_translate_expression_accepted(expr, expected):
+    assert translate_expression(expr) == expected
+
+
+# --- translate_expression — rejected ---------------------------------------
+
+
+@pytest.mark.parametrize(
+    "expr",
+    [
+        "name.str.contains('a')",  # attribute access / method call
+        "@threshold > 1",          # injected variable
+        "pop ** 2",                # exponent — not portable
+        "total // 3",              # floor division
+        "col[0]",                  # indexing
+        "abs(value)",              # function call
+        "pop > 1; DROP TABLE t",   # statement break
+        "",                        # empty
+        "`weird col` > 1",         # backtick
+    ],
+)
+def test_translate_expression_rejects(expr):
+    with pytest.raises(Untranslatable):
+        translate_expression(expr)


### PR DESCRIPTION
ELT Lot 4C — premier batch.

Câble le manifeste v3 end-to-end via un `Materializer` + `run_manifest()`, implémente les modes de matérialisation **`view`** et **`table`**. `incremental` + cascade DELETE + refresh `schedule` arrivent dans la continuation.

### Surface livrée — `runtime/manifest_runner.py`
- **Enums** `MaterializationMode` (`view` / `table` / `incremental`) et `RefreshMode` (`manual` / `on_change` / `schedule`).
- **`MaterializedModel`** — résultat caché + metadata.
- **`Materializer`** — persistance par mode :
  - `view` garde le résultat en mémoire.
  - `table` le garde en mémoire **et** appelle `engine.register` sous le nom préfixé, pour que le push-down SQL Lot 1-3 puisse JOIN dessus depuis les modèles avals.
  - `incremental` lève un `NotImplementedError` clair jusqu'au câblage CDC.
- **`run_manifest()`** — parcourt les modèles en ordre topologique (réutilise `core.dag.topological_sort` du Lot 4B), résout les références `select:` / `with:` en GeoDataFrames réels (sources déclarées ou modèles déjà matérialisés), compile la chaîne de transforms en un petit PipelineSpec, exécute via `PipelineExecutor`, passe le résultat au materializer.

Re-valide le manifeste au point d'entrée pour que cycles/références non résolues remontent depuis `run_manifest` aussi.

### Tests
`tests/unit/test_manifest_runner.py` — 8 cas : VIEW mono-modèle, ordre topo A→B, TABLE atteint `engine.register`, INCREMENTAL → NotImplementedError, propagation erreurs validation, cache partagé materializer, garde "TABLE needs engine", `with:` ref_layer routing.

### Reste pour la continuation de #249
- `materialize: incremental` (delta CDC + first-run snapshot + bridge `change_log_watcher`).
- Cascade DELETE descendant (ADR 0002 bounded fixed-point).
- `refresh: schedule` (cron) + `refresh: on_change` short-circuit.

### Validation
`ruff` clean · 40 tests manifest-related verts (8 nouveaux + 26 manifest_v3 + 6 dag) · 280 unit broader sans nouvelle régression (6 résiduels `test_pipeline_schema` pré-existants).

PR empilée : main ← #264 ← #279 ← #282 ← #285 ← #287 ← #290 ← #291 (4B) ← cette PR. **Addresses #249** (partiel — ne ferme pas l'issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)