### PR TITLE
feat(plugin): gispulse-src-cadastre — bulk Etalab par département

### DIFF
--- a/plugins/gispulse-src-cadastre/gispulse_src_cadastre/source.py
+++ b/plugins/gispulse-src-cadastre/gispulse_src_cadastre/source.py
@@ -1,11 +1,25 @@
-"""French cadastre DataSource — parcels, communes and buildings.
+"""French cadastre DataSource — WFS point-query + Etalab bulk download.
 
-A :class:`~gispulse.plugins.api.DeclarativeSource`: the plugin only
-*declares* the available entries and their :class:`AccessSpec`; the
-actual WFS request is delegated to the registered protocol adapter, so
-this package ships zero network code.
+A :class:`~gispulse.plugins.api.DeclarativeSource` covering the two
+public redistributions of the DGFiP Plan Cadastral Informatisé (PCI
+vecteur):
 
-Data: IGN Géoplateforme WFS, ``CADASTRALPARCELS.PARCELLAIRE_EXPRESS``.
+* **WFS — IGN Géoplateforme** (``data.geopf.fr/wfs/ows``,
+  ``CADASTRALPARCELS.PARCELLAIRE_EXPRESS``). Three entries
+  (``parcelles`` / ``communes`` / ``batiments``) for point-query and
+  bbox-scoped reads against a live feature service.
+* **Bulk — Etalab** (``cadastre.data.gouv.fr/data/etalab-cadastre``).
+  Four entries (``parcelles_bulk`` / ``communes_bulk`` /
+  ``sections_bulk`` / ``batiments_bulk``) targeting the quarterly
+  per-département GeoJSON archives. Each bulk endpoint is a ``{key}``
+  URL template — ``{departement}`` is resolved at fetch time so a
+  single :class:`SourceEntryRef` covers all 101 départements without
+  inflating the catalogue (cf. ``core/plugin_model.py``).
+
+The two redistributions share the same upstream producer (DGFiP) and
+millésime cadence, but the redistributor, the access protocol, the
+freshness signal and the spatial granularity differ — hence the
+``redistributor`` field in each entry's ``metadata``.
 """
 
 from __future__ import annotations
@@ -29,10 +43,46 @@ _LAYER_PREFIX = "CADASTRALPARCELS.PARCELLAIRE_EXPRESS"
 _WFS_CAPABILITIES = (
     f"{_GEOPLATEFORME_WFS}?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetCapabilities"
 )
+
+# Etalab bulk redistribution of the DGFiP PCI vecteur — quarterly
+# millésime, GeoJSON-gzipped archives per département. The ``latest``
+# segment is a stable alias rotating to the most recent release. The
+# ``{departement}`` placeholder is resolved by ``dispatch_fetch`` from
+# ``access.params`` at fetch time (cf. ``core/plugin_model.py``).
+_ETALAB_CADASTRE_BASE = (
+    "https://cadastre.data.gouv.fr/data/etalab-cadastre/latest/geojson/departements"
+)
+
+# data.gouv.fr dataset API — a small JSON metadata document carrying a
+# top-level ``last_modified`` ISO-8601 timestamp updated on every
+# resource refresh. Used by revision() for the bulk entries: HEAD on the
+# .json.gz files alone won't surface a millésime change because the
+# ``latest`` symlink target is stable between releases.
+_ETALAB_DATASET_API = (
+    "https://www.data.gouv.fr/api/1/datasets/cadastre/"
+)
 _REVISION_TIMEOUT_S = 8.0
 
+# Per-département bulk entries declare the layer name once via this
+# ``layer`` slot in ``access.params`` (next to ``departement``); the
+# fetcher does not consume it but keeping it on the access keeps the
+# entry self-describing for catalogue introspection.
+_BULK_LAYERS: dict[str, str] = {
+    "parcelles_bulk": "parcelles",
+    "communes_bulk": "communes",
+    "sections_bulk": "sections",
+    "batiments_bulk": "batiments",
+}
 
-def _probe_revision(url: str) -> str | None:
+_BULK_LABELS: dict[str, str] = {
+    "parcelles_bulk": "Parcelles cadastrales (bulk Etalab, par département)",
+    "communes_bulk": "Communes cadastrales (bulk Etalab, par département)",
+    "sections_bulk": "Sections cadastrales (bulk Etalab, par département)",
+    "batiments_bulk": "Bâtiments cadastraux (bulk Etalab, par département)",
+}
+
+
+def _probe_revision_head(url: str) -> str | None:
     """Return a freshness token for ``url`` via a single HTTP HEAD.
 
     Derives the token from the ``ETag`` (preferred) or ``Last-Modified``
