### PR TITLE
feat(src-georisques): declarative Géorisques source over REST_TABLE (#196)

### DIFF
--- a/plugins/gispulse-src-georisques/gispulse_src_georisques/__init__.py
+++ b/plugins/gispulse-src-georisques/gispulse_src_georisques/__init__.py
@@ -1,0 +1,24 @@
+"""GISPulse data-source plugin — French Géorisques (issue #196).
+
+Declarative source over ``AccessProtocol.REST_TABLE`` (the paginated
+tabular-JSON fetcher, #196 wave 1). It replaces the per-product Géorisques
+HTTP clients duplicated in ``gispulse-permis`` and ``gispulse-foncier``:
+the plugin only declares the six Géorisques endpoints; the orchestrator
+supplies the runtime spatial key (``code_insee`` / ``latlon``) via
+:meth:`GeorisquesSource.access_for`.
+"""
+
+from __future__ import annotations
+
+
+def register() -> None:
+    """Entry-point hook for the ``gispulse.data_sources`` group.
+
+    Registers a :class:`GeorisquesSource` instance in the process-wide
+    ``gispulse.core.sources.SOURCES`` registry so the source watcher can
+    resolve ``georisques://<entry>`` URIs.
+    """
+    from gispulse.core.sources import SOURCES
+    from gispulse_src_georisques.source import GeorisquesSource
+
+    SOURCES.register(GeorisquesSource())

--- a/plugins/gispulse-src-georisques/gispulse_src_georisques/source.py
+++ b/plugins/gispulse-src-georisques/gispulse_src_georisques/source.py
@@ -173,14 +173,16 @@ class GeorisquesSource(DeclarativeSource):
         code_insee: str | None = None,
         latlon: str | None = None,
         local_path: str | None = None,
+        s3_uri: str | None = None,
+        s3_key: str | None = None,
     ) -> AccessSpec:
         """Build a per-query :class:`AccessSpec` for one spatial unit.
 
         The declarative entry carries the endpoint and its static query; this
         helper folds in the runtime spatial key (``code_insee`` *or*
-        ``latlon``, whichever the entry declares) and an optional
-        materialisation ``local_path``. No network — it only shapes the spec
-        the orchestrator hands to ``RestTableFetcher``.
+        ``latlon``, whichever the entry declares) and optional materialisation
+        destinations (local JSONL path or S3/Garage object). No network — it
+        only shapes the spec the orchestrator hands to ``RestTableFetcher``.
         """
         entry = self._entry(entry_id)
         query_key = entry.metadata["query_key"]
@@ -199,6 +201,10 @@ class GeorisquesSource(DeclarativeSource):
         params["query"] = {**params.get("query", {}), query_key: value}
         if local_path is not None:
             params["local_path"] = local_path
+        if s3_uri is not None:
+            params["s3_uri"] = s3_uri
+        if s3_key is not None:
+            params["s3_key"] = s3_key
         return replace(entry.access, params=params)
 
     def schema(self, entry_id: str) -> dict[str, str]:

--- a/plugins/gispulse-src-georisques/gispulse_src_georisques/source.py
+++ b/plugins/gispulse-src-georisques/gispulse_src_georisques/source.py
@@ -64,7 +64,7 @@ _ENTRIES: dict[str, dict[str, Any]] = {
         "scope": "point",
         "static_query": {},
         # 2024+ API answers a top-level object, not {"data": [...]}.
-        "pagination": {"row_shape": "object", "empty_body_is_empty": True},
+        "pagination": {"row_source": "body", "empty_body_is_empty": True},
     },
     "tri-zonage": {
         "label": "Territoire à risque important d'inondation (point)",
@@ -82,7 +82,7 @@ _ENTRIES: dict[str, dict[str, Any]] = {
         "scope": "point",
         "static_query": {"rayon": 500, "page_size": 5},
         # 2024+ API nests the count under {"casias": {...}} — keep the raw body.
-        "pagination": {"row_shape": "object"},
+        "pagination": {"row_source": "body"},
     },
 }
 

