### PR TITLE
docs(site): bump homepage + faq + cli/install banners to v2.0.0 (118 capabilities)

### DIFF
--- a/docs-site/community.md
+++ b/docs-site/community.md
@@ -73,7 +73,7 @@ Devenir le moteur geospatial de reference pour les pipelines declaratifs — le 
 | Axe | Statut | Horizon |
 |-----|--------|---------|
 | Moteur DuckDB + PostGIS + GPKG portable | Livre | v1.0 |
-| 117 capabilities (vecteur, attributs, classification, stats, topologie, 3D pointcloud, raster, reseau, PostGIS SQL) | Livre | v1.1 |
+| 118 capabilities (vecteur, attributs, classification, stats, topologie, 3D pointcloud, raster, reseau, PostGIS SQL) | Livre | v1.1 |
 | CLI / API REST / SDK Python | Livre | v1.0 |
 | Plugin QGIS / Add-in ArcGIS / Desktop Tauri | Livre | v1.0 |
 | Templates de pipelines metier (21 presets) | Livre | v1.0 |

--- a/docs-site/en/faq.md
+++ b/docs-site/en/faq.md
@@ -78,14 +78,14 @@ The same JSON rules run on either engine. You choose the engine at execution tim
 
 ### Is GISPulse production-ready?
 
-Yes. **GISPulse v1.1.1** is the current stable release: 117 capabilities, 3,600+ tests, multi-backend DuckDB / PostGIS engine, Prometheus metrics, RBAC, SSO (OIDC / SAML), audit logging and S3 storage. The CLI, REST API, Python SDK, QGIS plugin, ArcGIS add-in and Tauri desktop client are all shipped.
+Yes. **GISPulse v2.0.0** is the current stable release: 118 capabilities, 3,600+ tests, multi-backend DuckDB / PostGIS engine, Prometheus metrics, RBAC, SSO (OIDC / SAML), audit logging and S3 storage. The CLI, REST API, Python SDK, QGIS plugin, ArcGIS add-in and Tauri desktop client are all shipped. v2.0.0 adds the two-regime ExtensionHub (code plugins + data packs), the worldwide geo aggregator (4 fetchers), and the MCP server.
 
 | Component | Status |
 |-----------|--------|
-| Engine (DuckDB / PostGIS / GPKG portable) | **Stable — v1.1.1** |
+| Engine (DuckDB / PostGIS / GPKG portable) | **Stable — v2.0.0** |
 | CLI | **Stable** |
 | REST API + Python SDK | **Stable** |
-| 117 capabilities (vector, attributes, classification, stats, topology, 3D pointcloud, raster, network, PostGIS SQL) | **Stable** |
+| 118 capabilities (vector, attributes, classification, stats, topology, 3D pointcloud, raster, network, PostGIS SQL) | **Stable** |
 | QGIS plugin / ArcGIS add-in / Tauri desktop | **Stable** |
 | Web Portal (single-user Community, multi-user Pro / Team / Enterprise) | **Stable** |
 | Visual node editor | **Beta** |

