### PR TITLE
feat(src-sup): SUP servitudes source (ABF, PPR, servitudes) over WFS

### DIFF
--- a/plugins/gispulse-src-sup/README.md
+++ b/plugins/gispulse-src-sup/README.md
@@ -1,0 +1,63 @@
+# gispulse-src-sup
+
+French Servitudes d'Utilité Publique (SUP) data source for GISPulse —
+Géoplateforme WFS layers from the Géoportail de l'Urbanisme.
+
+## Provider
+
+| Field | Value |
+|-------|-------|
+| Upstream producer | IGN / Géoportail de l'Urbanisme |
+| Platform | WFS SUP |
+| Endpoint | `https://data.geopf.fr/wfs/ows` |
+| Namespace | `wfs_sup` |
+| Payload | `VECTOR` |
+| Domain | `REGLEMENTAIRE` |
+| Jurisdiction | `FR` |
+
+`SupSource` is deliberately declarative. It exposes raw SUP WFS feature
+types and two filtered assiette views; it does not implement
+`RegulatorySource` or `ruleset()`.
+
+## Entries
+
+All entries use `AccessProtocol.WFS`, endpoint
+`https://data.geopf.fr/wfs/ows`, and format `application/json`.
+
+| id | WFS typename | CQL filter |
+|----|--------------|------------|
+| `servitude` | `wfs_sup:servitude` | |
+| `assiette-surf` | `wfs_sup:assiette_sup_s` | |
+| `assiette-lin` | `wfs_sup:assiette_sup_l` | |
+| `assiette-pct` | `wfs_sup:assiette_sup_p` | |
+| `generateur-surf` | `wfs_sup:generateur_sup_s` | |
+| `generateur-lin` | `wfs_sup:generateur_sup_l` | |
+| `generateur-pct` | `wfs_sup:generateur_sup_p` | |
+| `heritage-abf` | `wfs_sup:assiette_sup_s` | `suptype IN ('AC1','AC2','AC4')` |
+| `risk-ppr-zoning` | `wfs_sup:assiette_sup_s` | `suptype IN ('PM1','PM1BIS','PM3')` |
+
+Schema highlights: `gid`, `suptype`, `idsup`, `nomsuplitt`, `geometry`.
+The schema remains raw WFS SUP; ABF/PPR interpretation belongs to
+product plugins such as Permis Check.
+
+## Revision
+
+`revision(entry_id)` issues a single HTTP HEAD against:
+
+```text
+https://data.geopf.fr/wfs/ows?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetCapabilities
+```
+
+The freshness token is derived from `ETag` or `Last-Modified`. Network
+errors return `None`.
+
+## Usage
+
+```python
+from gispulse_src_sup.source import SupSource
+
+src = SupSource()
+entry = next(e for e in src.catalog() if e.id == "heritage-abf")
+entry.access.params
+# {"typename": "wfs_sup:assiette_sup_s", "cql_filter": "suptype IN ('AC1','AC2','AC4')"}
+```

--- a/plugins/gispulse-src-sup/gispulse_src_sup/__init__.py
+++ b/plugins/gispulse-src-sup/gispulse_src_sup/__init__.py
@@ -1,0 +1,17 @@
+"""GISPulse data-source plugin — Servitudes d'Utilité Publique (SUP).
+
+Declarative ``Payload.VECTOR`` WFS source for the French SUP layers
+published by the Géoplateforme / Géoportail de l'Urbanisme. The plugin
+declares raw access specs only; interpretation as ABF, PPR or other
+product rules stays downstream.
+"""
+
+from __future__ import annotations
+
+
+def register() -> None:
+    """Entry-point hook for the ``gispulse.data_sources`` group."""
+    from gispulse.core.sources import SOURCES
+    from gispulse_src_sup.source import SupSource
+
+    SOURCES.register(SupSource())

