### PR TITLE
feat(plugins): gispulse-src-bodacc source plugin

### DIFF
--- a/plugins/gispulse-src-bodacc/gispulse_src_bodacc/__init__.py
+++ b/plugins/gispulse-src-bodacc/gispulse_src_bodacc/__init__.py
@@ -1,0 +1,11 @@
+"""GISPulse data-source plugin for BODACC commercial notices."""
+
+from __future__ import annotations
+
+
+def register() -> None:
+    """Entry-point hook for the ``gispulse.data_sources`` group."""
+    from gispulse.core.sources import SOURCES
+    from gispulse_src_bodacc.source import BodaccSource
+
+    SOURCES.register(BodaccSource())

--- a/plugins/gispulse-src-bodacc/gispulse_src_bodacc/source.py
+++ b/plugins/gispulse-src-bodacc/gispulse_src_bodacc/source.py
@@ -36,8 +36,16 @@ _COMMON_METADATA = {
     "dataset_id": BODACC_DATASET_ID,
     "license": "Licence Ouverte 2.0",
     "ods_pagination": "limit-offset",
+    "pagination_scope": "single_ods_page",
+    "page_size_parameter": "limit",
+    "page_offset_parameter": "offset",
+    "total_count_key": "total_count",
     "core_fetcher_note": (
-        "REST_TABLE currently materializes one ODS page; pass offset for more."
+        "BODACC REST_TABLE entries intentionally materialize one ODS page."
+    ),
+    "orchestration_note": (
+        "Loop explicitly by calling access_for(..., offset=offset+limit) "
+        "until total_count is reached or the page is empty."
     ),
     "filter_fields": (
         "registre",
@@ -68,6 +76,11 @@ _ENTRIES: dict[str, dict[str, str | None]] = {
         "familleavis": "collective",
         "familleavis_lib": "Procedures collectives",
     },
+    "depots-comptes": {
+        "label": "BODACC depots des comptes",
+        "familleavis": "dpc",
+        "familleavis_lib": "Depots des comptes",
+    },
     "immatriculations": {
         "label": "BODACC immatriculations",
         "familleavis": "immatriculation",
@@ -97,6 +110,16 @@ _ENTRIES: dict[str, dict[str, str | None]] = {
         "label": "BODACC retablissements professionnels",
         "familleavis": "retablissement_professionnel",
         "familleavis_lib": "Procedures de retablissement professionnel",
+    },
+    "annonces-diverses": {
+        "label": "BODACC annonces diverses",
+        "familleavis": "divers",
+        "familleavis_lib": "Annonces diverses",
+    },
+    "famille-inconnue": {
+        "label": "BODACC famille inconnue",
+        "familleavis": "inconnue",
+        "familleavis_lib": None,
     },
 }
 

--- a/plugins/gispulse-src-bodacc/gispulse_src_bodacc/source.py
+++ b/plugins/gispulse-src-bodacc/gispulse_src_bodacc/source.py
@@ -1,0 +1,318 @@
+"""BODACC DataSource over the official DILA OpenDataSoft API.
+
+The source stays declarative: it exposes BODACC commercial-notice rows from
+``annonces-commerciales`` as raw table records. Normalising those rows into
+Marchand'biens scoring features remains downstream.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import date
+from typing import Any
+
+from gispulse.plugins.api import (
+    AccessProtocol,
+    AccessSpec,
+    DeclarativeSource,
+    Payload,
+    SourceDomain,
+    SourceEntryRef,
+)
+
+BODACC_DATASET_ID = "annonces-commerciales"
+BODACC_DATASET_ENDPOINT = (
+    "https://bodacc-datadila.opendatasoft.com/api/explore/v2.1/"
+    f"catalog/datasets/{BODACC_DATASET_ID}"
+)
+BODACC_RECORDS_ENDPOINT = f"{BODACC_DATASET_ENDPOINT}/records"
+_DEFAULT_LIMIT = 100
+_MAX_LIMIT = 100
+_REVISION_TIMEOUT_S = 8.0
+
+_COMMON_METADATA = {
+    "provider": "DILA",
+    "platform": "bodacc-datadila.opendatasoft.com API v2.1",
+    "dataset_id": BODACC_DATASET_ID,
+    "license": "Licence Ouverte 2.0",
+    "ods_pagination": "limit-offset",
+    "core_fetcher_note": (
+        "REST_TABLE currently materializes one ODS page; pass offset for more."
+    ),
+    "filter_fields": (
+        "registre",
+        "ville",
+        "cp",
+        "numerodepartement",
+        "dateparution",
+    ),
+    "civil_notices_note": (
+        "Data.gouv states civil succession notices are not included in this "
+        "database for personal-data protection reasons."
+    ),
+}
+
+_ENTRIES: dict[str, dict[str, str | None]] = {
+    "annonces-commerciales": {
+        "label": "BODACC annonces commerciales",
+        "familleavis": None,
+        "familleavis_lib": None,
+    },
+    "ventes-cessions": {
+        "label": "BODACC ventes et cessions",
+        "familleavis": "vente",
+        "familleavis_lib": "Ventes et cessions",
+    },
+    "procedures-collectives": {
+        "label": "BODACC procedures collectives",
+        "familleavis": "collective",
+        "familleavis_lib": "Procedures collectives",
+    },
+    "immatriculations": {
+        "label": "BODACC immatriculations",
+        "familleavis": "immatriculation",
+        "familleavis_lib": "Immatriculations",
+    },
+    "creations-etablissements": {
+        "label": "BODACC creations d'etablissements",
+        "familleavis": "creation",
+        "familleavis_lib": "Creations",
+    },
+    "modifications": {
+        "label": "BODACC modifications generales",
+        "familleavis": "modification",
+        "familleavis_lib": "Modifications diverses",
+    },
+    "radiations": {
+        "label": "BODACC radiations",
+        "familleavis": "radiation",
+        "familleavis_lib": "Radiations",
+    },
+    "conciliations": {
+        "label": "BODACC procedures de conciliation",
+        "familleavis": "conciliation",
+        "familleavis_lib": "Procedures de conciliation",
+    },
+    "retablissements-professionnels": {
+        "label": "BODACC retablissements professionnels",
+        "familleavis": "retablissement_professionnel",
+        "familleavis_lib": "Procedures de retablissement professionnel",
+    },
+}
+
+_SCHEMA = {
+    "id": "str",
+    "publicationavis": "str",
+    "parution": "str",
+    "dateparution": "date",
+    "numeroannonce": "int",
+    "typeavis": "str",
+    "typeavis_lib": "str",
+    "familleavis": "str",
+    "familleavis_lib": "str",
+    "numerodepartement": "str",
+    "departement_nom_officiel": "str",
+    "region_code": "int",
+    "region_nom_officiel": "str",
+    "tribunal": "str",
+    "commercant": "str",
+    "ville": "str",
+    "registre": "list[str]",
+    "cp": "str",
+    "listepersonnes": "json-string",
+    "listeetablissements": "json-string",
+    "jugement": "json-string",
+    "acte": "json-string",
+    "modificationsgenerales": "json-string",
+    "radiationaurcs": "json-string",
+    "depot": "json-string",
+    "listeprecedentexploitant": "json-string",
+    "listeprecedentproprietaire": "json-string",
+    "divers": "json-string",
+    "parutionavisprecedent": "str",
+    "url_complete": "str",
+}
+
+
+def _quote(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def _digits(value: str) -> str:
+    return "".join(ch for ch in value if ch.isdigit())
+
+
+def _date_literal(value: str) -> str:
+    parsed = date.fromisoformat(value)
+    return f"date'{parsed.isoformat()}'"
+
+
+def _and_where(clauses: list[str]) -> str:
+    return " AND ".join(clause for clause in clauses if clause)
+
+
+def _probe_dataset_revision() -> str | None:
+    """Return the OpenDataSoft dataset freshness token from a tiny JSON probe."""
+    import httpx
+
+    try:
+        resp = httpx.get(
+            BODACC_DATASET_ENDPOINT,
+            timeout=_REVISION_TIMEOUT_S,
+            follow_redirects=True,
+        )
+        resp.raise_for_status()
+    except Exception:  # noqa: BLE001 - unreachable source means unknown freshness
+        return None
+
+    try:
+        default_metas = resp.json().get("metas", {}).get("default", {})
+    except ValueError:
+        default_metas = {}
+    data_processed = default_metas.get("data_processed")
+    if data_processed:
+        return str(data_processed)
+    metadata_processed = default_metas.get("metadata_processed")
+    if metadata_processed:
+        return str(metadata_processed)
+    last_modified = resp.headers.get("last-modified")
+    if last_modified:
+        return last_modified
+    return None
+
+
+class BodaccSource(DeclarativeSource):
+    """BODACC legal notices exposed as a GISPulse declarative source."""
+
+    name = "bodacc"
+    domain = SourceDomain.STATISTIQUE
+    payload = Payload.TABLE
+    jurisdiction = "FR"
+
+    def entries(self) -> list[SourceEntryRef]:
+        return [self._entry_ref(entry_id) for entry_id in _ENTRIES]
+
+    def _entry_ref(self, entry_id: str) -> SourceEntryRef:
+        spec = _ENTRIES[entry_id]
+        familleavis = spec["familleavis"]
+        query: dict[str, Any] = {"limit": _DEFAULT_LIMIT, "offset": 0}
+        if familleavis:
+            query["where"] = f"familleavis={_quote(familleavis)}"
+        return SourceEntryRef(
+            id=entry_id,
+            name=str(spec["label"]),
+            access=AccessSpec(
+                protocol=AccessProtocol.REST_TABLE,
+                endpoint=BODACC_RECORDS_ENDPOINT,
+                params={
+                    "query": query,
+                    "pagination": {
+                        "data_key": "results",
+                        "max_pages": 1,
+                        "max_rows": _DEFAULT_LIMIT,
+                    },
+                },
+                format="application/json",
+            ),
+            revision_token=None,
+            domain=self.domain,
+            payload=self.payload,
+            jurisdiction=self.jurisdiction,
+            metadata={
+                **_COMMON_METADATA,
+                "familleavis": familleavis,
+                "familleavis_lib": spec["familleavis_lib"],
+            },
+        )
+
+    def access_for(
+        self,
+        entry_id: str,
+        *,
+        siren: str | None = None,
+        siret: str | None = None,
+        commune: str | None = None,
+        code_postal: str | None = None,
+        departement: str | None = None,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        offset: int = 0,
+        limit: int = _DEFAULT_LIMIT,
+        local_path: str | None = None,
+        s3_uri: str | None = None,
+        s3_key: str | None = None,
+    ) -> AccessSpec:
+        """Build a filtered BODACC API AccessSpec.
+
+        BODACC exposes SIREN values in the top-level ``registre`` field.
+        SIRET is not a top-level column in the OpenDataSoft dataset, so the
+        SIRET filter searches the raw record text and also includes the SIREN
+        prefix through ``registre``.
+        """
+        if limit < 1 or limit > _MAX_LIMIT:
+            raise ValueError(f"limit must be between 1 and {_MAX_LIMIT}")
+        if offset < 0:
+            raise ValueError("offset must be positive or zero")
+
+        entry = self._entry(entry_id)
+        params = dict(entry.access.params)
+        for nested_key in ("query", "pagination"):
+            nested = params.get(nested_key)
+            if isinstance(nested, dict):
+                params[nested_key] = dict(nested)
+
+        query = dict(params.get("query") or {})
+        clauses: list[str] = []
+        static_where = query.get("where")
+        if static_where:
+            clauses.append(str(static_where))
+        if siren:
+            siren_digits = _digits(siren)
+            if len(siren_digits) != 9:
+                raise ValueError("siren must contain exactly 9 digits")
+            clauses.append(f"registre={_quote(siren_digits)}")
+        if siret:
+            siret_digits = _digits(siret)
+            if len(siret_digits) != 14:
+                raise ValueError("siret must contain exactly 14 digits")
+            siren_prefix = siret_digits[:9]
+            clauses.append(
+                f"(search({_quote(siret_digits)}) OR registre={_quote(siren_prefix)})"
+            )
+        if commune:
+            clauses.append(f"ville={_quote(commune)}")
+        if code_postal:
+            clauses.append(f"cp={_quote(code_postal)}")
+        if departement:
+            clauses.append(f"numerodepartement={_quote(departement)}")
+        if date_from:
+            clauses.append(f"dateparution>={_date_literal(date_from)}")
+        if date_to:
+            clauses.append(f"dateparution<={_date_literal(date_to)}")
+
+        query["limit"] = limit
+        query["offset"] = offset
+        where = _and_where(clauses)
+        if where:
+            query["where"] = where
+        else:
+            query.pop("where", None)
+        params["query"] = query
+        params["pagination"]["max_rows"] = limit
+
+        if local_path is not None:
+            params["local_path"] = local_path
+        if s3_uri is not None:
+            params["s3_uri"] = s3_uri
+        if s3_key is not None:
+            params["s3_key"] = s3_key
+        return replace(entry.access, params=params)
+
+    def schema(self, entry_id: str) -> dict[str, str]:
+        self._entry(entry_id)  # validates the id
+        return dict(_SCHEMA)
+
+    def revision(self, entry_id: str) -> str | None:
+        self._entry(entry_id)  # validates the id
+        return _probe_dataset_revision()

--- a/plugins/gispulse-src-bodacc/pyproject.toml
+++ b/plugins/gispulse-src-bodacc/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gispulse-src-bodacc"
+version = "0.1.0"
+description = "French BODACC data source for GISPulse"
+requires-python = ">=3.10"
+license = "AGPL-3.0-or-later"
+authors = [{ name = "GISPulse", email = "dev@gispulse.io" }]
+dependencies = [
+    "gispulse>=2.0.0,<3.0.0",
+]
+
+[project.entry-points."gispulse.data_sources"]
+bodacc = "gispulse_src_bodacc:register"
+
+[tool.gispulse.plugin]
+kind = "source"
+protocol = ">=1.0,<2.0"
+domain = "statistique"
+jurisdiction = "FR"
+display_name = "BODACC - annonces commerciales (France)"

--- a/tests/unit/test_src_bodacc.py
+++ b/tests/unit/test_src_bodacc.py
@@ -1,0 +1,248 @@
+"""Unit tests for the gispulse-src-bodacc plugin.
+
+Zero-network: the plugin only declares BODACC OpenDataSoft AccessSpecs and
+builds filtered query specs. Core fetchers own HTTP and materialization.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_PKG = Path(__file__).resolve().parents[2] / "plugins" / "gispulse-src-bodacc"
+_PKG_PATH = str(_PKG)
+if _PKG_PATH in sys.path:
+    sys.path.remove(_PKG_PATH)
+sys.path.insert(0, _PKG_PATH)
+for _module in ("gispulse_src_bodacc.source", "gispulse_src_bodacc"):
+    sys.modules.pop(_module, None)
+
+from gispulse_src_bodacc.source import BodaccSource  # noqa: E402
+
+from gispulse.core.plugin_model import (  # noqa: E402
+    AccessProtocol,
+    Payload,
+    SourceDomain,
+)
+from gispulse.core.sources import DataSource  # noqa: E402
+
+pytestmark = pytest.mark.usefixtures("offline_ssrf")
+
+
+class _FakeResponse:
+    """Minimal ``httpx.Response`` stand-in for revision() tests."""
+
+    def __init__(
+        self,
+        payload: dict | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        self._payload = payload or {}
+        self.headers = headers or {}
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict:
+        return self._payload
+
+
+@pytest.fixture
+def source() -> BodaccSource:
+    return BodaccSource()
+
+
+def test_is_a_datasource(source: BodaccSource) -> None:
+    assert isinstance(source, DataSource)
+    assert source.name == "bodacc"
+    assert source.domain is SourceDomain.STATISTIQUE
+    assert source.payload is Payload.TABLE
+    assert source.jurisdiction == "FR"
+
+
+def test_declares_commercial_notice_entries(source: BodaccSource) -> None:
+    ids = {e.id for e in source.entries()}
+
+    assert ids == {
+        "annonces-commerciales",
+        "ventes-cessions",
+        "procedures-collectives",
+        "immatriculations",
+        "creations-etablissements",
+        "modifications",
+        "radiations",
+        "conciliations",
+        "retablissements-professionnels",
+    }
+
+
+def test_entries_use_bodacc_opendatasoft_rest_table(source: BodaccSource) -> None:
+    by_id = {e.id: e for e in source.entries()}
+    entry = by_id["ventes-cessions"]
+
+    assert entry.access.protocol is AccessProtocol.REST_TABLE
+    assert entry.access.endpoint == (
+        "https://bodacc-datadila.opendatasoft.com/api/explore/v2.1/"
+        "catalog/datasets/annonces-commerciales/records"
+    )
+    assert entry.access.params["pagination"] == {
+        "data_key": "results",
+        "max_pages": 1,
+        "max_rows": 100,
+    }
+    assert entry.access.params["query"]["limit"] == 100
+    assert entry.access.params["query"]["offset"] == 0
+    assert entry.access.params["query"]["where"] == 'familleavis="vente"'
+    assert entry.metadata["dataset_id"] == "annonces-commerciales"
+    assert entry.metadata["ods_pagination"] == "limit-offset"
+    assert entry.metadata["core_fetcher_note"] == (
+        "REST_TABLE currently materializes one ODS page; pass offset for more."
+    )
+
+
+def test_entry_metadata_records_real_family_codes(source: BodaccSource) -> None:
+    by_id = {e.id: e for e in source.entries()}
+
+    assert by_id["ventes-cessions"].metadata["familleavis"] == "vente"
+    assert by_id["procedures-collectives"].metadata["familleavis"] == "collective"
+    assert by_id["conciliations"].metadata["familleavis"] == "conciliation"
+    assert (
+        by_id["retablissements-professionnels"].metadata["familleavis"]
+        == "retablissement_professionnel"
+    )
+    assert by_id["annonces-commerciales"].metadata["familleavis"] is None
+
+
+def test_access_for_merges_siren_commune_and_dates(source: BodaccSource) -> None:
+    access = source.access_for(
+        "ventes-cessions",
+        siren="514 395 532",
+        commune="Rieulay",
+        code_postal="59870",
+        date_from="2009-01-01",
+        date_to="2009-12-31",
+        local_path="/tmp/bodacc.jsonl",
+    )
+
+    assert access.protocol is AccessProtocol.REST_TABLE
+    assert access.params["query"]["limit"] == 100
+    assert access.params["query"]["offset"] == 0
+    assert access.params["query"]["where"] == (
+        'familleavis="vente" AND registre="514395532" AND ville="Rieulay" '
+        "AND cp=\"59870\" AND dateparution>=date'2009-01-01' "
+        "AND dateparution<=date'2009-12-31'"
+    )
+    assert access.params["local_path"] == "/tmp/bodacc.jsonl"
+
+
+def test_access_for_accepts_siret_by_searching_siret_and_siren_prefix(
+    source: BodaccSource,
+) -> None:
+    access = source.access_for("procedures-collectives", siret="51439553200016")
+
+    assert access.params["query"]["where"] == (
+        'familleavis="collective" AND '
+        '(search("51439553200016") OR registre="514395532")'
+    )
+
+
+def test_access_for_supports_department_offset_limit_and_s3_key(
+    source: BodaccSource,
+) -> None:
+    access = source.access_for(
+        "annonces-commerciales",
+        departement="59",
+        offset=200,
+        limit=25,
+        s3_key="raw/bodacc/59/page-200.jsonl",
+    )
+
+    assert access.params["query"] == {
+        "limit": 25,
+        "offset": 200,
+        "where": 'numerodepartement="59"',
+    }
+    assert access.params["s3_key"] == "raw/bodacc/59/page-200.jsonl"
+    assert access.params["pagination"]["max_rows"] == 25
+
+
+def test_access_for_copies_nested_params(source: BodaccSource) -> None:
+    first = source.access_for("ventes-cessions", siren="514395532")
+    first.params["pagination"]["data_key"] = "mutated"
+
+    second = source.access_for("ventes-cessions", siren="752461681")
+    entry = source._entry("ventes-cessions")
+
+    assert second.params["pagination"]["data_key"] == "results"
+    assert entry.access.params["pagination"]["data_key"] == "results"
+
+
+def test_access_for_rejects_unbounded_limit(source: BodaccSource) -> None:
+    with pytest.raises(ValueError, match="limit"):
+        source.access_for("ventes-cessions", limit=101)
+
+
+def test_access_for_unknown_entry_raises(source: BodaccSource) -> None:
+    with pytest.raises(KeyError, match="unknown_entry"):
+        source.access_for("unknown_entry", siren="514395532")
+
+
+def test_schema_exposes_raw_bodacc_columns(source: BodaccSource) -> None:
+    schema = source.schema("procedures-collectives")
+
+    assert schema["registre"] == "list[str]"
+    assert schema["ville"] == "str"
+    assert schema["jugement"] == "json-string"
+    assert schema["acte"] == "json-string"
+    assert "normalized_signal" not in schema
+
+
+def test_revision_reads_dataset_processed_timestamp(
+    source: BodaccSource,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[str] = []
+
+    def fake_get(url, **_kw):
+        captured.append(url)
+        return _FakeResponse(
+            {
+                "metas": {
+                    "default": {
+                        "data_processed": "2026-05-31T06:16:26.303000+00:00",
+                        "metadata_processed": "2026-06-01T01:13:20.035000+00:00",
+                    }
+                }
+            }
+        )
+
+    monkeypatch.setattr("httpx.get", fake_get)
+
+    assert source.revision("ventes-cessions") == "2026-05-31T06:16:26.303000+00:00"
+    assert captured == [
+        "https://bodacc-datadila.opendatasoft.com/api/explore/v2.1/"
+        "catalog/datasets/annonces-commerciales"
+    ]
+
+
+def test_revision_falls_back_to_last_modified_header(
+    source: BodaccSource,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_get(url, **_kw):
+        return _FakeResponse(headers={"last-modified": "Mon, 01 Jun 2026 01:13:20 GMT"})
+
+    monkeypatch.setattr("httpx.get", fake_get)
+    assert source.revision("procedures-collectives") == (
+        "Mon, 01 Jun 2026 01:13:20 GMT"
+    )
+
+
+def test_register_adds_source_to_registry() -> None:
+    from gispulse.core.sources import SOURCES
+    from gispulse_src_bodacc import register
+
+    register()
+    assert SOURCES.get("bodacc") is not None

--- a/tests/unit/test_src_bodacc.py
+++ b/tests/unit/test_src_bodacc.py
@@ -69,12 +69,15 @@ def test_declares_commercial_notice_entries(source: BodaccSource) -> None:
         "annonces-commerciales",
         "ventes-cessions",
         "procedures-collectives",
+        "depots-comptes",
         "immatriculations",
         "creations-etablissements",
         "modifications",
         "radiations",
         "conciliations",
         "retablissements-professionnels",
+        "annonces-diverses",
+        "famille-inconnue",
     }
 
 
@@ -97,8 +100,12 @@ def test_entries_use_bodacc_opendatasoft_rest_table(source: BodaccSource) -> Non
     assert entry.access.params["query"]["where"] == 'familleavis="vente"'
     assert entry.metadata["dataset_id"] == "annonces-commerciales"
     assert entry.metadata["ods_pagination"] == "limit-offset"
-    assert entry.metadata["core_fetcher_note"] == (
-        "REST_TABLE currently materializes one ODS page; pass offset for more."
+    assert entry.metadata["pagination_scope"] == "single_ods_page"
+    assert entry.metadata["page_size_parameter"] == "limit"
+    assert entry.metadata["page_offset_parameter"] == "offset"
+    assert entry.metadata["orchestration_note"] == (
+        "Loop explicitly by calling access_for(..., offset=offset+limit) "
+        "until total_count is reached or the page is empty."
     )
 
 
@@ -107,11 +114,15 @@ def test_entry_metadata_records_real_family_codes(source: BodaccSource) -> None:
 
     assert by_id["ventes-cessions"].metadata["familleavis"] == "vente"
     assert by_id["procedures-collectives"].metadata["familleavis"] == "collective"
+    assert by_id["depots-comptes"].metadata["familleavis"] == "dpc"
     assert by_id["conciliations"].metadata["familleavis"] == "conciliation"
     assert (
         by_id["retablissements-professionnels"].metadata["familleavis"]
         == "retablissement_professionnel"
     )
+    assert by_id["annonces-diverses"].metadata["familleavis"] == "divers"
+    assert by_id["famille-inconnue"].metadata["familleavis"] == "inconnue"
+    assert by_id["famille-inconnue"].metadata["familleavis_lib"] is None
     assert by_id["annonces-commerciales"].metadata["familleavis"] is None
 
 
@@ -166,6 +177,19 @@ def test_access_for_supports_department_offset_limit_and_s3_key(
     }
     assert access.params["s3_key"] == "raw/bodacc/59/page-200.jsonl"
     assert access.params["pagination"]["max_rows"] == 25
+
+
+def test_access_for_keeps_limit_as_single_page_size(source: BodaccSource) -> None:
+    first_page = source.access_for("annonces-commerciales", offset=0, limit=25)
+    next_page = source.access_for("annonces-commerciales", offset=25, limit=25)
+
+    assert first_page.params["query"]["offset"] == 0
+    assert next_page.params["query"]["offset"] == 25
+    assert first_page.params["pagination"] == {
+        "data_key": "results",
+        "max_pages": 1,
+        "max_rows": 25,
+    }
 
 
 def test_access_for_copies_nested_params(source: BodaccSource) -> None:
@@ -244,5 +268,9 @@ def test_register_adds_source_to_registry() -> None:
     from gispulse.core.sources import SOURCES
     from gispulse_src_bodacc import register
 
-    register()
-    assert SOURCES.get("bodacc") is not None
+    SOURCES.clear()
+    try:
+        register()
+        assert SOURCES.get("bodacc") is not None
+    finally:
+        SOURCES.clear()


### PR DESCRIPTION
BODACC commercial announcements (DILA / OpenDataSoft API). Zero-network unit tests green, real source probed, adversarial review fixes applied.

Depends on #358 (adds `AccessProtocol.TABLE_FILE`) — CI is red until #358 merges. Sits in the `beta-national` integration branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)