### PR TITLE
fix(_compat): preserve class identity across legacy/canonical namespaces (closes #333)

### DIFF
--- a/src/gispulse/_compat.py
+++ b/src/gispulse/_compat.py
@@ -36,17 +36,39 @@ _warned: set[str] = set()
 
 
 class _AliasLoader(Loader):
-    """Loader that resolves a legacy name to its ``gispulse.*`` module."""
+    """Loader that aliases a legacy name to its ``gispulse.*`` module.
+
+    CRITICAL — class identity (see imagodata/gispulse#333): legacy and
+    canonical names MUST point to the *same* module object so that
+    ``from persistence.storage import StorageError`` yields the same class
+    as ``from gispulse.persistence.storage import StorageError``. Without
+    this, ``isinstance(err, StorageError)`` and ``pytest.raises(...)``
+    silently fail across the namespace boundary.
+
+    Implementation: ``exec_module`` overwrites ``sys.modules[spec.name]``
+    with the canonical module *after* Python's import machinery has placed
+    its freshly-created (empty) module there. This is the only point at
+    which the override sticks — doing it in ``create_module`` is reverted
+    by the import system because the returned module's ``__name__`` is the
+    canonical one, not ``spec.name``.
+    """
 
     def __init__(self, target: str) -> None:
         self._target = target
 
-    def create_module(self, spec: importlib.machinery.ModuleSpec) -> ModuleType:
-        return importlib.import_module(self._target)
+    def create_module(self, spec: importlib.machinery.ModuleSpec) -> ModuleType | None:
+        # Returning None lets Python allocate a default empty module under
+        # ``spec.name``; we replace it in ``exec_module``.
+        return None
 
     def exec_module(self, module: ModuleType) -> None:
-        # ``import_module`` in ``create_module`` already executed the module.
-        return None
+        # Resolve the canonical module (may already be cached) and
+        # overwrite the sys.modules entry the import machinery just
+        # installed. From this point on, ``import <legacy>`` and
+        # ``import gispulse.<legacy>`` resolve to the same object, so
+        # class identity holds across both namespaces.
+        target = importlib.import_module(self._target)
+        sys.modules[module.__name__] = target
 
 
 class _LegacyTopLevelFinder(MetaPathFinder):
@@ -76,9 +98,21 @@ class _LegacyTopLevelFinder(MetaPathFinder):
 
 
 def install() -> None:
-    """Append the legacy finder to ``sys.meta_path`` (idempotent)."""
+    """Insert the legacy finder at the front of ``sys.meta_path`` (idempotent).
+
+    The finder MUST run before ``PathFinder``: once we alias
+    ``sys.modules['persistence'] = gispulse.persistence``, the legacy
+    package inherits ``__path__`` from the canonical one. If a standard
+    ``PathFinder`` reached a sub-import (``persistence.storage``) before
+    our shim, it would discover ``gispulse/persistence/storage.py`` via
+    the parent's ``__path__`` and execute it a *second* time under the
+    legacy name — duplicating every class (StorageError, …) and breaking
+    ``isinstance()`` checks (imagodata/gispulse#333).
+
+    Prepending guarantees the alias hook intercepts every legacy import
+    before any path-based finder runs, so ``sys.modules`` ends up with
+    one shared module object per (root, sub) tuple.
+    """
     if any(isinstance(finder, _LegacyTopLevelFinder) for finder in sys.meta_path):
         return
-    # Appended last: real packages always win; the shim only catches names
-    # that no genuine finder could resolve.
-    sys.meta_path.append(_LegacyTopLevelFinder())
+    sys.meta_path.insert(0, _LegacyTopLevelFinder())

--- a/tests/unit/test_compat_shim.py
+++ b/tests/unit/test_compat_shim.py
@@ -1,0 +1,84 @@
+"""Regression tests for the v1.8.0 legacy import shim (`gispulse/_compat.py`).
+
+These tests pin the behaviour expected by gispulse-enterprise consumers
+that still import from the pre-consolidation top-level packages
+(``persistence.*``, ``core.*``, …). The most important guarantee is
+**class identity across namespaces** — see imagodata/gispulse#333.
+"""
+from __future__ import annotations
+
+import importlib
+import sys
+import warnings
+
+import pytest
+
+# Importing ``gispulse`` triggers ``_compat.install()`` which registers the
+# meta-path finder that aliases the legacy roots. Tests below rely on it.
+import gispulse  # noqa: F401  (side-effect import)
+
+
+@pytest.fixture(autouse=True)
+def _silence_deprecation():
+    # The shim raises a DeprecationWarning on first import of each legacy
+    # root. We exercise that path on purpose; silence it for clarity.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        yield
+
+
+class TestStorageErrorClassIdentity:
+    """imagodata/gispulse#333 — StorageError must be the same class object
+    whether imported via the legacy or the canonical namespace."""
+
+    def test_module_object_is_shared(self):
+        legacy = importlib.import_module("persistence.storage")
+        canonical = importlib.import_module("gispulse.persistence.storage")
+        assert legacy is canonical, (
+            "Legacy and canonical module objects must be the same; otherwise "
+            "their classes are duplicated and isinstance() breaks."
+        )
+
+    def test_storage_error_class_is_shared(self):
+        from persistence.storage import StorageError as Legacy
+        from gispulse.persistence.storage import StorageError as Canonical
+        assert Legacy is Canonical
+
+    def test_pytest_raises_legacy_matches_canonical_raise(self):
+        """The original failure mode of imagodata/gispulse#333: a test
+        importing ``StorageError`` from the legacy path could not catch
+        an error raised from the canonical implementation."""
+        from persistence.storage import StorageError as Legacy
+        from gispulse.persistence.storage import validate_storage_key
+        with pytest.raises(Legacy, match="Null byte"):
+            validate_storage_key("foo\x00bar")
+
+    def test_validate_storage_key_function_is_shared(self):
+        """Functions exported by both namespaces are the same object."""
+        from persistence.storage import validate_storage_key as legacy
+        from gispulse.persistence.storage import validate_storage_key as canonical
+        assert legacy is canonical
+
+
+class TestLegacyRoots:
+    """Every legacy root (``core``, ``capabilities``, …) aliases cleanly."""
+
+    LEGACY_ROOTS = ["core", "capabilities", "rules", "orchestration",
+                    "persistence", "catalog"]
+
+    @pytest.mark.parametrize("root", LEGACY_ROOTS)
+    def test_root_alias_shares_module(self, root):
+        legacy = importlib.import_module(root)
+        canonical = importlib.import_module(f"gispulse.{root}")
+        assert legacy is canonical, f"`{root}` and `gispulse.{root}` diverged"
+
+
+class TestSysModulesConsistency:
+    """sys.modules must hold the same object under both keys."""
+
+    def test_sys_modules_share_object(self):
+        importlib.import_module("persistence.storage")
+        importlib.import_module("gispulse.persistence.storage")
+        assert sys.modules["persistence.storage"] is sys.modules[
+            "gispulse.persistence.storage"
+        ]

--- a/tests/unit/test_plugin_contracts_compat.py
+++ b/tests/unit/test_plugin_contracts_compat.py
@@ -75,6 +75,13 @@ def test_via_legacy_top_level_shim() -> None:
     is redirected by the ``_compat`` meta-path finder; the symbol must resolve.
     """
     import gispulse  # noqa: F401 - ensures _compat.install() has run
+    from gispulse import _compat
+
+    # The shim warns only once per root package (session-global ``_warned``
+    # set); another test may already have imported the ``core`` root. Discard
+    # it so the DeprecationWarning fires deterministically here, regardless of
+    # test execution order.
+    _compat._warned.discard("core")
 
     with pytest.warns(DeprecationWarning):
         legacy = importlib.import_module("core.plugin_contracts")


### PR DESCRIPTION
## Summary

- Root cause for #333: the legacy import shim's meta-path finder was appended (lowest priority), so once `sys.modules['persistence']` aliased to `gispulse.persistence`, the canonical `__path__` leaked and the standard `PathFinder` intercepted sub-imports (`persistence.storage`) and re-executed the same source file under the legacy name → duplicated classes → `isinstance` / `pytest.raises` silently failed across namespaces.
- Fix: prepend the finder to `sys.meta_path`, and overwrite `sys.modules[module.__name__]` in `exec_module` (the only point where the override sticks).
- Add 11 regression tests in `tests/unit/test_compat_shim.py` pinning module-object identity, class identity, `pytest.raises` cross-namespace behaviour, and `sys.modules` consistency for all six legacy roots (`core`, `capabilities`, `rules`, `orchestration`, `persistence`, `catalog`).

## Test plan

- [x] `PYTHONPATH=src pytest tests/unit/test_compat_shim.py` — 11 passed (new)
- [x] `PYTHONPATH=src pytest tests/unit/test_storage.py tests/unit/test_robustness.py` — 74 passed
- [x] `PYTHONPATH=src pytest tests/integration/test_full_pipeline.py tests/unit/test_app_facade.py` — covered, no regression
- [x] Full unit suite: 819 passed, 1 pre-existing failure unrelated (`test_cli_mcp.py` requires the `mcp` extra in dev env — same fail on `main`)
- [ ] CI green (matrix py3.10/3.11/3.12 + Windows/macOS)
- [ ] After merge + release 2.0.1: drop the xfail on `tests_enterprise/test_security.py::test_validate_storage_key_null_byte` (commit a6b59b9 in gispulse-enterprise)

Closes #333.

🤖 Generated with [Claude Code](https://claude.com/claude-code)