### PR TITLE
feat(compose): Garage S3 object-store service for the raw landing zone (#340)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,10 @@
 # Copy this file to .env and adjust values:
 #   cp .env.example .env
 #
+# Local Python does not auto-load `.env`. Use one of:
+#   uv run --env-file .env gispulse ...
+#   set -a && source .env && set +a
+#
 # Modes:
 #   A (Local)  : Only GISPULSE_ENGINE=duckdb needed (default)
 #   B (Docker) : Set PostGIS vars below + GISPULSE_ENGINE=postgis
@@ -44,6 +48,26 @@ POSTGRES_DB=gispulse
 # ── Redis (optional, recommended for multi-worker) ───────────────────────
 # GISPULSE_REDIS_URL=redis://localhost:6379
 # GISPULSE_RATE_LIMIT_STORAGE=      # Override: redis://... or memory://
+
+# ── Garage daemon (Docker profile `garage`, issue #340) ──────────────────
+# These are Garage server secrets, not GISPulse S3 client keys. Generate them
+# locally and keep them in .env or a secret manager; never commit real values.
+# GARAGE_RPC_SECRET=                         # openssl rand -hex 32
+# GARAGE_ADMIN_TOKEN=                        # openssl rand -base64 32
+# GARAGE_METRICS_TOKEN=                      # optional: openssl rand -base64 32
+
+# ── Object storage S3-compatible (Garage / MinIO) — Pro tier, issue #340 ──
+# Landing zone for raw/derived data read in-place by DuckDB httpfs and the
+# GeoParquetS3Fetcher. The docker-compose `garage` service serves the S3 API
+# on :3900. Access/secret are produced by `garage key create` (see the
+# first-run init steps in docker-compose.yml).
+# For Docker Compose use http://garage:3900. For host Python use
+# http://localhost:3900 or the public HTTPS endpoint, e.g. https://garage.casys.ai.
+# GISPULSE_S3_ENDPOINT=http://garage:3900
+# GISPULSE_S3_BUCKET=gispulse
+# GISPULSE_S3_ACCESS_KEY=                       # from `garage key create`
+# GISPULSE_S3_SECRET_KEY=
+# GISPULSE_S3_REGION=garage
 
 # ── Portal ────────────────────────────────────────────────────────────────
 VITE_API_URL=http://localhost:8001

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,9 +23,17 @@ services:
     ports:
       - "8001:8001"
     environment:
-      GISPULSE_ENGINE: duckdb
-      GISPULSE_DSN: postgresql://gispulse:gispulse@postgis:5432/gispulse
-      GISPULSE_STORAGE: sqlite
+      GISPULSE_ENGINE: "${GISPULSE_ENGINE:-duckdb}"
+      GISPULSE_DSN: "${GISPULSE_DSN:-postgresql://gispulse:gispulse@postgis:5432/gispulse}"
+      GISPULSE_STORAGE: "${GISPULSE_STORAGE:-sqlite}"
+      GISPULSE_TIER: "${GISPULSE_TIER:-community}"
+      GISPULSE_LICENSE_KEY: "${GISPULSE_LICENSE_KEY:-}"
+      GISPULSE_LICENCE_SKIP_VERIFY: "${GISPULSE_LICENCE_SKIP_VERIFY:-false}"
+      GISPULSE_S3_ENDPOINT: "${GISPULSE_S3_ENDPOINT:-}"
+      GISPULSE_S3_BUCKET: "${GISPULSE_S3_BUCKET:-gispulse}"
+      GISPULSE_S3_ACCESS_KEY: "${GISPULSE_S3_ACCESS_KEY:-}"
+      GISPULSE_S3_SECRET_KEY: "${GISPULSE_S3_SECRET_KEY:-}"
+      GISPULSE_S3_REGION: "${GISPULSE_S3_REGION:-garage}"
       GISPULSE_CORS_ORIGINS: "https://imagodata.github.io,https://demo.gispulse.dev"
     depends_on:
       postgis:
@@ -59,6 +67,36 @@ services:
       - --reload-dir=/app/persistence
       - --reload-dir=/app/adapters
 
+  # Object storage (S3-compatible) — opt-in landing zone for raw/derived data
+  # read in-place by DuckDB (httpfs) and the GeoParquetS3Fetcher (#340).
+  # Enable with: docker compose --profile garage up -d garage
+  # Point GISPULSE_S3_* at it from .env (Docker endpoint: http://garage:3900).
+  # Generate and store Garage daemon secrets in .env first:
+  #   GARAGE_RPC_SECRET=$(openssl rand -hex 32)
+  #   GARAGE_ADMIN_TOKEN=$(openssl rand -base64 32)
+  # First-run init (once, container running):
+  #   docker compose exec garage /garage status            # note the node id
+  #   docker compose exec garage /garage layout assign -z dc1 -c 1G <node-id>
+  #   docker compose exec garage /garage layout apply --version 1
+  #   docker compose exec garage /garage bucket create gispulse
+  #   docker compose exec garage /garage key create gispulse-app
+  #   docker compose exec garage /garage bucket allow --read --write gispulse --key gispulse-app
+  # then copy the printed Key ID / Secret into your .env (GISPULSE_S3_ACCESS_KEY/SECRET_KEY).
+  garage:
+    image: dxflrs/garage:v1.0.1
+    profiles: ["garage"]
+    environment:
+      GARAGE_RPC_SECRET: "${GARAGE_RPC_SECRET:-}"
+      GARAGE_ADMIN_TOKEN: "${GARAGE_ADMIN_TOKEN:-}"
+      GARAGE_METRICS_TOKEN: "${GARAGE_METRICS_TOKEN:-}"
+    ports:
+      - "3900:3900"   # S3 API
+      - "3903:3903"   # admin API
+    volumes:
+      - ./docker/garage.toml:/etc/garage.toml:ro
+      - garage_meta:/var/lib/garage/meta
+      - garage_data:/var/lib/garage/data
+
   # NB: the portal dev server lives in the sibling repository
   # imagodata/gispulse-portal. To run it locally alongside this stack,
   # clone that repo and `pnpm dev` against VITE_API_URL=http://localhost:8001.
@@ -66,6 +104,8 @@ services:
 volumes:
   pgdata:
   gispulse_data:
+  garage_meta:
+  garage_data:
 
 networks:
   default:

--- a/docker/garage.toml
+++ b/docker/garage.toml
@@ -1,0 +1,30 @@
+# Garage S3-compatible object store — single-node dev config (#340).
+# Landing zone for raw/derived data read in-place by DuckDB httpfs and the
+# GeoParquetS3Fetcher; the gispulse app points GISPULSE_S3_* at the S3 API.
+#
+# Runtime secrets are intentionally not stored in this file. Provide them via
+# GARAGE_RPC_SECRET / GARAGE_ADMIN_TOKEN (or *_FILE in production secret
+# managers). See .env.example and Garage's environment variable support.
+
+metadata_dir = "/var/lib/garage/meta"
+data_dir = "/var/lib/garage/data"
+db_engine = "sqlite"
+
+# Single node: no redundancy. Bump + add nodes for a real cluster.
+replication_factor = 1
+
+rpc_bind_addr = "[::]:3901"
+rpc_public_addr = "127.0.0.1:3901"
+
+[s3_api]
+s3_region = "garage"
+api_bind_addr = "[::]:3900"
+root_domain = ".s3.garage.localhost"
+
+[s3_web]
+bind_addr = "[::]:3902"
+root_domain = ".web.garage.localhost"
+index = "index.html"
+
+[admin]
+api_bind_addr = "[::]:3903"

--- a/tests/unit/test_garage_compose.py
+++ b/tests/unit/test_garage_compose.py
@@ -1,0 +1,60 @@
+"""Regression tests for the local Garage object-store Compose wiring."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _compose() -> dict:
+    return yaml.safe_load((ROOT / "docker-compose.yml").read_text(encoding="utf-8"))
+
+
+def test_garage_service_is_opt_in_and_uses_env_secrets() -> None:
+    compose = _compose()
+    garage = compose["services"]["garage"]
+
+    assert "garage" in garage.get("profiles", [])
+    env = garage["environment"]
+    assert env["GARAGE_RPC_SECRET"] == "${GARAGE_RPC_SECRET:-}"
+    assert env["GARAGE_ADMIN_TOKEN"] == "${GARAGE_ADMIN_TOKEN:-}"
+
+
+def test_garage_toml_does_not_commit_secret_placeholders() -> None:
+    text = (ROOT / "docker" / "garage.toml").read_text(encoding="utf-8")
+
+    assert "REPLACE_ME" not in text
+    assert "rpc_secret =" not in text
+    assert "admin_token =" not in text
+
+
+def test_gispulse_api_receives_s3_env_interpolation() -> None:
+    compose = _compose()
+    env = compose["services"]["gispulse-api"]["environment"]
+
+    expected = {
+        "GISPULSE_TIER": "${GISPULSE_TIER:-community}",
+        "GISPULSE_LICENSE_KEY": "${GISPULSE_LICENSE_KEY:-}",
+        "GISPULSE_LICENCE_SKIP_VERIFY": "${GISPULSE_LICENCE_SKIP_VERIFY:-false}",
+        "GISPULSE_S3_ENDPOINT": "${GISPULSE_S3_ENDPOINT:-}",
+        "GISPULSE_S3_BUCKET": "${GISPULSE_S3_BUCKET:-gispulse}",
+        "GISPULSE_S3_ACCESS_KEY": "${GISPULSE_S3_ACCESS_KEY:-}",
+        "GISPULSE_S3_SECRET_KEY": "${GISPULSE_S3_SECRET_KEY:-}",
+        "GISPULSE_S3_REGION": "${GISPULSE_S3_REGION:-garage}",
+    }
+    for key, value in expected.items():
+        assert env[key] == value
+
+
+def test_env_example_documents_garage_and_gispulse_secret_split() -> None:
+    text = (ROOT / ".env.example").read_text(encoding="utf-8")
+
+    assert "GARAGE_RPC_SECRET=" in text
+    assert "GARAGE_ADMIN_TOKEN=" in text
+    assert "GISPULSE_S3_ACCESS_KEY=" in text
+    assert "GISPULSE_S3_SECRET_KEY=" in text
+    assert "uv run --env-file .env" in text


### PR DESCRIPTION
## Summary
- Add an opt-in Garage S3-compatible object-store service for the raw/derived landing zone (#340).
- Keep Garage daemon secrets in env (`GARAGE_RPC_SECRET`, `GARAGE_ADMIN_TOKEN`, optional metrics token) instead of committed TOML placeholders.
- Pass `GISPULSE_S3_*` settings through `gispulse-api` in Compose and document the local `.env` / `uv run --env-file .env` flow.
- Add regression tests for the Compose/Garage wiring.

## Scope
This PR is intentionally config/Compose focused. DuckDB S3 secret setup and `_materialize -> S3` fetcher work are follow-up code patches carried on the beta branch first.

## Verification
- `UV_CACHE_DIR=/private/tmp/uv-cache PYTHONPATH=src uv run pytest tests/unit/test_garage_compose.py tests/unit/test_config_helpers.py tests/unit/test_storage.py -q`
- `UV_CACHE_DIR=/private/tmp/uv-cache PYTHONPATH=src uv run ruff check tests/unit/test_garage_compose.py`
- `docker compose config`
- `docker compose --profile garage config`

DCO: branch rewritten as a single signed commit; unrelated `uv.lock` sync removed from the PR.