### PR TITLE
feat(src-insee): INSEE statistical-units source (IRIS) over WFS

### DIFF
--- a/plugins/gispulse-src-insee/README.md
+++ b/plugins/gispulse-src-insee/README.md
@@ -1,0 +1,59 @@
+# gispulse-src-insee
+
+French INSEE statistical units source for GISPulse. The first entry is the IRIS infra-communal statistical mesh, redistributed through the IGN Géoplateforme WFS (domain: `STATISTIQUE`, jurisdiction: `FR`).
+
+## Provider
+
+| Field             | Value                                                       |
+|-------------------|-------------------------------------------------------------|
+| Upstream producer | INSEE                                                       |
+| Redistributor     | IGN / Géoplateforme WFS                                     |
+| Platform          | WFS Géoplateforme                                           |
+| Licence           | Licence Ouverte 2.0                                         |
+| Cadence           | Annual                                                      |
+
+## Entries
+
+All entries use `AccessProtocol.WFS`, endpoint `https://data.geopf.fr/wfs/ows`, format `application/json`.
+
+| id     | Label                                  | WFS typename                         | Payload | Jurisdiction |
+|--------|----------------------------------------|--------------------------------------|---------|--------------|
+| `iris` | IRIS — découpage infra-communal INSEE  | `STATISTICALUNITS.IRIS:contour_iris` | VECTOR  | FR           |
+
+Schema highlights for `iris`:
+
+- `code_iris`
+- `nom_iris`
+- `insee_com`
+- `nom_com`
+- `type_iris`
+- `geometry`
+
+Field names are raw upstream names. The plugin does not normalise INSEE commune codes or IRIS labels.
+
+## Revision
+
+`revision(entry_id)` issues a single **HTTP HEAD** against the Géoplateforme WFS GetCapabilities URL:
+
+```text
+https://data.geopf.fr/wfs/ows?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetCapabilities
+```
+
+The freshness token is derived from the `ETag` header (preferred) or the `Last-Modified` header. Returns `None` when the endpoint is unreachable or exposes neither header.
+
+## Usage
+
+```python
+from gispulse.plugins.api import get_catalog_entry
+
+entry = get_catalog_entry("insee", "iris")
+# entry.access.protocol -> AccessProtocol.WFS
+# entry.access.endpoint -> "https://data.geopf.fr/wfs/ows"
+# entry.access.params   -> {"typename": "STATISTICALUNITS.IRIS:contour_iris"}
+```
+
+The plugin registers automatically via the `gispulse.data_sources` entry-point when installed:
+
+```bash
+pip install gispulse-src-insee
+```

--- a/plugins/gispulse-src-insee/gispulse_src_insee/__init__.py
+++ b/plugins/gispulse-src-insee/gispulse_src_insee/__init__.py
@@ -1,0 +1,21 @@
+"""GISPulse data-source plugin — French INSEE statistical units.
+
+Pilot of the ``gispulse-src-*`` family for statistical units exposed
+through the IGN Géoplateforme WFS. The first entry is IRIS, the
+infra-communal statistical grid used by INSEE.
+"""
+
+from __future__ import annotations
+
+
+def register() -> None:
+    """Entry-point hook for the ``gispulse.data_sources`` group.
+
+    Registers an :class:`InseeSource` instance in the process-wide
+    ``gispulse.core.sources.SOURCES`` registry so the source watcher can
+    resolve ``insee://<entry>`` URIs declared in ``triggers.yaml``.
+    """
+    from gispulse.core.sources import SOURCES
+    from gispulse_src_insee.source import InseeSource
+
+    SOURCES.register(InseeSource())