--- a/plugins/gispulse-src-georisques/gispulse_src_georisques/source.py
+++ b/plugins/gispulse-src-georisques/gispulse_src_georisques/source.py
@@ -1,0 +1,218 @@
+"""Géorisques DataSource — natural/technological risk signals (#196).
+
+A :class:`DeclarativeSource` over :attr:`AccessProtocol.REST_TABLE`. Each of
+the six Géorisques endpoints is one declarative entry; the endpoint and its
+static query (page size, radius) are fixed here, but the **runtime spatial
+key** — ``code_insee`` for the communal endpoints, ``latlon`` for the point
+endpoints — is supplied per call by the ingestion orchestrator through
+:meth:`GeorisquesSource.access_for`.
+
+The plugin is intentionally *raw*: ``schema`` describes the upstream fields,
+not a normalised ``radon_class`` / ``RiskConstraint`` shape. Normalisation
+stays in the consuming product (permis service, foncier dbt) — keeping this
+source from becoming a disguised business client.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any
+
+from gispulse.plugins.api import (
+    AccessProtocol,
+    AccessSpec,
+    DeclarativeSource,
+    Payload,
+    SourceDomain,
+    SourceEntryRef,
+)
+
+GEORISQUES_BASE_URL = "https://www.georisques.gouv.fr"
+
+# entry_id -> declarative spec. ``query_key`` names the runtime spatial
+# parameter; ``scope`` is the granularity it filters at. ``static_query``
+# is folded into every request; ``pagination`` is the REST_TABLE recipe.
+_ENTRIES: dict[str, dict[str, Any]] = {
+    "gaspar-risques": {
+        "label": "Risques recensés GASPAR (commune)",
+        "path": "/api/v1/gaspar/risques",
+        "query_key": "code_insee",
+        "scope": "commune",
+        "static_query": {"page_size": 100},
+        "pagination": {"data_key": "data", "next_key": "next"},
+    },
+    "radon": {
+        "label": "Potentiel radon (commune)",
+        "path": "/api/v1/radon",
+        "query_key": "code_insee",
+        "scope": "commune",
+        "static_query": {},
+        "pagination": {"data_key": "data"},
+    },
+    "sismicite": {
+        "label": "Zonage sismique (commune)",
+        "path": "/api/v1/zonage_sismique",
+        "query_key": "code_insee",
+        "scope": "commune",
+        "static_query": {"page_size": 10},
+        "pagination": {"data_key": "data"},
+    },
+    "rga": {
+        "label": "Retrait-gonflement des argiles (point)",
+        "path": "/api/v1/rga",
+        "query_key": "latlon",
+        "scope": "point",
+        "static_query": {},
+        # 2024+ API answers a top-level object, not {"data": [...]}.
+        "pagination": {"row_shape": "object", "empty_body_is_empty": True},
+    },
+    "tri-zonage": {
+        "label": "Territoire à risque important d'inondation (point)",
+        "path": "/api/v1/tri_zonage",
+        "query_key": "latlon",
+        "scope": "point",
+        "static_query": {},
+        # absence of a TRI is served as 404 — treat it as an empty result.
+        "pagination": {"data_key": "data", "empty_statuses": [404]},
+    },
+    "ssp": {
+        "label": "Sites et sols pollués à proximité (point)",
+        "path": "/api/v1/ssp",
+        "query_key": "latlon",
+        "scope": "point",
+        "static_query": {"rayon": 500, "page_size": 5},
+        # 2024+ API nests the count under {"casias": {...}} — keep the raw body.
+        "pagination": {"row_shape": "object"},
+    },
+}
+
+_METADATA_COMMON = {
+    "provider": "Géorisques / BRGM-MTE",
+    "platform": "georisques.gouv.fr API v1",
+    "license": "Licence Ouverte 2.0",
+}
+
+# Raw upstream fields per entry — what the REST_TABLE rows carry. The
+# normalisation to radon_class / rga_class / RiskConstraint lives downstream.
+_SCHEMAS: dict[str, dict[str, str]] = {
+    "gaspar-risques": {
+        "code_insee": "str",
+        "risques_detail": "json",
+    },
+    "radon": {
+        "code_insee": "str",
+        "classe_potentiel": "str",
+    },
+    "sismicite": {
+        "code_insee": "str",
+        "code_zone": "str",
+        "libelle_commune": "str",
+        "zone_sismicite": "str",
+        "libelle_zone": "str",
+    },
+    "rga": {
+        "codeExposition": "str",
+        "exposition": "str",
+        "alea": "str",
+    },
+    "tri-zonage": {
+        "code_national_tri": "str",
+        "libelle_tri": "str",
+    },
+    "ssp": {
+        "casias": "json",
+        "instructions": "json",
+        "conclusions_sis": "json",
+        "conclusions_sup": "json",
+    },
+}
+
+
+class GeorisquesSource(DeclarativeSource):
+    """Géorisques risk signals exposed as a GISPulse declarative source."""
+
+    name = "georisques"
+    domain = SourceDomain.ENVIRONNEMENT
+    payload = Payload.TABLE
+    jurisdiction = "FR"
+
+    def entries(self) -> list[SourceEntryRef]:
+        return [self._entry_ref(entry_id) for entry_id in _ENTRIES]
+
+    def _entry_ref(self, entry_id: str) -> SourceEntryRef:
+        spec = _ENTRIES[entry_id]
+        params: dict[str, Any] = {"pagination": dict(spec["pagination"])}
+        if spec["static_query"]:
+            params["query"] = dict(spec["static_query"])
+        return SourceEntryRef(
+            id=entry_id,
+            name=spec["label"],
+            access=AccessSpec(
+                protocol=AccessProtocol.REST_TABLE,
+                endpoint=f"{GEORISQUES_BASE_URL}{spec['path']}",
+                params=params,
+                format="application/json",
+            ),
+            # The data depends on a runtime spatial key, so there is no
+            # source-wide revision token (see revision()).
+            revision_token=None,
+            domain=self.domain,
+            payload=self.payload,
+            jurisdiction=self.jurisdiction,
+            metadata={
+                **_METADATA_COMMON,
+                "query_key": spec["query_key"],
+                "query_scope": spec["scope"],
+            },
+        )
+
+    def access_for(
+        self,
+        entry_id: str,
+        *,
+        code_insee: str | None = None,
+        latlon: str | None = None,
+        local_path: str | None = None,
+    ) -> AccessSpec:
+        """Build a per-query :class:`AccessSpec` for one spatial unit.
+
+        The declarative entry carries the endpoint and its static query; this
+        helper folds in the runtime spatial key (``code_insee`` *or*
+        ``latlon``, whichever the entry declares) and an optional
+        materialisation ``local_path``. No network — it only shapes the spec
+        the orchestrator hands to ``RestTableFetcher``.
+        """
+        entry = self._entry(entry_id)
+        query_key = entry.metadata["query_key"]
+        value = code_insee if query_key == "code_insee" else latlon
+        if value is None:
+            raise ValueError(
+                f"entry {entry_id!r} filters by {query_key!r}; "
+                f"pass {query_key}=<value>"
+            )
+
+        params = dict(entry.access.params)
+        for nested_key in ("query", "pagination"):
+            nested = params.get(nested_key)
+            if isinstance(nested, dict):
+                params[nested_key] = dict(nested)
+        params["query"] = {**params.get("query", {}), query_key: value}
+        if local_path is not None:
+            params["local_path"] = local_path
+        return replace(entry.access, params=params)
+
+    def schema(self, entry_id: str) -> dict[str, str]:
+        self._entry(entry_id)  # validates the id
+        return dict(_SCHEMAS[entry_id])
+
+    def revision(self, entry_id: str) -> str | None:
+        """No cheap source-wide freshness token.
+
+        Géorisques has no dataset-level ``last_modified`` and the data is
+        keyed on a runtime spatial parameter, so there is nothing to probe
+        without a full per-unit fetch. The guide says ``revision()`` must
+        stay cheap, so it returns ``None`` (= freshness unknown) and the
+        source watcher skips it.
+        """
+        self._entry(entry_id)  # validates the id
+        return None

--- a/plugins/gispulse-src-georisques/pyproject.toml
+++ b/plugins/gispulse-src-georisques/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gispulse-src-georisques"
+version = "0.1.0"
+description = "French Géorisques data source for GISPulse (natural/technological risk signals)"
+requires-python = ">=3.10"
+license = "AGPL-3.0-or-later"
+authors = [{ name = "GISPulse", email = "dev@gispulse.io" }]
+dependencies = [
+    "gispulse>=2.0.0,<3.0.0",
+]
+
+# Registered as a data source — discovered by core.plugin_hub.PluginHub.
+[project.entry-points."gispulse.data_sources"]
+georisques = "gispulse_src_georisques:register"
+
+[tool.gispulse.plugin]
+kind = "source"
+protocol = ">=1.0,<2.0"
+domain = "environnement"
+jurisdiction = "FR"
+display_name = "Géorisques — risques naturels et technologiques (France)"

--- a/src/gispulse/adapters/rest/rest_table_fetcher.py
+++ b/src/gispulse/adapters/rest/rest_table_fetcher.py
@@ -7,9 +7,8 @@ served by Géorisques (``/api/v1/...``), BAN and RNB.
 
 The fetcher is **materialize-only**: a paginated REST API has no
 zero-copy DuckDB scan, so :attr:`~core.plugin_model.FetchMode.REFERENCE`
-raises. Rows are streamed to a local newline-delimited JSON (JSONL) file
-and the path is returned in :attr:`SourceResult.data` with
-``payload = Payload.TABLE`` for a downstream key-based spatial join.
+raises. Rows are streamed to newline-delimited JSON (JSONL): local file
+by default, or S3/Garage when ``s3_uri`` / ``s3_key`` is supplied.
 
 Like :class:`RestGeoJsonFetcher`, importing this module self-registers
 the fetcher in the process-wide :data:`core.sources.PROTOCOLS` registry
@@ -25,9 +24,10 @@ from dataclasses import dataclass, field
 from os import PathLike
 import tempfile
 import time
-from typing import Any
+from typing import Any, BinaryIO
 from urllib.parse import urlencode, urljoin, urlsplit
 
+from gispulse.core.config import settings
 from gispulse.core.logging import get_logger
 from gispulse.core.plugin_model import (
     AccessProtocol,
@@ -160,6 +160,74 @@ def _write_jsonl(
     return local_path, digest.hexdigest(), row_count
 
 
+def _resolve_s3_materialize_uri(params: dict[str, Any]) -> str | None:
+    s3_uri = str(params.get("s3_uri", "") or "").strip()
+    if s3_uri:
+        return s3_uri
+
+    s3_key = str(params.get("s3_key", "") or "").strip().lstrip("/")
+    if not s3_key:
+        return None
+
+    bucket = str(params.get("s3_bucket", "") or "").strip() or settings.s3.bucket
+    return f"s3://{bucket}/{s3_key}"
+
+
+def _write_jsonl_row(row: Any, fh: BinaryIO, digest: Any) -> int:
+    line = (json.dumps(row, separators=(",", ":")) + "\n").encode("utf-8")
+    digest.update(line)
+    fh.write(line)
+    return 1
+
+
+def _run_async(coro: Any) -> Any:
+    import asyncio
+    import threading
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+
+    result: dict[str, Any] = {}
+
+    def runner() -> None:
+        try:
+            result["value"] = asyncio.run(coro)
+        except BaseException as exc:  # noqa: BLE001 - propagate from worker
+            result["error"] = exc
+
+    thread = threading.Thread(target=runner)
+    thread.start()
+    thread.join()
+    if "error" in result:
+        raise result["error"]
+    return result.get("value")
+
+
+def _upload_jsonl_to_s3(s3_uri: str, body: BinaryIO) -> None:
+    parsed = urlsplit(s3_uri)
+    bucket = parsed.netloc
+    key = parsed.path.lstrip("/")
+    if parsed.scheme != "s3" or not bucket or not key:
+        raise ValueError(f"Invalid REST_TABLE S3 destination: {s3_uri!r}")
+    if not settings.s3.endpoint:
+        raise ValueError("REST_TABLE S3 materialization requires GISPULSE_S3_ENDPOINT")
+
+    from gispulse.persistence.storage import S3Storage
+    from gispulse.persistence.tier import check_tier
+
+    check_tier("pro")
+    storage = S3Storage(
+        endpoint_url=settings.s3.endpoint,
+        bucket=bucket,
+        access_key=settings.s3.access_key,
+        secret_key=settings.s3.secret_key,
+        region=settings.s3.region,
+    )
+    _run_async(storage.upload(key, body, content_type="application/x-ndjson"))
+
+
 class RestTableFetcher:
     """:class:`~core.sources.Fetcher` for ``AccessProtocol.REST_TABLE``."""
 
@@ -194,35 +262,63 @@ class RestTableFetcher:
         if query:
             sep = "&" if "?" in origin else "?"
             origin = f"{origin}{sep}{urlencode(query)}"
-        rows: list[Any] = []
+        s3_uri = _resolve_s3_materialize_uri(params)
+        local_path = params.get("local_path")
+        if s3_uri:
+            fh: BinaryIO = tempfile.SpooledTemporaryFile(
+                max_size=64 * 1024 * 1024,
+                mode="w+b",
+            )
+        else:
+            if not local_path:
+                handle = tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False)
+                handle.close()
+                local_path = handle.name
+            fh = open(local_path, "wb")
+
+        digest = hashlib.sha256()
+        row_count = 0
         page_count = 0
         seen: set[str] = set()
         url: str | None = origin
-        while url:
-            guard_outbound_url(url)
-            seen.add(url)
-            try:
-                body = _get_json(url, timeout)
-            except httpx.HTTPStatusError as exc:
-                if exc.response.status_code in pagination.empty_statuses:
-                    break  # "no data here" — leave the result empty
-                raise
-            except json.JSONDecodeError:
-                if pagination.empty_body_is_empty:
-                    break  # empty/malformed body configured as "no data here"
-                raise
-            page_count += 1
-            rows.extend(_rows_from_body(body, pagination))
-            if pagination.max_rows is not None and len(rows) >= pagination.max_rows:
-                del rows[pagination.max_rows :]
-                break
-            if page_count >= pagination.max_pages:
-                break
-            if deadline is not None and time.monotonic() >= deadline:
-                break
-            url = _next_page_url(body, url, origin, seen, pagination)
+        try:
+            while url:
+                guard_outbound_url(url)
+                seen.add(url)
+                try:
+                    body = _get_json(url, timeout)
+                except httpx.HTTPStatusError as exc:
+                    if exc.response.status_code in pagination.empty_statuses:
+                        break  # "no data here" — leave the result empty
+                    raise
+                except json.JSONDecodeError:
+                    if pagination.empty_body_is_empty:
+                        break  # empty/malformed body configured as "no data here"
+                    raise
+                page_count += 1
+                for row in _rows_from_body(body, pagination):
+                    if (
+                        pagination.max_rows is not None
+                        and row_count >= pagination.max_rows
+                    ):
+                        break
+                    row_count += _write_jsonl_row(row, fh, digest)
+                if (
+                    pagination.max_rows is not None
+                    and row_count >= pagination.max_rows
+                ):
+                    break
+                if page_count >= pagination.max_pages:
+                    break
+                if deadline is not None and time.monotonic() >= deadline:
+                    break
+                url = _next_page_url(body, url, origin, seen, pagination)
 
-        local_path, sha256, row_count = _write_jsonl(rows, params.get("local_path"))
+            if s3_uri:
+                fh.seek(0)
+                _upload_jsonl_to_s3(s3_uri, fh)
+        finally:
+            fh.close()
 
         log.info(
             "rest_table_materialized",
@@ -230,16 +326,21 @@ class RestTableFetcher:
             row_count=row_count,
             page_count=page_count,
         )
+        data = s3_uri if s3_uri else local_path
+        metadata = {
+            "row_count": row_count,
+            "page_count": page_count,
+            "source_url": access.endpoint,
+            "sha256": digest.hexdigest(),
+        }
+        if s3_uri:
+            metadata["s3_uri"] = s3_uri
         return SourceResult(
             payload=Payload.TABLE,
             mode=FetchMode.MATERIALIZE,
-            data=local_path,
-            metadata={
-                "row_count": row_count,
-                "page_count": page_count,
-                "source_url": access.endpoint,
-                "sha256": sha256,
-            },
+            data=data,
+            reference=s3_uri,
+            metadata=metadata,
         )
 
 

--- a/src/gispulse/adapters/rest/rest_table_fetcher.py
+++ b/src/gispulse/adapters/rest/rest_table_fetcher.py
@@ -92,6 +92,14 @@ class RestTableFetcher:
         pagination = dict(params.get("pagination") or {})
         data_key = pagination.get("data_key", "data")
         next_key = pagination.get("next_key")
+        # "list" (default): rows live in body[data_key]; "object": the whole
+        # JSON body is a single row (non-paginated single-object endpoints,
+        # e.g. Géorisques RGA/SSP 2024+).
+        row_shape = pagination.get("row_shape", "list")
+        # HTTP statuses that mean "no data here" rather than an error — the
+        # walk treats them as an empty result (e.g. Géorisques tri_zonage 404).
+        empty_statuses = set(pagination.get("empty_statuses") or [])
+        empty_body_is_empty = bool(pagination.get("empty_body_is_empty", False))
         max_pages = int(pagination.get("max_pages", _DEFAULT_MAX_PAGES))
         max_rows = pagination.get("max_rows")
         max_rows = int(max_rows) if max_rows is not None else None
@@ -104,6 +112,8 @@ class RestTableFetcher:
             if max_total_seconds is not None
             else None
         )
+
+        import httpx
 
         from gispulse.core.ssrf import guard_outbound_url
 
@@ -119,11 +129,23 @@ class RestTableFetcher:
         while url:
             guard_outbound_url(url)
             seen.add(url)
-            body = _get_json(url, timeout)
+            try:
+                body = _get_json(url, timeout)
+            except httpx.HTTPStatusError as exc:
+                if exc.response.status_code in empty_statuses:
+                    break  # "no data here" — leave the result empty
+                raise
+            except json.JSONDecodeError:
+                if empty_body_is_empty:
+                    break  # empty/malformed body configured as "no data here"
+                raise
             page_count += 1
-            page_rows = body.get(data_key)
-            if isinstance(page_rows, list):  # ignore a malformed/non-list data_key
-                rows.extend(page_rows)
+            if row_shape == "object":
+                rows.append(body)  # the whole body is a single row
+            else:
+                page_rows = body.get(data_key)
+                if isinstance(page_rows, list):  # ignore a non-list data_key
+                    rows.extend(page_rows)
             if max_rows is not None and len(rows) >= max_rows:
                 del rows[max_rows:]
                 break

--- a/src/gispulse/adapters/rest/rest_table_fetcher.py
+++ b/src/gispulse/adapters/rest/rest_table_fetcher.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 
 import hashlib
 import json
+from dataclasses import dataclass, field
+from os import PathLike
 import tempfile
 import time
 from typing import Any
@@ -41,6 +43,8 @@ _DEFAULT_TIMEOUT_S = 20.0
 #: Hard ceiling on pages followed when the AccessSpec does not set one —
 #: a tabular API with a runaway ``next`` must never loop unbounded.
 _DEFAULT_MAX_PAGES = 1000
+_ROW_SOURCE_KEY = "key"
+_ROW_SOURCE_BODY = "body"
 
 
 def _same_origin(a: str, b: str) -> bool:
@@ -71,6 +75,91 @@ def _get_json(url: str, timeout: float) -> dict[str, Any]:
     return resp.json()
 
 
+def _normalize_row_source(value: Any) -> str:
+    if value in {_ROW_SOURCE_BODY, "object"}:
+        return _ROW_SOURCE_BODY
+    return _ROW_SOURCE_KEY
+
+
+@dataclass(frozen=True)
+class PaginationSpec:
+    """Typed REST_TABLE pagination recipe compiled from ``AccessSpec.params``."""
+
+    data_key: Any = "data"
+    next_key: Any | None = None
+    row_source: str = _ROW_SOURCE_KEY
+    empty_statuses: frozenset[Any] = field(default_factory=frozenset)
+    empty_body_is_empty: bool = False
+    max_pages: int = _DEFAULT_MAX_PAGES
+    max_rows: int | None = None
+    max_total_seconds: float | None = None
+
+    @classmethod
+    def from_params(cls, params: dict[str, Any]) -> PaginationSpec:
+        pagination = dict(params.get("pagination") or {})
+        row_source = pagination.get("row_source", pagination.get("row_shape"))
+        max_rows = pagination.get("max_rows")
+        max_total_seconds = pagination.get("max_total_seconds")
+        return cls(
+            data_key=pagination.get("data_key", "data"),
+            next_key=pagination.get("next_key"),
+            row_source=_normalize_row_source(row_source),
+            empty_statuses=frozenset(pagination.get("empty_statuses") or []),
+            empty_body_is_empty=bool(pagination.get("empty_body_is_empty", False)),
+            max_pages=int(pagination.get("max_pages", _DEFAULT_MAX_PAGES)),
+            max_rows=int(max_rows) if max_rows is not None else None,
+            max_total_seconds=(
+                float(max_total_seconds) if max_total_seconds is not None else None
+            ),
+        )
+
+
+def _rows_from_body(body: dict[str, Any], spec: PaginationSpec) -> list[Any]:
+    if spec.row_source == _ROW_SOURCE_BODY:
+        return [body]
+    page_rows = body.get(spec.data_key)
+    if isinstance(page_rows, list):  # ignore a non-list data_key
+        return page_rows
+    return []
+
+
+def _next_page_url(
+    body: dict[str, Any],
+    current_url: str,
+    origin: str,
+    seen: set[str],
+    spec: PaginationSpec,
+) -> str | None:
+    nxt = body.get(spec.next_key) if spec.next_key else None
+    if not nxt:
+        return None
+    # Resolve a relative ``next`` ("?page=2") against the current page URL,
+    # then re-guard the absolute result before the next request.
+    candidate = urljoin(current_url, str(nxt))
+    if candidate not in seen and _same_origin(origin, candidate):
+        return candidate
+    return None
+
+
+def _write_jsonl(
+    rows: list[Any],
+    local_path: str | PathLike[str] | None,
+) -> tuple[str | PathLike[str], str, int]:
+    if not local_path:
+        handle = tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False)
+        handle.close()
+        local_path = handle.name
+    digest = hashlib.sha256()
+    row_count = 0
+    with open(local_path, "wb") as fh:
+        for row in rows:
+            line = (json.dumps(row, separators=(",", ":")) + "\n").encode("utf-8")
+            digest.update(line)
+            fh.write(line)
+            row_count += 1
+    return local_path, digest.hexdigest(), row_count
+
+
 class RestTableFetcher:
     """:class:`~core.sources.Fetcher` for ``AccessProtocol.REST_TABLE``."""
 
@@ -89,27 +178,10 @@ class RestTableFetcher:
 
         params = dict(access.params or {})
         timeout = float(params.get("timeout", _DEFAULT_TIMEOUT_S))
-        pagination = dict(params.get("pagination") or {})
-        data_key = pagination.get("data_key", "data")
-        next_key = pagination.get("next_key")
-        # "list" (default): rows live in body[data_key]; "object": the whole
-        # JSON body is a single row (non-paginated single-object endpoints,
-        # e.g. Géorisques RGA/SSP 2024+).
-        row_shape = pagination.get("row_shape", "list")
-        # HTTP statuses that mean "no data here" rather than an error — the
-        # walk treats them as an empty result (e.g. Géorisques tri_zonage 404).
-        empty_statuses = set(pagination.get("empty_statuses") or [])
-        empty_body_is_empty = bool(pagination.get("empty_body_is_empty", False))
-        max_pages = int(pagination.get("max_pages", _DEFAULT_MAX_PAGES))
-        max_rows = pagination.get("max_rows")
-        max_rows = int(max_rows) if max_rows is not None else None
-        max_total_seconds = pagination.get("max_total_seconds")
-        max_total_seconds = (
-            float(max_total_seconds) if max_total_seconds is not None else None
-        )
+        pagination = PaginationSpec.from_params(params)
         deadline = (
-            time.monotonic() + max_total_seconds
-            if max_total_seconds is not None
+            time.monotonic() + pagination.max_total_seconds
+            if pagination.max_total_seconds is not None
             else None
         )
 
@@ -132,55 +204,30 @@ class RestTableFetcher:
             try:
                 body = _get_json(url, timeout)
             except httpx.HTTPStatusError as exc:
-                if exc.response.status_code in empty_statuses:
+                if exc.response.status_code in pagination.empty_statuses:
                     break  # "no data here" — leave the result empty
                 raise
             except json.JSONDecodeError:
-                if empty_body_is_empty:
+                if pagination.empty_body_is_empty:
                     break  # empty/malformed body configured as "no data here"
                 raise
             page_count += 1
-            if row_shape == "object":
-                rows.append(body)  # the whole body is a single row
-            else:
-                page_rows = body.get(data_key)
-                if isinstance(page_rows, list):  # ignore a non-list data_key
-                    rows.extend(page_rows)
-            if max_rows is not None and len(rows) >= max_rows:
-                del rows[max_rows:]
+            rows.extend(_rows_from_body(body, pagination))
+            if pagination.max_rows is not None and len(rows) >= pagination.max_rows:
+                del rows[pagination.max_rows :]
                 break
-            if page_count >= max_pages:
+            if page_count >= pagination.max_pages:
                 break
             if deadline is not None and time.monotonic() >= deadline:
                 break
-            nxt = body.get(next_key) if next_key else None
-            if nxt:
-                # Resolve a relative ``next`` ("?page=2") against the current
-                # page URL, then re-guard the absolute result.
-                candidate = urljoin(url, str(nxt))
-                if candidate not in seen and _same_origin(origin, candidate):
-                    url = candidate
-                else:
-                    url = None
-            else:
-                url = None
+            url = _next_page_url(body, url, origin, seen, pagination)
 
-        local_path = params.get("local_path")
-        if not local_path:
-            handle = tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False)
-            handle.close()
-            local_path = handle.name
-        digest = hashlib.sha256()
-        with open(local_path, "wb") as fh:
-            for row in rows:
-                line = (json.dumps(row, separators=(",", ":")) + "\n").encode("utf-8")
-                digest.update(line)
-                fh.write(line)
+        local_path, sha256, row_count = _write_jsonl(rows, params.get("local_path"))
 
         log.info(
             "rest_table_materialized",
             endpoint=access.endpoint,
-            row_count=len(rows),
+            row_count=row_count,
             page_count=page_count,
         )
         return SourceResult(
@@ -188,10 +235,10 @@ class RestTableFetcher:
             mode=FetchMode.MATERIALIZE,
             data=local_path,
             metadata={
-                "row_count": len(rows),
+                "row_count": row_count,
                 "page_count": page_count,
                 "source_url": access.endpoint,
-                "sha256": digest.hexdigest(),
+                "sha256": sha256,
             },
         )
 

--- a/src/gispulse/persistence/storage.py
+++ b/src/gispulse/persistence/storage.py
@@ -40,6 +40,21 @@ class StorageError(Exception):
     """Raised when a storage operation fails."""
 
 
+def _make_s3_boto_config(BotoConfig):
+    base = {
+        "signature_version": "s3v4",
+        "retries": {"max_attempts": 3, "mode": "standard"},
+    }
+    checksum_compat = {
+        "request_checksum_calculation": "when_required",
+        "response_checksum_validation": "when_required",
+    }
+    try:
+        return BotoConfig(**base, **checksum_compat)
+    except TypeError:
+        return BotoConfig(**base)
+
+
 def validate_storage_key(key: str) -> str:
     """Validate and normalize a storage key, rejecting traversal attempts.
 
