### PR TITLE
feat(fetcher): RestTableFetcher — paginated tabular-JSON REST (REST_TABLE, #196)

### DIFF
--- a/docs/SOURCE_PLUGIN_GUIDE.md
+++ b/docs/SOURCE_PLUGIN_GUIDE.md
@@ -123,6 +123,33 @@ core fetchers shipped with GISPulse:
 | `OGC_FEATURES` | `OgcFeaturesFetcher` | `collection` *(required)*, `crs` |
 | `STAC` | `StacFetcher` | `collection`/`collections` *(required)*, `datetime`, `limit`, `asset` |
 | `REST_API` | `RestGeoJsonFetcher` | `geom_param` *(optional)*; any other key is forwarded verbatim |
+| `REST_TABLE` | `RestTableFetcher` | `query` *(dict, forwarded verbatim)*; `pagination` *(dict, see below)* |
+
+`REST_TABLE` reads a **paginated tabular JSON** API that answers
+`{"data": [...], "next": ...}` (Géorisques, BAN, RNB) — as opposed to
+`REST_API` which expects a GeoJSON `FeatureCollection`. It is
+**materialize-only** (`FetchMode.REFERENCE` raises): a paginated API has no
+zero-copy DuckDB scan. Rows are streamed to a local JSONL file; the
+`SourceResult.metadata` carries `row_count`, `page_count`, `source_url` and
+a `sha256` of the output. The `pagination` block is bounded and same-origin
+guarded:
+
+```python
+params={
+    "query": {"code_insee": "63113", "page_size": 100},
+    "pagination": {
+        "data_key": "data",          # JSON key holding the row list
+        "next_key": "next",          # key holding the next-page URL (abs or relative)
+        "max_pages": 1000,           # hard ceiling (default)
+        "max_rows": 100_000,         # optional row cap (truncates)
+        "max_total_seconds": 120,    # optional wall-clock deadline
+    },
+}
+```
+
+A `next` link is resolved relative to the current page, must stay
+**same-origin** as the declared endpoint, is SSRF-guarded per hop, and a
+loop on an already-seen URL stops the walk.
 
 A plugin of `kind = "protocol"` can register additional fetchers for
 other protocols — but most source authors only declare an `AccessSpec`

--- a/src/gispulse/adapters/rest/__init__.py
+++ b/src/gispulse/adapters/rest/__init__.py
@@ -1,13 +1,15 @@
-"""REST service adapter — generic GeoJSON-over-HTTP fetcher.
+"""REST service adapters — GeoJSON and tabular-JSON over HTTP.
 
-Importing this package self-registers the core REST GeoJSON transport
-adapter in :data:`core.sources.PROTOCOLS` (issue #192), so the ETL fetch
-path has a real ``rest-api`` fetcher to dispatch to.
+Importing this package self-registers the core REST transport adapters in
+:data:`core.sources.PROTOCOLS`, so the ETL fetch path has real fetchers to
+dispatch to: ``rest-api`` (GeoJSON FeatureCollection, #192) and
+``rest-table`` (paginated tabular JSON, #196).
 """
 
 from __future__ import annotations
 
-# Side-effect import: RestGeoJsonFetcher registers itself on import.
+# Side-effect imports: each fetcher registers itself on import.
 from gispulse.adapters.rest import rest_fetcher  # noqa: F401
+from gispulse.adapters.rest import rest_table_fetcher  # noqa: F401
 
-__all__ = ["rest_fetcher"]
+__all__ = ["rest_fetcher", "rest_table_fetcher"]

--- a/src/gispulse/adapters/rest/rest_table_fetcher.py
+++ b/src/gispulse/adapters/rest/rest_table_fetcher.py
@@ -1,0 +1,194 @@
+"""Paginated tabular-JSON REST fetcher — ``AccessProtocol.REST_TABLE``.
+
+Issue #196. Sibling of :class:`RestGeoJsonFetcher` (#192): where that
+adapter reads a GeoJSON ``FeatureCollection``, this one reads a tabular
+JSON REST API that answers ``{"data": [...], "next": ...}`` — the shape
+served by Géorisques (``/api/v1/...``), BAN and RNB.
+
+The fetcher is **materialize-only**: a paginated REST API has no
+zero-copy DuckDB scan, so :attr:`~core.plugin_model.FetchMode.REFERENCE`
+raises. Rows are streamed to a local newline-delimited JSON (JSONL) file
+and the path is returned in :attr:`SourceResult.data` with
+``payload = Payload.TABLE`` for a downstream key-based spatial join.
+
+Like :class:`RestGeoJsonFetcher`, importing this module self-registers
+the fetcher in the process-wide :data:`core.sources.PROTOCOLS` registry
+(idempotent), so the ETL fetch path has a real ``rest-table`` adapter to
+dispatch to.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import tempfile
+import time
+from typing import Any
+from urllib.parse import urlencode, urljoin, urlsplit
+
+from gispulse.core.logging import get_logger
+from gispulse.core.plugin_model import (
+    AccessProtocol,
+    AccessSpec,
+    FetchMode,
+    Payload,
+    SourceResult,
+)
+
+log = get_logger(__name__)
+
+_DEFAULT_TIMEOUT_S = 20.0
+#: Hard ceiling on pages followed when the AccessSpec does not set one —
+#: a tabular API with a runaway ``next`` must never loop unbounded.
+_DEFAULT_MAX_PAGES = 1000
+
+
+def _same_origin(a: str, b: str) -> bool:
+    """True if ``a`` and ``b`` share scheme + host + port.
+
+    A paginated ``next`` link must not steer the fetch to another host —
+    a malicious catalogue entry could otherwise exfiltrate the request or
+    pivot to an internal service across pages.
+    """
+    sa, sb = urlsplit(a), urlsplit(b)
+    return (sa.scheme, sa.netloc) == (sb.scheme, sb.netloc)
+
+
+def _get_json(url: str, timeout: float) -> dict[str, Any]:
+    """GET ``url`` and return the parsed JSON body."""
+    import httpx
+
+    # follow_redirects is OFF: httpx would otherwise chase a 3xx to an
+    # arbitrary host *after* the SSRF/same-origin guard has cleared the
+    # original URL, re-opening the very hole the guard closes (#199).
+    resp = httpx.get(
+        url,
+        timeout=timeout,
+        follow_redirects=False,
+        headers={"Accept": "application/json"},
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+class RestTableFetcher:
+    """:class:`~core.sources.Fetcher` for ``AccessProtocol.REST_TABLE``."""
+
+    protocol = AccessProtocol.REST_TABLE
+    payload = Payload.TABLE
+
+    def fetch(
+        self,
+        access: AccessSpec,
+        *,
+        extent: Any | None = None,
+        mode: FetchMode = FetchMode.MATERIALIZE,
+    ) -> SourceResult:
+        if mode is FetchMode.REFERENCE:
+            raise NotImplementedError("REST_TABLE is materialize-only")
+
+        params = dict(access.params or {})
+        timeout = float(params.get("timeout", _DEFAULT_TIMEOUT_S))
+        pagination = dict(params.get("pagination") or {})
+        data_key = pagination.get("data_key", "data")
+        next_key = pagination.get("next_key")
+        max_pages = int(pagination.get("max_pages", _DEFAULT_MAX_PAGES))
+        max_rows = pagination.get("max_rows")
+        max_rows = int(max_rows) if max_rows is not None else None
+        max_total_seconds = pagination.get("max_total_seconds")
+        max_total_seconds = (
+            float(max_total_seconds) if max_total_seconds is not None else None
+        )
+        deadline = (
+            time.monotonic() + max_total_seconds
+            if max_total_seconds is not None
+            else None
+        )
+
+        from gispulse.core.ssrf import guard_outbound_url
+
+        query = dict(params.get("query") or {})
+        origin = access.endpoint
+        if query:
+            sep = "&" if "?" in origin else "?"
+            origin = f"{origin}{sep}{urlencode(query)}"
+        rows: list[Any] = []
+        page_count = 0
+        seen: set[str] = set()
+        url: str | None = origin
+        while url:
+            guard_outbound_url(url)
+            seen.add(url)
+            body = _get_json(url, timeout)
+            page_count += 1
+            page_rows = body.get(data_key)
+            if isinstance(page_rows, list):  # ignore a malformed/non-list data_key
+                rows.extend(page_rows)
+            if max_rows is not None and len(rows) >= max_rows:
+                del rows[max_rows:]
+                break
+            if page_count >= max_pages:
+                break
+            if deadline is not None and time.monotonic() >= deadline:
+                break
+            nxt = body.get(next_key) if next_key else None
+            if nxt:
+                # Resolve a relative ``next`` ("?page=2") against the current
+                # page URL, then re-guard the absolute result.
+                candidate = urljoin(url, str(nxt))
+                if candidate not in seen and _same_origin(origin, candidate):
+                    url = candidate
+                else:
+                    url = None
+            else:
+                url = None
+
+        local_path = params.get("local_path")
+        if not local_path:
+            handle = tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False)
+            handle.close()
+            local_path = handle.name
+        digest = hashlib.sha256()
+        with open(local_path, "wb") as fh:
+            for row in rows:
+                line = (json.dumps(row, separators=(",", ":")) + "\n").encode("utf-8")
+                digest.update(line)
+                fh.write(line)
+
+        log.info(
+            "rest_table_materialized",
+            endpoint=access.endpoint,
+            row_count=len(rows),
+            page_count=page_count,
+        )
+        return SourceResult(
+            payload=Payload.TABLE,
+            mode=FetchMode.MATERIALIZE,
+            data=local_path,
+            metadata={
+                "row_count": len(rows),
+                "page_count": page_count,
+                "source_url": access.endpoint,
+                "sha256": digest.hexdigest(),
+            },
+        )
+
+
+def register_rest_table_fetcher(registry: Any | None = None) -> None:
+    """Register a :class:`RestTableFetcher` under ``REST_TABLE`` — idempotent."""
+    from gispulse.core.sources import PROTOCOLS, ProtocolNotSupported
+
+    target = registry if registry is not None else PROTOCOLS
+    try:
+        target.get_fetcher(AccessProtocol.REST_TABLE)
+        return  # already registered
+    except ProtocolNotSupported:
+        pass
+    target.register(RestTableFetcher())
+
+
+# Importing this module wires the fetcher into the global registry (#192 pattern).
+register_rest_table_fetcher()
+
+
+__all__ = ["RestTableFetcher", "register_rest_table_fetcher"]

--- a/src/gispulse/core/plugin_model.py
+++ b/src/gispulse/core/plugin_model.py
@@ -132,7 +132,8 @@ class AccessProtocol(str, Enum):
     OGC_TILES = "ogc-tiles"
     # catalogues / APIs
     STAC = "stac"
-    REST_API = "rest-api"
+    REST_API = "rest-api"          # GeoJSON FeatureCollection (#192)
+    REST_TABLE = "rest-table"      # paginated tabular JSON {"data": [...]} (#196)
     OVERPASS = "overpass"
     # files
     DOWNLOAD = "download"          # remote zip/shp/gpkg/geojson/csv

--- a/tests/unit/test_plugin_model.py
+++ b/tests/unit/test_plugin_model.py
@@ -51,7 +51,7 @@ def test_protocol_version_is_shared_with_contracts() -> None:
         (Tier, 4),
         (SourceDomain, 9),
         (Payload, 5),
-        (AccessProtocol, 15),
+        (AccessProtocol, 16),
         (FetchMode, 2),
         (WriteMode, 3),
     ],

--- a/tests/unit/test_rest_table_fetcher.py
+++ b/tests/unit/test_rest_table_fetcher.py
@@ -1,0 +1,494 @@
+"""Tests for the paginated tabular REST fetcher (``AccessProtocol.REST_TABLE``).
+
+Issue #196 — generic transport adapter for tabular JSON REST APIs that
+answer ``{"data": [...], "next": ...}`` (Géorisques, BAN, RNB, …), as
+opposed to :class:`RestGeoJsonFetcher` (#192) which expects a GeoJSON
+``FeatureCollection``. MATERIALIZE-only: a paginated API has no zero-copy
+DuckDB scan, so ``FetchMode.REFERENCE`` is not supported.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from gispulse.core.plugin_model import (
+    AccessProtocol,
+    AccessSpec,
+    FetchMode,
+    Payload,
+)
+
+# Every fetch crosses the LazyFetcher/SSRF guard; offline_ssrf resolves
+# test hosts to a public IP (no network) while keeping IP literals blockable.
+pytestmark = pytest.mark.usefixtures("offline_ssrf")
+
+
+def test_rest_table_protocol_member_exists() -> None:
+    assert AccessProtocol.REST_TABLE.value == "rest-table"
+
+
+def test_single_page_materializes_rows_to_jsonl(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from gispulse.adapters.rest import rest_table_fetcher
+    from gispulse.adapters.rest.rest_table_fetcher import RestTableFetcher
+
+    def fake_get(url: str, timeout: float) -> dict:
+        return {"data": [{"code_insee": "63113"}, {"code_insee": "63001"}]}
+
+    monkeypatch.setattr(rest_table_fetcher, "_get_json", fake_get)
+
+    out = tmp_path / "out.jsonl"
+    access = AccessSpec(
+        protocol=AccessProtocol.REST_TABLE,
+        endpoint="https://www.georisques.gouv.fr/api/v1/rga",
+        params={"local_path": str(out)},
+    )
+    result = RestTableFetcher().fetch(access)
+
+    assert result.payload is Payload.TABLE
+    assert result.mode is FetchMode.MATERIALIZE
+    assert result.metadata["row_count"] == 2
+    rows = [json.loads(line) for line in out.read_text().splitlines()]
+    assert rows == [{"code_insee": "63113"}, {"code_insee": "63001"}]
+
+
+def test_follows_next_url_and_accumulates_pages(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from gispulse.adapters.rest import rest_table_fetcher
+    from gispulse.adapters.rest.rest_table_fetcher import RestTableFetcher
+
+    pages = {
+        "https://geo.example.org/api?page=1": {
+            "data": [{"i": 1}],
+            "next": "https://geo.example.org/api?page=2",
+        },
+        "https://geo.example.org/api?page=2": {"data": [{"i": 2}], "next": None},
+    }
+    calls: list[str] = []
+
+    def fake_get(url: str, timeout: float) -> dict:
+        calls.append(url)
+        return pages[url]
+
+    monkeypatch.setattr(rest_table_fetcher, "_get_json", fake_get)
+
+    out = tmp_path / "out.jsonl"
+    access = AccessSpec(
+        protocol=AccessProtocol.REST_TABLE,
+        endpoint="https://geo.example.org/api?page=1",
+        params={"local_path": str(out), "pagination": {"next_key": "next"}},
+    )
+    result = RestTableFetcher().fetch(access)
+
+    assert calls == list(pages.keys())
+    assert result.metadata["row_count"] == 2
+    assert result.metadata["page_count"] == 2
+    rows = [json.loads(line) for line in out.read_text().splitlines()]
+    assert rows == [{"i": 1}, {"i": 2}]
+
+
+def _chained_pages(n: int) -> dict[str, dict]:
+    """``n`` pages, each linking to the next; the last one has ``next=None``."""
+    base = "https://geo.example.org/api?page="
+    return {
+        f"{base}{i}": {
+            "data": [{"i": i}],
+            "next": f"{base}{i + 1}" if i < n else None,
+        }
+        for i in range(1, n + 1)
+    }
+
+
+def test_max_pages_caps_pagination(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from gispulse.adapters.rest import rest_table_fetcher
+    from gispulse.adapters.rest.rest_table_fetcher import RestTableFetcher
+
+    pages = _chained_pages(5)
+    calls: list[str] = []
+
+    def fake_get(url: str, timeout: float) -> dict:
+        calls.append(url)
+        return pages[url]
+
+    monkeypatch.setattr(rest_table_fetcher, "_get_json", fake_get)
+
+    access = AccessSpec(
+        protocol=AccessProtocol.REST_TABLE,
+        endpoint="https://geo.example.org/api?page=1",
+        params={
+            "local_path": str(tmp_path / "out.jsonl"),
+            "pagination": {"next_key": "next", "max_pages": 2},
+        },
+    )
+    result = RestTableFetcher().fetch(access)
+
+    assert result.metadata["page_count"] == 2
+    assert len(calls) == 2
+
+
+def test_max_rows_caps_and_truncates(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from gispulse.adapters.rest import rest_table_fetcher
+    from gispulse.adapters.rest.rest_table_fetcher import RestTableFetcher
+
+    base = "https://geo.example.org/api?page="
+    pages = {
+        f"{base}1": {"data": [{"i": 1}, {"i": 2}], "next": f"{base}2"},
+        f"{base}2": {"data": [{"i": 3}, {"i": 4}], "next": f"{base}3"},
+        f"{base}3": {"data": [{"i": 5}], "next": None},
+    }
+
+    def fake_get(url: str, timeout: float) -> dict:
+        return pages[url]
+
+    monkeypatch.setattr(rest_table_fetcher, "_get_json", fake_get)
+
+    out = tmp_path / "out.jsonl"
+    access = AccessSpec(
+        protocol=AccessProtocol.REST_TABLE,
+        endpoint=f"{base}1",
+        params={
+            "local_path": str(out),
+            "pagination": {"next_key": "next", "max_rows": 3},
+        },
+    )
+    result = RestTableFetcher().fetch(access)
+
+    assert result.metadata["row_count"] == 3
+    rows = [json.loads(line) for line in out.read_text().splitlines()]
+    assert rows == [{"i": 1}, {"i": 2}, {"i": 3}]
+
+
+def test_stops_on_already_seen_next_url(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from gispulse.adapters.rest import rest_table_fetcher
+    from gispulse.adapters.rest.rest_table_fetcher import RestTableFetcher
+
+    p1 = "https://geo.example.org/api?page=1"
+    p2 = "https://geo.example.org/api?page=2"
+    pages = {  # p2 cycles back to p1
+        p1: {"data": [{"i": 1}], "next": p2},
+        p2: {"data": [{"i": 2}], "next": p1},
+    }
+    calls: list[str] = []
+
+    def fake_get(url: str, timeout: float) -> dict:
+        calls.append(url)
+        return pages[url]
+
+    monkeypatch.setattr(rest_table_fetcher, "_get_json", fake_get)
+
+    access = AccessSpec(
+        protocol=AccessProtocol.REST_TABLE,
+        endpoint=p1,
+        params={
+            "local_path": str(tmp_path / "out.jsonl"),
+            "pagination": {"next_key": "next"},
+        },
+    )
+    result = RestTableFetcher().fetch(access)
+
+    assert calls == [p1, p2]
+    assert result.metadata["page_count"] == 2
+
+
+def test_rejects_cross_origin_next_url(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from gispulse.adapters.rest import rest_table_fetcher
+    from gispulse.adapters.rest.rest_table_fetcher import RestTableFetcher
+
+    p1 = "https://geo.example.org/api?page=1"
+    evil = "https://evil.example.com/api?page=2"
+    pages = {
+        p1: {"data": [{"i": 1}], "next": evil},
+        evil: {"data": [{"i": 99}], "next": None},
+    }
+    calls: list[str] = []
+
+    def fake_get(url: str, timeout: float) -> dict:
+        calls.append(url)
+        return pages[url]
+
+    monkeypatch.setattr(rest_table_fetcher, "_get_json", fake_get)
+
+    out = tmp_path / "out.jsonl"
+    access = AccessSpec(
+        protocol=AccessProtocol.REST_TABLE,
+        endpoint=p1,
+        params={"local_path": str(out), "pagination": {"next_key": "next"}},
+    )
+    result = RestTableFetcher().fetch(access)
+
+    assert calls == [p1]  # the cross-origin next URL is not followed
+    assert result.metadata["page_count"] == 1
+    rows = [json.loads(line) for line in out.read_text().splitlines()]
+    assert rows == [{"i": 1}]
+
+
+def test_rejects_ssrf_internal_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gispulse.adapters.rest import rest_table_fetcher
+    from gispulse.adapters.rest.rest_table_fetcher import RestTableFetcher
+    from gispulse.core.ssrf import SSRFError
+
+    def must_not_fetch(url: str, timeout: float) -> dict:
+        raise AssertionError("SSRF guard should block before any GET")
+
+    monkeypatch.setattr(rest_table_fetcher, "_get_json", must_not_fetch)
+
+    access = AccessSpec(
+        protocol=AccessProtocol.REST_TABLE,
+        endpoint="http://127.0.0.1/api/v1/rga",
+        params={},
+    )
+    with pytest.raises(SSRFError):
+        RestTableFetcher().fetch(access)
+
+
+def test_reference_mode_is_not_supported() -> None:
+    from gispulse.adapters.rest.rest_table_fetcher import RestTableFetcher
+
+    access = AccessSpec(
+        protocol=AccessProtocol.REST_TABLE,
+        endpoint="https://geo.example.org/api/v1/rga",
+        params={},
+    )
+    with pytest.raises(NotImplementedError):
+        RestTableFetcher().fetch(access, mode=FetchMode.REFERENCE)
+
+
+def test_register_files_under_rest_table_without_touching_rest_api() -> None:
+    from gispulse.adapters.rest.rest_fetcher import (
+        RestGeoJsonFetcher,
+        register_rest_geojson_fetcher,
+    )
+    from gispulse.adapters.rest.rest_table_fetcher import (
+        RestTableFetcher,
+        register_rest_table_fetcher,
+    )
+    from gispulse.core.sources import ProtocolRegistry
+
+    reg = ProtocolRegistry()
+    register_rest_geojson_fetcher(reg)
+    register_rest_table_fetcher(reg)
+
+    assert isinstance(reg.get_fetcher(AccessProtocol.REST_TABLE), RestTableFetcher)
+    assert isinstance(reg.get_fetcher(AccessProtocol.REST_API), RestGeoJsonFetcher)
+
+
+def test_query_params_are_forwarded_to_url(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from urllib.parse import parse_qs, urlsplit
+
+    from gispulse.adapters.rest import rest_table_fetcher
+    from gispulse.adapters.rest.rest_table_fetcher import RestTableFetcher
+
+    seen: dict[str, str] = {}
+
+    def fake_get(url: str, timeout: float) -> dict:
+        seen["url"] = url
+        return {"data": []}
+
+    monkeypatch.setattr(rest_table_fetcher, "_get_json", fake_get)
+
+    access = AccessSpec(
+        protocol=AccessProtocol.REST_TABLE,
+        endpoint="https://geo.example.org/api/v1/rga",
+        params={
+            "local_path": str(tmp_path / "out.jsonl"),
+            "query": {"code_insee": "63113", "page_size": 100},
+        },
+    )
+    RestTableFetcher().fetch(access)
+
+    q = parse_qs(urlsplit(seen["url"]).query)
+    assert q["code_insee"] == ["63113"]
+    assert q["page_size"] == ["100"]
+
+
+def test_metadata_carries_sha256_of_output(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import hashlib
+
+    from gispulse.adapters.rest import rest_table_fetcher
+    from gispulse.adapters.rest.rest_table_fetcher import RestTableFetcher
+
+    def fake_get(url: str, timeout: float) -> dict:
+        return {"data": [{"a": 1}, {"a": 2}]}
+
+    monkeypatch.setattr(rest_table_fetcher, "_get_json", fake_get)
+
+    out = tmp_path / "out.jsonl"
+    access = AccessSpec(
+        protocol=AccessProtocol.REST_TABLE,
+        endpoint="https://geo.example.org/api/v1/rga",
+        params={"local_path": str(out)},
+    )
+    result = RestTableFetcher().fetch(access)
+
+    expected = hashlib.sha256(out.read_bytes()).hexdigest()
+    assert result.metadata["sha256"] == expected
+
+
+def test_follows_relative_next_url(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from gispulse.adapters.rest import rest_table_fetcher
+    from gispulse.adapters.rest.rest_table_fetcher import RestTableFetcher
+
+    base = "https://geo.example.org/api/v1/rga"
+    pages = {
+        f"{base}?page=1": {"data": [{"i": 1}], "next": "?page=2"},  # relative
+        f"{base}?page=2": {"data": [{"i": 2}], "next": None},
+    }
+    calls: list[str] = []
+
+    def fake_get(url: str, timeout: float) -> dict:
+        calls.append(url)
+        return pages[url]
+
+    monkeypatch.setattr(rest_table_fetcher, "_get_json", fake_get)
+
+    access = AccessSpec(
+        protocol=AccessProtocol.REST_TABLE,
+        endpoint=f"{base}?page=1",
+        params={
+            "local_path": str(tmp_path / "out.jsonl"),
+            "pagination": {"next_key": "next"},
+        },
+    )
+    result = RestTableFetcher().fetch(access)
+
+    assert calls == [f"{base}?page=1", f"{base}?page=2"]
+    assert result.metadata["page_count"] == 2
+
+
+def test_non_list_data_key_yields_no_rows(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from gispulse.adapters.rest import rest_table_fetcher
+    from gispulse.adapters.rest.rest_table_fetcher import RestTableFetcher
+
+    def fake_get(url: str, timeout: float) -> dict:
+        return {"data": {"not": "a list"}}  # malformed: dict, not a list
+
+    monkeypatch.setattr(rest_table_fetcher, "_get_json", fake_get)
+
+    access = AccessSpec(
+        protocol=AccessProtocol.REST_TABLE,
+        endpoint="https://geo.example.org/api/v1/rga",
+        params={"local_path": str(tmp_path / "out.jsonl")},
+    )
+    result = RestTableFetcher().fetch(access)
+
+    assert result.metadata["row_count"] == 0
+
+
+def test_get_json_disables_redirects(monkeypatch: pytest.MonkeyPatch) -> None:
+    import httpx
+
+    from gispulse.adapters.rest.rest_table_fetcher import _get_json
+
+    captured: dict[str, object] = {}
+
+    class _FakeResp:
+        def raise_for_status(self) -> None: ...
+
+        def json(self) -> dict:
+            return {"data": []}
+
+    def fake_httpx_get(url: str, **kwargs: object) -> _FakeResp:
+        captured.update(kwargs)
+        return _FakeResp()
+
+    monkeypatch.setattr(httpx, "get", fake_httpx_get)
+    _get_json("https://geo.example.org/api/v1/rga", 5.0)
+
+    assert captured["follow_redirects"] is False
+
+
+def test_max_total_seconds_caps_wallclock(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from gispulse.adapters.rest import rest_table_fetcher
+    from gispulse.adapters.rest.rest_table_fetcher import RestTableFetcher
+
+    pages = _chained_pages(5)
+
+    def fake_get(url: str, timeout: float) -> dict:
+        return pages[url]
+
+    monkeypatch.setattr(rest_table_fetcher, "_get_json", fake_get)
+
+    access = AccessSpec(
+        protocol=AccessProtocol.REST_TABLE,
+        endpoint="https://geo.example.org/api?page=1",
+        params={
+            "local_path": str(tmp_path / "out.jsonl"),
+            # budget 0 → the deadline is reached right after the first page
+            "pagination": {"next_key": "next", "max_total_seconds": 0},
+        },
+    )
+    result = RestTableFetcher().fetch(access)
+
+    assert result.metadata["page_count"] == 1
+
+
+def test_package_import_registers_rest_table_in_global_protocols() -> None:
+    import gispulse.adapters.rest  # noqa: F401  (side-effect import)
+    from gispulse.adapters.rest.rest_table_fetcher import RestTableFetcher
+    from gispulse.core.sources import PROTOCOLS
+
+    assert isinstance(
+        PROTOCOLS.get_fetcher(AccessProtocol.REST_TABLE), RestTableFetcher
+    )
+
+
+@pytest.mark.parametrize(
+    "evil_next",
+    [
+        "//evil.com/api",                  # scheme-relative → resolves cross-host
+        "http://geo.example.org/api",      # scheme downgrade https → http
+        "https://evil.example.com/api",    # outright different host
+        "https://geo.example.org.evil.com/api",  # suffix-spoof host
+    ],
+)
+def test_rejects_malicious_next_urls(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, evil_next: str
+) -> None:
+    from gispulse.adapters.rest import rest_table_fetcher
+    from gispulse.adapters.rest.rest_table_fetcher import RestTableFetcher
+
+    origin = "https://geo.example.org/api?page=1"
+    calls: list[str] = []
+
+    def fake_get(url: str, timeout: float) -> dict:
+        calls.append(url)
+        if url == origin:
+            return {"data": [{"i": 1}], "next": evil_next}
+        return {"data": [{"i": 99}]}  # would only be hit if the guard failed
+
+    monkeypatch.setattr(rest_table_fetcher, "_get_json", fake_get)
+
+    access = AccessSpec(
+        protocol=AccessProtocol.REST_TABLE,
+        endpoint=origin,
+        params={"local_path": str(tmp_path / "out.jsonl"), "pagination": {"next_key": "next"}},
+    )
+    result = RestTableFetcher().fetch(access)
+
+    assert calls == [origin]  # the malicious next is never followed
+    assert result.metadata["page_count"] == 1


### PR DESCRIPTION
## Quoi

Ajoute `AccessProtocol.REST_TABLE` + `RestTableFetcher` : un adaptateur de transport générique pour les **API REST tabulaires paginées** qui répondent `{"data": [...], "next": ...}` (Géorisques, BAN, RNB). Frère de `RestGeoJsonFetcher` (#192) qui, lui, ne gère que les `FeatureCollection` GeoJSON et reste sur `REST_API`.

## Pourquoi

Plusieurs sources du backlog d'ingestion (Géorisques, BAN, RNB) sont des API REST tabulaires paginées par `code_insee`/`latlon`. Aucun fetcher du core ne couvrait ce motif — d'où des clients HTTP dupliqués hors-core (permis, foncier). Cette brique débloque leur remontée en plugins `gispulse-src-*` déclaratifs (#196).

## Détails

- **Materialize-only** : une API paginée n'a pas de scan DuckDB zéro-copie → `FetchMode.REFERENCE` lève. Hérite de `Fetcher` (pas `LazyFetcher`), comme `RestGeoJsonFetcher`.
- **Pagination déclarative bornée** dans `params["pagination"]` : `data_key`, `next_key`, `max_pages` (défaut 1000), `max_rows` (tronque), `max_total_seconds` (deadline).
- **Sécurité** : stop anti-cycle (URLs vues), `next` contraint **same-origin**, SSRF guard (#199) par hop, `follow_redirects=False` (un 3xx ne doit pas contourner le guard), `next` relatif résolu via `urljoin`.
- **Sortie** : JSONL local + metadata `{row_count, page_count, source_url, sha256}`.
- Auto-enregistrement sous `REST_TABLE` à l'import (motif #192).
- `SOURCE_PLUGIN_GUIDE.md` mis à jour ; cardinalité `AccessProtocol` 15→16.

## Tests

20 tests unitaires zéro-réseau (pagination, bornes, cycle, same-origin, SSRF, redirections, REFERENCE, registration). Non-régression #192 confirmée. `ruff` clean.

## Revue

Relu et fact-checké par Codex (architecture + sécurité) — verdict détaillé en commentaire ci-dessous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