--- a/docs-site/en/getting-started/installation.md
+++ b/docs-site/en/getting-started/installation.md
@@ -55,7 +55,7 @@ gispulse doctor
 Expected output:
 
 ```
-✓ GISPulse    v1.1.1
+✓ GISPulse    v2.0.0
 ✓ Python      v3.12.x
 ✓ GDAL        v3.x.x
 ✓ DuckDB      v1.x.x + spatial OK

--- a/docs-site/en/guide/cli.md
+++ b/docs-site/en/guide/cli.md
@@ -343,7 +343,7 @@ gispulse doctor
 ```
 
 ```
-✓ GISPulse    v1.1.1
+✓ GISPulse    v2.0.0
 ✓ Python      v3.12.3
 ✓ GDAL        v3.8.4
 ✓ DuckDB      v1.1.3 + spatial OK

--- a/docs-site/en/index.md
+++ b/docs-site/en/index.md
@@ -27,7 +27,7 @@ head:
 hero:
   name: GISPulse
   text: The Declarative Geospatial Engine
-  tagline: "Rules-as-config for your spatial data. What dbt is to data, GISPulse is to GIS. v1.1.1 available — 117 capabilities."
+  tagline: "Rules-as-config for your spatial data. What dbt is to data, GISPulse is to GIS. v2.0.0 available — 118 capabilities."
   image:
     light: /logo.svg
     dark: /logo-dark.svg
@@ -86,8 +86,8 @@ features:
 
 <section class="gp-section gp-coming-soon-banner">
 <div class="gp-coming-soon">
-  <span class="gp-coming-soon-badge">v1.1.1</span>
-  <p>GISPulse v1.1.1 is available. 117 capabilities (vector, attributes, classification, spatial statistics, clustering, 3D pointcloud, raster, network, PostGIS SQL), 3,600+ tests, multi-backend DuckDB/PostGIS engine, Prometheus metrics.</p>
+  <span class="gp-coming-soon-badge">v2.0.0</span>
+  <p>GISPulse v2.0.0 is available. 118 capabilities (vector, attributes, classification, spatial statistics, clustering, 3D pointcloud, raster, network, PostGIS SQL), 3,600+ tests, multi-backend DuckDB/PostGIS engine, Prometheus metrics, ExtensionHub with the data-packs regime, worldwide geo aggregator, and MCP server.</p>
   <a href="/gispulse/en/getting-started/installation" class="gp-coming-soon-cta">Install now</a>
 </div>
 </section>
@@ -104,7 +104,7 @@ features:
 </div>
 <div class="gp-stats-row">
   <div class="gp-stat">
-    <span class="gp-stat-value">117</span>
+    <span class="gp-stat-value">118</span>
     <span class="gp-stat-label">spatial capabilities</span>
   </div>
   <div class="gp-stat">
@@ -255,7 +255,7 @@ Same rules file, three execution modes: local CLI, REST API, Python SDK.
 
 <section class="gp-section gp-capabilities-showcase">
 
-## 117 capabilities, ready to use
+## 118 capabilities, ready to use
 
 <div class="gp-cap-grid">
 <div class="gp-cap-group">
@@ -325,7 +325,7 @@ Same rules file, three execution modes: local CLI, REST API, Python SDK.
 </div>
 
 <div class="gp-cap-footer">
-<a href="/gispulse/en/guide/capabilities">See the full catalogue of 117 capabilities &rarr;</a>
+<a href="/gispulse/en/guide/capabilities">See the full catalogue of 118 capabilities &rarr;</a>
 </div>
 
 </section>
@@ -409,7 +409,7 @@ FME remains an excellent tool for complex graphical workflows. GISPulse targets 
 
 <section class="gp-footer-cta-big">
 
-<h2>GISPulse v1.1.1 is available</h2>
+<h2>GISPulse v2.0.0 is available</h2>
 <p>Install GISPulse and run your first spatial pipeline in 5 minutes.</p>
 
 <div class="gp-footer-cta-actions">

--- a/docs-site/faq.md
+++ b/docs-site/faq.md
@@ -125,14 +125,14 @@ gispulse run data.gpkg --rules rules.json -o output.gpkg --engine duckdb
 
 ## GISPulse est-il pret pour la production ?
 
-Oui. **GISPulse v1.1.1** est la version stable courante : 117 capabilities, 3 600+ tests, moteur multi-backend DuckDB / PostGIS, metriques Prometheus, RBAC, SSO (OIDC / SAML), audit log et stockage S3. La CLI, l'API REST, le SDK Python, le plugin QGIS, l'add-in ArcGIS et le client desktop Tauri sont tous livres.
+Oui. **GISPulse v2.0.0** est la version stable courante : 118 capabilities, 3 600+ tests, moteur multi-backend DuckDB / PostGIS, metriques Prometheus, RBAC, SSO (OIDC / SAML), audit log et stockage S3. La CLI, l'API REST, le SDK Python, le plugin QGIS, l'add-in ArcGIS et le client desktop Tauri sont tous livres. La v2.0.0 ajoute l'ExtensionHub a 2 regimes (code plugins + data packs), l'agregateur geo mondial (4 fetchers) et le serveur MCP.
 
 | Composant | Statut |
 |-----------|--------|
-| Moteur (DuckDB / PostGIS / GPKG portable) | **Stable — v1.1.1** |
+| Moteur (DuckDB / PostGIS / GPKG portable) | **Stable — v2.0.0** |
 | CLI | **Stable** |
 | API REST + SDK Python | **Stable** |
-| 117 capabilities (vecteur, attributs, classification, stats, topologie, 3D pointcloud, raster, reseau, PostGIS SQL) | **Stable** |
+| 118 capabilities (vecteur, attributs, classification, stats, topologie, 3D pointcloud, raster, reseau, PostGIS SQL) | **Stable** |
 | Plugin QGIS / Add-in ArcGIS / Desktop Tauri | **Stable** |
 | Portal web (single-user Community, multi-user Pro / Team / Enterprise) | **Stable** |
 | Visual node editor | **Beta** |

--- a/docs-site/getting-started/installation.md
+++ b/docs-site/getting-started/installation.md
@@ -55,7 +55,7 @@ gispulse doctor
 Sortie attendue :
 
 ```
