### PR TITLE
fix(src-dvf): re-source from live geo-DVF CSV (parquet mirror removed upstream)

### DIFF
--- a/plugins/gispulse-src-dvf/README.md
+++ b/plugins/gispulse-src-dvf/README.md
@@ -1,6 +1,6 @@
 # gispulse-src-dvf
 
-French real-estate transactions (DVF) data source for GISPulse — Etalab geo-enriched GeoParquet mirror (domain: `STATISTIQUE`, jurisdiction: `FR`).
+French real-estate transactions (DVF) data source for GISPulse — Etalab geo-enriched CSV mirror (domain: `STATISTIQUE`, jurisdiction: `FR`).
 
 ## Provider
 
@@ -10,21 +10,26 @@ French real-estate transactions (DVF) data source for GISPulse — Etalab geo-en
 | Provider (runtime)| Etalab (`metadata.provider = "Etalab"`)                       |
 | Redistributor     | data.gouv.fr / `files.data.gouv.fr`                           |
 | Dataset           | Demandes de Valeurs Foncières (DVF)                           |
-| Mirror            | `files.data.gouv.fr/geo-dvf` (geo-enriched GeoParquet)        |
+| Mirror            | `files.data.gouv.fr/geo-dvf` (geo-enriched CSV gzip)          |
 | Licence           | Licence Ouverte 2.0                                           |
 | Cadence           | Semestrial (April / October — rolling 5-year window)          |
 
 ## Entries
 
-| id          | Label                                        | AccessProtocol  | Endpoint                                                               | Payload | Jurisdiction |
-|-------------|----------------------------------------------|-----------------|------------------------------------------------------------------------|---------|--------------|
-| `mutations` | Mutations DVF (transactions immobilières)    | `REMOTE_TABLE`  | `https://files.data.gouv.fr/geo-dvf/latest/parquet/full.parquet`       | TABLE   | FR           |
+| id          | Label                                        | AccessProtocol  | Endpoint base                                           | Payload | Jurisdiction |
+|-------------|----------------------------------------------|-----------------|---------------------------------------------------------|---------|--------------|
+| `mutations` | Mutations DVF (transactions immobilières)    | `REMOTE_TABLE`  | `https://files.data.gouv.fr/geo-dvf/latest/csv`         | TABLE   | FR           |
 
 Schema highlights (field names mirror the Etalab geo-dvf CSV header):
 
-`id_mutation`, `date_mutation`, `nature_mutation`, `valeur_fonciere`, `type_local`, `surface_reelle_bati`, `surface_terrain`, `code_commune`, `nom_commune`, `code_departement`, `prefixe_section`, `section`, `numero_plan`, `id_parcelle` (synthesised join key), `longitude`, `latitude`
+`id_mutation`, `date_mutation`, `nature_mutation`, `valeur_fonciere`, `type_local`, `surface_reelle_bati`, `surface_terrain`, `code_commune`, `nom_commune`, `code_departement`, `id_parcelle`, `prefixe_section`, `section`, `numero_plan`, `longitude`, `latitude`
 
