### PR TITLE
feat(plugins): gispulse-src-rnb source plugin

### DIFF
--- a/plugins/gispulse-src-rnb/gispulse_src_rnb/__init__.py
+++ b/plugins/gispulse-src-rnb/gispulse_src_rnb/__init__.py
@@ -1,0 +1,11 @@
+"""GISPulse data-source plugin - RNB building identity API."""
+
+from __future__ import annotations
+
+
+def register() -> None:
+    """Entry-point hook for the ``gispulse.data_sources`` group."""
+    from gispulse.core.sources import SOURCES
+    from gispulse_src_rnb.source import RnbSource
+
+    SOURCES.register(RnbSource())

--- a/plugins/gispulse-src-rnb/gispulse_src_rnb/source.py
+++ b/plugins/gispulse-src-rnb/gispulse_src_rnb/source.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import replace
 from typing import Any
+from urllib.parse import quote
 
 from gispulse.plugins.api import (
     AccessProtocol,
@@ -153,6 +154,12 @@ def _coerce_limit(limit: int) -> int:
     return int(limit)
 
 
+def _coerce_max_rows(max_rows: int) -> int:
+    if max_rows < 1:
+        raise ValueError("max_rows must be at least 1")
+    return int(max_rows)
+
+
 def _normalise_bbox(value: str | Sequence[float | int | str]) -> str:
     if isinstance(value, str):
         parts = [part.strip() for part in value.split(",")]
@@ -160,6 +167,11 @@ def _normalise_bbox(value: str | Sequence[float | int | str]) -> str:
         parts = [str(part).strip() for part in value]
     if len(parts) != 4 or any(not part for part in parts):
         raise ValueError("bbox must contain four comma-separated coordinates")
+    for part in parts:
+        try:
+            float(part)
+        except ValueError as exc:
+            raise ValueError("bbox coordinates must be numeric") from exc
     return ",".join(parts)
 
 
@@ -167,7 +179,7 @@ def _normalise_plot_id(value: object | None) -> str:
     plot_id = str(value or "").strip().upper()
     if not plot_id:
         raise ValueError("plot_id must not be empty")
-    return plot_id
+    return quote(plot_id, safe="")
 
 
 def _status_query(status: str | Sequence[str]) -> str:
@@ -237,6 +249,7 @@ class RnbSource(DeclarativeSource):
         with_plots: bool | None = None,
         min_score: float | None = None,
         limit: int = _DEFAULT_LIMIT,
+        max_rows: int | None = None,
         local_path: str | None = None,
         s3_uri: str | None = None,
         s3_key: str | None = None,
@@ -281,7 +294,8 @@ class RnbSource(DeclarativeSource):
             raise ValueError(f"unsupported RNB query kind: {query_kind!r}")
 
         params["query"] = query
-        params["pagination"]["max_rows"] = limit
+        if max_rows is not None:
+            params["pagination"]["max_rows"] = _coerce_max_rows(max_rows)
         _apply_materialization(
             params,
             local_path=local_path,

--- a/plugins/gispulse-src-rnb/gispulse_src_rnb/source.py
+++ b/plugins/gispulse-src-rnb/gispulse_src_rnb/source.py
@@ -1,0 +1,299 @@
+"""RNB DataSource over the public RNB building API.
+
+The Referentiel National des Batiments (RNB) is the building identity pivot:
+its API returns stable ``rnb_id`` values, geometry/point, status, addresses,
+external identifiers and cadastral-plot intersections. This plugin stays
+declarative and exposes query-scoped REST_TABLE entries; core fetchers own
+HTTP, pagination and materialization.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import replace
+from typing import Any
+
+from gispulse.plugins.api import (
+    AccessProtocol,
+    AccessSpec,
+    DeclarativeSource,
+    Payload,
+    SourceDomain,
+    SourceEntryRef,
+)
+
+RNB_API_BASE_URL = "https://rnb-api.beta.gouv.fr"
+RNB_BUILDINGS_ENDPOINT = f"{RNB_API_BASE_URL}/api/alpha/buildings/"
+RNB_PLOT_ENDPOINT = f"{RNB_API_BASE_URL}/api/alpha/buildings/plot/{{plot_id}}/"
+RNB_ADDRESS_ENDPOINT = f"{RNB_API_BASE_URL}/api/alpha/buildings/address/"
+
+_DEFAULT_DEPARTEMENT = "63"
+_DEFAULT_INSEE_CODE = "63113"
+_DEFAULT_BBOX = "3.0885,45.7943,3.0895,45.7950"
+_DEFAULT_PLOT_ID = "63113000MT0158"
+_DEFAULT_BAN_KEY = "63113_2615_00089"
+_DEFAULT_ADDRESS = "89 rue Lecuelle, 63100 Clermont-Ferrand"
+_DEFAULT_LIMIT = 100
+_MAX_LIMIT = 100
+
+_PAGINATION = {
+    "data_key": "results",
+    "next_key": "next",
+    "max_pages": 10,
+    "max_rows": 1000,
+}
+
+_COMMON_METADATA = {
+    "provider": "RNB / IGN - Fabrique des Geocommuns",
+    "platform": "rnb-api.beta.gouv.fr API alpha",
+    "license": "Licence Ouverte 2.0",
+    "default_departement": _DEFAULT_DEPARTEMENT,
+    "default_insee_code": _DEFAULT_INSEE_CODE,
+    "identity_key": "rnb_id",
+    "join_keys": ("rnb_id", "addresses.id", "plots.id"),
+    "geometry_key": "shape",
+    "point_key": "point",
+}
+
+_ENTRIES: dict[str, dict[str, Any]] = {
+    "buildings-bbox": {
+        "label": "RNB buildings by bounding box",
+        "endpoint": RNB_BUILDINGS_ENDPOINT,
+        "query_kind": "bbox",
+        "params": {
+            "query": {
+                "bbox": _DEFAULT_BBOX,
+                "limit": _DEFAULT_LIMIT,
+                "withPlots": 1,
+            },
+            "pagination": dict(_PAGINATION),
+        },
+        "metadata": {
+            "filter_fields": (
+                "bbox",
+                "insee_code",
+                "status",
+                "cle_interop_ban",
+                "withPlots",
+            ),
+            "default_bbox": _DEFAULT_BBOX,
+        },
+    },
+    "buildings-parcelle": {
+        "label": "RNB buildings by cadastral plot",
+        "endpoint": RNB_PLOT_ENDPOINT,
+        "query_kind": "parcelle",
+        "params": {
+            "plot_id": _DEFAULT_PLOT_ID,
+            "query": {"limit": _DEFAULT_LIMIT},
+            "pagination": dict(_PAGINATION),
+        },
+        "metadata": {
+            "filter_fields": ("plot_id",),
+            "default_plot_id": _DEFAULT_PLOT_ID,
+            "plot_match_note": (
+                "RNB ranks buildings by geometric cover ratio over the plot."
+            ),
+        },
+    },
+    "buildings-address": {
+        "label": "RNB buildings by BAN address key",
+        "endpoint": RNB_ADDRESS_ENDPOINT,
+        "query_kind": "address",
+        "params": {
+            "query": {
+                "cle_interop_ban": _DEFAULT_BAN_KEY,
+                "limit": _DEFAULT_LIMIT,
+            },
+            "pagination": dict(_PAGINATION),
+        },
+        "metadata": {
+            "filter_fields": ("q", "cle_interop_ban", "min_score"),
+            "default_address": _DEFAULT_ADDRESS,
+            "default_cle_interop_ban": _DEFAULT_BAN_KEY,
+        },
+    },
+}
+
+_SCHEMA = {
+    "rnb_id": "str",
+    "status": "str",
+    "point": "geojson-point",
+    "shape": "geojson-geometry",
+    "addresses": "list[json]",
+    "addresses.id": "str",
+    "addresses.source": "str",
+    "addresses.street_number": "str",
+    "addresses.street": "str",
+    "addresses.city_zipcode": "str",
+    "addresses.city_insee_code": "str",
+    "ext_ids": "list[json]",
+    "ext_ids.id": "str",
+    "ext_ids.source": "str",
+    "is_active": "bool",
+    "plots": "list[json]",
+    "plots.id": "str",
+    "bdg_cover_ratio": "float",
+    "marked_as_correct_by": "list[json]",
+}
+
+
+def _copy_params(params: dict[str, Any]) -> dict[str, Any]:
+    copied = dict(params)
+    for nested_key in ("query", "pagination"):
+        nested = copied.get(nested_key)
+        if isinstance(nested, dict):
+            copied[nested_key] = dict(nested)
+    return copied
+
+
+def _coerce_limit(limit: int) -> int:
+    if limit < 1 or limit > _MAX_LIMIT:
+        raise ValueError(f"limit must be between 1 and {_MAX_LIMIT}")
+    return int(limit)
+
+
+def _normalise_bbox(value: str | Sequence[float | int | str]) -> str:
+    if isinstance(value, str):
+        parts = [part.strip() for part in value.split(",")]
+    else:
+        parts = [str(part).strip() for part in value]
+    if len(parts) != 4 or any(not part for part in parts):
+        raise ValueError("bbox must contain four comma-separated coordinates")
+    return ",".join(parts)
+
+
+def _normalise_plot_id(value: object | None) -> str:
+    plot_id = str(value or "").strip().upper()
+    if not plot_id:
+        raise ValueError("plot_id must not be empty")
+    return plot_id
+
+
+def _status_query(status: str | Sequence[str]) -> str:
+    if isinstance(status, str):
+        return status
+    return ",".join(str(item).strip() for item in status if str(item).strip())
+
+
+def _apply_materialization(
+    params: dict[str, Any],
+    *,
+    local_path: str | None,
+    s3_uri: str | None,
+    s3_key: str | None,
+) -> None:
+    if local_path is not None:
+        params["local_path"] = local_path
+    if s3_uri is not None:
+        params["s3_uri"] = s3_uri
+    if s3_key is not None:
+        params["s3_key"] = s3_key
+
+
+class RnbSource(DeclarativeSource):
+    """RNB building identity records exposed as a GISPulse source."""
+
+    name = "rnb"
+    domain = SourceDomain.FONCIER
+    payload = Payload.TABLE
+    jurisdiction = "FR"
+
+    def entries(self) -> list[SourceEntryRef]:
+        return [self._entry_ref(entry_id) for entry_id in _ENTRIES]
+
+    def _entry_ref(self, entry_id: str) -> SourceEntryRef:
+        spec = _ENTRIES[entry_id]
+        return SourceEntryRef(
+            id=entry_id,
+            name=spec["label"],
+            access=AccessSpec(
+                protocol=AccessProtocol.REST_TABLE,
+                endpoint=spec["endpoint"],
+                params=_copy_params(spec["params"]),
+                format="application/json",
+            ),
+            revision_token=None,
+            domain=self.domain,
+            payload=self.payload,
+            jurisdiction=self.jurisdiction,
+            metadata={
+                **_COMMON_METADATA,
+                **spec["metadata"],
+                "query_kind": spec["query_kind"],
+            },
+        )
+
+    def access_for(
+        self,
+        entry_id: str,
+        *,
+        bbox: str | Sequence[float | int | str] | None = None,
+        insee_code: str | None = None,
+        status: str | Sequence[str] | None = None,
+        cle_interop_ban: str | None = None,
+        q: str | None = None,
+        plot_id: str | None = None,
+        with_plots: bool | None = None,
+        min_score: float | None = None,
+        limit: int = _DEFAULT_LIMIT,
+        local_path: str | None = None,
+        s3_uri: str | None = None,
+        s3_key: str | None = None,
+    ) -> AccessSpec:
+        """Build a filtered RNB API AccessSpec without network access."""
+        limit = _coerce_limit(limit)
+        entry = self._entry(entry_id)
+        query_kind = entry.metadata["query_kind"]
+        params = _copy_params(entry.access.params)
+        query = dict(params.get("query") or {})
+
+        if query_kind == "bbox":
+            if bbox is not None:
+                query["bbox"] = _normalise_bbox(bbox)
+            if insee_code is not None:
+                query["insee_code"] = insee_code
+                if bbox is None:
+                    query.pop("bbox", None)
+            if cle_interop_ban is not None:
+                query["cle_interop_ban"] = cle_interop_ban
+                if bbox is None and insee_code is None:
+                    query.pop("bbox", None)
+            if status is not None:
+                query["status"] = _status_query(status)
+            if with_plots is not None:
+                query["withPlots"] = 1 if with_plots else 0
+            query["limit"] = limit
+        elif query_kind == "parcelle":
+            params["plot_id"] = _normalise_plot_id(plot_id or params.get("plot_id"))
+            query = {"limit": limit}
+        elif query_kind == "address":
+            if cle_interop_ban:
+                query.pop("q", None)
+                query["cle_interop_ban"] = cle_interop_ban
+            elif q:
+                query.pop("cle_interop_ban", None)
+                query["q"] = q
+            if min_score is not None:
+                query["min_score"] = float(min_score)
+            query["limit"] = limit
+        else:  # pragma: no cover - defensive for future local specs
+            raise ValueError(f"unsupported RNB query kind: {query_kind!r}")
+
+        params["query"] = query
+        params["pagination"]["max_rows"] = limit
+        _apply_materialization(
+            params,
+            local_path=local_path,
+            s3_uri=s3_uri,
+            s3_key=s3_key,
+        )
+        return replace(entry.access, params=params)
+
+    def schema(self, entry_id: str) -> dict[str, str]:
+        self._entry(entry_id)  # validates the id
+        return dict(_SCHEMA)
+
+    def revision(self, entry_id: str) -> str | None:
+        self._entry(entry_id)  # validates the id
+        return None

--- a/plugins/gispulse-src-rnb/pyproject.toml
+++ b/plugins/gispulse-src-rnb/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gispulse-src-rnb"
+version = "0.1.0"
+description = "French RNB building identity source for GISPulse"
+requires-python = ">=3.10"
+license = "AGPL-3.0-or-later"
+authors = [{ name = "GISPulse", email = "dev@gispulse.io" }]
+dependencies = [
+    "gispulse>=2.0.0,<3.0.0",
+]
+
+# Registered as a data source - discovered by core.plugin_hub.PluginHub.
+[project.entry-points."gispulse.data_sources"]
+rnb = "gispulse_src_rnb:register"
+
+[tool.gispulse.plugin]
+kind = "source"
+protocol = ">=1.0,<2.0"
+domain = "foncier"
+jurisdiction = "FR"
+display_name = "RNB - Referentiel National des Batiments (France)"

--- a/tests/unit/test_src_rnb.py
+++ b/tests/unit/test_src_rnb.py
@@ -25,6 +25,7 @@ from gispulse.core.plugin_model import (  # noqa: E402
     AccessProtocol,
     Payload,
     SourceDomain,
+    resolve_access_endpoint,
 )
 from gispulse.core.sources import DataSource  # noqa: E402
 
@@ -144,9 +145,32 @@ def test_access_for_bbox_overrides_query_without_mutating_catalog(
         "status": "constructed,demolished",
         "withPlots": 0,
     }
-    assert access.params["pagination"]["max_rows"] == 25
+    assert access.params["pagination"]["max_rows"] == 1000
     assert access.params["s3_key"] == "raw/rnb/paris.jsonl"
     assert original.params["query"]["bbox"] == "3.0885,45.7943,3.0895,45.7950"
+
+
+def test_access_for_can_set_page_size_without_forcing_row_cap(
+    source: RnbSource,
+) -> None:
+    access = source.access_for("buildings-bbox", limit=25)
+
+    assert access.params["query"]["limit"] == 25
+    assert access.params["pagination"]["max_rows"] == 1000
+
+
+def test_access_for_can_set_explicit_row_cap_separately_from_page_size(
+    source: RnbSource,
+) -> None:
+    access = source.access_for("buildings-bbox", limit=25, max_rows=40)
+
+    assert access.params["query"]["limit"] == 25
+    assert access.params["pagination"]["max_rows"] == 40
+
+
+def test_access_for_rejects_non_numeric_bbox_coordinates(source: RnbSource) -> None:
+    with pytest.raises(ValueError, match="numeric"):
+        source.access_for("buildings-bbox", bbox="2.42,48.83,boom,48.84")
 
 
 def test_access_for_plot_replaces_path_parameter_and_materialization(
@@ -165,6 +189,22 @@ def test_access_for_plot_replaces_path_parameter_and_materialization(
     assert access.params["local_path"] == "/tmp/rnb-plot.jsonl"
 
 
+def test_access_for_plot_encodes_malicious_path_fragments(source: RnbSource) -> None:
+    access = source.access_for(
+        "buildings-parcelle",
+        plot_id="63113000MT0158/../../evil?next=http://evil.test",
+    )
+    resolved = resolve_access_endpoint(access)
+
+    assert access.params["plot_id"] == (
+        "63113000MT0158%2F..%2F..%2FEVIL%3FNEXT%3DHTTP%3A%2F%2FEVIL.TEST"
+    )
+    assert resolved.endpoint == (
+        "https://rnb-api.beta.gouv.fr/api/alpha/buildings/plot/"
+        "63113000MT0158%2F..%2F..%2FEVIL%3FNEXT%3DHTTP%3A%2F%2FEVIL.TEST/"
+    )
+
+
 def test_access_for_address_prefers_ban_key_over_text_query(
     source: RnbSource,
 ) -> None:
@@ -174,6 +214,7 @@ def test_access_for_address_prefers_ban_key_over_text_query(
         cle_interop_ban="63113_2615_00089",
         min_score=0.9,
         limit=1,
+        max_rows=1,
     )
 
     assert access.params["query"] == {
@@ -187,6 +228,9 @@ def test_access_for_address_prefers_ban_key_over_text_query(
 def test_access_for_rejects_unbounded_limit(source: RnbSource) -> None:
     with pytest.raises(ValueError, match="limit"):
         source.access_for("buildings-bbox", limit=101)
+
+    with pytest.raises(ValueError, match="max_rows"):
+        source.access_for("buildings-bbox", max_rows=0)
 
 
 def test_schema_exposes_identity_geometry_and_join_fields(source: RnbSource) -> None:

--- a/tests/unit/test_src_rnb.py
+++ b/tests/unit/test_src_rnb.py
@@ -1,0 +1,220 @@
+"""Unit tests for the gispulse-src-rnb plugin.
+
+Zero-network: the plugin only declares RNB API AccessSpecs and builds filtered
+query specs. Core fetchers own HTTP and materialization.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_PKG = Path(__file__).resolve().parents[2] / "plugins" / "gispulse-src-rnb"
+_PKG_PATH = str(_PKG)
+if _PKG_PATH in sys.path:
+    sys.path.remove(_PKG_PATH)
+sys.path.insert(0, _PKG_PATH)
+for _module in ("gispulse_src_rnb.source", "gispulse_src_rnb"):
+    sys.modules.pop(_module, None)
+
+from gispulse_src_rnb.source import RnbSource  # noqa: E402
+
+from gispulse.core.plugin_model import (  # noqa: E402
+    AccessProtocol,
+    Payload,
+    SourceDomain,
+)
+from gispulse.core.sources import DataSource  # noqa: E402
+
+pytestmark = pytest.mark.usefixtures("offline_ssrf")
+
+
+@pytest.fixture
+def source() -> RnbSource:
+    return RnbSource()
+
+
+def test_pyproject_declares_rnb_entrypoint_and_foncier_manifest() -> None:
+    tomllib = pytest.importorskip("tomllib")
+    pyproject = tomllib.loads((_PKG / "pyproject.toml").read_text())
+
+    assert pyproject["project"]["entry-points"]["gispulse.data_sources"] == {
+        "rnb": "gispulse_src_rnb:register"
+    }
+
+    manifest = pyproject["tool"]["gispulse"]["plugin"]
+    assert manifest["kind"] == "source"
+    assert manifest["domain"] == "foncier"
+    assert manifest["jurisdiction"] == "FR"
+
+
+def test_is_a_foncier_table_datasource(source: RnbSource) -> None:
+    assert isinstance(source, DataSource)
+    assert source.name == "rnb"
+    assert source.domain is SourceDomain.FONCIER
+    assert source.payload is Payload.TABLE
+    assert source.jurisdiction == "FR"
+
+
+def test_declares_building_lookup_entries(source: RnbSource) -> None:
+    ids = {entry.id for entry in source.entries()}
+
+    assert ids == {
+        "buildings-bbox",
+        "buildings-parcelle",
+        "buildings-address",
+    }
+
+
+def test_buildings_bbox_entry_uses_rnb_rest_table_with_dept63_default(
+    source: RnbSource,
+) -> None:
+    entry = {entry.id: entry for entry in source.entries()}["buildings-bbox"]
+
+    assert entry.access.protocol is AccessProtocol.REST_TABLE
+    assert entry.access.endpoint == "https://rnb-api.beta.gouv.fr/api/alpha/buildings/"
+    assert entry.access.format == "application/json"
+    assert entry.access.params["query"] == {
+        "bbox": "3.0885,45.7943,3.0895,45.7950",
+        "limit": 100,
+        "withPlots": 1,
+    }
+    assert entry.access.params["pagination"] == {
+        "data_key": "results",
+        "next_key": "next",
+        "max_pages": 10,
+        "max_rows": 1000,
+    }
+    assert entry.metadata["default_departement"] == "63"
+    assert entry.metadata["default_insee_code"] == "63113"
+    assert entry.metadata["query_kind"] == "bbox"
+    assert entry.metadata["join_keys"] == ("rnb_id", "addresses.id", "plots.id")
+
+
+def test_parcelle_entry_uses_plot_path_template_with_real_dept63_plot(
+    source: RnbSource,
+) -> None:
+    entry = {entry.id: entry for entry in source.entries()}["buildings-parcelle"]
+
+    assert entry.access.protocol is AccessProtocol.REST_TABLE
+    assert entry.access.endpoint == (
+        "https://rnb-api.beta.gouv.fr/api/alpha/buildings/plot/{plot_id}/"
+    )
+    assert entry.access.params["plot_id"] == "63113000MT0158"
+    assert entry.access.params["query"] == {"limit": 100}
+    assert entry.metadata["query_kind"] == "parcelle"
+    assert entry.metadata["default_plot_id"] == "63113000MT0158"
+
+
+def test_address_entry_uses_address_endpoint_and_ban_key_default(
+    source: RnbSource,
+) -> None:
+    entry = {entry.id: entry for entry in source.entries()}["buildings-address"]
+
+    assert entry.access.protocol is AccessProtocol.REST_TABLE
+    assert entry.access.endpoint == (
+        "https://rnb-api.beta.gouv.fr/api/alpha/buildings/address/"
+    )
+    assert entry.access.params["query"] == {
+        "cle_interop_ban": "63113_2615_00089",
+        "limit": 100,
+    }
+    assert entry.metadata["query_kind"] == "address"
+    assert entry.metadata["default_address"] == "89 rue Lecuelle, 63100 Clermont-Ferrand"
+
+
+def test_access_for_bbox_overrides_query_without_mutating_catalog(
+    source: RnbSource,
+) -> None:
+    access = source.access_for(
+        "buildings-bbox",
+        bbox="2.424525,48.839201,2.434158,48.845782",
+        status=("constructed", "demolished"),
+        with_plots=False,
+        limit=25,
+        s3_key="raw/rnb/paris.jsonl",
+    )
+    original = source._entry("buildings-bbox").access
+
+    assert access.params["query"] == {
+        "bbox": "2.424525,48.839201,2.434158,48.845782",
+        "limit": 25,
+        "status": "constructed,demolished",
+        "withPlots": 0,
+    }
+    assert access.params["pagination"]["max_rows"] == 25
+    assert access.params["s3_key"] == "raw/rnb/paris.jsonl"
+    assert original.params["query"]["bbox"] == "3.0885,45.7943,3.0895,45.7950"
+
+
+def test_access_for_plot_replaces_path_parameter_and_materialization(
+    source: RnbSource,
+) -> None:
+    access = source.access_for(
+        "buildings-parcelle",
+        plot_id="63113000MT0434",
+        limit=10,
+        local_path="/tmp/rnb-plot.jsonl",
+    )
+
+    assert access.endpoint.endswith("/plot/{plot_id}/")
+    assert access.params["plot_id"] == "63113000MT0434"
+    assert access.params["query"] == {"limit": 10}
+    assert access.params["local_path"] == "/tmp/rnb-plot.jsonl"
+
+
+def test_access_for_address_prefers_ban_key_over_text_query(
+    source: RnbSource,
+) -> None:
+    access = source.access_for(
+        "buildings-address",
+        q="ignored when cle_interop_ban is supplied",
+        cle_interop_ban="63113_2615_00089",
+        min_score=0.9,
+        limit=1,
+    )
+
+    assert access.params["query"] == {
+        "cle_interop_ban": "63113_2615_00089",
+        "limit": 1,
+        "min_score": 0.9,
+    }
+    assert access.params["pagination"]["max_rows"] == 1
+
+
+def test_access_for_rejects_unbounded_limit(source: RnbSource) -> None:
+    with pytest.raises(ValueError, match="limit"):
+        source.access_for("buildings-bbox", limit=101)
+
+
+def test_schema_exposes_identity_geometry_and_join_fields(source: RnbSource) -> None:
+    schema = source.schema("buildings-bbox")
+
+    assert schema["rnb_id"] == "str"
+    assert schema["status"] == "str"
+    assert schema["point"] == "geojson-point"
+    assert schema["shape"] == "geojson-geometry"
+    assert schema["addresses"] == "list[json]"
+    assert schema["addresses.id"] == "str"
+    assert schema["plots"] == "list[json]"
+    assert schema["plots.id"] == "str"
+    assert schema["bdg_cover_ratio"] == "float"
+
+
+def test_revision_is_unknown_for_query_scoped_api_entries(source: RnbSource) -> None:
+    assert source.revision("buildings-bbox") is None
+    assert source.revision("buildings-parcelle") is None
+
+
+def test_register_adds_source_to_registry() -> None:
+    from gispulse.core.sources import SOURCES
+    from gispulse_src_rnb import register
+
+    SOURCES.clear()
+    try:
+        register()
+        assert SOURCES.get("rnb") is not None
+    finally:
+        SOURCES.clear()


### PR DESCRIPTION
RNB buildings (Geoplateforme API, plot_id URL-encoded). Zero-network unit tests green, real source probed, adversarial review fixes applied.

Depends on #358 (adds `AccessProtocol.TABLE_FILE`) — CI is red until #358 merges. Sits in the `beta-national` integration branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)