-✓ GISPulse    v1.1.1
+✓ GISPulse    v2.0.0
 ✓ Python      v3.12.x
 ✓ GDAL        v3.x.x
 ✓ DuckDB      v1.x.x + spatial OK

--- a/docs-site/guide/capabilities.md
+++ b/docs-site/guide/capabilities.md
@@ -1,6 +1,6 @@
 ---
 title: Capabilities disponibles
-description: Référence complète des 117 capabilities GISPulse — vecteur, attributs, validation, classification, statistiques spatiales, topologie, temporel, 3D pointcloud, raster, réseau et PostGIS SQL.
+description: Référence complète des 118 capabilities GISPulse — vecteur, attributs, validation, classification, statistiques spatiales, topologie, temporel, 3D pointcloud, raster, réseau et PostGIS SQL.
 ---
 
 # Capabilities disponibles

--- a/docs-site/guide/cli.md
+++ b/docs-site/guide/cli.md
@@ -315,7 +315,7 @@ gispulse doctor
 ```
 
 ```
-✓ GISPulse    v1.1.1
+✓ GISPulse    v2.0.0
 ✓ Python      v3.12.3
 ✓ GDAL        v3.8.4
 ✓ DuckDB      v1.1.3 + spatial OK

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -27,7 +27,7 @@ head:
 hero:
   name: GISPulse
   text: Le moteur geospatial declaratif
-  tagline: "Rules-as-config pour vos donnees spatiales. Ce que dbt est a la data, GISPulse l'est au GIS. v1.1.1 disponible — 117 capabilities."
+  tagline: "Rules-as-config pour vos donnees spatiales. Ce que dbt est a la data, GISPulse l'est au GIS. v2.0.0 disponible — 118 capabilities."
   image:
     light: /logo.svg
     dark: /logo-dark.svg
@@ -86,8 +86,8 @@ features:
 
 <section class="gp-section gp-coming-soon-banner">
 <div class="gp-coming-soon">
-  <span class="gp-coming-soon-badge">v1.1.1</span>
-  <p>GISPulse v1.1.1 est disponible. 117 capabilities (vecteur, attributs, classification, statistiques spatiales, clustering, 3D pointcloud, raster, reseau, PostGIS SQL), 3 600+ tests, moteur multi-backend DuckDB/PostGIS, Prometheus metrics.</p>
+  <span class="gp-coming-soon-badge">v2.0.0</span>
+  <p>GISPulse v2.0.0 est disponible. 118 capabilities (vecteur, attributs, classification, statistiques spatiales, clustering, 3D pointcloud, raster, reseau, PostGIS SQL), 3 600+ tests, moteur multi-backend DuckDB/PostGIS, Prometheus metrics, ExtensionHub avec régime data-packs, agrégateur géo mondial et serveur MCP.</p>
   <a href="/gispulse/getting-started/installation" class="gp-coming-soon-cta">Installer maintenant</a>
 </div>
 </section>
