### PR TITLE
feat(compose): add Martin tile server sidecar

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,29 @@ services:
   # imagodata/gispulse-portal. To run it locally alongside this stack,
   # clone that repo and `pnpm dev` against VITE_API_URL=http://localhost:8001.
 
+  # Martin tile server (Rust, MapLibre project). Serves MVT for
+  # foncier-radar from the sibling repo gispulse-foncier/martin/config.yaml.
+  # Reads the same PostgreSQL/PostGIS as gispulse-api, via the
+  # radar_*_mvt PL/pgSQL functions installed by martin/migrations/.
+  # See gispulse-foncier/martin/PHASE1_5_REPORT.md for the cutover details.
+  martin:
+    image: ghcr.io/maplibre/martin:1.10.1
+    ports:
+      - "3000:3000"
+    environment:
+      MARTIN_POSTGRES_DSN: postgresql://gispulse:gispulse@postgis:5432/gispulse
+    volumes:
+      - ../gispulse-foncier/martin/config.yaml:/config.yaml:ro
+    command: ["--config", "/config.yaml"]
+    depends_on:
+      postgis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:3000/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
 volumes:
   pgdata:
   gispulse_data:


### PR DESCRIPTION
## Summary

Adds the Martin tile server (`ghcr.io/maplibre/martin:1.10.1`) as a sidecar service in `docker-compose.yml`. Serves MVT (Mapbox Vector Tiles) for the foncier-radar feature from the sibling repo `gispulse-foncier`.

- Image GHCR vérifiée (1.10.1, release 2026-05-20 — note: tag GHCR sans préfixe `v` contrairement aux git tags).
- DSN PostGIS via le docker network interne (`postgresql://gispulse:gispulse@postgis:5432/gispulse`).
- Volume mount read-only sur `../gispulse-foncier/martin/config.yaml` (sibling repo dans le workspace).
- Healthcheck `/health`, dépend du `postgis` service healthy.

Phase 1.5 cutover du radar foncier : remplace les anciennes routes `/api/radar/tiles/{z}/{x}/{y}.mvt` côté Next.js par un serveur Martin natif Rust. Les fonctions PL/pgSQL `radar_*_mvt` sont installées par `gispulse-foncier/martin/migrations/`.

## Context

Commit local du `2026-05-23` non poussé en upstream à l'époque. PR créée a posteriori pour rattraper la trace. Smoke local validé par l'auteur lors du commit initial (`docker compose up -d martin`, `/catalog` liste 6 sources, curl tile z=10 Clermont ~12 KB) — non re-vérifié dans cette session.

## Test plan

- [ ] `docker compose up -d martin` boote sur stack fraîche
- [ ] `/catalog` liste les sources attendues (4 cells + parcels + parcels_filtered)
- [ ] `curl` tile z=10 Clermont renvoie un MVT non vide
- [ ] CI / smoke complet (postgis + api + martin) si applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)