### PR TITLE
feat(plugins): gispulse-src-bdnb source plugin

### DIFF
--- a/plugins/gispulse-src-bdnb/gispulse_src_bdnb/__init__.py
+++ b/plugins/gispulse-src-bdnb/gispulse_src_bdnb/__init__.py
@@ -1,0 +1,11 @@
+"""GISPulse data-source plugin - BDNB building archives."""
+
+from __future__ import annotations
+
+
+def register() -> None:
+    """Entry-point hook for the ``gispulse.data_sources`` group."""
+    from gispulse.core.sources import SOURCES
+    from gispulse_src_bdnb.source import BdnbSource
+
+    SOURCES.register(BdnbSource())

--- a/plugins/gispulse-src-bdnb/gispulse_src_bdnb/source.py
+++ b/plugins/gispulse-src-bdnb/gispulse_src_bdnb/source.py
@@ -27,12 +27,15 @@ _BDNB_S3_BASE = (
     f"https://open-data.s3.fr-par.scw.cloud/bdnb_millesime_{_MILLESIME_PATH}"
 )
 
-_VALID_DEPARTEMENTS = (
-    {f"{value:02d}" for value in range(1, 96)}
-    - {"20"}
-    | {"2A", "2B"}
-    | {str(value) for value in range(971, 979)}
+_PUBLISHED_DEPARTEMENTS = (
+    *(f"{value:02d}" for value in range(1, 20)),
+    *(f"{value:02d}" for value in range(21, 96)),
+    "2a",
+    "2b",
 )
+_VALID_DEPARTEMENTS = set(_PUBLISHED_DEPARTEMENTS)
+_BUILDING_GROUP_TABLE = "batiment_groupe"
+_BUILDING_GROUP_ARCHIVE_MEMBER = f"csv/{_BUILDING_GROUP_TABLE}.csv"
 
 
 @dataclass(frozen=True)
@@ -59,7 +62,7 @@ _ENTRY_SPECS: dict[str, _EntrySpec] = {
         },
     ),
     "batiments_tables": _EntrySpec(
-        label="BDNB - batiments, archive CSV departementale",
+        label="BDNB - batiment_groupe, table CSV departementale",
         protocol=AccessProtocol.TABLE_FILE,
         payload=Payload.TABLE,
         archive_kind="csv",
@@ -68,16 +71,13 @@ _ENTRY_SPECS: dict[str, _EntrySpec] = {
             "departement": _DEFAULT_DEPARTEMENT,
             "archive_format": "zip",
             "table_format": "csv",
+            "archive_member": _BUILDING_GROUP_ARCHIVE_MEMBER,
         },
     ),
 }
 
 _SOURCE_TABLES = (
-    "batiment_groupe",
-    "batiment_groupe_compile",
-    "batiment_groupe_bdtopo_bat",
-    "batiment_groupe_dpe_representatif_logement",
-    "batiment_groupe_dpe_statistique_logement",
+    _BUILDING_GROUP_TABLE,
 )
 
 _SCHEMA = {
@@ -102,7 +102,9 @@ def _department_archive_endpoint(kind: str) -> str:
 
 
 def _normalise_departement(raw: object | None) -> str:
-    value = str(raw or "").strip().upper()
+    value = str(raw or "").strip()
+    if value.upper() in {"2A", "2B"}:
+        value = value.lower()
     if value.isdigit() and len(value) <= 2:
         value = value.zfill(2)
     if value in _VALID_DEPARTEMENTS:
@@ -166,6 +168,34 @@ class BdnbSource(DeclarativeSource):
 
     @staticmethod
     def _entry_ref(entry_id: str, spec: _EntrySpec) -> SourceEntryRef:
+        metadata = {
+            "provider": "CSTB",
+            "dataset": "Base de Donnees Nationale des Batiments",
+            "platform": "bdnb.io / data.gouv.fr",
+            "license": "Licence Ouverte 2.0",
+            "millesime": _MILLESIME_LABEL,
+            "update_cadence": "semestrial",
+            "archive_format": "zip",
+            "data_format": spec.data_format,
+            "archive_scope": (
+                "single_member"
+                if "archive_member" in spec.params
+                else "full_archive"
+            ),
+            "department_param": "departement",
+            "default_departement": _DEFAULT_DEPARTEMENT,
+            "published_departements": _PUBLISHED_DEPARTEMENTS,
+            "join_key": "batiment_groupe_id",
+            "geometry_key": "geometry",
+        }
+        if "archive_member" in spec.params:
+            metadata.update(
+                {
+                    "archive_member": spec.params["archive_member"],
+                    "source_tables": _SOURCE_TABLES,
+                    "table_name": _BUILDING_GROUP_TABLE,
+                }
+            )
         return SourceEntryRef(
             id=entry_id,
             name=spec.label,
@@ -179,19 +209,5 @@ class BdnbSource(DeclarativeSource):
             domain=SourceDomain.FONCIER,
             payload=spec.payload,
             jurisdiction="FR",
-            metadata={
-                "provider": "CSTB",
-                "dataset": "Base de Donnees Nationale des Batiments",
-                "platform": "bdnb.io / data.gouv.fr",
-                "license": "Licence Ouverte 2.0",
-                "millesime": _MILLESIME_LABEL,
-                "update_cadence": "semestrial",
-                "archive_format": "zip",
-                "data_format": spec.data_format,
-                "department_param": "departement",
-                "default_departement": _DEFAULT_DEPARTEMENT,
-                "source_tables": _SOURCE_TABLES,
-                "join_key": "batiment_groupe_id",
-                "geometry_key": "geometry",
-            },
+            metadata=metadata,
         )

--- a/plugins/gispulse-src-bdnb/gispulse_src_bdnb/source.py
+++ b/plugins/gispulse-src-bdnb/gispulse_src_bdnb/source.py
@@ -1,0 +1,197 @@
+"""BDNB DataSource - French national building database.
+
+The BDNB open-data distribution is a set of large downloadable archives:
+France-wide exports plus department archives. This source deliberately stays
+declarative: it exposes the current public department ZIP archives and leaves
+download/materialisation to the registered GISPulse fetchers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+from gispulse.plugins.api import (
+    AccessProtocol,
+    AccessSpec,
+    DeclarativeSource,
+    Payload,
+    SourceDomain,
+    SourceEntryRef,
+)
+
+_MILLESIME_LABEL = "2026-02.a"
+_MILLESIME_PATH = "2026-02-a"
+_REVISION = "bdnb-2026-02-a"
+_DEFAULT_DEPARTEMENT = "63"
+_BDNB_S3_BASE = (
+    f"https://open-data.s3.fr-par.scw.cloud/bdnb_millesime_{_MILLESIME_PATH}"
+)
+
+_VALID_DEPARTEMENTS = (
+    {f"{value:02d}" for value in range(1, 96)}
+    - {"20"}
+    | {"2A", "2B"}
+    | {str(value) for value in range(971, 979)}
+)
+
+
+@dataclass(frozen=True)
+class _EntrySpec:
+    label: str
+    protocol: AccessProtocol
+    payload: Payload
+    archive_kind: str
+    data_format: str
+    params: dict[str, str]
+
+
+_ENTRY_SPECS: dict[str, _EntrySpec] = {
+    "batiments": _EntrySpec(
+        label="BDNB - batiments, archive GPKG departementale",
+        protocol=AccessProtocol.DOWNLOAD,
+        payload=Payload.VECTOR,
+        archive_kind="gpkg",
+        data_format="gpkg",
+        params={
+            "departement": _DEFAULT_DEPARTEMENT,
+            "archive_format": "zip",
+            "data_format": "gpkg",
+        },
+    ),
+    "batiments_tables": _EntrySpec(
+        label="BDNB - batiments, archive CSV departementale",
+        protocol=AccessProtocol.TABLE_FILE,
+        payload=Payload.TABLE,
+        archive_kind="csv",
+        data_format="csv",
+        params={
+            "departement": _DEFAULT_DEPARTEMENT,
+            "archive_format": "zip",
+            "table_format": "csv",
+        },
+    ),
+}
+
+_SOURCE_TABLES = (
+    "batiment_groupe",
+    "batiment_groupe_compile",
+    "batiment_groupe_bdtopo_bat",
+    "batiment_groupe_dpe_representatif_logement",
+    "batiment_groupe_dpe_statistique_logement",
+)
+
+_SCHEMA = {
+    "batiment_groupe_id": "str",
+    "code_departement_insee": "str",
+    "code_commune_insee": "str",
+    "parcelle_unifiee_id": "str",
+    "s_geom_groupe": "float",
+    "hauteur_mean": "float",
+    "dpe_arrete_2021_annee_construction_dpe": "int",
+    "dpe_arrete_2021_periode_construction_dpe": "str",
+    "dpe_arrete_2021_classe_conso_energie": "str",
+    "geometry": "geometry",
+}
+
+
+def _department_archive_endpoint(kind: str) -> str:
+    return (
+        f"{_BDNB_S3_BASE}/millesime_{_MILLESIME_PATH}_dep{{departement}}/"
+        f"open_data_millesime_{_MILLESIME_PATH}_dep{{departement}}_{kind}.zip"
+    )
+
+
+def _normalise_departement(raw: object | None) -> str:
+    value = str(raw or "").strip().upper()
+    if value.isdigit() and len(value) <= 2:
+        value = value.zfill(2)
+    if value in _VALID_DEPARTEMENTS:
+        return value
+    raise ValueError(f"invalid BDNB department code: {raw!r}")
+
+
+class BdnbSource(DeclarativeSource):
+    """BDNB building-level open-data archives."""
+
+    name = "bdnb"
+    domain = SourceDomain.FONCIER
+    payload = Payload.VECTOR
+    jurisdiction = "FR"
+
+    def entries(self) -> list[SourceEntryRef]:
+        return [
+            self._entry_ref(entry_id, spec)
+            for entry_id, spec in _ENTRY_SPECS.items()
+        ]
+
+    def access_for(
+        self,
+        entry_id: str,
+        *,
+        departement: str | None = None,
+        department: str | None = None,
+        code_departement: str | None = None,
+        local_path: str | None = None,
+        s3_uri: str | None = None,
+        s3_key: str | None = None,
+    ) -> AccessSpec:
+        """Return a per-department AccessSpec without mutating the catalog."""
+        entry = self._entry(entry_id)
+        selected = (
+            departement
+            if departement is not None
+            else department
+            if department is not None
+            else code_departement
+        )
+        params = dict(entry.access.params)
+        params["departement"] = _normalise_departement(
+            selected or params.get("departement")
+        )
+        if local_path is not None:
+            params["local_path"] = local_path
+        if s3_uri is not None:
+            params["s3_uri"] = s3_uri
+        if s3_key is not None:
+            params["s3_key"] = s3_key
+        return replace(entry.access, params=params)
+
+    def schema(self, entry_id: str) -> dict[str, str]:
+        self._entry(entry_id)  # validates the id
+        return dict(_SCHEMA)
+
+    def revision(self, entry_id: str) -> str | None:
+        self._entry(entry_id)  # validates the id
+        return _REVISION
+
+    @staticmethod
+    def _entry_ref(entry_id: str, spec: _EntrySpec) -> SourceEntryRef:
+        return SourceEntryRef(
+            id=entry_id,
+            name=spec.label,
+            access=AccessSpec(
+                protocol=spec.protocol,
+                endpoint=_department_archive_endpoint(spec.archive_kind),
+                params=dict(spec.params),
+                format="application/zip",
+            ),
+            revision_token=_REVISION,
+            domain=SourceDomain.FONCIER,
+            payload=spec.payload,
+            jurisdiction="FR",
+            metadata={
+                "provider": "CSTB",
+                "dataset": "Base de Donnees Nationale des Batiments",
+                "platform": "bdnb.io / data.gouv.fr",
+                "license": "Licence Ouverte 2.0",
+                "millesime": _MILLESIME_LABEL,
+                "update_cadence": "semestrial",
+                "archive_format": "zip",
+                "data_format": spec.data_format,
+                "department_param": "departement",
+                "default_departement": _DEFAULT_DEPARTEMENT,
+                "source_tables": _SOURCE_TABLES,
+                "join_key": "batiment_groupe_id",
+                "geometry_key": "geometry",
+            },
+        )

--- a/plugins/gispulse-src-bdnb/pyproject.toml
+++ b/plugins/gispulse-src-bdnb/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gispulse-src-bdnb"
+version = "0.1.0"
+description = "French BDNB building source for GISPulse"
+requires-python = ">=3.10"
+license = "AGPL-3.0-or-later"
+authors = [{ name = "GISPulse", email = "dev@gispulse.io" }]
+dependencies = [
+    "gispulse>=2.0.0,<3.0.0",
+]
+
+# Registered as a data source - discovered by core.plugin_hub.PluginHub.
+[project.entry-points."gispulse.data_sources"]
+bdnb = "gispulse_src_bdnb:register"
+
+[tool.gispulse.plugin]
+kind = "source"
+protocol = ">=1.0,<2.0"
+domain = "foncier"
+jurisdiction = "FR"
+display_name = "BDNB - Base de Donnees Nationale des Batiments (France)"

--- a/tests/unit/test_src_bdnb.py
+++ b/tests/unit/test_src_bdnb.py
@@ -130,9 +130,13 @@ def test_catalog_declares_departmental_gpkg_and_csv_building_archives(source) ->
         "departement": "63",
         "archive_format": "zip",
         "table_format": "csv",
+        "archive_member": "csv/batiment_groupe.csv",
     }
     assert tables.payload is Payload.TABLE
-    assert "batiment_groupe_compile" in tables.metadata["source_tables"]
+    assert tables.metadata["table_name"] == "batiment_groupe"
+    assert tables.metadata["archive_member"] == "csv/batiment_groupe.csv"
+    assert "971" not in tables.metadata["published_departements"]
+    assert "2a" in tables.metadata["published_departements"]
 
 
 def test_access_for_resolves_department_without_mutating_catalog(source) -> None:
@@ -157,9 +161,18 @@ def test_access_for_accepts_code_departement_alias_and_normalises_single_digit(
     assert access.endpoint.endswith("_dep{departement}_csv.zip")
 
 
-def test_access_for_rejects_unknown_department(source) -> None:
+def test_access_for_maps_corsica_to_published_lowercase_key(source) -> None:
+    access = source.access_for("batiments_tables", departement="2A")
+
+    assert access.params["departement"] == "2a"
+
+
+def test_access_for_rejects_unpublished_department_keys(source) -> None:
     with pytest.raises(ValueError, match="invalid BDNB department code"):
         source.access_for("batiments", departement="999")
+
+    with pytest.raises(ValueError, match="invalid BDNB department code"):
+        source.access_for("batiments", departement="971")
 
 
 def test_fetch_batiments_resolves_default_department_template() -> None:
@@ -195,6 +208,7 @@ def test_fetch_tables_resolves_default_department_template() -> None:
     )
     assert len(table_file.calls) == 1
     assert table_file.calls[0].protocol is AccessProtocol.TABLE_FILE
+    assert table_file.calls[0].params["archive_member"] == "csv/batiment_groupe.csv"
 
 
 def test_schema_exposes_bdnb_building_headline_fields(source) -> None:

--- a/tests/unit/test_src_bdnb.py
+++ b/tests/unit/test_src_bdnb.py
@@ -1,0 +1,215 @@
+"""Unit tests for the gispulse-src-bdnb plugin."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+_PKG = Path(__file__).resolve().parents[2] / "plugins" / "gispulse-src-bdnb"
+if str(_PKG) not in sys.path:
+    sys.path.insert(0, str(_PKG))
+
+from gispulse.core.plugin_model import (  # noqa: E402
+    AccessProtocol,
+    FetchMode,
+    Payload,
+    SourceDomain,
+    SourceResult,
+)
+from gispulse.core.sources import DataSource, ProtocolRegistry  # noqa: E402
+
+
+class FakeDownload:
+    """Records resolved BDNB GPKG archive AccessSpecs."""
+
+    protocol = AccessProtocol.DOWNLOAD
+
+    def __init__(self) -> None:
+        self.calls: list = []
+
+    def fetch(self, access, *, extent=None, mode=FetchMode.MATERIALIZE):
+        self.calls.append(access)
+        return SourceResult(payload=Payload.VECTOR, mode=mode, data=access.endpoint)
+
+
+class FakeTableFile:
+    """Records resolved BDNB CSV archive AccessSpecs."""
+
+    protocol = AccessProtocol.TABLE_FILE
+
+    def __init__(self) -> None:
+        self.calls: list = []
+
+    def fetch(self, access, *, extent=None, mode=FetchMode.MATERIALIZE):
+        self.calls.append(access)
+        return SourceResult(payload=Payload.TABLE, mode=mode, data=access.endpoint)
+
+
+def _source_class():
+    return importlib.import_module("gispulse_src_bdnb.source").BdnbSource
+
+
+@pytest.fixture
+def source():
+    reg = ProtocolRegistry()
+    reg.register(FakeDownload())
+    reg.register(FakeTableFile())
+    return _source_class()(registry=reg)
+
+
+def test_pyproject_declares_bdnb_entrypoint_and_foncier_manifest() -> None:
+    tomllib = pytest.importorskip("tomllib")
+    pyproject = tomllib.loads((_PKG / "pyproject.toml").read_text())
+
+    assert pyproject["project"]["entry-points"]["gispulse.data_sources"] == {
+        "bdnb": "gispulse_src_bdnb:register"
+    }
+
+    manifest = pyproject["tool"]["gispulse"]["plugin"]
+    assert manifest["kind"] == "source"
+    assert manifest["domain"] == "foncier"
+    assert manifest["jurisdiction"] == "FR"
+
+
+def test_register_adds_bdnb_source_to_global_registry() -> None:
+    from gispulse.core.sources import SOURCES
+
+    BdnbSource = _source_class()
+    register = importlib.import_module("gispulse_src_bdnb").register
+
+    SOURCES.clear()
+    try:
+        register()
+        registered = SOURCES.get("bdnb")
+        assert isinstance(registered, BdnbSource)
+        assert {entry.id for entry in registered.catalog()} == {
+            "batiments",
+            "batiments_tables",
+        }
+    finally:
+        SOURCES.clear()
+
+
+def test_bdnb_is_a_foncier_vector_datasource(source) -> None:
+    assert isinstance(source, DataSource)
+    assert source.name == "bdnb"
+    assert source.domain is SourceDomain.FONCIER
+    assert source.payload is Payload.VECTOR
+    assert source.jurisdiction == "FR"
+
+
+def test_catalog_declares_departmental_gpkg_and_csv_building_archives(source) -> None:
+    entries = {entry.id: entry for entry in source.catalog()}
+
+    batiments = entries["batiments"]
+    assert batiments.access.protocol is AccessProtocol.DOWNLOAD
+    assert batiments.access.endpoint == (
+        "https://open-data.s3.fr-par.scw.cloud/bdnb_millesime_2026-02-a/"
+        "millesime_2026-02-a_dep{departement}/"
+        "open_data_millesime_2026-02-a_dep{departement}_gpkg.zip"
+    )
+    assert batiments.access.params == {
+        "departement": "63",
+        "archive_format": "zip",
+        "data_format": "gpkg",
+    }
+    assert batiments.access.format == "application/zip"
+    assert batiments.payload is Payload.VECTOR
+    assert batiments.metadata["millesime"] == "2026-02.a"
+    assert batiments.metadata["department_param"] == "departement"
+    assert batiments.metadata["join_key"] == "batiment_groupe_id"
+    assert batiments.metadata["geometry_key"] == "geometry"
+
+    tables = entries["batiments_tables"]
+    assert tables.access.protocol is AccessProtocol.TABLE_FILE
+    assert tables.access.endpoint.endswith("_dep{departement}_csv.zip")
+    assert tables.access.params == {
+        "departement": "63",
+        "archive_format": "zip",
+        "table_format": "csv",
+    }
+    assert tables.payload is Payload.TABLE
+    assert "batiment_groupe_compile" in tables.metadata["source_tables"]
+
+
+def test_access_for_resolves_department_without_mutating_catalog(source) -> None:
+    access = source.access_for("batiments", departement="75", local_path="/tmp/bdnb75.zip")
+    original = source._entry("batiments").access
+
+    assert access.params["departement"] == "75"
+    assert access.params["local_path"] == "/tmp/bdnb75.zip"
+    assert original.params == {
+        "departement": "63",
+        "archive_format": "zip",
+        "data_format": "gpkg",
+    }
+
+
+def test_access_for_accepts_code_departement_alias_and_normalises_single_digit(
+    source,
+) -> None:
+    access = source.access_for("batiments_tables", code_departement="7")
+
+    assert access.params["departement"] == "07"
+    assert access.endpoint.endswith("_dep{departement}_csv.zip")
+
+
+def test_access_for_rejects_unknown_department(source) -> None:
+    with pytest.raises(ValueError, match="invalid BDNB department code"):
+        source.access_for("batiments", departement="999")
+
+
+def test_fetch_batiments_resolves_default_department_template() -> None:
+    download = FakeDownload()
+    reg = ProtocolRegistry()
+    reg.register(download)
+    reg.register(FakeTableFile())
+    src = _source_class()(registry=reg)
+
+    result = src.fetch("batiments")
+
+    assert result.payload is Payload.VECTOR
+    assert result.data == (
+        "https://open-data.s3.fr-par.scw.cloud/bdnb_millesime_2026-02-a/"
+        "millesime_2026-02-a_dep63/open_data_millesime_2026-02-a_dep63_gpkg.zip"
+    )
+    assert len(download.calls) == 1
+    assert download.calls[0].protocol is AccessProtocol.DOWNLOAD
+
+
+def test_fetch_tables_resolves_default_department_template() -> None:
+    table_file = FakeTableFile()
+    reg = ProtocolRegistry()
+    reg.register(FakeDownload())
+    reg.register(table_file)
+    src = _source_class()(registry=reg)
+
+    result = src.fetch("batiments_tables")
+
+    assert result.payload is Payload.TABLE
+    assert result.data.endswith(
+        "/millesime_2026-02-a_dep63/open_data_millesime_2026-02-a_dep63_csv.zip"
+    )
+    assert len(table_file.calls) == 1
+    assert table_file.calls[0].protocol is AccessProtocol.TABLE_FILE
+
+
+def test_schema_exposes_bdnb_building_headline_fields(source) -> None:
+    schema = source.schema("batiments")
+
+    assert schema["batiment_groupe_id"] == "str"
+    assert schema["code_departement_insee"] == "str"
+    assert schema["s_geom_groupe"] == "float"
+    assert schema["hauteur_mean"] == "float"
+    assert schema["dpe_arrete_2021_annee_construction_dpe"] == "int"
+    assert schema["dpe_arrete_2021_periode_construction_dpe"] == "str"
+    assert schema["dpe_arrete_2021_classe_conso_energie"] == "str"
+    assert schema["geometry"] == "geometry"
+
+
+def test_revision_is_the_declared_bdnb_millesime(source) -> None:
+    assert source.revision("batiments") == "bdnb-2026-02-a"
+    assert source.revision("batiments_tables") == "bdnb-2026-02-a"


### PR DESCRIPTION
BDNB buildings (bdnb.io, CSV/GPKG per departement). Zero-network unit tests green, real source probed, adversarial review fixes applied.

Depends on #358 (adds `AccessProtocol.TABLE_FILE`) — CI is red until #358 merges. Sits in the `beta-national` integration branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)