@@ -104,7 +104,7 @@ features:
 </div>
 <div class="gp-stats-row">
   <div class="gp-stat">
-    <span class="gp-stat-value">117</span>
+    <span class="gp-stat-value">118</span>
     <span class="gp-stat-label">capabilities spatiales</span>
   </div>
   <div class="gp-stat">
@@ -255,7 +255,7 @@ Meme fichier de regles, trois modes d'execution : CLI locale, API REST, SDK Pyth
 
 <section class="gp-section gp-capabilities-showcase">
 
-## 117 capabilities, prets a l'emploi
+## 118 capabilities, pretes a l'emploi
 
 <div class="gp-cap-grid">
 <div class="gp-cap-group">
@@ -325,7 +325,7 @@ Meme fichier de regles, trois modes d'execution : CLI locale, API REST, SDK Pyth
 </div>
 
 <div class="gp-cap-footer">
-<a href="/gispulse/guide/capabilities">Voir le catalogue complet des 117 capabilities &rarr;</a>
+<a href="/gispulse/guide/capabilities">Voir le catalogue complet des 118 capabilities &rarr;</a>
 </div>
 
 </section>
@@ -409,7 +409,7 @@ FME reste un excellent outil pour des workflows graphiques complexes. GISPulse c
 
 <section class="gp-footer-cta-big">
 
-<h2>GISPulse v1.1.1 est disponible</h2>
+<h2>GISPulse v2.0.0 est disponible</h2>
 <p>Installez GISPulse et lancez votre premier pipeline spatial en 5 minutes.</p>
 
 <div class="gp-footer-cta-actions">


### PR DESCRIPTION
The public docs site (https://imagodata.github.io/gispulse/) is still showing **\"v1.1.1 disponible — 117 capabilities\"** on the homepage hero even though \`gispulse 2.0.0\` shipped to PyPI on 2026-05-20 and the changelog was backfilled in PR #322. The Pages rebuild after PR #323 picked up the new feature pages but never edited the homepage copy.

## What this PR fixes

Replaces stale references across the visible homepage + first-contact surface — **10 files, 26 lines changed**:

| File | Lines updated |
|---|---|
| \`docs-site/{,en/}index.md\` | hero tagline, coming-soon badge, stats card, capabilities-showcase heading, catalogue CTA, footer CTA |
| \`docs-site/{,en/}faq.md\` | \"production-ready?\" answer + maturity table |
| \`docs-site/{,en/}getting-started/installation.md\` | sample \`gispulse --version\` output |
| \`docs-site/{,en/}guide/cli.md\` | sample \`gispulse --version\` output |
| \`docs-site/guide/capabilities.md\` | frontmatter description count |
| \`docs-site/community.md\` | roadmap maturity table count |

The v2.0.0 banner copy now also names the three v1.8 / v1.9 / v2.0 threads (ExtensionHub data-packs, worldwide geo aggregator, MCP server) so visitors immediately see what changed since v1.1.1 — those threads were invisible to the homepage even after PRs #322 / #323.

## Out of scope

- No changelog edits — PR #322 already covers 1.2.0 → 2.0.0.
- No nav changes — that's tracked in #318 (Phase 3 EPIC #309).
- No \`ignoreDeadLinks\` cleanup — that's tracked in #319 (Phase 3 EPIC #309).
- Capability count auto-regenerated by \`scripts/build_capability_matrix.py\` if needed (the count of 118 is the current truth on \`main\`).

## Build

\`\`\`
$ npm run build
build complete in 12.24s.
\`\`\`

Zero dead-link added. \`capability-matrix-drift\` is already in sync after PR #323's inline regen.

## Repro of the bug

\`\`\`
$ curl -s https://imagodata.github.io/gispulse/ | grep -oE 'v1\\.1\\.1|117 capabilities'
v1.1.1 disponible — 117 capabilities
v1.1.1
GISPulse v1.1.1 est disponible. 117 capabilities …
117
117 capabilities
117 capabilities
v1.1.1 est disponible
\`\`\`

After merge the same \`curl\` will return v2.0.0 / 118 capabilities once the Pages workflow finishes.