### PR TITLE
ci(docs): changelog coverage gate + extended docs.yml paths + latest-tag smoke check (Phase 4)

### DIFF
--- a/.github/workflows/docs-gate.yml
+++ b/.github/workflows/docs-gate.yml
@@ -1,0 +1,32 @@
+name: docs gate
+
+# Phase 4 of EPIC #309 (closes #320). Block PRs that bump
+# pyproject.toml::version without a matching entry in
+# docs-site/changelog.md (FR) — and warn when the EN mirror is missing.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "pyproject.toml"
+      - "docs-site/changelog.md"
+      - "docs-site/en/changelog.md"
+      - "scripts/check_changelog_coverage.py"
+      - ".github/workflows/docs-gate.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  changelog-coverage:
+    name: changelog covers version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Check changelog coverage for current pyproject.toml version
+        run: python scripts/check_changelog_coverage.py

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,12 +3,21 @@ name: Deploy docs to GitHub Pages
 on:
   push:
     branches: [main]
+    # Phase 4 of EPIC #309 (closes #321) — also redeploy when the changelog,
+    # migration guides, or pyproject.toml version change, so the published
+    # site never lags the latest tag.
     paths:
       - "docs-site/**"
       - "templates/**"
+      - "CHANGELOG.md"
+      - "MIGRATION-*.md"
+      - "pyproject.toml"
       - "scripts/build_playground_data.py"
       - "scripts/build_templates_index.py"
+      - "scripts/smoke_test_docs.py"
       - ".github/workflows/docs.yml"
+    tags:
+      - "v*"
   workflow_dispatch:
 
 permissions:
@@ -60,6 +69,10 @@ jobs:
         run: npm run build
 
       - name: Smoke-test dist artifacts
+        # When triggered by a tag push, inject the tag explicitly — the
+        # default checkout is shallow and ``git describe`` would fail.
+        env:
+          DOCS_SMOKE_LATEST_TAG: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
         run: python scripts/smoke_test_docs.py
 
       - name: Upload artifact

--- a/scripts/check_changelog_coverage.py
+++ b/scripts/check_changelog_coverage.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""
+Changelog coverage gate (Phase 4 of EPIC #309, closes #320).
+
+Reads the current version from ``pyproject.toml`` (``[project] version = ...``)
+and verifies that an entry for that version exists in both:
+
+  - ``docs-site/changelog.md`` (FR, hard requirement)
+  - ``docs-site/en/changelog.md`` (EN, soft warning by default; flip with
+    ``--strict-en`` to make it hard)
+
+Wired into a ``pull_request`` job that path-filters on ``pyproject.toml`` so
+that a version bump cannot land on ``main`` without a matching changelog
+entry. See ``.github/workflows/docs-gate.yml``.
+
+Exit codes:
+  0  — both changelogs (or FR only when EN soft) cover the current version
+  1  — FR changelog missing the entry
+  2  — EN changelog missing the entry AND ``--strict-en`` is set
+  3  — version cannot be parsed from ``pyproject.toml``
+
+The entry header matched is ``## [<version>]`` — anything else (notes,
+date, suffix) is allowed on the same line. ``[Unreleased]`` is not a
+match. We deliberately match on the bracketed form to avoid false hits
+in prose.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = ROOT / "pyproject.toml"
+FR_CHANGELOG = ROOT / "docs-site" / "changelog.md"
+EN_CHANGELOG = ROOT / "docs-site" / "en" / "changelog.md"
+
+
+def _read_version() -> str:
+    if not PYPROJECT.exists():
+        print(f"[gate] FAIL: {PYPROJECT} missing", file=sys.stderr)
+        raise SystemExit(3)
+    data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    version = (data.get("project") or {}).get("version")
+    if not isinstance(version, str) or not version.strip():
+        print(
+            "[gate] FAIL: [project].version not found in pyproject.toml",
+            file=sys.stderr,
+        )
+        raise SystemExit(3)
+    return version.strip()
+
+
+def _has_entry(path: Path, version: str) -> bool:
+    if not path.exists():
+        return False
+    pattern = re.compile(rf"^##\s+\[{re.escape(version)}\]", re.MULTILINE)
+    return bool(pattern.search(path.read_text(encoding="utf-8")))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--strict-en",
+        action="store_true",
+        help="treat missing EN entry as a hard failure (default: warn only)",
+    )
+    args = parser.parse_args()
+
+    version = _read_version()
+    print(f"[gate] pyproject.toml version = {version}")
+
+    fr_ok = _has_entry(FR_CHANGELOG, version)
+    en_ok = _has_entry(EN_CHANGELOG, version)
+
+    if fr_ok:
+        print(f"[gate] OK  : FR changelog covers {version}")
+    else:
+        print(
+            f"[gate] FAIL: {FR_CHANGELOG.relative_to(ROOT)} has no "
+            f"`## [{version}]` entry",
+            file=sys.stderr,
+        )
+
+    if en_ok:
+        print(f"[gate] OK  : EN changelog covers {version}")
+    elif args.strict_en:
+        print(
+            f"[gate] FAIL: {EN_CHANGELOG.relative_to(ROOT)} has no "
+            f"`## [{version}]` entry (--strict-en)",
+            file=sys.stderr,
+        )
+    else:
+        print(
+            f"[gate] WARN: {EN_CHANGELOG.relative_to(ROOT)} has no "
+            f"`## [{version}]` entry (soft)",
+            file=sys.stderr,
+        )
+
+    if not fr_ok:
+        return 1
+    if not en_ok and args.strict_en:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke_test_docs.py
+++ b/scripts/smoke_test_docs.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 import gzip
 import json
