### PR TITLE
ci(realign-2.0): expose reusable compat-matrix workflow for satellites

### DIFF
--- a/.github/workflows/compat-matrix.yml
+++ b/.github/workflows/compat-matrix.yml
@@ -1,0 +1,79 @@
+name: Compat Matrix (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      satellite-name:
+        description: "Name of the satellite repo (for issue title only)"
+        required: true
+        type: string
+      python-versions:
+        description: "JSON array of Python versions to test"
+        required: false
+        type: string
+        default: '["3.11", "3.12"]'
+      gispulse-versions:
+        description: "JSON array of gispulse versions (use 'latest' for the floating tip)"
+        required: false
+        type: string
+        default: '["latest", "2.0.0"]'
+      install-command:
+        description: "Shell command to install the satellite in editable mode"
+        required: false
+        type: string
+        default: "pip install -e . --no-deps"
+      sanity-import:
+        description: "Python import statement(s) to validate the satellite imports cleanly"
+        required: true
+        type: string
+      pytest-target:
+        description: "Path to pytest collect-only (e.g. 'tests/' or 'tests_enterprise/')"
+        required: false
+        type: string
+        default: "tests/"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  compat:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ${{ fromJSON(inputs.python-versions) }}
+        gispulse-version: ${{ fromJSON(inputs.gispulse-versions) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install gispulse ${{ matrix.gispulse-version }}
+        run: |
+          if [ "${{ matrix.gispulse-version }}" = "latest" ]; then
+            pip install --upgrade gispulse
+          else
+            pip install gispulse==${{ matrix.gispulse-version }}
+          fi
+      - name: Install satellite
+        run: ${{ inputs.install-command }}
+      - name: Sanity import
+        run: |
+          python -c "${{ inputs.sanity-import }}"
+      - name: Pytest collect-only
+        run: |
+          pip install pytest
+          pytest --collect-only ${{ inputs.pytest-target }} 2>&1 | tail -20
+      - name: Open issue on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `[compat-matrix] ${{ inputs.satellite-name }} broken on gispulse ${{ matrix.gispulse-version }} (py ${{ matrix.python-version }})`,
+              body: `Nightly compat-matrix detected breakage.\n\nRun: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}\n\nLikely a new gispulse OSS release introduced a breaking change. First responder action:\n- bump local pin in pyproject.toml, OR\n- push a compat shim in gispulse_enterprise.compat / equivalent.`,
+              labels: ['compat-matrix', 'regression', 'realign-2.0']
+            })


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/compat-matrix.yml` as a **reusable workflow** (`workflow_call`) so satellite repos can run a nightly compat-matrix against the latest OSS `gispulse` PyPI release.
- Matrix axes: `python-version` (default `3.11`, `3.12`) x `gispulse-version` (default `latest`, `2.0.0`).
- Steps: install OSS gispulse -> install satellite (`pip install -e . --no-deps` by default) -> sanity import -> `pytest --collect-only` -> on failure auto-open issue labeled `compat-matrix`, `regression`, `realign-2.0`.

First-line defense against the **5x-recurring "post-split silent bugs"** pattern (see MEMORY entries 2026-04-29, 2026-05-02, etc.). When OSS ships a minor, satellites that don't re-test against the new release stay broken silently for days.

## Consumer skeleton

```yaml
# satellite repo: .github/workflows/compat-nightly.yml
name: Compat Nightly
on:
  schedule: [{ cron: "0 4 * * *" }]
  workflow_dispatch: {}
jobs:
  run:
    uses: imagodata/gispulse/.github/workflows/compat-matrix.yml@main
    with:
      satellite-name: "gispulse-enterprise"
      sanity-import: "import gispulse_enterprise"
      pytest-target: "tests_enterprise/"
```

## Sprint+1 follow-up (out of scope)

The 3 satellites pinned in Realign 2.0 must migrate to this reusable call:

- [ ] `gispulse-enterprise` -> remove standalone `compat-matrix.yml` from PR-E4 (#579), replace with `uses: imagodata/gispulse/.github/workflows/compat-matrix.yml@main`
- [ ] `gispulse-portal` -> add consumer workflow (P2 lockstep)
- [ ] `gispulse-portal-pro` -> add consumer workflow (PP1)
- [ ] `gispulse-dvf` / `gispulse-permis` -> adopt when next touched

## Test plan

- [x] YAML syntax validated locally (`python3 -c "import yaml; yaml.safe_load(open(...))"`)
- [ ] Real-world validation comes when a satellite repo wires the consumer workflow (sprint+1). The `workflow_call` trigger cannot be tested standalone on this PR.

## Risks

- `workflow_call` is GitHub-native since 2021 (stable). Syntax is straightforward. Main residual risk: input quoting in shell `python -c "${{ inputs.sanity-import }}"` if a consumer ships an import statement with double quotes. Document this gotcha in sprint+1 follow-up issue.

Closes #328
Refs EPIC #327

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>