### PR TITLE
chore(realign-2.0): pin 10 internal plugins to gispulse>=2.0,<3.0

### DIFF
--- a/plugins/gispulse-cap-filtermate/pyproject.toml
+++ b/plugins/gispulse-cap-filtermate/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"
 authors = [{ name = "GISPulse", email = "dev@gispulse.io" }]
 dependencies = [
-    "gispulse",
+    "gispulse>=2.0.0,<3.0.0",
     "geopandas>=0.14",
     "shapely>=2.0",
 ]

--- a/plugins/gispulse-cap-ftth/pyproject.toml
+++ b/plugins/gispulse-cap-ftth/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"
 authors = [{ name = "GISPulse", email = "dev@gispulse.io" }]
 dependencies = [
-    "gispulse",
+    "gispulse>=2.0.0,<3.0.0",
     "geopandas>=0.14",
     "shapely>=2.0",
     "networkx>=3.0",

--- a/plugins/gispulse-cap-h3/pyproject.toml
+++ b/plugins/gispulse-cap-h3/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"
 authors = [{ name = "GISPulse", email = "dev@gispulse.io" }]
 dependencies = [
-    "gispulse",
+    "gispulse>=2.0.0,<3.0.0",
     "geopandas>=0.14",
     "shapely>=2.0",
     "h3>=3.7",

--- a/plugins/gispulse-cap-osm-import/pyproject.toml
+++ b/plugins/gispulse-cap-osm-import/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.10"
 license = "MIT"
 authors = [{ name = "osm-community" }]
 dependencies = [
-    "gispulse",
+    "gispulse>=2.0.0,<3.0.0",
     "geopandas>=0.14",
     "shapely>=2.0",
     "requests>=2.28",

--- a/plugins/gispulse-cap-report/pyproject.toml
+++ b/plugins/gispulse-cap-report/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"
 authors = [{ name = "GISPulse", email = "dev@gispulse.io" }]
 dependencies = [
-    "gispulse",
+    "gispulse>=2.0.0,<3.0.0",
     "geopandas>=0.14",
     "jinja2>=3.1",
 ]

--- a/plugins/gispulse-cap-stac/pyproject.toml
+++ b/plugins/gispulse-cap-stac/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.10"
 license = "MIT"
 authors = [{ name = "community-geo" }]
 dependencies = [
-    "gispulse",
+    "gispulse>=2.0.0,<3.0.0",
     "geopandas>=0.14",
     "shapely>=2.0",
     "pystac-client>=0.6",

--- a/plugins/gispulse-src-cadastre/pyproject.toml
+++ b/plugins/gispulse-src-cadastre/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"
 authors = [{ name = "GISPulse", email = "dev@gispulse.io" }]
 dependencies = [
-    "gispulse",
+    "gispulse>=2.0.0,<3.0.0",
 ]
 
 # Registered as a data source — discovered by core.plugin_hub.PluginHub.

--- a/plugins/gispulse-src-dvf/pyproject.toml
+++ b/plugins/gispulse-src-dvf/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"
 authors = [{ name = "GISPulse", email = "dev@gispulse.io" }]
 dependencies = [
-    "gispulse",
+    "gispulse>=2.0.0,<3.0.0",
 ]
 
 # Registered as a data source — discovered by core.plugin_hub.PluginHub.

--- a/plugins/gispulse-src-gpu/pyproject.toml
+++ b/plugins/gispulse-src-gpu/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"
 authors = [{ name = "GISPulse", email = "dev@gispulse.io" }]
 dependencies = [
-    "gispulse",
+    "gispulse>=2.0.0,<3.0.0",
 ]
 
 # Registered as a data source — discovered by core.plugin_hub.PluginHub.

--- a/plugins/gispulse-src-ign/pyproject.toml
+++ b/plugins/gispulse-src-ign/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"
 authors = [{ name = "GISPulse", email = "dev@gispulse.io" }]
 dependencies = [
-    "gispulse",
+    "gispulse>=2.0.0,<3.0.0",
 ]
 
 # Registered as a data source — discovered by core.plugin_hub.PluginHub.


### PR DESCRIPTION
## Summary

The 10 internal plugins in `plugins/gispulse-*` declared `"gispulse"` as a dependency **without any version bound**. Any future major bump (3.0, 4.0...) would silently break them at install/upgrade time.

This PR pins them to `>=2.0.0,<3.0.0` to match the published OSS major and lock in compatibility with the current 2.x API surface.

## Plugins touched (10/10)

| Plugin | Before | After |
|---|---|---|
| `gispulse-cap-stac` | `"gispulse"` | `"gispulse>=2.0.0,<3.0.0"` |
| `gispulse-cap-h3` | `"gispulse"` | `"gispulse>=2.0.0,<3.0.0"` |
| `gispulse-cap-ftth` | `"gispulse"` | `"gispulse>=2.0.0,<3.0.0"` |
| `gispulse-cap-osm-import` | `"gispulse"` | `"gispulse>=2.0.0,<3.0.0"` |
| `gispulse-cap-filtermate` | `"gispulse"` | `"gispulse>=2.0.0,<3.0.0"` |
| `gispulse-cap-report` | `"gispulse"` | `"gispulse>=2.0.0,<3.0.0"` |
| `gispulse-src-cadastre` | `"gispulse"` | `"gispulse>=2.0.0,<3.0.0"` |
| `gispulse-src-dvf` | `"gispulse"` | `"gispulse>=2.0.0,<3.0.0"` |
| `gispulse-src-gpu` | `"gispulse"` | `"gispulse>=2.0.0,<3.0.0"` |
| `gispulse-src-ign` | `"gispulse"` | `"gispulse>=2.0.0,<3.0.0"` |

Zero plugin had a pre-existing pin. Zero used the `[extras]` syntax. Diff is rigorously +10/-10 across 10 files.

## Test plan

- [x] `python3 -c "import tomllib; tomllib.load(...)"` passes on all 10 `pyproject.toml`
- [x] `git diff --stat` shows exactly +10/-10 across the 10 plugin manifests
- [x] No file touched outside `plugins/gispulse-*/pyproject.toml` (no overlap with PR-X1 `compat-matrix.yml`)
- [ ] CI: lint + plugin builds remain green

## Coordination

- **PR-X1** (compat-matrix shared) — touches `.github/workflows/compat-matrix.yml`, **zero file overlap**.
- **PR-P4** (CVE sweep portal) — different repo.
- **Plugins not yet on PyPI** — tracked under #306-308. This pin is the foundation for sane dependency resolution downstream once they ship.

## Residual risks

- **Low**: plugins currently exercise the 2.x API; if a plugin secretly relies on a pre-2.0 module path still kept via `_compat.py` shim, the pin remains satisfied (2.0.0 ships the shim). Audit recommended pre-PyPI publish (#306-308).
- **Forward**: when a future plugin needs a 2.x feature introduced post-2.0.0 (say 2.3.0), bump its lower bound individually — do not relax the upper.

Closes #329
Refs EPIC #327

---

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>