--- a/plugins/gispulse-src-insee/gispulse_src_insee/source.py
+++ b/plugins/gispulse-src-insee/gispulse_src_insee/source.py
@@ -1,0 +1,120 @@
+"""French INSEE DataSource — statistical units served by Géoplateforme WFS.
+
+A :class:`~gispulse.plugins.api.DeclarativeSource`: the plugin only
+declares its access spec; the actual WFS request is delegated to the
+registered WFS fetcher. This package ships zero network code besides a
+HEAD probe for :meth:`revision`.
+
+The first entry is IRIS (Ilots Regroupés pour l'Information
+Statistique), an INSEE infra-communal statistical mesh redistributed
+through the IGN Géoplateforme WFS.
+"""
+
+from __future__ import annotations
+
+from gispulse.plugins.api import (
+    AccessProtocol,
+    AccessSpec,
+    DeclarativeSource,
+    Payload,
+    SourceDomain,
+    SourceEntryRef,
+)
+
+# IGN Géoplateforme — public WFS endpoint for statistical units.
+_GEOPLATEFORME_WFS = "https://data.geopf.fr/wfs/ows"
+_WFS_CAPABILITIES = (
+    f"{_GEOPLATEFORME_WFS}?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetCapabilities"
+)
+_REVISION_TIMEOUT_S = 8.0
+
+_IRIS_TYPENAME = "STATISTICALUNITS.IRIS:contour_iris"
+
+_ENTRIES: dict[str, tuple[str, str]] = {
+    "iris": (
+        "IRIS — découpage infra-communal INSEE",
+        _IRIS_TYPENAME,
+    ),
+}
+
+
+def _probe_revision(url: str) -> str | None:
+    """Return a freshness token for ``url`` via a single HTTP HEAD.
+
+    Derives the token from the ``ETag`` (preferred) / ``Last-Modified``
+    response header. Returns ``None`` on any network error or when the
+    endpoint exposes neither header, so the source watcher skips it
+    rather than emitting a spurious change.
+    """
+    import httpx  # local import — keeps module import network-free
+
+    try:
+        resp = httpx.head(
+            url, timeout=_REVISION_TIMEOUT_S, follow_redirects=True
+        )
+    except Exception:  # noqa: BLE001 — any transport error ⇒ unknown
+        return None
+    etag = resp.headers.get("etag")
+    if etag:
+        return etag.strip('"')
+    last_modified = resp.headers.get("last-modified")
+    if last_modified:
+        return last_modified
+    return None
+
+
+class InseeSource(DeclarativeSource):
+    """INSEE statistical units exposed through the Géoplateforme WFS."""
+
+    name = "insee"
+    domain = SourceDomain.STATISTIQUE
+    payload = Payload.VECTOR
+    jurisdiction = "FR"
+
+    def entries(self) -> list[SourceEntryRef]:
+        return [
+            SourceEntryRef(
+                id=entry_id,
+                name=label,
+                access=AccessSpec(
+                    protocol=AccessProtocol.WFS,
+                    endpoint=_GEOPLATEFORME_WFS,
+                    params={"typename": typename},
+                    format="application/json",
+                ),
+                revision_token=None,
+                domain=self.domain,
+                payload=self.payload,
+                jurisdiction=self.jurisdiction,
+                metadata={
+                    "provider": "IGN / INSEE",
+                    "platform": "WFS Géoplateforme",
+                    "license": "Licence Ouverte 2.0",
+                    "update_cadence": "annuel",
+                    "typename": typename,
+                },
+            )
+            for entry_id, (label, typename) in _ENTRIES.items()
+        ]
+
+    def revision(self, entry_id: str) -> str | None:
+        """Cheap freshness token for the source watcher.
+
+        One HTTP HEAD against the Géoplateforme WFS GetCapabilities. The
+        IRIS millésime is service-wide for this WFS declaration, so the
+        entry id is only validated here.
+        """
+        self._entry(entry_id)  # validate the id
+        return _probe_revision(_WFS_CAPABILITIES)
+
+    def schema(self, entry_id: str) -> dict:
+        """Raw upstream IRIS attributes exposed by the WFS layer."""
+        self._entry(entry_id)  # validates the id
+        return {
+            "code_iris": "str",
+            "nom_iris": "str",
+            "insee_com": "str",
+            "nom_com": "str",
+            "type_iris": "str",
+            "geometry": "geometry",
+        }

--- a/plugins/gispulse-src-insee/pyproject.toml
+++ b/plugins/gispulse-src-insee/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gispulse-src-insee"
+version = "0.1.0"
+description = "French INSEE statistical units source for GISPulse (IRIS WFS)"
+requires-python = ">=3.10"
+license = "AGPL-3.0-or-later"
+authors = [{ name = "GISPulse", email = "dev@gispulse.io" }]
+dependencies = [
+    "gispulse>=2.0.0,<3.0.0",
+]
+
+# Registered as a data source — discovered by core.plugin_hub.PluginHub.
+[project.entry-points."gispulse.data_sources"]
+insee = "gispulse_src_insee:register"
+
+[tool.gispulse.plugin]
+kind = "source"
+protocol = ">=1.0,<2.0"
+domain = "statistique"
+jurisdiction = "FR"
+display_name = "INSEE — unités statistiques (France)"