+import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -91,6 +93,63 @@ def check_pages() -> None:
     _ok("core pages rendered (templates, playground)")
 
 
+def _latest_tag() -> str | None:
+    """Return the latest git tag (without leading ``v``), or ``None`` if none."""
+    # In CI, ``DOCS_SMOKE_LATEST_TAG`` lets the workflow inject the tag
+    # explicitly when the checkout is shallow and ``git describe`` would
+    # fail. Locally we fall back to ``git describe --tags --abbrev=0``.
+    env_tag = os.environ.get("DOCS_SMOKE_LATEST_TAG", "").strip()
+    if env_tag:
+        return env_tag.lstrip("v")
+    try:
+        out = subprocess.check_output(
+            ["git", "describe", "--tags", "--abbrev=0"],
+            cwd=ROOT,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    if not out:
+        return None
+    return out.lstrip("v")
+
+
+def check_latest_tag_visible() -> None:
+    """Verify the latest released tag is present in the built changelog HTML.
+
+    This catches the class of bugs where `pyproject.toml` bumps but the
+    docs-site changelog never reflects it (the original drift that drove
+    EPIC #309). In CI we set ``DOCS_SMOKE_LATEST_TAG`` from ``github.ref``
+    on tag pushes so the check stays meaningful even on shallow clones.
+    """
+    tag = _latest_tag()
+    if not tag:
+        # No tag yet, or git history unavailable — emit a warning, not a
+        # failure. The CI tag-push job always provides
+        # ``DOCS_SMOKE_LATEST_TAG`` so this branch is only hit locally.
+        print(
+            "[smoke] WARN: no latest tag resolved (skipping changelog tag check)"
+        )
+        return
+    candidates = [
+        DIST / "changelog.html",
+        DIST / "en" / "changelog.html",
+    ]
+    found_in: list[str] = []
+    for path in candidates:
+        if not path.exists():
+            continue
+        if tag in path.read_text(encoding="utf-8"):
+            found_in.append(path.relative_to(ROOT).as_posix())
+    if not found_in:
+        _fail(
+            f"latest tag '{tag}' not found in built changelog HTML "
+            f"({', '.join(p.relative_to(ROOT).as_posix() for p in candidates if p.exists()) or 'no changelog HTML'})"
+        )
+    _ok(f"latest tag '{tag}' visible in {len(found_in)} changelog page(s)")
+
+
 # Chunks expected to stay code-split so they never ship on first paint.
 # If one of these gets inlined into the theme/framework bundle, pages that
 # don't render a map would suddenly pay the full download cost.
@@ -151,6 +210,7 @@ def main() -> int:
     check_playground()
     check_templates()
     check_bundles()
+    check_latest_tag_visible()
     _ok("all checks passed")
     return 0
 


### PR DESCRIPTION
Closes #320, closes #321. Phase 4 of EPIC #309.

## Problem

EPIC #309 was triggered by 8 versions (1.2.0 → 2.0.0) landing on PyPI / tags without matching changelog entries on docs-site/. Phase 1+2+3 cleaned the backlog; Phase 4 guards the rhythm so the drift cannot accumulate again.

## Changes

### `scripts/check_changelog_coverage.py` (new, +99)

Reads `[project].version` from `pyproject.toml` and asserts a `## [<version>]` header exists in:

- `docs-site/changelog.md` (FR) — hard requirement, exit 1 if missing.
- `docs-site/en/changelog.md` (EN) — soft warning by default, hard with `--strict-en`.

`tomllib` (stdlib) → no extra deps. Returns distinct exit codes (1, 2, 3) so the workflow can surface the cause.

### `.github/workflows/docs-gate.yml` (new)

`pull_request` on `main`, path-filtered to `pyproject.toml` and both changelogs. Runs the gate. PRs that bump version without an entry now fail with a clear log.

### `.github/workflows/docs.yml` (extended)

- `paths` now includes `CHANGELOG.md`, `MIGRATION-*.md`, `pyproject.toml`, and `scripts/smoke_test_docs.py`. The docs site redeploys on those changes.
- New `tags: [v*]` trigger so tagged releases redeploy automatically.
- Smoke step now exports `DOCS_SMOKE_LATEST_TAG` from `github.ref_name` on tag pushes so the latest-tag check works on the default shallow clone.

### `scripts/smoke_test_docs.py` (extended)

New `check_latest_tag_visible()` step:

1. Resolves the latest tag via `git describe --tags --abbrev=0`, falling back to `DOCS_SMOKE_LATEST_TAG` env var on shallow CI clones.
2. Verifies the tag string is present in at least one of `changelog.html` / `en/changelog.html` in the built dist.
3. Hard failure if both candidates exist but neither carries the tag.

This catches exactly the drift class that drove EPIC #309: a version bump that never made it to docs.

## Local verification

```
$ python scripts/check_changelog_coverage.py --strict-en
[gate] pyproject.toml version = 2.0.0
[gate] OK  : FR changelog covers 2.0.0
[gate] OK  : EN changelog covers 2.0.0

$ cd docs-site && npm run build
build complete in 12.49s.

$ python scripts/smoke_test_docs.py
[smoke] OK  : core pages rendered (templates, playground)
[smoke] OK  : playground manifest: 1 scenarios, 92687 features total
[smoke] OK  : templates: 21 presets indexed and served
[smoke] OK  : eager chunk 'framework' = 109 kB (budget 244 kB)
[smoke] OK  : eager chunk 'theme' = 61 kB (budget 146 kB)
[smoke] OK  : latest tag '2.0.0' visible in 2 changelog page(s)
[smoke] OK  : all checks passed
```

## EPIC #309 status after this PR

- Phase 1 (#311 #312) — MERGED via PR #322
- Phase 2 (#313–#317) — MERGED via PR #323
- Homepage v2.0.0 — MERGED via PR #324
- Phase 3 links (#319) — MERGED via PR #325
- Phase 4 gates (#320 #321) — **this PR**
- Phase 0 audit (#310) — backlog (low priority, retro-audit only — Phases 1-3 closed the drift it would have inventoried)
- Phase 3 nav (#318) — already covered by #323 (frNav/enNav + sidebars updated for the 9 new pages); to be closed administratively

## Why no Phase 0 included

#310 is an audit-before-action ticket whose deliverable is the drift inventory. By the time Phases 1-3 closed, the inventory was discovered-by-doing. Keeping the ticket open as a backlog tombstone is fine; reopening it to write a retrospective doc adds no signal. Open question for the next review.