@@ -235,10 +250,7 @@ class S3Storage(DatasetStorage):
             aws_access_key_id=access_key or None,
             aws_secret_access_key=secret_key or None,
             region_name=region,
-            config=BotoConfig(
-                signature_version="s3v4",
-                retries={"max_attempts": 3, "mode": "standard"},
-            ),
+            config=_make_s3_boto_config(BotoConfig),
         )
 
         # Ensure bucket exists (MinIO-friendly)

--- a/tests/unit/test_rest_table_fetcher.py
+++ b/tests/unit/test_rest_table_fetcher.py
@@ -56,6 +56,47 @@ def test_single_page_materializes_rows_to_jsonl(
     assert rows == [{"code_insee": "63113"}, {"code_insee": "63001"}]
 
 
+def test_s3_uri_materializes_rows_to_storage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import hashlib
+
+    from gispulse.adapters.rest import rest_table_fetcher
+    from gispulse.adapters.rest.rest_table_fetcher import RestTableFetcher
+
+    def fake_get(url: str, timeout: float) -> dict:
+        return {"data": [{"code_insee": "63113"}, {"code_insee": "63001"}]}
+
+    captured: dict[str, object] = {}
+
+    def fake_upload(s3_uri: str, body) -> None:
+        captured["s3_uri"] = s3_uri
+        captured["body"] = body.read()
+
+    monkeypatch.setattr(rest_table_fetcher, "_get_json", fake_get)
+    monkeypatch.setattr(
+        rest_table_fetcher, "_upload_jsonl_to_s3", fake_upload, raising=False
+    )
+
+    uri = "s3://gispulse/raw/georisques/radon-63113.jsonl"
+    access = AccessSpec(
+        protocol=AccessProtocol.REST_TABLE,
+        endpoint="https://www.georisques.gouv.fr/api/v1/radon",
+        params={"s3_uri": uri},
+    )
+    result = RestTableFetcher().fetch(access)
+
+    body = b'{"code_insee":"63113"}\n{"code_insee":"63001"}\n'
+    assert result.payload is Payload.TABLE
+    assert result.mode is FetchMode.MATERIALIZE
+    assert result.data == uri
+    assert result.reference == uri
+    assert result.metadata["s3_uri"] == uri
+    assert result.metadata["row_count"] == 2
+    assert result.metadata["sha256"] == hashlib.sha256(body).hexdigest()
+    assert captured == {"s3_uri": uri, "body": body}
+
+
 def test_follows_next_url_and_accumulates_pages(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/unit/test_rest_table_fetcher.py
+++ b/tests/unit/test_rest_table_fetcher.py
@@ -595,7 +595,7 @@ def test_non_empty_status_still_raises(
         RestTableFetcher().fetch(access)
 
 
-def test_object_row_shape_wraps_whole_body(
+def test_body_row_source_wraps_whole_body(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     from gispulse.adapters.rest import rest_table_fetcher
@@ -613,7 +613,7 @@ def test_object_row_shape_wraps_whole_body(
         endpoint="https://geo.example.org/api/v1/rga",
         params={
             "local_path": str(out),
-            "pagination": {"row_shape": "object"},
+            "pagination": {"row_source": "body"},
         },
     )
     result = RestTableFetcher().fetch(access)

--- a/tests/unit/test_rest_table_fetcher.py
+++ b/tests/unit/test_rest_table_fetcher.py
@@ -397,6 +397,51 @@ def test_non_list_data_key_yields_no_rows(
     assert result.metadata["row_count"] == 0
 
 
+def test_empty_body_decode_error_can_be_treated_as_empty(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from gispulse.adapters.rest import rest_table_fetcher
+    from gispulse.adapters.rest.rest_table_fetcher import RestTableFetcher
+
+    def fake_get(url: str, timeout: float) -> dict:
+        raise json.JSONDecodeError("Expecting value", "", 0)
+
+    monkeypatch.setattr(rest_table_fetcher, "_get_json", fake_get)
+
+    access = AccessSpec(
+        protocol=AccessProtocol.REST_TABLE,
+        endpoint="https://geo.example.org/api/v1/rga",
+        params={
+            "local_path": str(tmp_path / "out.jsonl"),
+            "pagination": {"empty_body_is_empty": True},
+        },
+    )
+    result = RestTableFetcher().fetch(access)
+
+    assert result.metadata["row_count"] == 0
+    assert Path(result.data).read_text() == ""
+
+
+def test_empty_body_decode_error_still_raises_by_default(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from gispulse.adapters.rest import rest_table_fetcher
+    from gispulse.adapters.rest.rest_table_fetcher import RestTableFetcher
+
+    def fake_get(url: str, timeout: float) -> dict:
+        raise json.JSONDecodeError("Expecting value", "", 0)
+
+    monkeypatch.setattr(rest_table_fetcher, "_get_json", fake_get)
+
+    access = AccessSpec(
+        protocol=AccessProtocol.REST_TABLE,
+        endpoint="https://geo.example.org/api/v1/rga",
+        params={"local_path": str(tmp_path / "out.jsonl")},
+    )
+    with pytest.raises(json.JSONDecodeError):
+        RestTableFetcher().fetch(access)
+
+
 def test_get_json_disables_redirects(monkeypatch: pytest.MonkeyPatch) -> None:
     import httpx
 
@@ -492,3 +537,87 @@ def test_rejects_malicious_next_urls(
 
     assert calls == [origin]  # the malicious next is never followed
     assert result.metadata["page_count"] == 1
+
+
+def test_empty_status_returns_empty_table(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import httpx
+
+    from gispulse.adapters.rest import rest_table_fetcher
+    from gispulse.adapters.rest.rest_table_fetcher import RestTableFetcher
+
+    def fake_get(url: str, timeout: float) -> dict:
+        request = httpx.Request("GET", url)
+        response = httpx.Response(404, request=request)
+        raise httpx.HTTPStatusError("404", request=request, response=response)
+
+    monkeypatch.setattr(rest_table_fetcher, "_get_json", fake_get)
+
+    access = AccessSpec(
+        protocol=AccessProtocol.REST_TABLE,
+        endpoint="https://geo.example.org/api/v1/tri_zonage",
+        params={
+            "local_path": str(tmp_path / "out.jsonl"),
+            "pagination": {"empty_statuses": [404]},
+        },
+    )
+    result = RestTableFetcher().fetch(access)
+
+    assert result.metadata["row_count"] == 0
+    assert result.metadata["page_count"] == 0
+
+
+def test_non_empty_status_still_raises(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import httpx
+
+    from gispulse.adapters.rest import rest_table_fetcher
+    from gispulse.adapters.rest.rest_table_fetcher import RestTableFetcher
+
+    def fake_get(url: str, timeout: float) -> dict:
+        request = httpx.Request("GET", url)
+        response = httpx.Response(500, request=request)
+        raise httpx.HTTPStatusError("500", request=request, response=response)
+
+    monkeypatch.setattr(rest_table_fetcher, "_get_json", fake_get)
+
+    access = AccessSpec(
+        protocol=AccessProtocol.REST_TABLE,
+        endpoint="https://geo.example.org/api/v1/tri_zonage",
+        params={
+            "local_path": str(tmp_path / "out.jsonl"),
+            "pagination": {"empty_statuses": [404]},  # 500 not listed → must raise
+        },
+    )
+    with pytest.raises(httpx.HTTPStatusError):
+        RestTableFetcher().fetch(access)
+
+
+def test_object_row_shape_wraps_whole_body(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from gispulse.adapters.rest import rest_table_fetcher
+    from gispulse.adapters.rest.rest_table_fetcher import RestTableFetcher
+
+    def fake_get(url: str, timeout: float) -> dict:
+        # Géorisques RGA 2024+ shape: a top-level object, no "data" list.
+        return {"codeExposition": "2", "exposition": "moyen"}
+
+    monkeypatch.setattr(rest_table_fetcher, "_get_json", fake_get)
+
+    out = tmp_path / "out.jsonl"
+    access = AccessSpec(
+        protocol=AccessProtocol.REST_TABLE,
+        endpoint="https://geo.example.org/api/v1/rga",
+        params={
+            "local_path": str(out),
+            "pagination": {"row_shape": "object"},
+        },
+    )
+    result = RestTableFetcher().fetch(access)
+
+    assert result.metadata["row_count"] == 1
+    rows = [json.loads(line) for line in out.read_text().splitlines()]
+    assert rows == [{"codeExposition": "2", "exposition": "moyen"}]

--- a/tests/unit/test_src_georisques.py
+++ b/tests/unit/test_src_georisques.py
@@ -1,0 +1,158 @@
+"""Unit tests for the gispulse-src-georisques plugin (#196).
+
+Zero-network: the plugin only *declares* AccessSpecs against REST_TABLE and
+builds per-query AccessSpecs via :meth:`GeorisquesSource.access_for`. The
+actual fetch is the core ``RestTableFetcher``'s job (tested elsewhere).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_PKG = Path(__file__).resolve().parents[2] / "plugins" / "gispulse-src-georisques"
+if str(_PKG) not in sys.path:
+    sys.path.insert(0, str(_PKG))
+
+from gispulse_src_georisques.source import GeorisquesSource  # noqa: E402
+
+from gispulse.core.plugin_model import (  # noqa: E402
+    AccessProtocol,
+    Payload,
+    SourceDomain,
+)
+from gispulse.core.sources import DataSource  # noqa: E402
+
+_CODE_INSEE_ENTRIES = {"gaspar-risques", "radon", "sismicite"}
+_LATLON_ENTRIES = {"rga", "tri-zonage", "ssp"}
+
+
+@pytest.fixture
+def source() -> GeorisquesSource:
+    return GeorisquesSource()
+
+
+def test_is_a_datasource(source: GeorisquesSource) -> None:
+    assert isinstance(source, DataSource)
+    assert source.name == "georisques"
+    assert source.domain is SourceDomain.ENVIRONNEMENT
+    assert source.payload is Payload.TABLE
+    assert source.jurisdiction == "FR"
+
+
+def test_declares_six_entries(source: GeorisquesSource) -> None:
+    ids = {e.id for e in source.entries()}
+    assert ids == _CODE_INSEE_ENTRIES | _LATLON_ENTRIES
+
+
+def test_all_entries_use_rest_table(source: GeorisquesSource) -> None:
+    for entry in source.entries():
+        assert entry.access.protocol is AccessProtocol.REST_TABLE
+        assert entry.access.endpoint.startswith("https://www.georisques.gouv.fr/")
+
+
+def test_query_key_metadata(source: GeorisquesSource) -> None:
+    by_id = {e.id: e for e in source.entries()}
+    for entry_id in _CODE_INSEE_ENTRIES:
+        assert by_id[entry_id].metadata["query_key"] == "code_insee"
+    for entry_id in _LATLON_ENTRIES:
+        assert by_id[entry_id].metadata["query_key"] == "latlon"
+
+
+def test_rga_and_ssp_use_object_row_shape(source: GeorisquesSource) -> None:
+    by_id = {e.id: e for e in source.entries()}
+    for entry_id in ("rga", "ssp"):
+        assert by_id[entry_id].access.params["pagination"]["row_shape"] == "object"
+
+
+def test_rga_treats_empty_body_as_empty(source: GeorisquesSource) -> None:
+    by_id = {e.id: e for e in source.entries()}
+    assert by_id["rga"].access.params["pagination"]["empty_body_is_empty"] is True
+
+
+def test_tri_treats_404_as_empty(source: GeorisquesSource) -> None:
+    by_id = {e.id: e for e in source.entries()}
+    assert 404 in by_id["tri-zonage"].access.params["pagination"]["empty_statuses"]
+
+
+def test_access_for_merges_code_insee(source: GeorisquesSource) -> None:
+    access = source.access_for("radon", code_insee="63113", local_path="/tmp/r.jsonl")
+    assert access.protocol is AccessProtocol.REST_TABLE
+    assert access.params["query"]["code_insee"] == "63113"
+    assert access.params["local_path"] == "/tmp/r.jsonl"
+
+
+def test_access_for_merges_latlon_and_preserves_static_query(
+    source: GeorisquesSource,
+) -> None:
+    access = source.access_for("ssp", latlon="3.08,45.77", local_path="/tmp/ssp.jsonl")
+    assert access.params["query"]["latlon"] == "3.08,45.77"
+    assert access.params["query"]["rayon"] == 500
+    assert access.params["query"]["page_size"] == 5
+    assert access.params["pagination"]["row_shape"] == "object"
+
+
+def test_access_for_unknown_entry_raises(source: GeorisquesSource) -> None:
+    with pytest.raises(KeyError, match="unknown_entry"):
+        source.access_for("unknown_entry", code_insee="x")
+
+
+def test_access_for_rejects_wrong_query_arg(source: GeorisquesSource) -> None:
+    # radon is a code_insee endpoint — passing latlon is a usage error
+    with pytest.raises(ValueError):
+        source.access_for("radon", latlon="3.08,45.77")
+
+
+def test_access_for_copies_nested_pagination(source: GeorisquesSource) -> None:
+    first = source.access_for("ssp", latlon="3.08,45.77")
+    first.params["pagination"]["row_shape"] = "mutated"
+
+    second = source.access_for("ssp", latlon="3.09,45.78")
+    entry = source._entry("ssp")
+
+    assert first.params["query"]["latlon"] == "3.08,45.77"
+    assert second.params["query"]["latlon"] == "3.09,45.78"
+    assert second.params["pagination"]["row_shape"] == "object"
+    assert entry.access.params["pagination"]["row_shape"] == "object"
+
+
+def test_schema_radon_exposes_raw_classe_potentiel(source: GeorisquesSource) -> None:
+    schema = source.schema("radon")
+    assert "classe_potentiel" in schema
+
+
+def test_schema_gaspar_exposes_raw_risques_detail(source: GeorisquesSource) -> None:
+    schema = source.schema("gaspar-risques")
+    assert schema["code_insee"] == "str"
+    assert schema["risques_detail"] == "json"
+    assert "num_risque" not in schema
+    assert "libelle_risque_long" not in schema
+
+
+def test_schema_sismicite_exposes_raw_zone_fields(source: GeorisquesSource) -> None:
+    schema = source.schema("sismicite")
+    assert schema["code_zone"] == "str"
+    assert schema["libelle_commune"] == "str"
+
+
+def test_schema_ssp_exposes_raw_casias_payload(source: GeorisquesSource) -> None:
+    schema = source.schema("ssp")
+    assert schema["casias"] == "json"
+    assert schema["instructions"] == "json"
+    assert schema["conclusions_sis"] == "json"
+    assert schema["conclusions_sup"] == "json"
+    assert "results" not in schema
+
+
+def test_revision_is_none(source: GeorisquesSource) -> None:
+    assert source.revision("radon") is None
+
+
+def test_register_adds_source_to_registry() -> None:
+    from gispulse.core.sources import SOURCES
+    from gispulse_src_georisques import register
+
+    register()
+    assert SOURCES.get("georisques") is not None

--- a/tests/unit/test_src_georisques.py
+++ b/tests/unit/test_src_georisques.py
@@ -61,10 +61,10 @@ def test_query_key_metadata(source: GeorisquesSource) -> None:
         assert by_id[entry_id].metadata["query_key"] == "latlon"
 
 
-def test_rga_and_ssp_use_object_row_shape(source: GeorisquesSource) -> None:
+def test_rga_and_ssp_use_body_row_source(source: GeorisquesSource) -> None:
     by_id = {e.id: e for e in source.entries()}
     for entry_id in ("rga", "ssp"):
-        assert by_id[entry_id].access.params["pagination"]["row_shape"] == "object"
+        assert by_id[entry_id].access.params["pagination"]["row_source"] == "body"
 
 
 def test_rga_treats_empty_body_as_empty(source: GeorisquesSource) -> None:
@@ -91,7 +91,7 @@ def test_access_for_merges_latlon_and_preserves_static_query(
     assert access.params["query"]["latlon"] == "3.08,45.77"
     assert access.params["query"]["rayon"] == 500
     assert access.params["query"]["page_size"] == 5
-    assert access.params["pagination"]["row_shape"] == "object"
+    assert access.params["pagination"]["row_source"] == "body"
 
 
 def test_access_for_unknown_entry_raises(source: GeorisquesSource) -> None:
@@ -107,15 +107,15 @@ def test_access_for_rejects_wrong_query_arg(source: GeorisquesSource) -> None:
 
 def test_access_for_copies_nested_pagination(source: GeorisquesSource) -> None:
     first = source.access_for("ssp", latlon="3.08,45.77")
-    first.params["pagination"]["row_shape"] = "mutated"
+    first.params["pagination"]["row_source"] = "mutated"
 
     second = source.access_for("ssp", latlon="3.09,45.78")
     entry = source._entry("ssp")
 
     assert first.params["query"]["latlon"] == "3.08,45.77"
     assert second.params["query"]["latlon"] == "3.09,45.78"
-    assert second.params["pagination"]["row_shape"] == "object"
-    assert entry.access.params["pagination"]["row_shape"] == "object"
+    assert second.params["pagination"]["row_source"] == "body"
+    assert entry.access.params["pagination"]["row_source"] == "body"
 
 
 def test_schema_radon_exposes_raw_classe_potentiel(source: GeorisquesSource) -> None:

--- a/tests/unit/test_src_georisques.py
+++ b/tests/unit/test_src_georisques.py
@@ -84,6 +84,16 @@ def test_access_for_merges_code_insee(source: GeorisquesSource) -> None:
     assert access.params["local_path"] == "/tmp/r.jsonl"
 
 
+def test_access_for_can_target_s3_key(source: GeorisquesSource) -> None:
+    access = source.access_for(
+        "radon",
+        code_insee="63113",
+        s3_key="raw/georisques/radon/63113.jsonl",
+    )
+    assert access.params["query"]["code_insee"] == "63113"
+    assert access.params["s3_key"] == "raw/georisques/radon/63113.jsonl"
+
+
 def test_access_for_merges_latlon_and_preserves_static_query(
     source: GeorisquesSource,
 ) -> None:

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -15,6 +15,7 @@ from gispulse.persistence.storage import (
     LocalStorage,
     StorageError,
     create_storage,
+    _make_s3_boto_config,
     validate_storage_key,
 )
 
@@ -201,6 +202,40 @@ class TestS3Storage:
         key = _run(storage.upload("org1/ds1/file.gpkg", b"data", "application/geopackage"))
         assert key == "org1/ds1/file.gpkg"
         client.upload_fileobj.assert_called_once()
+
+    def test_boto_config_uses_garage_compatible_checksums(self):
+        mock_boto3, mock_botocore_config, _ = _make_mock_boto3()
+        _create_s3_storage(mock_boto3, mock_botocore_config)
+
+        mock_botocore_config.Config.assert_called_once_with(
+            signature_version="s3v4",
+            retries={"max_attempts": 3, "mode": "standard"},
+            request_checksum_calculation="when_required",
+            response_checksum_validation="when_required",
+        )
+
+    def test_boto_config_falls_back_for_older_botocore(self):
+        mock_config = MagicMock(side_effect=[TypeError("unknown"), "legacy-config"])
+
+        assert _make_s3_boto_config(mock_config) == "legacy-config"
+        assert mock_config.call_args_list == [
+            (
+                (),
+                {
+                    "signature_version": "s3v4",
+                    "retries": {"max_attempts": 3, "mode": "standard"},
+                    "request_checksum_calculation": "when_required",
+                    "response_checksum_validation": "when_required",
+                },
+            ),
+            (
+                (),
+                {
+                    "signature_version": "s3v4",
+                    "retries": {"max_attempts": 3, "mode": "standard"},
+                },
+            ),
+        ]
 
     def test_download(self):
         storage, client = self._make()

--- a/uv.lock
+++ b/uv.lock
@@ -981,7 +981,7 @@ wheels = [
 
 [[package]]
 name = "gispulse"
-version = "1.6.2"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
## Quoi

Nouveau plugin `gispulse-src-georisques` : les **6 endpoints Géorisques v1** (GASPAR, radon, sismicité, RGA, TRI, sites & sols pollués) exposés comme `DeclarativeSource` sur `AccessProtocol.REST_TABLE`.

Cette PR ajoute aussi le chemin attendu pour l'ingestion beta : `RestTableFetcher` peut maintenant matérialiser les lignes REST_TABLE en JSONL local **ou directement dans S3/Garage** via `s3_uri` / `s3_key`.

## Détails

- 6 entrées : `gaspar-risques`/`radon`/`sismicite` (filtre `code_insee`), `rga`/`tri-zonage`/`ssp` (filtre `latlon`).
- Helper sans réseau `access_for(entry_id, code_insee|latlon, local_path|s3_uri|s3_key)` : l'orchestrateur d'ingestion injecte la clé spatiale runtime et la destination de matérialisation dans `params`.
- `schema()` expose les **champs bruts upstream** ; la normalisation (`radon_class`, `RiskConstraint`…) reste dans le produit consommateur (permis/dbt).
- `RestTableFetcher` streame les lignes en JSONL au fil des pages au lieu d'accumuler toute la réponse en mémoire, puis retourne un `s3://...` quand la destination est Garage/S3.
- `S3Storage` configure botocore en mode checksum compatible Garage (`when_required`) avec fallback pour anciens botocore.

Extensions REST_TABLE conservées :
- `pagination.empty_statuses=[404]` → table vide au lieu de lever (TRI absent).
- `pagination.row_shape="object"` → emballe un body JSON top-level comme 1 ligne (RGA/SSP API 2024+).
- `pagination.empty_body_is_empty=True` → RGA répond parfois `200` body vide.

## Tests

- `pytest tests/unit/test_rest_table_fetcher.py tests/unit/test_src_georisques.py tests/unit/test_storage.py -q` → 90 passed.
- `ruff check` sur les fichiers modifiés → clean.
- Smoke réel Garage : REST_TABLE mock Géorisques écrit un JSONL dans `s3://gispulse/_codex/...`, relit l'objet, puis le supprime.