@@ -57,8 +107,39 @@ def _probe_revision(url: str) -> str | None:
     return None
 
 
+def _probe_revision_datagouv(api_url: str) -> str | None:
+    """Return ``last_modified`` from the data.gouv.fr dataset API.
+
+    Same pattern as ``gispulse-src-dvf``: a small GET against the JSON
+    metadata endpoint, returns the top-level ``last_modified`` string.
+    The bulk archives behind the ``latest`` alias do not surface a
+    millésime through HTTP headers (the symlink target is stable across
+    releases), so a HEAD on the .json.gz is useless — the dataset-level
+    API is the only honest signal.
+
+    Returns ``None`` on any network error, non-2xx response, malformed
+    JSON, or missing field — the watcher treats that as "unknown".
+    """
+    import httpx
+
+    try:
+        resp = httpx.get(
+            api_url, timeout=_REVISION_TIMEOUT_S, follow_redirects=True
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception:  # noqa: BLE001 — any transport error ⇒ unknown
+        return None
+    token = data.get("last_modified") if isinstance(data, dict) else None
+    return token if isinstance(token, str) and token else None
+
+
+def _is_bulk_entry(entry_id: str) -> bool:
+    return entry_id.endswith("_bulk")
+
+
 class CadastreSource(DeclarativeSource):
-    """French cadastre (Parcellaire Express) exposed as a GISPulse source."""
+    """French cadastre exposed as a GISPulse source — WFS + bulk redistributions."""
 
     name = "cadastre"
     domain = SourceDomain.FONCIER
@@ -67,13 +148,19 @@ class CadastreSource(DeclarativeSource):
 
     def entries(self) -> list[SourceEntryRef]:
         return [
-            self._entry_ref("parcelles", "Parcelles cadastrales", "parcelle"),
-            self._entry_ref("communes", "Communes cadastrales", "commune"),
-            self._entry_ref("batiments", "Bâtiments cadastraux", "batiment"),
+            # IGN Géoplateforme — WFS live, point-query / bbox-scoped.
+            self._wfs_entry_ref("parcelles", "Parcelles cadastrales (WFS IGN)", "parcelle"),
+            self._wfs_entry_ref("communes", "Communes cadastrales (WFS IGN)", "commune"),
+            self._wfs_entry_ref("batiments", "Bâtiments cadastraux (WFS IGN)", "batiment"),
+            # Etalab — quarterly bulk archive per département.
+            self._bulk_entry_ref("parcelles_bulk"),
+            self._bulk_entry_ref("communes_bulk"),
+            self._bulk_entry_ref("sections_bulk"),
+            self._bulk_entry_ref("batiments_bulk"),
         ]
 
     @staticmethod
-    def _entry_ref(entry_id: str, label: str, layer: str) -> SourceEntryRef:
+    def _wfs_entry_ref(entry_id: str, label: str, layer: str) -> SourceEntryRef:
         return SourceEntryRef(
             id=entry_id,
             name=label,
@@ -86,32 +173,113 @@ class CadastreSource(DeclarativeSource):
             # revision() probes the WFS live (issue #198); the declared
             # token stays None so nothing hard-codes a stale millésime.
             revision_token=None,
-            metadata={"provider": "IGN", "dataset": "Parcellaire Express"},
+            domain=SourceDomain.FONCIER,
+            payload=Payload.VECTOR,
+            jurisdiction="FR",
+            metadata={
+                "provider": "DGFiP",
+                "redistributor": "IGN Géoplateforme",
+                "dataset": "Plan Cadastral Informatisé (PCI vecteur)",
+                "redistribution": "Parcellaire Express",
+                "update_cadence": "continuous",
+                "license": "Licence Ouverte 2.0",
+            },
+        )
+
+    @staticmethod
+    def _bulk_entry_ref(entry_id: str) -> SourceEntryRef:
+        layer = _BULK_LAYERS[entry_id]
+        # Endpoint carries a ``{departement}`` template — resolved by
+        # ``ProtocolRegistry.dispatch_fetch`` at fetch time from
+        # ``access.params``. The default ``"75"`` is a placeholder for
+        # the per-entry catalogue view; real ingest passes a département
+        # via a derived AccessSpec or by overriding ``params``.
+        return SourceEntryRef(
+            id=entry_id,
+            name=_BULK_LABELS[entry_id],
+            access=AccessSpec(
+                protocol=AccessProtocol.DOWNLOAD,
+                endpoint=(
+                    f"{_ETALAB_CADASTRE_BASE}/{{departement}}/"
+                    f"cadastre-{{departement}}-{layer}.json.gz"
+                ),
+                params={"departement": "75", "layer": layer},
+                format="application/geo+json+gzip",
+            ),
+            revision_token=None,
+            domain=SourceDomain.FONCIER,
+            payload=Payload.VECTOR,
+            jurisdiction="FR",
+            metadata={
+                "provider": "DGFiP",
+                "redistributor": "Etalab",
+                "dataset": "Plan Cadastral Informatisé (PCI vecteur)",
+                "redistribution": "Cadastre Etalab",
+                "mirror": "cadastre.data.gouv.fr",
+                "update_cadence": "quarterly",
+                "license": "Licence Ouverte 2.0",
+            },
         )
 
     def revision(self, entry_id: str) -> str | None:
-        """Cheap freshness token for the source watcher (issue #187/#198).
+        """Cheap freshness token, dispatched by entry family.
 
-        Issues a single HTTP HEAD against the Géoplateforme WFS
-        GetCapabilities URL and derives the token from its ``ETag`` /
-        ``Last-Modified`` header — never a full ``fetch()``. The
-        Parcellaire Express millésime is dataset-wide, so every entry
-        shares one probe; ``entry_id`` is only validated here.
-
-        Returns ``None`` when the endpoint is unreachable or exposes no
-        freshness header — the watcher treats that as "unknown" and
-        skips it instead of emitting a spurious ``source.changed``.
+        WFS entries use a HEAD probe against the Géoplateforme
+        GetCapabilities URL (issue #198). Bulk entries use a GET against
+        the ``data.gouv.fr`` dataset metadata API — the ``latest`` alias
+        on the .json.gz files does not surface a release change through
+        HTTP headers, so the dataset-level ``last_modified`` is the only
+        honest signal. Returns ``None`` when the probe is unreachable —
+        the watcher treats that as "unknown".
         """
         self._entry(entry_id)  # validate the id
-        return _probe_revision(_WFS_CAPABILITIES)
+        if _is_bulk_entry(entry_id):
+            return _probe_revision_datagouv(_ETALAB_DATASET_API)
+        return _probe_revision_head(_WFS_CAPABILITIES)
 
     def schema(self, entry_id: str) -> dict:
         """Normalised attribute schema of a cadastre layer."""
         self._entry(entry_id)  # validates the id
-        common = {"idu": "str", "geometry": "geometry"}
+        # Bulk entries surface the Etalab GeoJSON column shape, slightly
+        # richer than the WFS Parcellaire Express (created/updated, the
+        # ``arpente`` flag, etc.).
         if entry_id == "parcelles":
-            return {**common, "commune": "str", "section": "str", "numero": "str",
-                    "contenance": "int"}
+            return {
+                "idu": "str", "geometry": "geometry",
+                "commune": "str", "section": "str", "numero": "str",
+                "contenance": "int",
+            }
         if entry_id == "communes":
-            return {**common, "nom": "str", "code_insee": "str"}
-        return {**common, "nature": "str"}  # batiments
+            return {"idu": "str", "geometry": "geometry", "nom": "str", "code_insee": "str"}
+        if entry_id == "batiments":
+            return {"idu": "str", "geometry": "geometry", "nature": "str"}
+        # Bulk shapes verified against live Etalab GeoJSON for dpt 75
+        # (cadastre.data.gouv.fr/data/etalab-cadastre/latest/geojson/...).
+        if entry_id == "parcelles_bulk":
+            return {
+                "id": "str", "geometry": "geometry",
+                "commune": "str", "prefixe": "str", "section": "str",
+                "numero": "str", "contenance": "int", "arpente": "bool",
+                "created": "date", "updated": "date",
+            }
+        if entry_id == "communes_bulk":
+            return {
+                "id": "str", "geometry": "geometry",
+                "nom": "str", "created": "date", "updated": "date",
+            }
+        if entry_id == "sections_bulk":
+            return {
+                "id": "str", "geometry": "geometry",
+                "commune": "str", "prefixe": "str", "code": "str",
+                "created": "date", "updated": "date",
+            }
+        if entry_id == "batiments_bulk":
+            # Etalab GeoJSON bâtiments features have no feature-id; the
+            # identity is decomposed across ``type`` / ``nom`` / ``commune``.
+            return {
+                "geometry": "geometry",
+                "type": "str", "nom": "str", "commune": "str",
+                "created": "date", "updated": "date",
+            }
+        # Unreachable — ``_entry()`` above raised for unknown ids.
+        return {}

--- a/plugins/gispulse-src-cadastre/pyproject.toml
+++ b/plugins/gispulse-src-cadastre/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gispulse-src-cadastre"
-version = "0.1.0"
-description = "French cadastre data source for GISPulse (IGN Parcellaire Express)"
+version = "0.2.0"
+description = "French cadastre data source for GISPulse (IGN Parcellaire Express WFS + Etalab bulk)"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"
 authors = [{ name = "GISPulse", email = "dev@gispulse.io" }]

--- a/tests/unit/test_src_cadastre.py
+++ b/tests/unit/test_src_cadastre.py
@@ -13,7 +13,13 @@ if str(_PKG) not in sys.path:
 
 from gispulse_src_cadastre.source import CadastreSource  # noqa: E402
 
-from gispulse.core.plugin_model import AccessProtocol, FetchMode, Payload, SourceDomain, SourceResult  # noqa: E402
+from gispulse.core.plugin_model import (  # noqa: E402
+    AccessProtocol,
+    FetchMode,
+    Payload,
+    SourceDomain,
+    SourceResult,
+)
 from gispulse.core.sources import DataSource, ProtocolRegistry  # noqa: E402
 
 
@@ -30,10 +36,24 @@ class FakeWFS:
         return SourceResult(payload=Payload.VECTOR, mode=mode, data=access.params["typename"])
 
 
+class FakeDownload:
+    """Records resolved AccessSpec for the bulk Etalab entries."""
+
+    protocol = AccessProtocol.DOWNLOAD
+
+    def __init__(self) -> None:
+        self.calls: list = []
+
+    def fetch(self, access, *, extent=None, mode=FetchMode.MATERIALIZE):
+        self.calls.append(access)
+        return SourceResult(payload=Payload.VECTOR, mode=mode, data=access.endpoint)
+
+
 @pytest.fixture
 def source() -> CadastreSource:
     reg = ProtocolRegistry()
     reg.register(FakeWFS())
+    reg.register(FakeDownload())
     return CadastreSource(registry=reg)
 
 
@@ -50,25 +70,32 @@ def test_cadastre_is_a_datasource(source: CadastreSource) -> None:
     assert source.jurisdiction == "FR"
 
 
-def test_catalog_lists_three_entries(source: CadastreSource) -> None:
+def test_catalog_lists_wfs_and_bulk_entries(source: CadastreSource) -> None:
     ids = {e.id for e in source.catalog()}
-    assert ids == {"parcelles", "communes", "batiments"}
+    assert ids == {
+        # IGN Géoplateforme — WFS live
+        "parcelles", "communes", "batiments",
+        # Etalab — bulk per département
+        "parcelles_bulk", "communes_bulk", "sections_bulk", "batiments_bulk",
+    }
 
 
 def test_catalog_search(source: CadastreSource) -> None:
-    found = source.catalog(search="parcel")
-    assert [e.id for e in found] == ["parcelles"]
+    # WFS + bulk both surface for the same family search term.
+    found = {e.id for e in source.catalog(search="parcel")}
+    assert found == {"parcelles", "parcelles_bulk"}
 
 
 # --------------------------------------------------------------------------
-# Declarative fetch — delegates to the WFS adapter, zero network code
+# WFS family — declarative fetch + protocol, redistributor metadata
 # --------------------------------------------------------------------------
 
 
-def test_fetch_delegates_to_wfs_adapter() -> None:
+def test_fetch_wfs_delegates_to_wfs_adapter() -> None:
     wfs = FakeWFS()
     reg = ProtocolRegistry()
     reg.register(wfs)
+    reg.register(FakeDownload())
     src = CadastreSource(registry=reg)
 
     result = src.fetch("parcelles")
@@ -79,38 +106,126 @@ def test_fetch_delegates_to_wfs_adapter() -> None:
     assert wfs.calls[0].protocol is AccessProtocol.WFS
 
 
+def test_wfs_entry_metadata_advertises_ign(source: CadastreSource) -> None:
+    entry = next(e for e in source.catalog() if e.id == "parcelles")
+    assert entry.access.protocol is AccessProtocol.WFS
+    assert entry.metadata["provider"] == "DGFiP"
+    assert entry.metadata["redistributor"] == "IGN Géoplateforme"
+    # Per-entry classification axes (#227) repeat the source-level
+    # facets so the worldwide catalogue can index the entry directly.
+    assert entry.domain is SourceDomain.FONCIER
+    assert entry.jurisdiction == "FR"
+
+
 def test_fetch_unknown_entry_raises(source: CadastreSource) -> None:
     with pytest.raises(KeyError, match="unknown entry 'ghost'"):
         source.fetch("ghost")
 
 
 # --------------------------------------------------------------------------
-# Schema + revision
+# Bulk family — DOWNLOAD protocol, template endpoint, Etalab metadata
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "entry_id, layer",
+    [
+        ("parcelles_bulk", "parcelles"),
+        ("communes_bulk", "communes"),
+        ("sections_bulk", "sections"),
+        ("batiments_bulk", "batiments"),
+    ],
+)
+def test_bulk_entry_declares_download_with_template(
+    source: CadastreSource, entry_id: str, layer: str
+) -> None:
+    entry = next(e for e in source.catalog() if e.id == entry_id)
+    access = entry.access
+    assert access.protocol is AccessProtocol.DOWNLOAD
+    # ``{departement}`` placeholder must be present — resolution happens
+    # at fetch time via ``ProtocolRegistry.dispatch_fetch`` (#276).
+    assert "{departement}" in access.endpoint
+    assert access.endpoint.endswith(f"-{{departement}}-{layer}.json.gz")
+    # ``layer`` slot is self-describing (introspection); ``departement``
+    # carries a default that callers override at fetch time.
+    assert access.params == {"departement": "75", "layer": layer}
+
+
+def test_bulk_entry_metadata_advertises_etalab(source: CadastreSource) -> None:
+    entry = next(e for e in source.catalog() if e.id == "parcelles_bulk")
+    assert entry.metadata["provider"] == "DGFiP"
+    assert entry.metadata["redistributor"] == "Etalab"
+    assert entry.metadata["mirror"] == "cadastre.data.gouv.fr"
+    assert entry.metadata["update_cadence"] == "quarterly"
+
+
+def test_fetch_bulk_resolves_departement_template() -> None:
+    """End-to-end: dispatch_fetch interpolates ``{departement}`` from params."""
+    download = FakeDownload()
+    reg = ProtocolRegistry()
+    reg.register(FakeWFS())
+    reg.register(download)
+    src = CadastreSource(registry=reg)
+
+    result = src.fetch("parcelles_bulk")
+    # The fetcher receives a resolved endpoint, not the template.
+    assert "{departement}" not in result.data
+    assert "departements/75/cadastre-75-parcelles.json.gz" in result.data
+    assert len(download.calls) == 1
+    assert download.calls[0].protocol is AccessProtocol.DOWNLOAD
+
+
+# --------------------------------------------------------------------------
+# Schema + revision — WFS uses HEAD/Capabilities, bulk uses GET/datagouv
 # --------------------------------------------------------------------------
 
 
 def test_schema_per_layer(source: CadastreSource) -> None:
+    # WFS family
     assert "contenance" in source.schema("parcelles")
     assert "code_insee" in source.schema("communes")
     assert source.schema("batiments")["geometry"] == "geometry"
+    # Bulk family — Etalab GeoJSON column shape (verified live for dpt 75)
+    p_bulk = source.schema("parcelles_bulk")
+    assert "arpente" in p_bulk and "updated" in p_bulk
+    assert source.schema("sections_bulk")["prefixe"] == "str"
+    # Bâtiments have no feature-id — identity is decomposed across props.
+    b_bulk = source.schema("batiments_bulk")
+    assert "id" not in b_bulk
+    assert b_bulk["type"] == "str" and b_bulk["nom"] == "str"
 
 
 class _FakeResponse:
-    """Minimal stand-in for an ``httpx.Response`` — only ``.headers``."""
+    """Minimal stand-in for an ``httpx.Response`` — headers + json + raise."""
 
-    def __init__(self, headers: dict[str, str]) -> None:
-        self.headers = headers
+    def __init__(
+        self,
+        *,
+        headers: dict[str, str] | None = None,
+        json_data: object = None,
+        status_ok: bool = True,
+    ) -> None:
+        self.headers = headers or {}
+        self._json = json_data
+        self._ok = status_ok
+
+    def raise_for_status(self) -> None:
+        if not self._ok:
+            raise RuntimeError("HTTP error")
+
+    def json(self) -> object:
+        return self._json
 
 
-def test_revision_probes_wfs_and_uses_etag(
+def test_wfs_revision_probes_wfs_and_uses_etag(
     source: CadastreSource, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """revision() derives its token from the WFS ETag header (#198)."""
+    """revision() on a WFS entry derives its token from the WFS ETag header."""
     captured: list[str] = []
 
     def fake_head(url, **_kw):
         captured.append(url)
-        return _FakeResponse({"etag": '"millesime-2026-07"'})
+        return _FakeResponse(headers={"etag": '"millesime-2026-07"'})
 
     monkeypatch.setattr("httpx.head", fake_head)
     token = source.revision("parcelles")
@@ -119,40 +234,79 @@ def test_revision_probes_wfs_and_uses_etag(
     assert captured and "GetCapabilities" in captured[0]
 
 
-def test_revision_falls_back_to_last_modified(
+def test_wfs_revision_falls_back_to_last_modified(
     source: CadastreSource, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(
         "httpx.head",
         lambda *_a, **_kw: _FakeResponse(
-            {"last-modified": "Wed, 01 Jul 2026 00:00:00 GMT"}
+            headers={"last-modified": "Wed, 01 Jul 2026 00:00:00 GMT"}
         ),
     )
     assert source.revision("communes") == "Wed, 01 Jul 2026 00:00:00 GMT"
 
 
-def test_revision_returns_none_on_network_error(
+def test_wfs_revision_returns_none_on_network_error(
     source: CadastreSource, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """An unreachable endpoint yields None — the watcher skips it."""
-
-    def boom(*_a, **_kw):
-        raise RuntimeError("connection refused")
-
-    monkeypatch.setattr("httpx.head", boom)
+    monkeypatch.setattr(
+        "httpx.head", lambda *_a, **_kw: (_ for _ in ()).throw(RuntimeError("nope"))
+    )
     assert source.revision("parcelles") is None
 
 
-def test_revision_returns_none_without_freshness_header(
+def test_wfs_revision_returns_none_without_freshness_header(
     source: CadastreSource, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setattr("httpx.head", lambda *_a, **_kw: _FakeResponse({}))
+    monkeypatch.setattr("httpx.head", lambda *_a, **_kw: _FakeResponse(headers={}))
     assert source.revision("batiments") is None
 
 
 def test_revision_validates_entry_id(
     source: CadastreSource, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setattr("httpx.head", lambda *_a, **_kw: _FakeResponse({}))
+    monkeypatch.setattr("httpx.head", lambda *_a, **_kw: _FakeResponse(headers={}))
     with pytest.raises(KeyError, match="unknown entry 'ghost'"):
         source.revision("ghost")
+
+
+def test_bulk_revision_probes_datagouv_api(
+    source: CadastreSource, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A bulk entry probes the data.gouv dataset metadata API, not the WFS HEAD."""
+    head_calls: list[str] = []
+    get_calls: list[str] = []
+
+    monkeypatch.setattr(
+        "httpx.head",
+        lambda url, **_kw: head_calls.append(url) or _FakeResponse(headers={}),
+    )
+
+    def fake_get(url, **_kw):
+        get_calls.append(url)
+        return _FakeResponse(json_data={"last_modified": "2026-03-01T00:00:00Z"})
+
+    monkeypatch.setattr("httpx.get", fake_get)
+
+    token = source.revision("parcelles_bulk")
+    assert token == "2026-03-01T00:00:00Z"
+    assert not head_calls, "bulk revision must not HEAD the WFS Capabilities"
+    assert get_calls and "data.gouv.fr/api/1/datasets/cadastre" in get_calls[0]
+
+
+def test_bulk_revision_returns_none_on_network_error(
+    source: CadastreSource, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "httpx.get", lambda *_a, **_kw: (_ for _ in ()).throw(RuntimeError("nope"))
+    )
+    assert source.revision("communes_bulk") is None
+
+
+def test_bulk_revision_returns_none_on_missing_field(
+    source: CadastreSource, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "httpx.get", lambda *_a, **_kw: _FakeResponse(json_data={"title": "Cadastre"})
+    )
+    assert source.revision("batiments_bulk") is None


### PR DESCRIPTION
## Contexte

Le plugin core `gispulse-src-cadastre` expose les entrées WFS point-query (`parcelles` / `communes` / `batiments`) mais **pas** les exports bulk Etalab par département. Conséquence côté consommateurs (ex. `gispulse-foncier/scripts/ingest_bulk.py` qui résout `communes_bulk`, `sections_bulk`…) : `StopIteration`, car le catalog ne contient aucune entrée `_bulk`.

Le prérequis (templating d'URL `{key}`, #276) est déjà mergé dans `main`. Cette PR ajoute le plugin bulk lui-même, qui n'avait jamais été ouvert en PR.

## Ce que ça ajoute

Quatre entrées bulk au catalog, chacune un template d'URL `{departement}` résolu au fetch (PCI vecteur Etalab, archives GeoJSON gzip par département) :

- `parcelles_bulk` · `communes_bulk` · `sections_bulk` · `batiments_bulk`

Les entrées WFS existantes sont conservées (renommées en interne `_wfs_entry_ref`). Aucune divergence du plugin entre le fork et upstream — cherry-pick propre sur `main`.

## Vérification

- `CadastreSource().catalog()` → `[parcelles, communes, batiments, parcelles_bulk, communes_bulk, sections_bulk, batiments_bulk]`
- `communes_bulk` se résout (plus de `StopIteration`)
- `pytest tests/unit/test_src_cadastre.py` → 21 passed
- `ruff check plugins/gispulse-src-cadastre/` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)