--- a/plugins/gispulse-src-sup/gispulse_src_sup/source.py
+++ b/plugins/gispulse-src-sup/gispulse_src_sup/source.py
@@ -1,0 +1,156 @@
+"""French SUP DataSource — Servitudes d'Utilité Publique WFS layers.
+
+This package is a :class:`~gispulse.plugins.api.DeclarativeSource`: it
+declares the public WFS endpoint, typenames and optional CQL filters.
+Actual materialisation is delegated to the host ``WfsFetcher`` through
+``AccessProtocol.WFS``.
+
+The filtered ``heritage-abf`` and ``risk-ppr-zoning`` entries are views
+over ``wfs_sup:assiette_sup_s``. They are intentionally not promoted to
+product-level rules here; this source exposes raw SUP data only.
+"""
+
+from __future__ import annotations
+
+from gispulse.plugins.api import (
+    AccessProtocol,
+    AccessSpec,
+    DeclarativeSource,
+    Payload,
+    SourceDomain,
+    SourceEntryRef,
+)
+
+_GEOPLATEFORME_WFS = "https://data.geopf.fr/wfs/ows"
+_WFS_CAPABILITIES = (
+    f"{_GEOPLATEFORME_WFS}?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetCapabilities"
+)
+_REVISION_TIMEOUT_S = 8.0
+
+# Entry-id -> (display label, WFS typename, optional CQL filter).
+#
+# gispulse-permis keeps SUP type constants as lowercase (ac1, pm1bis...).
+# The WFS-facing convention declared here is uppercase CnIG codes in
+# cql_filter, matching the provided authoritative task inputs.
+_ENTRIES: dict[str, tuple[str, str, str | None]] = {
+    "servitude": (
+        "SUP — servitudes",
+        "wfs_sup:servitude",
+        None,
+    ),
+    "assiette-surf": (
+        "SUP — assiettes surfaciques",
+        "wfs_sup:assiette_sup_s",
+        None,
+    ),
+    "assiette-lin": (
+        "SUP — assiettes linéaires",
+        "wfs_sup:assiette_sup_l",
+        None,
+    ),
+    "assiette-pct": (
+        "SUP — assiettes ponctuelles",
+        "wfs_sup:assiette_sup_p",
+        None,
+    ),
+    "generateur-surf": (
+        "SUP — générateurs surfaciques",
+        "wfs_sup:generateur_sup_s",
+        None,
+    ),
+    "generateur-lin": (
+        "SUP — générateurs linéaires",
+        "wfs_sup:generateur_sup_l",
+        None,
+    ),
+    "generateur-pct": (
+        "SUP — générateurs ponctuels",
+        "wfs_sup:generateur_sup_p",
+        None,
+    ),
+    "heritage-abf": (
+        "SUP — assiettes patrimoine et abords ABF",
+        "wfs_sup:assiette_sup_s",
+        "suptype IN ('AC1','AC2','AC4')",
+    ),
+    "risk-ppr-zoning": (
+        "SUP — assiettes zonages PPR",
+        "wfs_sup:assiette_sup_s",
+        "suptype IN ('PM1','PM1BIS','PM3')",
+    ),
+}
+
+
+def _probe_revision(url: str) -> str | None:
+    """Return a freshness token for ``url`` via a single HTTP HEAD."""
+    import httpx  # local import keeps module import network-free
+
+    try:
+        resp = httpx.head(
+            url, timeout=_REVISION_TIMEOUT_S, follow_redirects=True
+        )
+    except Exception:  # noqa: BLE001 - transport errors mean unknown freshness
+        return None
+    etag = resp.headers.get("etag")
+    if etag:
+        return etag.strip('"')
+    last_modified = resp.headers.get("last-modified")
+    if last_modified:
+        return last_modified
+    return None
+
+
+class SupSource(DeclarativeSource):
+    """Géoplateforme SUP WFS layers and filtered assiette views."""
+
+    name = "sup"
+    domain = SourceDomain.REGLEMENTAIRE
+    payload = Payload.VECTOR
+    jurisdiction = "FR"
+
+    def entries(self) -> list[SourceEntryRef]:
+        refs: list[SourceEntryRef] = []
+        for entry_id, (label, typename, cql_filter) in _ENTRIES.items():
+            params = {"typename": typename}
+            metadata = {
+                "provider": "IGN / Géoportail de l'Urbanisme",
+                "platform": "WFS SUP",
+                "typename": typename,
+            }
+            if cql_filter:
+                params["cql_filter"] = cql_filter
+                metadata["suptype_filter"] = cql_filter
+            refs.append(
+                SourceEntryRef(
+                    id=entry_id,
+                    name=label,
+                    access=AccessSpec(
+                        protocol=AccessProtocol.WFS,
+                        endpoint=_GEOPLATEFORME_WFS,
+                        params=params,
+                        format="application/json",
+                    ),
+                    revision_token=None,
+                    domain=self.domain,
+                    payload=self.payload,
+                    jurisdiction=self.jurisdiction,
+                    metadata=metadata,
+                )
+            )
+        return refs
+
+    def schema(self, entry_id: str) -> dict:
+        """Raw WFS SUP attributes shared by layers and filtered views."""
+        self._entry(entry_id)
+        return {
+            "gid": "int",
+            "suptype": "str",
+            "idsup": "str",
+            "nomsuplitt": "str",
+            "geometry": "geometry",
+        }
+
+    def revision(self, entry_id: str) -> str | None:
+        """Cheap freshness token from the WFS GetCapabilities headers."""
+        self._entry(entry_id)
+        return _probe_revision(_WFS_CAPABILITIES)