--- a/tests/unit/test_src_insee.py
+++ b/tests/unit/test_src_insee.py
@@ -1,0 +1,245 @@
+"""Unit tests for the gispulse-src-insee pilot plugin."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+_PKG = Path(__file__).resolve().parents[2] / "plugins" / "gispulse-src-insee"
+if str(_PKG) not in sys.path:
+    sys.path.insert(0, str(_PKG))
+
+from gispulse.core.plugin_model import (  # noqa: E402
+    AccessProtocol,
+    FetchMode,
+    Payload,
+    SourceDomain,
+    SourceResult,
+)
+from gispulse.core.sources import DataSource, ProtocolRegistry  # noqa: E402
+
+
+class FakeWFS:
+    """Records the AccessSpec it is handed and returns a marker result."""
+
+    protocol = AccessProtocol.WFS
+
+    def __init__(self) -> None:
+        self.calls: list = []
+
+    def fetch(self, access, *, extent=None, mode=FetchMode.MATERIALIZE):
+        self.calls.append(access)
+        return SourceResult(
+            payload=Payload.VECTOR, mode=mode, data=access.params["typename"]
+        )
+
+
+def _source_class():
+    return importlib.import_module("gispulse_src_insee.source").InseeSource
+
+
+@pytest.fixture
+def source():
+    reg = ProtocolRegistry()
+    reg.register(FakeWFS())
+    return _source_class()(registry=reg)
+
+
+# --------------------------------------------------------------------------
+# Packaging + registration
+# --------------------------------------------------------------------------
+
+
+def test_pyproject_declares_insee_entrypoint_and_statistical_manifest() -> None:
+    # tomllib is stdlib only on Python 3.11+; the CI matrix includes 3.10.
+    tomllib = pytest.importorskip("tomllib")
+    pyproject = tomllib.loads((_PKG / "pyproject.toml").read_text())
+
+    assert pyproject["project"]["entry-points"]["gispulse.data_sources"] == {
+        "insee": "gispulse_src_insee:register"
+    }
+
+    manifest = pyproject["tool"]["gispulse"]["plugin"]
+    assert manifest["kind"] == "source"
+    assert manifest["domain"] == "statistique"
+    assert manifest["jurisdiction"] == "FR"
+
+
+def test_register_adds_insee_source_to_global_registry() -> None:
+    from gispulse.core.sources import SOURCES
+
+    InseeSource = _source_class()
+    register = importlib.import_module("gispulse_src_insee").register
+
+    SOURCES.clear()
+    try:
+        register()
+        registered = SOURCES.get("insee")
+        assert isinstance(registered, InseeSource)
+        assert {entry.id for entry in registered.catalog()} == {"iris"}
+    finally:
+        SOURCES.clear()
+
+
+# --------------------------------------------------------------------------
+# Contract conformance + declared axes
+# --------------------------------------------------------------------------
+
+
+def test_insee_is_a_statistical_vector_datasource(source) -> None:
+    assert isinstance(source, DataSource)
+    assert source.name == "insee"
+    assert source.domain is SourceDomain.STATISTIQUE
+    assert source.payload is Payload.VECTOR
+    assert source.jurisdiction == "FR"
+
+
+def test_catalog_lists_only_iris_entry(source) -> None:
+    ids = {entry.id for entry in source.catalog()}
+    assert ids == {"iris"}
+
+
+def test_catalog_search_iris(source) -> None:
+    found = source.catalog(search="iris")
+    assert [entry.id for entry in found] == ["iris"]
+
+
+# --------------------------------------------------------------------------
+# AccessSpec — WFS against the Géoplateforme statistical units namespace
+# --------------------------------------------------------------------------
+
+
+def test_iris_targets_geoplateforme_wfs_typename(source) -> None:
+    entry = next(iter(source.catalog()))
+    access = entry.access
+
+    assert access.protocol is AccessProtocol.WFS
+    assert access.endpoint == "https://data.geopf.fr/wfs/ows"
+    assert access.params == {"typename": "STATISTICALUNITS.IRIS:contour_iris"}
+    assert access.format == "application/json"
+
+
+def test_iris_entry_carries_classification_axes_and_metadata(source) -> None:
+    entry = next(iter(source.catalog()))
+
+    assert entry.domain is SourceDomain.STATISTIQUE
+    assert entry.payload is Payload.VECTOR
+    assert entry.jurisdiction == "FR"
+    assert entry.metadata == {
+        "provider": "IGN / INSEE",
+        "platform": "WFS Géoplateforme",
+        "license": "Licence Ouverte 2.0",
+        "update_cadence": "annuel",
+        "typename": "STATISTICALUNITS.IRIS:contour_iris",
+    }
+
+
+# --------------------------------------------------------------------------
+# Declarative fetch — delegates to the WFS adapter, zero network code
+# --------------------------------------------------------------------------
+
+
+def test_fetch_delegates_to_wfs_adapter() -> None:
+    wfs = FakeWFS()
+    reg = ProtocolRegistry()
+    reg.register(wfs)
+    src = _source_class()(registry=reg)
+
+    result = src.fetch("iris")
+
+    assert result.payload is Payload.VECTOR
+    assert result.data == "STATISTICALUNITS.IRIS:contour_iris"
+    assert len(wfs.calls) == 1
+    assert wfs.calls[0].protocol is AccessProtocol.WFS
+
+
+def test_fetch_unknown_entry_raises(source) -> None:
+    with pytest.raises(KeyError, match="unknown entry 'ghost'"):
+        source.fetch("ghost")
+
+
+# --------------------------------------------------------------------------
+# Schema — raw upstream IRIS attributes
+# --------------------------------------------------------------------------
+
+
+def test_schema_exposes_raw_iris_fields(source) -> None:
+    schema = source.schema("iris")
+
+    assert schema["code_iris"] == "str"
+    assert schema["nom_iris"] == "str"
+    assert schema["insee_com"] == "str"
+    assert schema["nom_com"] == "str"
+    assert schema["type_iris"] == "str"
+    assert schema["geometry"] == "geometry"
+
+
+def test_schema_validates_entry_id(source) -> None:
+    with pytest.raises(KeyError, match="unknown entry 'ghost'"):
+        source.schema("ghost")
+
+
+# --------------------------------------------------------------------------
+# revision() — HEAD on WFS GetCapabilities, never a fetch()
+# --------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    """Minimal stand-in for an ``httpx.Response`` — only ``.headers``."""
+
+    def __init__(self, headers: dict[str, str]) -> None:
+        self.headers = headers
+
+
+def test_revision_probes_wfs_capabilities_and_uses_etag(
+    source, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: list[str] = []
+
+    def fake_head(url, **_kw):
+        captured.append(url)
+        return _FakeResponse({"etag": '"iris-millesime-2026"'})
+
+    monkeypatch.setattr("httpx.head", fake_head)
+    token = source.revision("iris")
+
+    assert token == "iris-millesime-2026"
+    assert captured and "GetCapabilities" in captured[0]
+
+
+def test_revision_falls_back_to_last_modified(
+    source, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fake_head(url, **_kw):
+        return _FakeResponse({"last-modified": "Mon, 01 Jun 2026 00:00:00 GMT"})
+
+    monkeypatch.setattr("httpx.head", fake_head)
+    assert source.revision("iris") == "Mon, 01 Jun 2026 00:00:00 GMT"
+
+
+def test_revision_returns_none_on_network_error(
+    source, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fake_head(url, **_kw):
+        raise RuntimeError("simulated DNS failure")
+
+    monkeypatch.setattr("httpx.head", fake_head)
+    assert source.revision("iris") is None
+
+
+def test_revision_returns_none_without_freshness_header(
+    source, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("httpx.head", lambda *_a, **_kw: _FakeResponse({}))
+    assert source.revision("iris") is None
+
+
+def test_revision_validates_entry_id(
+    source, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("httpx.head", lambda *_a, **_kw: _FakeResponse({}))
+    with pytest.raises(KeyError, match="unknown entry 'ghost'"):
+        source.revision("ghost")


### PR DESCRIPTION
Plugin déclaratif `gispulse-src-insee` : unités statistiques INSEE via WFS Géoplateforme. 1ère entrée **IRIS** (`STATISTICALUNITS.IRIS:contour_iris`), domain **STATISTIQUE** (pas BASE — donnée INSEE), extensible aux bases socio-démo (recensement, FiLoSoFi). Remplace l'IRIS catalog-provider-only (`opendata_ign`, qui refuse `fetch()`) par un `DataSource` natif. 16 tests zéro-réseau.

Lié à #339.

🤖 Generated with [Claude Code](https://claude.com/claude-code)