### PR TITLE
feat(src-nature): protected-areas source (Natura 2000 + ZNIEFF) over REST_API

### DIFF
--- a/plugins/gispulse-src-nature/README.md
+++ b/plugins/gispulse-src-nature/README.md
@@ -1,0 +1,31 @@
+# gispulse-src-nature
+
+IGN / INPN protected natural areas for GISPulse via API Carto Nature
+(domain: `ENVIRONNEMENT`, jurisdiction: `FR`).
+
+## Provider
+
+| Field             | Value                           |
+|-------------------|---------------------------------|
+| Upstream producer | IGN / INPN                      |
+| Platform          | API Carto Nature                |
+| Base endpoint     | `https://apicarto.ign.fr/api/nature` |
+| Licence           | Licence Ouverte 2.0             |
+
+## Entries
+
+All entries use `AccessProtocol.REST_API`, format `application/json`, and
+`params = {"geom_param": "geom"}` so the REST GeoJSON fetcher sends the
+runtime extent as a GeoJSON polygon in the `geom` query parameter.
+
+| id                | Label                          | Path              |
+|-------------------|--------------------------------|-------------------|
+| `natura-habitat`  | Natura 2000 directive Habitat  | `/natura-habitat` |
+| `natura-oiseaux`  | Natura 2000 directive Oiseaux  | `/natura-oiseaux` |
+| `znieff1`         | ZNIEFF type 1                  | `/znieff1`        |
+| `znieff2`         | ZNIEFF type 2                  | `/znieff2`        |
+
+## Revision
+
+`revision(entry_id)` returns `None`: the API is queried with a runtime
+geometry filter and exposes no simple dataset-wide freshness probe.

--- a/plugins/gispulse-src-nature/gispulse_src_nature/__init__.py
+++ b/plugins/gispulse-src-nature/gispulse_src_nature/__init__.py
@@ -1,0 +1,14 @@
+"""GISPulse data-source plugin — API Carto Nature (IGN / INPN)."""
+
+from __future__ import annotations
+
+
+def register() -> None:
+    """Entry-point hook for the ``gispulse.data_sources`` group."""
+    import sys
+
+    from gispulse.plugins.api import DataSource
+    from gispulse_src_nature.source import NatureSource
+
+    sources = getattr(sys.modules[DataSource.__module__], "SOURCES")
+    sources.register(NatureSource())

--- a/plugins/gispulse-src-nature/gispulse_src_nature/source.py
+++ b/plugins/gispulse-src-nature/gispulse_src_nature/source.py
@@ -1,0 +1,92 @@
+"""French protected natural areas via IGN API Carto Nature.
+
+This source is intentionally declarative: each entry points at an API
+Carto Nature REST endpoint, and the core ``RestGeoJsonFetcher`` injects
+the runtime extent as a GeoJSON polygon in the ``geom`` query parameter.
+"""
+
+from __future__ import annotations
+
+from gispulse.plugins.api import (
+    AccessProtocol,
+    AccessSpec,
+    DeclarativeSource,
+    Payload,
+    SourceDomain,
+    SourceEntryRef,
+)
+
+_API_CARTO_NATURE = "https://apicarto.ign.fr/api/nature"
+_METADATA = {
+    "provider": "IGN / INPN",
+    "platform": "API Carto Nature",
+    "license": "Licence Ouverte 2.0",
+}
+
+# Entry-id -> (display label, API Carto Nature path).
+_ENTRIES: dict[str, tuple[str, str]] = {
+    "natura-habitat": (
+        "Natura 2000 directive Habitat",
+        "/natura-habitat",
+    ),
+    "natura-oiseaux": (
+        "Natura 2000 directive Oiseaux",
+        "/natura-oiseaux",
+    ),
+    "znieff1": (
+        "ZNIEFF type 1",
+        "/znieff1",
+    ),
+    "znieff2": (
+        "ZNIEFF type 2",
+        "/znieff2",
+    ),
+}
+
+_RAW_SCHEMA = {
+    "gml_id": "str",
+    "id": "str",
+    "nom": "str",
+    "sitename": "str",
+    "sitecode": "str",
+    "geometry": "geometry",
+}
+
+
+class NatureSource(DeclarativeSource):
+    """Protected natural areas from IGN / INPN API Carto Nature."""
+
+    name = "nature"
+    domain = SourceDomain.ENVIRONNEMENT
+    payload = Payload.VECTOR
+    jurisdiction = "FR"
+
+    def entries(self) -> list[SourceEntryRef]:
+        return [
+            SourceEntryRef(
+                id=entry_id,
+                name=label,
+                access=AccessSpec(
+                    protocol=AccessProtocol.REST_API,
+                    endpoint=f"{_API_CARTO_NATURE}{path}",
+                    params={"geom_param": "geom"},
+                    format="application/json",
+                ),
+                revision_token=None,
+                domain=self.domain,
+                payload=self.payload,
+                jurisdiction=self.jurisdiction,
+                metadata=dict(_METADATA),
+            )
+            for entry_id, (label, path) in _ENTRIES.items()
+        ]
+
+    def schema(self, entry_id: str) -> dict:
+        """Expose raw upstream fields without domain-level normalisation."""
+        self._entry(entry_id)
+        return dict(_RAW_SCHEMA)
+
+    def revision(self, entry_id: str) -> str | None:
+        """No cheap freshness probe exists for geometry-filtered runtime calls."""
+        self._entry(entry_id)
+        return None