-The `AccessProtocol.REMOTE_TABLE` adapter is handled by `GeoParquetS3Fetcher` (A3, issue #229, shipped in core since v1.9.0): it scans `full.parquet` via DuckDB `read_parquet` + `httpfs` with bbox predicate pushdown — a foncier query on one département touches a few MB of the national file, not 2 GB.
+The former `latest/parquet/full.parquet` mirror now resolves to a missing S3 object. The plugin uses the live CSV layout instead:
+
+- preferred when a department hint is available: `https://files.data.gouv.fr/geo-dvf/latest/csv/{year}/departements/{departement}.csv.gz`
+- fallback without a department hint: `https://files.data.gouv.fr/geo-dvf/latest/csv/{year}/full.csv.gz`
+
+The local `REMOTE_TABLE` fetcher emits DuckDB `read_csv_auto` scans over the rolling `2021..2025` files, then applies bbox predicates on `longitude` / `latitude`. The CSV no longer carries `prefixe_section`, `section`, and `numero_plan` as standalone fields, so the scan recreates those legacy columns from `id_parcelle`.
 
 ## Revision
 
@@ -43,8 +48,20 @@ from gispulse.plugins.api import get_catalog_entry
 
 entry = get_catalog_entry("dvf", "mutations")
 # entry.access.protocol → AccessProtocol.REMOTE_TABLE
-# entry.access.endpoint → "https://files.data.gouv.fr/geo-dvf/latest/parquet/full.parquet"
-# entry.access.format   → "application/parquet"
+# entry.access.endpoint → "https://files.data.gouv.fr/geo-dvf/latest/csv"
+# entry.access.format   → "text/csv"
+```
+
+To use the lighter department shards during a lazy fetch, pass the department hint alongside the bbox:
+
+```python
+from gispulse.core.plugin_model import FetchMode
+
+result = source.fetch(
+    "mutations",
+    extent={"bbox": (3.0, 45.0, 4.0, 46.0), "departement": "63"},
+    mode=FetchMode.REFERENCE,
+)
 ```
 
 The plugin registers automatically via the `gispulse.data_sources` entry-point when installed:

--- a/plugins/gispulse-src-dvf/gispulse_src_dvf/__init__.py
+++ b/plugins/gispulse-src-dvf/gispulse_src_dvf/__init__.py
@@ -7,6 +7,10 @@ spatial join is keyed on cadastral references rather than geometry.
 
 from __future__ import annotations
 
+from typing import Any
+
+__all__ = ["dvf_registry", "register", "resolve_dvf_scan"]
+
 
 def register() -> None:
     """Entry-point hook for the ``gispulse.data_sources`` group.
@@ -20,3 +24,17 @@ def register() -> None:
     from gispulse_src_dvf.source import DvfSource
 
     SOURCES.register(DvfSource())
+
+
+def dvf_registry():
+    """Return the plugin-local DVF CSV protocol registry."""
+    from gispulse_src_dvf.source import dvf_registry as _dvf_registry
+
+    return _dvf_registry()
+
+
+def resolve_dvf_scan(entry: object, *, extent: Any | None = None) -> str:
+    """Resolve a DVF catalog entry to a DuckDB ``read_csv_auto`` scan."""
+    from gispulse_src_dvf.source import resolve_dvf_scan as _resolve_dvf_scan
+
+    return _resolve_dvf_scan(entry, extent=extent)

--- a/plugins/gispulse-src-dvf/gispulse_src_dvf/source.py
+++ b/plugins/gispulse-src-dvf/gispulse_src_dvf/source.py
@@ -3,7 +3,8 @@
 A :class:`~gispulse.plugins.api.DeclarativeSource`: the plugin only
 *declares* its access spec; the actual data read is delegated to the
 registered :class:`Fetcher` for ``AccessSpec.protocol``. This package
-ships zero network code besides a single GET probe for ``revision()``.
+ships a tiny DVF-specific DuckDB CSV fetcher because the former upstream
+GeoParquet mirror has disappeared.
 
 Data: Etalab DVF (a.k.a. "Demande de Valeurs Foncières") — every
 real-estate transaction registered in France over a rolling 5-year
@@ -14,44 +15,79 @@ this plugin's schema declares.
 
 DVF mutations are *attribute rows* keyed on cadastral references, not
 vector geometry — hence :data:`Payload.TABLE`. The downstream join to a
-cadastral parcel is materialised on the canonical ``id_parcelle`` the
-schema synthesises from ``code_commune`` + ``prefixe_section`` +
-``section`` + ``numero_plan``.
+cadastral parcel is materialised on the canonical ``id_parcelle``. The
+current CSV carries that key directly; the fetcher recreates the older
+``prefixe_section`` / ``section`` / ``numero_plan`` columns from it.
 
 .. note::
-   :data:`AccessProtocol.REMOTE_TABLE` is declared **deliberately**:
-   DVF is a tabular dataset published as CSV (Etalab) or GeoParquet
-   (Cerema/IGN derivatives). The transport adapter for that protocol
-   ships in the core distribution since v1.9.0 —
-   :class:`~gispulse.core.fetchers.geoparquet_s3.GeoParquetS3Fetcher`
-   (issue #256), registered into the :data:`ProtocolRegistry` by
-   :func:`~gispulse.core.fetchers.register_core_fetchers`. Against the
-   ``full.parquet`` mirror this declaration targets, :meth:`fetch`
-   resolves to that fetcher and scans the file with bbox predicate
-   pushdown via DuckDB ``httpfs`` — no follow-up ``kind = "protocol"``
-   plugin is required.
+   :data:`AccessProtocol.REMOTE_TABLE` is still declared deliberately:
+   DVF remains a tabular dataset read lazily by DuckDB. The live Etalab
+   mirror now exposes gzip-compressed CSV files under
+   ``latest/csv/{year}/``. The local fetcher below emits
+   ``read_csv_auto`` scans over those files and applies bbox predicates
+   against ``longitude`` / ``latitude``.
 """
 
 from __future__ import annotations
 
+import re
+import tempfile
+from collections.abc import Mapping, Sequence
+from typing import Any, ClassVar
+
+from gispulse.core.fetchers import DUCKDB_SCAN_KEY, LazyFetcher
+from gispulse.core.plugin_model import FetchMode
 from gispulse.plugins.api import (
     AccessProtocol,
     AccessSpec,
     DeclarativeSource,
     Payload,
+    ProtocolRegistry,
     SourceDomain,
     SourceEntryRef,
+    SourceResult,
 )
 
-# Etalab geo-DVF mirror — the rolling-window full export. ``latest`` is
-# a millésime symlink rotated each release. The parquet variant is the
-# preferred entry: ``GeoParquetS3Fetcher`` (shipped in #256 with v1.9.0)
-# scans it via DuckDB ``read_parquet`` + ``httpfs`` and pushes the bbox
-# predicate into the row-group selection — a foncier query on one
-# département touches a few MB of the national parquet, not 2 GB.
-_DVF_GEO_PARQUET = (
-    "https://files.data.gouv.fr/geo-dvf/latest/parquet/full.parquet"
+# Etalab geo-DVF mirror — live CSV export. ``latest/csv`` currently
+# exposes a rolling 2021..2025 window (verified live on 2026-05-25) with
+# both national yearly files and lighter department shards.
+_DVF_GEO_CSV_BASE = "https://files.data.gouv.fr/geo-dvf/latest/csv"
+_DVF_CSV_YEARS = ("2021", "2022", "2023", "2024", "2025")
+_DVF_DEPARTMENT_ENDPOINT_TEMPLATE = (
+    "{base}/{year}/departements/{departement}.csv.gz"
 )
+_DVF_FULL_ENDPOINT_TEMPLATE = "{base}/{year}/full.csv.gz"
+
+_DVF_STRING_COLUMNS = (
+    "id_mutation",
+    "numero_disposition",
+    "nature_mutation",
+    "adresse_numero",
+    "adresse_suffixe",
+    "adresse_nom_voie",
+    "adresse_code_voie",
+    "code_postal",
+    "code_commune",
+    "nom_commune",
+    "code_departement",
+    "ancien_code_commune",
+    "ancien_nom_commune",
+    "id_parcelle",
+    "ancien_id_parcelle",
+    "numero_volume",
+    "lot1_numero",
+    "lot2_numero",
+    "lot3_numero",
+    "lot4_numero",
+    "lot5_numero",
+    "type_local",
+    "code_nature_culture",
+    "nature_culture",
+    "code_nature_culture_speciale",
+    "nature_culture_speciale",
+)
+
+_DVF_DEPARTMENT_RE = re.compile(r"^[0-9A-Z]{2,3}$")
 
 # Dataset metadata endpoint on data.gouv.fr — returns JSON with a
 # top-level ``last_modified`` ISO-8601 timestamp updated on every
@@ -64,6 +100,173 @@ _DVF_METADATA_API = (
     "demandes-de-valeurs-foncieres/"
 )
 _REVISION_TIMEOUT_S = 8.0
+
+
+def _sql_literal(value: object) -> str:
+    return "'" + str(value).replace("'", "''") + "'"
+
+
+def _sql_identifier(value: object) -> str:
+    return '"' + str(value).replace('"', '""') + '"'
+
+
+def _duckdb_types_sql() -> str:
+    parts = ", ".join(
+        f"{_sql_literal(column)}: {_sql_literal('VARCHAR')}"
+        for column in _DVF_STRING_COLUMNS
+    )
+    return "{" + parts + "}"
+
+
+def _normalise_years(raw: object) -> tuple[str, ...]:
+    if raw is None:
+        return _DVF_CSV_YEARS
+    if isinstance(raw, str):
+        years = (raw,)
+    elif isinstance(raw, Sequence):
+        years = tuple(str(year) for year in raw)
+    else:
+        years = (str(raw),)
+    for year in years:
+        if not (len(year) == 4 and year.isdecimal()):
+            raise ValueError(f"invalid DVF CSV year: {year!r}")
+    return years
+
+
+def _normalise_departement(raw: object | None) -> str | None:
+    if raw is None:
+        return None
+    code = str(raw).strip().upper()
+    if not code:
+        return None
+    if code.isdecimal() and len(code) == 1:
+        code = f"0{code}"
+    if not _DVF_DEPARTMENT_RE.match(code):
+        raise ValueError(f"invalid DVF department code: {raw!r}")
+    return code
+
+
+def _extent_parts(extent: Any | None) -> tuple[Any | None, str | None]:
+    if isinstance(extent, Mapping):
+        bbox = extent.get("bbox", extent.get("extent"))
+        departement = (
+            extent.get("departement")
+            or extent.get("department")
+            or extent.get("code_departement")
+        )
+        return bbox, _normalise_departement(departement)
+    return extent, None
+
+
+def _bbox_predicate(extent: Any | None, lon: object, lat: object) -> str | None:
+    if not extent:
+        return None
+    minx, miny, maxx, maxy = (float(coord) for coord in extent)
+    lon_col = _sql_identifier(lon)
+    lat_col = _sql_identifier(lat)
+    return (
+        f"{lon_col} BETWEEN {minx} AND {maxx} "
+        f"AND {lat_col} BETWEEN {miny} AND {maxy}"
+    )
+
+
+def _csv_source_sql(urls: Sequence[str]) -> str:
+    quoted = [_sql_literal(url) for url in urls]
+    if len(quoted) == 1:
+        return quoted[0]
+    return "[" + ", ".join(quoted) + "]"
+
+
+class _DvfGeoCsvFetcher(LazyFetcher):
+    """DVF-only remote table fetcher over the live geo-DVF CSV mirror."""
+
+    protocol: ClassVar[AccessProtocol] = AccessProtocol.REMOTE_TABLE
+    payload: ClassVar[Payload] = Payload.TABLE
+
+    @staticmethod
+    def _urls(access: AccessSpec, departement: str | None) -> tuple[str, ...]:
+        base = access.endpoint.rstrip("/")
+        years = _normalise_years(access.params.get("years"))
+        if departement is None:
+            template = str(
+                access.params.get(
+                    "full_endpoint_template", _DVF_FULL_ENDPOINT_TEMPLATE
+                )
+            )
+            return tuple(
+                template.format(base=base, year=year) for year in years
+            )
+        template = str(
+            access.params.get(
+                "department_endpoint_template",
+                _DVF_DEPARTMENT_ENDPOINT_TEMPLATE,
+            )
+        )
+        return tuple(
+            template.format(base=base, year=year, departement=departement)
+            for year in years
+        )
+
+    @staticmethod
+    def _read_csv_auto(urls: Sequence[str]) -> str:
+        source = _csv_source_sql(urls)
+        return (
+            f"read_csv_auto({source}, union_by_name=true, "
+            f"types={_duckdb_types_sql()})"
+        )
+
+    @staticmethod
+    def _legacy_projection(scan: str) -> str:
+        return (
+            f"(SELECT *, "
+            f'substr("id_parcelle", 6, 3) AS "prefixe_section", '
+            f'substr("id_parcelle", 9, 2) AS "section", '
+            f'substr("id_parcelle", 11, 4) AS "numero_plan" '
+            f"FROM {scan})"
+        )
+
+    def _reference_scan(self, access: AccessSpec, extent: Any | None) -> str:
+        bbox, extent_departement = _extent_parts(extent)
+        departement = extent_departement or _normalise_departement(
+            access.params.get("departement") or access.params.get("department")
+        )
+        scan = self._legacy_projection(self._read_csv_auto(self._urls(access, departement)))
+        predicate = _bbox_predicate(
+            bbox,
+            access.params.get("lon", "longitude"),
+            access.params.get("lat", "latitude"),
+        )
+        if predicate is None:
+            return scan
+        return f"(SELECT * FROM {scan} WHERE {predicate})"
+
+    def _materialize(self, access: AccessSpec, extent: Any | None) -> SourceResult:
+        from gispulse.persistence.duckdb_engine import DuckDBSession
+
+        local_path = access.params.get("local_path")
+        if not local_path:
+            handle = tempfile.NamedTemporaryFile(suffix=".parquet", delete=False)
+            handle.close()
+            local_path = handle.name
+
+        select = self._reference_scan(access, extent)
+        dest = str(local_path).replace("'", "''")
+        copy_sql = f"COPY (SELECT * FROM {select}) TO '{dest}' (FORMAT PARQUET)"
+        with DuckDBSession() as session:
+            session.conn.execute(copy_sql)
+        return SourceResult(
+            payload=self.payload,
+            mode=FetchMode.MATERIALIZE,
+            data=local_path,
+            extent=tuple(extent) if extent and not isinstance(extent, Mapping) else None,
+            metadata={"copy_sql": copy_sql, DUCKDB_SCAN_KEY: select},
+        )
+
+
+def _dvf_registry() -> ProtocolRegistry:
+    registry = ProtocolRegistry()
+    registry.register(_DvfGeoCsvFetcher())
+    return registry
 
 
 def _probe_revision(api_url: str) -> str | None:
@@ -101,6 +304,9 @@ class DvfSource(DeclarativeSource):
     payload = Payload.TABLE
     jurisdiction = "FR"
 
+    def __init__(self, registry: ProtocolRegistry | None = None) -> None:
+        super().__init__(registry=registry or _dvf_registry())
+
     def entries(self) -> list[SourceEntryRef]:
         return [
             self._entry_ref(
@@ -116,13 +322,17 @@ class DvfSource(DeclarativeSource):
             name=label,
             access=AccessSpec(
                 protocol=AccessProtocol.REMOTE_TABLE,
-                endpoint=_DVF_GEO_PARQUET,
-                # Static params — the AccessSpec is a declaration. Bbox
-                # predicate pushdown is handled by
-                # :class:`GeoParquetS3Fetcher` at scan time, not encoded
-                # here.
-                params={},
-                format="application/parquet",
+                endpoint=_DVF_GEO_CSV_BASE,
+                params={
+                    "years": _DVF_CSV_YEARS,
+                    "department_endpoint_template": (
+                        _DVF_DEPARTMENT_ENDPOINT_TEMPLATE
+                    ),
+                    "full_endpoint_template": _DVF_FULL_ENDPOINT_TEMPLATE,
+                    "lat": "latitude",
+                    "lon": "longitude",
+                },
+                format="text/csv",
             ),
             # revision() probes data.gouv.fr live (issue #198); the
             # declared token stays None so nothing hard-codes a stale
@@ -139,6 +349,7 @@ class DvfSource(DeclarativeSource):
                 "provider": "Etalab",
                 "dataset": "Demandes de Valeurs Foncières",
                 "mirror": "files.data.gouv.fr/geo-dvf",
+                "mirror_format": "csv.gz",
                 "update_cadence": "semestrial",
                 "license": "Licence Ouverte 2.0",
             },
@@ -164,15 +375,14 @@ class DvfSource(DeclarativeSource):
     def schema(self, entry_id: str) -> dict:
         """Normalised attribute schema of a DVF mutation row.
 
-        Field names mirror the Etalab ``geo-dvf`` CSV header so the
-        REMOTE_TABLE adapter can map columns one-to-one (no
-        runtime renaming).
+        Field names mirror the Etalab ``geo-dvf`` CSV header, plus the
+        three legacy cadastral pivot fields reconstructed from
+        ``id_parcelle`` for consumers that were written against the
+        former parquet mirror.
 
-        The synthetic ``id_parcelle`` field is the canonical cadastral
-        join key built from the four pivot columns
-        (``code_commune`` + ``prefixe_section`` + ``section`` +
-        ``numero_plan``); downstream plugins like ``gispulse-permis``
-        consume this rather than the four raw fields.
+        ``id_parcelle`` is the canonical cadastral join key. Downstream
+        plugins like ``gispulse-permis`` can still consume the legacy
+        split fields when needed; they are derived from ``id_parcelle``.
         """
         self._entry(entry_id)  # validates the id
         return {
@@ -183,23 +393,49 @@ class DvfSource(DeclarativeSource):
             "nature_mutation": "str",
             # Economics
             "valeur_fonciere": "float",
+            # Address
+            "adresse_numero": "str",
+            "adresse_suffixe": "str",
+            "adresse_nom_voie": "str",
+            "adresse_code_voie": "str",
             # Local typology
             "type_local": "str",
             "code_type_local": "int",
             "surface_reelle_bati": "float",
             "surface_terrain": "float",
             "nombre_pieces_principales": "int",
+            # Lots
+            "numero_volume": "str",
+            "lot1_numero": "str",
+            "lot1_surface_carrez": "float",
+            "lot2_numero": "str",
+            "lot2_surface_carrez": "float",
+            "lot3_numero": "str",
+            "lot3_surface_carrez": "float",
+            "lot4_numero": "str",
+            "lot4_surface_carrez": "float",
+            "lot5_numero": "str",
+            "lot5_surface_carrez": "float",
+            "nombre_lots": "int",
+            # Land nature
+            "code_nature_culture": "str",
+            "nature_culture": "str",
+            "code_nature_culture_speciale": "str",
+            "nature_culture_speciale": "str",
             # Geography — administrative
             "code_postal": "str",
             "code_commune": "str",
             "nom_commune": "str",
             "code_departement": "str",
+            "ancien_code_commune": "str",
+            "ancien_nom_commune": "str",
             # Cadastral pivot — the four raw fields and the canonical
             # join key downstream plugins consume.
             "prefixe_section": "str",
             "section": "str",
             "numero_plan": "str",
-            "id_parcelle": "str",  # synthesised
+            "id_parcelle": "str",
+            "ancien_id_parcelle": "str",
             # Geography — geocoded (geo-dvf mirror only)
             "longitude": "float",
             "latitude": "float",

--- a/plugins/gispulse-src-dvf/gispulse_src_dvf/source.py
+++ b/plugins/gispulse-src-dvf/gispulse_src_dvf/source.py
@@ -48,6 +48,8 @@ from gispulse.plugins.api import (
     SourceResult,
 )
 
+__all__ = ["DvfSource", "dvf_registry", "resolve_dvf_scan"]
+
 # Etalab geo-DVF mirror — live CSV export. ``latest/csv`` currently
 # exposes a rolling 2021..2025 window (verified live on 2026-05-25) with
 # both national yearly files and lighter department shards.
@@ -230,7 +232,9 @@ class _DvfGeoCsvFetcher(LazyFetcher):
         departement = extent_departement or _normalise_departement(
             access.params.get("departement") or access.params.get("department")
         )
-        scan = self._legacy_projection(self._read_csv_auto(self._urls(access, departement)))
+        scan = self._legacy_projection(
+            self._read_csv_auto(self._urls(access, departement))
+        )
         predicate = _bbox_predicate(
             bbox,
             access.params.get("lon", "longitude"),
@@ -263,10 +267,31 @@ class _DvfGeoCsvFetcher(LazyFetcher):
         )
 
 
-def _dvf_registry() -> ProtocolRegistry:
+def dvf_registry() -> ProtocolRegistry:
+    """Return a DVF-local registry whose REMOTE_TABLE slot is the CSV fetcher.
+
+    This intentionally does not mutate the process-wide ``PROTOCOLS``
+    registry: core owns the generic GeoParquet ``REMOTE_TABLE`` adapter,
+    while DVF is now a single-format CSV source.
+    """
     registry = ProtocolRegistry()
     registry.register(_DvfGeoCsvFetcher())
     return registry
+
+
+def resolve_dvf_scan(
+    entry: SourceEntryRef, *, extent: Any | None = None
+) -> str:
+    """Resolve a DVF entry to its DuckDB CSV scan through the local registry."""
+    result = dvf_registry().dispatch_fetch(
+        entry.access,
+        extent=extent,
+        mode=FetchMode.REFERENCE,
+    )
+    scan = result.metadata.get(DUCKDB_SCAN_KEY) if result.metadata else None
+    if not isinstance(scan, str) or not scan:
+        raise RuntimeError("DVF CSV fetcher did not return a DuckDB scan")
+    return scan
 
 
 def _probe_revision(api_url: str) -> str | None:
@@ -305,7 +330,7 @@ class DvfSource(DeclarativeSource):
     jurisdiction = "FR"
 
     def __init__(self, registry: ProtocolRegistry | None = None) -> None:
-        super().__init__(registry=registry or _dvf_registry())
+        super().__init__(registry=registry or dvf_registry())
 
     def entries(self) -> list[SourceEntryRef]:
         return [

--- a/plugins/gispulse-src-dvf/gispulse_src_dvf/source.py
+++ b/plugins/gispulse-src-dvf/gispulse_src_dvf/source.py
@@ -112,12 +112,11 @@ def _sql_identifier(value: object) -> str:
     return '"' + str(value).replace('"', '""') + '"'
 
 
-def _duckdb_types_sql() -> str:
-    parts = ", ".join(
-        f"{_sql_literal(column)}: {_sql_literal('VARCHAR')}"
-        for column in _DVF_STRING_COLUMNS
+def _csv_numeric_expr(column: object) -> str:
+    return (
+        f"try_cast(replace(cast({_sql_identifier(column)} as varchar), ',', '.') "
+        "as double)"
     )
-    return "{" + parts + "}"
 
 
 def _normalise_years(raw: object) -> tuple[str, ...]:
@@ -164,8 +163,8 @@ def _bbox_predicate(extent: Any | None, lon: object, lat: object) -> str | None:
     if not extent:
         return None
     minx, miny, maxx, maxy = (float(coord) for coord in extent)
-    lon_col = _sql_identifier(lon)
-    lat_col = _sql_identifier(lat)
+    lon_col = _csv_numeric_expr(lon)
+    lat_col = _csv_numeric_expr(lat)
     return (
         f"{lon_col} BETWEEN {minx} AND {maxx} "
         f"AND {lat_col} BETWEEN {miny} AND {maxy}"
@@ -214,7 +213,7 @@ class _DvfGeoCsvFetcher(LazyFetcher):
         source = _csv_source_sql(urls)
         return (
             f"read_csv_auto({source}, union_by_name=true, "
-            f"types={_duckdb_types_sql()})"
+            "all_varchar=true)"
         )
 
     @staticmethod

--- a/tests/unit/test_src_dvf.py
+++ b/tests/unit/test_src_dvf.py
@@ -71,16 +71,66 @@ def test_catalog_search(source: DvfSource) -> None:
 # --------------------------------------------------------------------------
 
 
-def test_access_spec_targets_etalab_geo_dvf(source: DvfSource) -> None:
-    """The declared endpoint must point at the geo-dvf parquet mirror so
-    the shipped GeoParquetS3Fetcher (#256) can scan it with bbox
-    pushdown via DuckDB httpfs."""
+def test_access_spec_targets_live_etalab_geo_dvf_csv(source: DvfSource) -> None:
+    """The declared endpoint must point at the living geo-dvf CSV mirror."""
     entry = next(iter(source.catalog()))
     access = entry.access
     assert access.protocol is AccessProtocol.REMOTE_TABLE
-    assert "files.data.gouv.fr/geo-dvf" in access.endpoint
-    assert access.endpoint.endswith(".parquet")
-    assert access.format == "application/parquet"
+    assert access.endpoint == "https://files.data.gouv.fr/geo-dvf/latest/csv"
+    assert access.params["years"] == ("2021", "2022", "2023", "2024", "2025")
+    assert (
+        access.params["department_endpoint_template"]
+        == "{base}/{year}/departements/{departement}.csv.gz"
+    )
+    assert access.params["full_endpoint_template"] == "{base}/{year}/full.csv.gz"
+    assert access.format == "text/csv"
+
+
+def test_reference_scan_uses_department_csv_shards_when_requested() -> None:
+    """A department hint selects the lighter geo-dvf shard before bbox filter."""
+    src = DvfSource()
+
+    result = src.fetch(
+        "mutations",
+        extent={"bbox": (3.0, 45.0, 4.0, 46.0), "departement": "63"},
+        mode=FetchMode.REFERENCE,
+    )
+
+    scan = result.metadata["duckdb_scan"]
+    assert result.payload is Payload.TABLE
+    assert "read_csv_auto(" in scan
+    assert "/2021/departements/63.csv.gz" in scan
+    assert "/2025/departements/63.csv.gz" in scan
+    assert "/full.csv.gz" not in scan
+    assert '"longitude" BETWEEN 3.0 AND 4.0' in scan
+    assert '"latitude" BETWEEN 45.0 AND 46.0' in scan
+
+
+def test_reference_scan_falls_back_to_full_csv_without_department() -> None:
+    """Without a department hint, the scan uses full yearly CSVs plus bbox."""
+    src = DvfSource()
+
+    result = src.fetch(
+        "mutations",
+        extent=(3.0, 45.0, 4.0, 46.0),
+        mode=FetchMode.REFERENCE,
+    )
+
+    scan = result.metadata["duckdb_scan"]
+    assert "/2021/full.csv.gz" in scan
+    assert "/2025/full.csv.gz" in scan
+    assert "/departements/" not in scan
+    assert '"longitude" BETWEEN 3.0 AND 4.0' in scan
+
+
+def test_reference_scan_restores_legacy_cadastral_columns() -> None:
+    """The CSV lacks raw pivot fields, so the scan recreates them."""
+    result = DvfSource().fetch("mutations", mode=FetchMode.REFERENCE)
+    scan = result.metadata["duckdb_scan"]
+
+    assert 'substr("id_parcelle", 6, 3) AS "prefixe_section"' in scan
+    assert 'substr("id_parcelle", 9, 2) AS "section"' in scan
+    assert 'substr("id_parcelle", 11, 4) AS "numero_plan"' in scan
 
 
 # --------------------------------------------------------------------------

--- a/tests/unit/test_src_dvf.py
+++ b/tests/unit/test_src_dvf.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import duckdb
 import pytest
 
 _PKG = Path(__file__).resolve().parents[2] / "plugins" / "gispulse-src-dvf"
@@ -13,6 +14,7 @@ if str(_PKG) not in sys.path:
 
 from gispulse_src_dvf.source import (  # noqa: E402
     DvfSource,
+    _DvfGeoCsvFetcher,
     dvf_registry,
     resolve_dvf_scan,
 )
@@ -103,11 +105,14 @@ def test_reference_scan_uses_department_csv_shards_when_requested() -> None:
     scan = result.metadata["duckdb_scan"]
     assert result.payload is Payload.TABLE
     assert "read_csv_auto(" in scan
+    assert "all_varchar=true" in scan
     assert "/2021/departements/63.csv.gz" in scan
     assert "/2025/departements/63.csv.gz" in scan
     assert "/full.csv.gz" not in scan
-    assert '"longitude" BETWEEN 3.0 AND 4.0' in scan
-    assert '"latitude" BETWEEN 45.0 AND 46.0' in scan
+    assert 'try_cast(replace(cast("longitude" as varchar)' in scan
+    assert "as double) BETWEEN 3.0 AND 4.0" in scan
+    assert 'try_cast(replace(cast("latitude" as varchar)' in scan
+    assert "as double) BETWEEN 45.0 AND 46.0" in scan
 
 
 def test_reference_scan_falls_back_to_full_csv_without_department() -> None:
@@ -124,7 +129,7 @@ def test_reference_scan_falls_back_to_full_csv_without_department() -> None:
     assert "/2021/full.csv.gz" in scan
     assert "/2025/full.csv.gz" in scan
     assert "/departements/" not in scan
-    assert '"longitude" BETWEEN 3.0 AND 4.0' in scan
+    assert 'try_cast(replace(cast("longitude" as varchar)' in scan
 
 
 def test_reference_scan_restores_legacy_cadastral_columns() -> None:
@@ -149,6 +154,7 @@ def test_public_dvf_registry_dispatches_to_csv_fetcher() -> None:
     scan = result.metadata["duckdb_scan"]
 
     assert "read_csv_auto(" in scan
+    assert "all_varchar=true" in scan
     assert "read_parquet" not in scan
     assert "/departements/63.csv.gz" in scan
 
@@ -162,8 +168,39 @@ def test_resolve_dvf_scan_returns_csv_scan() -> None:
     )
 
     assert "read_csv_auto(" in scan
+    assert "all_varchar=true" in scan
     assert "read_parquet" not in scan
-    assert '"longitude" BETWEEN 3.0 AND 4.0' in scan
+    assert 'try_cast(replace(cast("longitude" as varchar)' in scan
+
+
+def test_dvf_csv_scan_reads_dirty_numeric_columns_as_varchar(tmp_path: Path) -> None:
+    """Live DVF millesimes can contain non-numeric labels in numeric-looking columns."""
+    csv_path = tmp_path / "dvf-dirty.csv"
+    csv_path.write_text(
+        "\n".join(
+            (
+                "id_parcelle,surface_reelle_bati,longitude,latitude",
+                "631130000A0001,85,3.08,45.77",
+                "631130000A0002,Dépendance,3.09,45.78",
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    scan = _DvfGeoCsvFetcher._read_csv_auto([str(csv_path)])
+
+    assert "all_varchar=true" in scan
+    con = duckdb.connect()
+    try:
+        rows = con.execute(f'SELECT "surface_reelle_bati" FROM {scan}').fetchall()
+        dtype = con.execute(
+            f'SELECT typeof("surface_reelle_bati") FROM {scan} LIMIT 1'
+        ).fetchone()[0]
+    finally:
+        con.close()
+
+    assert dtype == "VARCHAR"
+    assert rows == [("85",), ("Dépendance",)]
 
 
 # --------------------------------------------------------------------------

--- a/tests/unit/test_src_dvf.py
+++ b/tests/unit/test_src_dvf.py
@@ -11,7 +11,11 @@ _PKG = Path(__file__).resolve().parents[2] / "plugins" / "gispulse-src-dvf"
 if str(_PKG) not in sys.path:
     sys.path.insert(0, str(_PKG))
 
-from gispulse_src_dvf.source import DvfSource  # noqa: E402
+from gispulse_src_dvf.source import (  # noqa: E402
+    DvfSource,
+    dvf_registry,
+    resolve_dvf_scan,
+)
 
 from gispulse.core.plugin_model import (  # noqa: E402
     AccessProtocol,
@@ -131,6 +135,35 @@ def test_reference_scan_restores_legacy_cadastral_columns() -> None:
     assert 'substr("id_parcelle", 6, 3) AS "prefixe_section"' in scan
     assert 'substr("id_parcelle", 9, 2) AS "section"' in scan
     assert 'substr("id_parcelle", 11, 4) AS "numero_plan"' in scan
+
+
+def test_public_dvf_registry_dispatches_to_csv_fetcher() -> None:
+    """Consumers can explicitly bypass the global REMOTE_TABLE slot."""
+    entry = next(iter(DvfSource().catalog()))
+
+    result = dvf_registry().dispatch_fetch(
+        entry.access,
+        extent={"bbox": (3.0, 45.0, 4.0, 46.0), "departement": "63"},
+        mode=FetchMode.REFERENCE,
+    )
+    scan = result.metadata["duckdb_scan"]
+
+    assert "read_csv_auto(" in scan
+    assert "read_parquet" not in scan
+    assert "/departements/63.csv.gz" in scan
+
+
+def test_resolve_dvf_scan_returns_csv_scan() -> None:
+    entry = next(iter(DvfSource().catalog()))
+
+    scan = resolve_dvf_scan(
+        entry,
+        extent={"bbox": (3.0, 45.0, 4.0, 46.0), "departement": "63"},
+    )
+
+    assert "read_csv_auto(" in scan
+    assert "read_parquet" not in scan
+    assert '"longitude" BETWEEN 3.0 AND 4.0' in scan
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Contexte
`gispulse-src-dvf` lisait le geo-DVF via `read_parquet` sur `files.data.gouv.fr/geo-dvf/latest/parquet/full.parquet`. Ce **miroir parquet a été supprimé upstream** (302 → S3 OVH → 404) ; seule la version **CSV** survit (`latest/csv/{year}/...`). Tout consommateur (ex. `gispulse-foncier/ingest_dvf_dept`) se prend un 404. Ce n'est pas une régression de merge — l'URL était inchangée depuis #223.

## Ce que fait la PR
- Re-source vers le **CSV vivant**, en privilégiant le **shard départemental** `latest/csv/{year}/departements/{dd}.csv.gz` (léger) avec fallback `full.csv.gz`.
- Lecture `read_csv_auto(..., union_by_name=true, all_varchar=true)` → robuste aux colonnes sales (ex. `surface_reelle_bati` contenant un libellé) ; casts numériques en aval.
- Expose une API publique `dvf_registry()` / `resolve_dvf_scan(entry, extent=...)` pour que les consommateurs dispatchent vers le fetcher CSV (sans collision avec le `GeoParquetS3Fetcher` REMOTE_TABLE du core).
- Contrat de sortie préservé (mêmes colonnes, `id_parcelle`, etc.).

## Vérification
- `pytest tests/unit/test_src_dvf.py` → 20 passed.
- Validé en réel (VPS) : `ingest_dvf_dept --departement 63 75` → **669 044 lignes** (2021-2025, shards départementaux), scan = `read_csv_auto`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)