--- a/plugins/gispulse-src-sup/pyproject.toml
+++ b/plugins/gispulse-src-sup/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gispulse-src-sup"
+version = "0.1.0"
+description = "French SUP data source for GISPulse (Servitudes d'Utilité Publique WFS)"
+requires-python = ">=3.10"
+license = "AGPL-3.0-or-later"
+authors = [{ name = "GISPulse", email = "dev@gispulse.io" }]
+dependencies = [
+    "gispulse>=2.0.0,<3.0.0",
+]
+
+# Registered as a data source — discovered by core.plugin_hub.PluginHub.
+[project.entry-points."gispulse.data_sources"]
+sup = "gispulse_src_sup:register"
+
+[tool.gispulse.plugin]
+kind = "source"
+protocol = ">=1.0,<2.0"
+domain = "reglementaire"
+jurisdiction = "FR"
+display_name = "SUP — Servitudes d'Utilité Publique (France)"

--- a/tests/unit/test_src_sup.py
+++ b/tests/unit/test_src_sup.py
@@ -1,0 +1,259 @@
+"""Unit tests for the gispulse-src-sup plugin."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_PKG = Path(__file__).resolve().parents[2] / "plugins" / "gispulse-src-sup"
+if str(_PKG) not in sys.path:
+    sys.path.insert(0, str(_PKG))
+
+from gispulse_src_sup import register  # noqa: E402
+from gispulse_src_sup.source import SupSource  # noqa: E402
+
+from gispulse.core.plugin_model import (  # noqa: E402
+    AccessProtocol,
+    FetchMode,
+    Payload,
+    SourceDomain,
+    SourceResult,
+)
+from gispulse.core.sources import (  # noqa: E402
+    SOURCES,
+    DataSource,
+    ProtocolRegistry,
+)
+
+
+class FakeWFS:
+    """Records the AccessSpec it is handed and returns a marker result."""
+
+    protocol = AccessProtocol.WFS
+
+    def __init__(self) -> None:
+        self.calls: list = []
+
+    def fetch(self, access, *, extent=None, mode=FetchMode.MATERIALIZE):
+        self.calls.append(access)
+        return SourceResult(
+            payload=Payload.VECTOR, mode=mode, data=access.params["typename"]
+        )
+
+
+@pytest.fixture
+def source() -> SupSource:
+    reg = ProtocolRegistry()
+    reg.register(FakeWFS())
+    return SupSource(registry=reg)
+
+
+# --------------------------------------------------------------------------
+# Contract conformance + declared axes
+# --------------------------------------------------------------------------
+
+
+def test_sup_is_a_datasource(source: SupSource) -> None:
+    assert isinstance(source, DataSource)
+    assert source.name == "sup"
+    assert source.domain is SourceDomain.REGLEMENTAIRE
+    assert source.payload is Payload.VECTOR
+    assert source.jurisdiction == "FR"
+
+
+def test_catalog_lists_raw_layers_and_filtered_views(source: SupSource) -> None:
+    ids = {e.id for e in source.catalog()}
+    assert ids == {
+        "servitude",
+        "assiette-surf",
+        "assiette-lin",
+        "assiette-pct",
+        "generateur-surf",
+        "generateur-lin",
+        "generateur-pct",
+        "heritage-abf",
+        "risk-ppr-zoning",
+    }
+
+
+def test_catalog_search_assiette_matches_raw_and_views(source: SupSource) -> None:
+    found = source.catalog(search="assiette")
+    assert {e.id for e in found} == {
+        "assiette-surf",
+        "assiette-lin",
+        "assiette-pct",
+        "heritage-abf",
+        "risk-ppr-zoning",
+    }
+
+
+def test_every_entry_carries_classification_axes(source: SupSource) -> None:
+    for entry in source.catalog():
+        assert entry.domain is SourceDomain.REGLEMENTAIRE, entry.id
+        assert entry.payload is Payload.VECTOR, entry.id
+        assert entry.jurisdiction == "FR", entry.id
+
+
+# --------------------------------------------------------------------------
+# AccessSpec — WFS SUP namespace on the Géoplateforme
+# --------------------------------------------------------------------------
+
+
+def test_every_entry_targets_wfs_sup_typename(source: SupSource) -> None:
+    expected = {
+        "servitude": ("wfs_sup:servitude", None),
+        "assiette-surf": ("wfs_sup:assiette_sup_s", None),
+        "assiette-lin": ("wfs_sup:assiette_sup_l", None),
+        "assiette-pct": ("wfs_sup:assiette_sup_p", None),
+        "generateur-surf": ("wfs_sup:generateur_sup_s", None),
+        "generateur-lin": ("wfs_sup:generateur_sup_l", None),
+        "generateur-pct": ("wfs_sup:generateur_sup_p", None),
+        "heritage-abf": (
+            "wfs_sup:assiette_sup_s",
+            "suptype IN ('AC1','AC2','AC4')",
+        ),
+        "risk-ppr-zoning": (
+            "wfs_sup:assiette_sup_s",
+            "suptype IN ('PM1','PM1BIS','PM3')",
+        ),
+    }
+
+    for entry in source.catalog():
+        access = entry.access
+        typename, cql_filter = expected[entry.id]
+        assert access.protocol is AccessProtocol.WFS
+        assert access.endpoint == "https://data.geopf.fr/wfs/ows"
+        assert access.params["typename"] == typename
+        assert access.params.get("cql_filter") == cql_filter
+        assert access.format == "application/json"
+
+
+def test_filtered_views_expose_suptype_filter_metadata(source: SupSource) -> None:
+    entries = {e.id: e for e in source.catalog()}
+
+    assert entries["heritage-abf"].metadata["suptype_filter"] == (
+        "suptype IN ('AC1','AC2','AC4')"
+    )
+    assert entries["risk-ppr-zoning"].metadata["suptype_filter"] == (
+        "suptype IN ('PM1','PM1BIS','PM3')"
+    )
+    assert "suptype_filter" not in entries["assiette-surf"].metadata
+
+
+def test_every_entry_carries_provider_metadata(source: SupSource) -> None:
+    for entry in source.catalog():
+        assert entry.metadata["provider"] == "IGN / Géoportail de l'Urbanisme"
+        assert entry.metadata["platform"] == "WFS SUP"
+        assert entry.metadata["typename"] == entry.access.params["typename"]
+
+
+# --------------------------------------------------------------------------
+# Declarative fetch — delegates to the WFS adapter, zero network code
+# --------------------------------------------------------------------------
+
+
+def test_fetch_delegates_to_wfs_adapter() -> None:
+    wfs = FakeWFS()
+    reg = ProtocolRegistry()
+    reg.register(wfs)
+    src = SupSource(registry=reg)
+
+    result = src.fetch("heritage-abf")
+
+    assert result.payload is Payload.VECTOR
+    assert "wfs_sup:assiette_sup_s" in result.data
+    assert len(wfs.calls) == 1
+    assert wfs.calls[0].protocol is AccessProtocol.WFS
+    assert wfs.calls[0].params["cql_filter"] == "suptype IN ('AC1','AC2','AC4')"
+
+
+def test_fetch_unknown_entry_raises(source: SupSource) -> None:
+    with pytest.raises(KeyError, match="unknown entry 'ghost'"):
+        source.fetch("ghost")
+
+
+# --------------------------------------------------------------------------
+# Schema — raw WFS SUP attributes only
+# --------------------------------------------------------------------------
+
+
+def test_schema_exposes_raw_wfs_sup_fields(source: SupSource) -> None:
+    schema = source.schema("heritage-abf")
+
+    assert schema["gid"] == "int"
+    assert schema["suptype"] == "str"
+    assert schema["idsup"] == "str"
+    assert schema["nomsuplitt"] == "str"
+    assert schema["geometry"] == "geometry"
+
+
+def test_schema_is_shared_by_raw_layers_and_filtered_views(source: SupSource) -> None:
+    raw_schema = source.schema("assiette-surf")
+    filtered_schema = source.schema("risk-ppr-zoning")
+
+    assert filtered_schema == raw_schema
+
+
+# --------------------------------------------------------------------------
+# revision() — HEAD on WFS GetCapabilities, never a fetch()
+# --------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    """Minimal stand-in for an ``httpx.Response`` — only ``.headers``."""
+
+    def __init__(self, headers: dict[str, str]) -> None:
+        self.headers = headers
+
+
+def test_revision_probes_wfs_capabilities_and_uses_etag(
+    source: SupSource, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: list[str] = []
+
+    def fake_head(url, **_kw):
+        captured.append(url)
+        return _FakeResponse({"etag": '"sup-millesime-2026-05"'})
+
+    monkeypatch.setattr("httpx.head", fake_head)
+    token = source.revision("servitude")
+
+    assert token == "sup-millesime-2026-05"
+    assert captured and "GetCapabilities" in captured[0]
+
+
+def test_revision_falls_back_to_last_modified(
+    source: SupSource, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fake_head(url, **_kw):
+        return _FakeResponse({"last-modified": "Mon, 12 May 2026 06:00:00 GMT"})
+
+    monkeypatch.setattr("httpx.head", fake_head)
+    assert source.revision("assiette-surf") == "Mon, 12 May 2026 06:00:00 GMT"
+
+
+def test_revision_returns_none_on_network_error(
+    source: SupSource, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fake_head(url, **_kw):
+        raise RuntimeError("simulated DNS failure")
+
+    monkeypatch.setattr("httpx.head", fake_head)
+    assert source.revision("risk-ppr-zoning") is None
+
+
+# --------------------------------------------------------------------------
+# register() entry-point hook
+# --------------------------------------------------------------------------
+
+
+def test_register_adds_sup_source_to_registry() -> None:
+    SOURCES.clear()
+    try:
+        register()
+        src = SOURCES.get("sup")
+        assert isinstance(src, SupSource)
+    finally:
+        SOURCES.clear()


### PR DESCRIPTION
Plugin déclaratif `gispulse-src-sup` : Servitudes d'Utilité Publique via WFS Géoplateforme (`wfs_sup`). Couches brutes (servitude, assiettes/générateurs s/l/p) + vues filtrées `cql_filter` sur `suptype` : **heritage-abf** (AC1/AC2/AC4), **risk-ppr-zoning** (PM1/PM1BIS/PM3). Domain REGLEMENTAIRE, schéma brut (mapping en avis ABF/RuleClause reste produit permis). 15 tests zéro-réseau.

Couvre les sources réglementaires de permis-check. Lié à #339.

🤖 Generated with [Claude Code](https://claude.com/claude-code)