--- a/plugins/gispulse-src-nature/pyproject.toml
+++ b/plugins/gispulse-src-nature/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gispulse-src-nature"
+version = "0.1.0"
+description = "IGN API Carto Nature data source for GISPulse"
+requires-python = ">=3.10"
+license = "AGPL-3.0-or-later"
+authors = [{ name = "GISPulse", email = "dev@gispulse.io" }]
+dependencies = [
+    "gispulse>=2.0.0,<3.0.0",
+]
+
+# Registered as a data source — discovered by core.plugin_hub.PluginHub.
+[project.entry-points."gispulse.data_sources"]
+nature = "gispulse_src_nature:register"
+
+[tool.gispulse.plugin]
+kind = "source"
+protocol = ">=1.0,<2.0"
+domain = "environnement"
+jurisdiction = "FR"
+display_name = "API Carto Nature (IGN / INPN)"

--- a/tests/unit/test_src_nature.py
+++ b/tests/unit/test_src_nature.py
@@ -1,0 +1,163 @@
+"""Unit tests for the gispulse-src-nature plugin."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+
+from gispulse.adapters.rest.rest_fetcher import register_rest_geojson_fetcher
+from gispulse.plugins.api import (
+    AccessProtocol,
+    DataSource,
+    Payload,
+    ProtocolRegistry,
+    SourceDomain,
+)
+
+_PKG = Path(__file__).resolve().parents[2] / "plugins" / "gispulse-src-nature"
+if str(_PKG) not in sys.path:
+    sys.path.insert(0, str(_PKG))
+
+_API_CARTO_NATURE = "https://apicarto.ign.fr/api/nature"
+_EXPECTED_ENTRIES = {
+    "natura-habitat": (
+        "Natura 2000 directive Habitat",
+        "/natura-habitat",
+    ),
+    "natura-oiseaux": (
+        "Natura 2000 directive Oiseaux",
+        "/natura-oiseaux",
+    ),
+    "znieff1": (
+        "ZNIEFF type 1",
+        "/znieff1",
+    ),
+    "znieff2": (
+        "ZNIEFF type 2",
+        "/znieff2",
+    ),
+}
+
+
+def _nature_source_cls():
+    try:
+        module = importlib.import_module("gispulse_src_nature.source")
+    except ModuleNotFoundError as exc:
+        pytest.fail(f"gispulse-src-nature source module should exist: {exc}")
+    return module.NatureSource
+
+
+@pytest.fixture
+def source():
+    return _nature_source_cls()()
+
+
+def test_nature_is_a_datasource(source) -> None:
+    assert isinstance(source, DataSource)
+    assert source.name == "nature"
+    assert source.domain is SourceDomain.ENVIRONNEMENT
+    assert source.payload is Payload.VECTOR
+    assert source.jurisdiction == "FR"
+
+
+def test_catalog_lists_four_nature_entries(source) -> None:
+    entries = source.catalog()
+    assert [entry.id for entry in entries] == list(_EXPECTED_ENTRIES)
+
+    for entry in entries:
+        label, path = _EXPECTED_ENTRIES[entry.id]
+        assert entry.name == label
+        assert entry.domain is SourceDomain.ENVIRONNEMENT
+        assert entry.payload is Payload.VECTOR
+        assert entry.jurisdiction == "FR"
+        assert entry.metadata == {
+            "provider": "IGN / INPN",
+            "platform": "API Carto Nature",
+            "license": "Licence Ouverte 2.0",
+        }
+        assert entry.access.protocol is AccessProtocol.REST_API
+        assert entry.access.endpoint == f"{_API_CARTO_NATURE}{path}"
+        assert entry.access.params == {"geom_param": "geom"}
+        assert entry.access.format == "application/json"
+
+
+def test_catalog_search_filters_by_id_or_label(source) -> None:
+    assert [entry.id for entry in source.catalog(search="oiseaux")] == [
+        "natura-oiseaux"
+    ]
+    assert [entry.id for entry in source.catalog(search="znieff")] == [
+        "znieff1",
+        "znieff2",
+    ]
+
+
+def test_schema_exposes_raw_api_carto_nature_fields(source) -> None:
+    expected_fields = {
+        "gml_id": "str",
+        "id": "str",
+        "nom": "str",
+        "sitename": "str",
+        "sitecode": "str",
+        "geometry": "geometry",
+    }
+
+    for entry_id in _EXPECTED_ENTRIES:
+        schema = source.schema(entry_id)
+        for field, kind in expected_fields.items():
+            assert schema[field] == kind
+
+
+def test_revision_is_unknown_without_a_runtime_geometry_probe(source) -> None:
+    for entry_id in _EXPECTED_ENTRIES:
+        assert source.revision(entry_id) is None
+
+
+def test_unknown_entry_raises(source) -> None:
+    with pytest.raises(KeyError, match="unknown entry 'ghost'"):
+        source.schema("ghost")
+    with pytest.raises(KeyError, match="unknown entry 'ghost'"):
+        source.revision("ghost")
+
+
+def test_fetch_delegates_to_rest_geojson_fetcher_with_geom(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    def fake_get_geojson(url: str, timeout: float) -> dict:
+        calls.append({"url": url, "timeout": timeout})
+        return {"type": "FeatureCollection", "features": []}
+
+    monkeypatch.setattr(
+        "gispulse.adapters.rest.rest_fetcher._get_geojson", fake_get_geojson
+    )
+    registry = ProtocolRegistry()
+    register_rest_geojson_fetcher(registry)
+
+    source = _nature_source_cls()(registry=registry)
+    result = source.fetch("znieff1", extent=(1, 2, 3, 4))
+
+    assert result.payload is Payload.VECTOR
+    assert len(calls) == 1
+    url = str(calls[0]["url"])
+    assert url.startswith(f"{_API_CARTO_NATURE}/znieff1?")
+    query = parse_qs(urlsplit(url).query)
+    geom = json.loads(query["geom"][0])
+    assert geom["type"] == "Polygon"
+
+
+def test_register_hook_registers_nature_source(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = importlib.import_module("gispulse_src_nature")
+    sources = getattr(sys.modules[DataSource.__module__], "SOURCES")
+
+    monkeypatch.setattr(sources, "_sources", {})
+    module.register()
+
+    registered = sources.get("nature")
+    assert isinstance(registered, DataSource)
+    assert registered.domain is SourceDomain.ENVIRONNEMENT


### PR DESCRIPTION
Plugin déclaratif `gispulse-src-nature` : zones naturelles protégées via API Carto Nature IGN (GeoJSON → `REST_API`). 4 entrées (Natura 2000 habitat/oiseaux, ZNIEFF 1/2), domain ENVIRONNEMENT. Couvre les sources "nature" de permis-check. 8 tests zéro-réseau, ruff clean.

Lié à #339 (convergence des sources vers le modèle plugin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)