### PR TITLE
feat(plugins): gispulse-src-ban source plugin

### DIFF
--- a/plugins/gispulse-src-ban/gispulse_src_ban/__init__.py
+++ b/plugins/gispulse-src-ban/gispulse_src_ban/__init__.py
@@ -1,0 +1,11 @@
+"""GISPulse data-source plugin - Base Adresse Nationale."""
+
+from __future__ import annotations
+
+
+def register() -> None:
+    """Entry-point hook for the ``gispulse.data_sources`` group."""
+    from gispulse.core.sources import SOURCES
+    from gispulse_src_ban.source import BanSource
+
+    SOURCES.register(BanSource())

--- a/plugins/gispulse-src-ban/gispulse_src_ban/source.py
+++ b/plugins/gispulse-src-ban/gispulse_src_ban/source.py
@@ -36,7 +36,7 @@ _DEFAULT_LON = 3.087025
 _DEFAULT_LAT = 45.777222
 _DEFAULT_SEARCH_LIMIT = 5
 _DEFAULT_REVERSE_LIMIT = 1
-_MAX_API_LIMIT = 20
+_MAX_API_LIMIT = 50
 
 _API_PAGINATION = {"data_key": "features", "max_pages": 1, "max_rows": 5}
 _BULK_PARAMS = {"departement": _DEFAULT_DEPARTEMENT, "table_format": "csv", "delimiter": ";"}
@@ -55,6 +55,10 @@ _COMMON_METADATA = {
     "api_host": "data.geopf.fr/geocodage",
     "legacy_api_host": "api-adresse.data.gouv.fr",
     "legacy_api_status": "deprecated; use Geoplateforme host",
+    "unmodelled_endpoints": (
+        "POST /search/csv requires multipart CSV upload and is not represented "
+        "as a declarative table source",
+    ),
 }
 
 _FEATURE_SCHEMA = {
@@ -330,22 +334,29 @@ class BanSource(DeclarativeSource):
         lat: float | None,
         limit: int | None,
     ) -> dict[str, Any]:
-        query = dict(base_query)
+        scope_filters = {
+            "citycode": citycode,
+            "postcode": postcode,
+            "depcode": depcode,
+        }
+        selected_scope_filters = {
+            key: value for key, value in scope_filters.items() if value is not None
+        }
+        if len(selected_scope_filters) > 1:
+            raise ValueError("citycode, postcode and depcode filters are exclusive")
+
+        replaces_default_query = q is not None or bool(selected_scope_filters)
+        query = {} if replaces_default_query else dict(base_query)
         if q is not None:
             query["q"] = q
-        if citycode is not None:
-            query["citycode"] = citycode
-        if postcode is not None:
-            query["postcode"] = postcode
-        if depcode is not None:
-            query["depcode"] = depcode
+        query.update(selected_scope_filters)
         if address_type is not None:
             query["type"] = address_type
         if lon is not None:
             query["lon"] = float(lon)
         if lat is not None:
             query["lat"] = float(lat)
-        query["limit"] = _coerce_limit(limit or int(query["limit"]))
+        query["limit"] = _coerce_limit(limit or int(base_query["limit"]))
         return query
 
     @staticmethod

--- a/plugins/gispulse-src-ban/gispulse_src_ban/source.py
+++ b/plugins/gispulse-src-ban/gispulse_src_ban/source.py
@@ -1,0 +1,378 @@
+"""Base Adresse Nationale DataSource.
+
+BAN is the French address identity pivot: address text, coordinates, commune
+codes and BAN identifiers. Runtime lookup uses the Geoplateforme geocoding API,
+while bulk ingest uses the official address CSV exports by department.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import replace
+from typing import Any
+
+from gispulse.plugins.api import (
+    AccessProtocol,
+    AccessSpec,
+    DeclarativeSource,
+    Payload,
+    SourceDomain,
+    SourceEntryRef,
+)
+
+BAN_GEOCODING_BASE_URL = "https://data.geopf.fr/geocodage"
+BAN_SEARCH_ENDPOINT = f"{BAN_GEOCODING_BASE_URL}/search/"
+BAN_REVERSE_ENDPOINT = f"{BAN_GEOCODING_BASE_URL}/reverse/"
+BAN_BULK_CSV_ENDPOINT = (
+    "https://adresse.data.gouv.fr/data/ban/adresses/latest/csv/"
+    "adresses-{departement}.csv.gz"
+)
+
+_DEFAULT_DEPARTEMENT = "63"
+_DEFAULT_CITYCODE = "63113"
+_DEFAULT_ADDRESS_QUERY = "1 rue abbe Girard Clermont-Ferrand"
+_DEFAULT_LON = 3.087025
+_DEFAULT_LAT = 45.777222
+_DEFAULT_SEARCH_LIMIT = 5
+_DEFAULT_REVERSE_LIMIT = 1
+_MAX_API_LIMIT = 20
+
+_API_PAGINATION = {"data_key": "features", "max_pages": 1, "max_rows": 5}
+_BULK_PARAMS = {"departement": _DEFAULT_DEPARTEMENT, "table_format": "csv", "delimiter": ";"}
+_DEPARTMENT_RE = re.compile(
+    r"^(?:0[1-9]|[1-8][0-9]|9[0-5]|2A|2B|97[1-8])$"
+)
+
+_COMMON_METADATA = {
+    "provider": "Base Adresse Nationale",
+    "platform": "data.geopf.fr/geocodage + adresse.data.gouv.fr exports",
+    "license": "Licence Ouverte 2.0",
+    "default_departement": _DEFAULT_DEPARTEMENT,
+    "default_citycode": _DEFAULT_CITYCODE,
+    "identity_source": "address",
+    "join_keys": ("properties.id", "properties.banId", "properties.citycode"),
+    "api_host": "data.geopf.fr/geocodage",
+    "legacy_api_host": "api-adresse.data.gouv.fr",
+    "legacy_api_status": "deprecated; use Geoplateforme host",
+}
+
+_FEATURE_SCHEMA = {
+    "type": "str",
+    "geometry.type": "str",
+    "geometry.coordinates": "list[float]",
+    "properties.label": "str",
+    "properties.score": "float",
+    "properties.housenumber": "str",
+    "properties.id": "str",
+    "properties.banId": "str",
+    "properties.name": "str",
+    "properties.postcode": "str",
+    "properties.citycode": "str",
+    "properties.x": "float",
+    "properties.y": "float",
+    "properties.city": "str",
+    "properties.context": "str",
+    "properties.type": "str",
+    "properties.importance": "float",
+    "properties.depcode": "str",
+    "properties.street": "str",
+    "properties.distance": "float",
+}
+
+_BULK_SCHEMA = {
+    "id": "str",
+    "id_fantoir": "str",
+    "numero": "str",
+    "rep": "str",
+    "nom_voie": "str",
+    "code_postal": "str",
+    "code_insee": "str",
+    "nom_commune": "str",
+    "code_insee_ancienne_commune": "str",
+    "nom_ancienne_commune": "str",
+    "x": "float",
+    "y": "float",
+    "lon": "float",
+    "lat": "float",
+    "type_position": "str",
+    "alias": "str",
+    "nom_ld": "str",
+    "libelle_acheminement": "str",
+    "nom_afnor": "str",
+    "source_position": "str",
+    "source_nom_voie": "str",
+    "certification_commune": "bool",
+    "cad_parcelles": "str",
+}
+
+
+def _copy_params(params: Mapping[str, Any]) -> dict[str, Any]:
+    copied = dict(params)
+    for nested_key in ("query", "pagination"):
+        nested = copied.get(nested_key)
+        if isinstance(nested, dict):
+            copied[nested_key] = dict(nested)
+    return copied
+
+
+def _coerce_limit(limit: int) -> int:
+    if limit < 1 or limit > _MAX_API_LIMIT:
+        raise ValueError(f"limit must be between 1 and {_MAX_API_LIMIT}")
+    return int(limit)
+
+
+def _normalise_departement(value: object | None) -> str:
+    code = str(value or "").strip().upper()
+    if code.isdecimal() and len(code) == 1:
+        code = f"0{code}"
+    if not _DEPARTMENT_RE.match(code):
+        raise ValueError(f"department code is not supported by BAN exports: {value!r}")
+    return code
+
+
+def _apply_materialization(
+    params: dict[str, Any],
+    *,
+    local_path: str | None,
+    s3_uri: str | None,
+    s3_key: str | None,
+) -> None:
+    if local_path is not None:
+        params["local_path"] = local_path
+    if s3_uri is not None:
+        params["s3_uri"] = s3_uri
+    if s3_key is not None:
+        params["s3_key"] = s3_key
+
+
+def _api_entry(
+    *,
+    entry_id: str,
+    label: str,
+    endpoint: str,
+    query: dict[str, Any],
+    limit: int,
+    metadata: dict[str, Any],
+) -> SourceEntryRef:
+    return SourceEntryRef(
+        id=entry_id,
+        name=label,
+        access=AccessSpec(
+            protocol=AccessProtocol.REST_TABLE,
+            endpoint=endpoint,
+            params={
+                "query": dict(query),
+                "pagination": {
+                    **_API_PAGINATION,
+                    "max_rows": limit,
+                },
+            },
+            format="application/json",
+        ),
+        revision_token=None,
+        domain=SourceDomain.BASE,
+        payload=Payload.TABLE,
+        jurisdiction="FR",
+        metadata={**_COMMON_METADATA, **metadata},
+    )
+
+
+class BanSource(DeclarativeSource):
+    """BAN address identity records exposed as a GISPulse source."""
+
+    name = "ban"
+    domain = SourceDomain.BASE
+    payload = Payload.TABLE
+    jurisdiction = "FR"
+
+    def entries(self) -> list[SourceEntryRef]:
+        return [
+            _api_entry(
+                entry_id="addresses-search",
+                label="BAN address search",
+                endpoint=BAN_SEARCH_ENDPOINT,
+                query={
+                    "q": _DEFAULT_ADDRESS_QUERY,
+                    "citycode": _DEFAULT_CITYCODE,
+                    "limit": _DEFAULT_SEARCH_LIMIT,
+                },
+                limit=_DEFAULT_SEARCH_LIMIT,
+                metadata={
+                    "query_kind": "search",
+                    "default_query": _DEFAULT_ADDRESS_QUERY,
+                    "filter_fields": (
+                        "q",
+                        "citycode",
+                        "postcode",
+                        "depcode",
+                        "type",
+                        "lat",
+                        "lon",
+                    ),
+                },
+            ),
+            _api_entry(
+                entry_id="addresses-reverse",
+                label="BAN reverse geocoding",
+                endpoint=BAN_REVERSE_ENDPOINT,
+                query={
+                    "lon": _DEFAULT_LON,
+                    "lat": _DEFAULT_LAT,
+                    "limit": _DEFAULT_REVERSE_LIMIT,
+                },
+                limit=_DEFAULT_REVERSE_LIMIT,
+                metadata={
+                    "query_kind": "reverse",
+                    "default_lon": _DEFAULT_LON,
+                    "default_lat": _DEFAULT_LAT,
+                    "filter_fields": ("lon", "lat", "type"),
+                },
+            ),
+            SourceEntryRef(
+                id="addresses-departement",
+                name="BAN address CSV export by department",
+                access=AccessSpec(
+                    protocol=AccessProtocol.TABLE_FILE,
+                    endpoint=BAN_BULK_CSV_ENDPOINT,
+                    params=dict(_BULK_PARAMS),
+                    format="text/csv",
+                ),
+                revision_token=None,
+                domain=self.domain,
+                payload=self.payload,
+                jurisdiction=self.jurisdiction,
+                metadata={
+                    "provider": "Base Adresse Nationale",
+                    "platform": "adresse.data.gouv.fr static exports",
+                    "license": "Licence Ouverte 2.0",
+                    "default_departement": _DEFAULT_DEPARTEMENT,
+                    "granularity": "departement",
+                    "format": "csv",
+                    "compression": "gzip",
+                    "delimiter": ";",
+                    "join_keys": ("id", "code_insee", "cad_parcelles"),
+                    "geometry_fields": ("lon", "lat", "x", "y"),
+                    "endpoint_template": BAN_BULK_CSV_ENDPOINT,
+                    "source_page": "https://adresse.data.gouv.fr/data/ban/adresses/latest/csv/",
+                },
+            ),
+        ]
+
+    def access_for(
+        self,
+        entry_id: str,
+        *,
+        q: str | None = None,
+        citycode: str | None = None,
+        postcode: str | None = None,
+        depcode: str | None = None,
+        address_type: str | None = None,
+        lon: float | None = None,
+        lat: float | None = None,
+        departement: str | None = None,
+        limit: int | None = None,
+        local_path: str | None = None,
+        s3_uri: str | None = None,
+        s3_key: str | None = None,
+    ) -> AccessSpec:
+        """Build a filtered BAN AccessSpec without network access."""
+        entry = self._entry(entry_id)
+        params = _copy_params(entry.access.params)
+        query_kind = entry.metadata.get("query_kind")
+
+        if query_kind == "search":
+            params["query"] = self._search_query(
+                params["query"],
+                q=q,
+                citycode=citycode,
+                postcode=postcode,
+                depcode=depcode,
+                address_type=address_type,
+                lon=lon,
+                lat=lat,
+                limit=limit,
+            )
+            params["pagination"]["max_rows"] = params["query"]["limit"]
+        elif query_kind == "reverse":
+            params["query"] = self._reverse_query(
+                params["query"],
+                lon=lon,
+                lat=lat,
+                address_type=address_type,
+                limit=limit,
+            )
+            params["pagination"]["max_rows"] = params["query"]["limit"]
+        elif entry_id == "addresses-departement":
+            if departement is not None:
+                params["departement"] = _normalise_departement(departement)
+        else:  # pragma: no cover - defensive for future local entries
+            raise ValueError(f"unsupported BAN entry: {entry_id!r}")
+
+        _apply_materialization(
+            params,
+            local_path=local_path,
+            s3_uri=s3_uri,
+            s3_key=s3_key,
+        )
+        return replace(entry.access, params=params)
+
+    @staticmethod
+    def _search_query(
+        base_query: Mapping[str, Any],
+        *,
+        q: str | None,
+        citycode: str | None,
+        postcode: str | None,
+        depcode: str | None,
+        address_type: str | None,
+        lon: float | None,
+        lat: float | None,
+        limit: int | None,
+    ) -> dict[str, Any]:
+        query = dict(base_query)
+        if q is not None:
+            query["q"] = q
+        if citycode is not None:
+            query["citycode"] = citycode
+        if postcode is not None:
+            query["postcode"] = postcode
+        if depcode is not None:
+            query["depcode"] = depcode
+        if address_type is not None:
+            query["type"] = address_type
+        if lon is not None:
+            query["lon"] = float(lon)
+        if lat is not None:
+            query["lat"] = float(lat)
+        query["limit"] = _coerce_limit(limit or int(query["limit"]))
+        return query
+
+    @staticmethod
+    def _reverse_query(
+        base_query: Mapping[str, Any],
+        *,
+        lon: float | None,
+        lat: float | None,
+        address_type: str | None,
+        limit: int | None,
+    ) -> dict[str, Any]:
+        query = dict(base_query)
+        if lon is not None:
+            query["lon"] = float(lon)
+        if lat is not None:
+            query["lat"] = float(lat)
+        if address_type is not None:
+            query["type"] = address_type
+        query["limit"] = _coerce_limit(limit or int(query["limit"]))
+        return query
+
+    def schema(self, entry_id: str) -> dict[str, str]:
+        entry = self._entry(entry_id)
+        if entry.access.protocol is AccessProtocol.TABLE_FILE:
+            return dict(_BULK_SCHEMA)
+        return dict(_FEATURE_SCHEMA)
+
+    def revision(self, entry_id: str) -> str | None:
+        self._entry(entry_id)  # validates the id
+        return None

--- a/plugins/gispulse-src-ban/pyproject.toml
+++ b/plugins/gispulse-src-ban/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gispulse-src-ban"
+version = "0.1.0"
+description = "French Base Adresse Nationale source for GISPulse"
+requires-python = ">=3.10"
+license = "AGPL-3.0-or-later"
+authors = [{ name = "GISPulse", email = "dev@gispulse.io" }]
+dependencies = [
+    "gispulse>=2.0.0,<3.0.0",
+]
+
+# Registered as a data source - discovered by core.plugin_hub.PluginHub.
+[project.entry-points."gispulse.data_sources"]
+ban = "gispulse_src_ban:register"
+
+[tool.gispulse.plugin]
+kind = "source"
+protocol = ">=1.0,<2.0"
+domain = "base"
+jurisdiction = "FR"
+display_name = "BAN - Base Adresse Nationale (France)"

--- a/tests/unit/test_src_ban.py
+++ b/tests/unit/test_src_ban.py
@@ -204,6 +204,35 @@ def test_access_for_search_overrides_query_without_mutating_catalog(source) -> N
     assert original.params["query"]["citycode"] == "63113"
 
 
+def test_access_for_search_q_replaces_clermont_default_citycode(source) -> None:
+    access = source.access_for(
+        "addresses-search",
+        q="10 rue de Rivoli Paris",
+    )
+
+    assert access.params["query"] == {
+        "q": "10 rue de Rivoli Paris",
+        "limit": 5,
+    }
+
+
+def test_access_for_search_depcode_replaces_clermont_default_filter(source) -> None:
+    access = source.access_for(
+        "addresses-search",
+        depcode="75",
+    )
+
+    assert access.params["query"] == {
+        "depcode": "75",
+        "limit": 5,
+    }
+
+
+def test_access_for_search_rejects_ambiguous_geographic_filters(source) -> None:
+    with pytest.raises(ValueError, match="exclusive"):
+        source.access_for("addresses-search", citycode="75101", depcode="75")
+
+
 def test_access_for_reverse_replaces_coordinates_and_type_filter(source) -> None:
     access = source.access_for(
         "addresses-reverse",
@@ -241,10 +270,17 @@ def test_access_for_bulk_normalises_department_and_materialization(source) -> No
 
 def test_access_for_rejects_invalid_limit_and_department(source) -> None:
     with pytest.raises(ValueError, match="limit"):
-        source.access_for("addresses-search", limit=21)
+        source.access_for("addresses-search", limit=51)
 
     with pytest.raises(ValueError, match="department"):
         source.access_for("addresses-departement", departement="999")
+
+
+def test_access_for_accepts_geoplateforme_limit_50(source) -> None:
+    access = source.access_for("addresses-search", limit=50)
+
+    assert access.params["query"]["limit"] == 50
+    assert access.params["pagination"]["max_rows"] == 50
 
 
 def test_fetch_delegates_search_to_rest_table_adapter() -> None:
@@ -291,6 +327,15 @@ def test_schema_exposes_search_feature_and_bulk_csv_fields(source) -> None:
     assert bulk_schema["lon"] == "float"
     assert bulk_schema["lat"] == "float"
     assert bulk_schema["cad_parcelles"] == "str"
+
+
+def test_metadata_documents_unmodelled_csv_post_endpoint(source) -> None:
+    entry = source._entry("addresses-search")
+
+    assert entry.metadata["unmodelled_endpoints"] == (
+        "POST /search/csv requires multipart CSV upload and is not represented "
+        "as a declarative table source",
+    )
 
 
 def test_revision_is_unknown_for_api_entries(source) -> None:

--- a/tests/unit/test_src_ban.py
+++ b/tests/unit/test_src_ban.py
@@ -1,0 +1,298 @@
+"""Unit tests for the gispulse-src-ban plugin.
+
+Zero-network: the plugin declares BAN geocoding API and bulk CSV AccessSpecs.
+Core fetchers own HTTP, file materialization and lazy scans.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+_PKG = Path(__file__).resolve().parents[2] / "plugins" / "gispulse-src-ban"
+_PKG_PATH = str(_PKG)
+if _PKG_PATH in sys.path:
+    sys.path.remove(_PKG_PATH)
+sys.path.insert(0, _PKG_PATH)
+for _module in ("gispulse_src_ban.source", "gispulse_src_ban"):
+    sys.modules.pop(_module, None)
+
+from gispulse.core.plugin_model import (  # noqa: E402
+    AccessProtocol,
+    FetchMode,
+    Payload,
+    SourceDomain,
+    SourceResult,
+)
+from gispulse.core.sources import DataSource, ProtocolRegistry  # noqa: E402
+
+pytestmark = pytest.mark.usefixtures("offline_ssrf")
+
+
+class FakeRestTable:
+    """Records REST_TABLE AccessSpecs and returns the endpoint."""
+
+    protocol = AccessProtocol.REST_TABLE
+
+    def __init__(self) -> None:
+        self.calls: list = []
+
+    def fetch(self, access, *, extent=None, mode=FetchMode.MATERIALIZE):
+        self.calls.append(access)
+        return SourceResult(payload=Payload.TABLE, mode=mode, data=access.endpoint)
+
+
+class FakeTableFile:
+    """Records TABLE_FILE AccessSpecs and returns the endpoint."""
+
+    protocol = AccessProtocol.TABLE_FILE
+
+    def __init__(self) -> None:
+        self.calls: list = []
+
+    def fetch(self, access, *, extent=None, mode=FetchMode.MATERIALIZE):
+        self.calls.append(access)
+        return SourceResult(payload=Payload.TABLE, mode=mode, data=access.endpoint)
+
+
+def _source_class():
+    return importlib.import_module("gispulse_src_ban.source").BanSource
+
+
+@pytest.fixture
+def source():
+    reg = ProtocolRegistry()
+    reg.register(FakeRestTable())
+    reg.register(FakeTableFile())
+    return _source_class()(registry=reg)
+
+
+def test_pyproject_declares_ban_entrypoint_and_base_manifest() -> None:
+    tomllib = pytest.importorskip("tomllib")
+    pyproject = tomllib.loads((_PKG / "pyproject.toml").read_text())
+
+    assert pyproject["project"]["entry-points"]["gispulse.data_sources"] == {
+        "ban": "gispulse_src_ban:register"
+    }
+
+    manifest = pyproject["tool"]["gispulse"]["plugin"]
+    assert manifest["kind"] == "source"
+    assert manifest["domain"] == "base"
+    assert manifest["jurisdiction"] == "FR"
+
+
+def test_register_adds_ban_source_to_global_registry() -> None:
+    from gispulse.core.sources import SOURCES
+
+    BanSource = _source_class()
+    register = importlib.import_module("gispulse_src_ban").register
+
+    SOURCES.clear()
+    try:
+        register()
+        registered = SOURCES.get("ban")
+        assert isinstance(registered, BanSource)
+        assert {entry.id for entry in registered.catalog()} == {
+            "addresses-search",
+            "addresses-reverse",
+            "addresses-departement",
+        }
+    finally:
+        SOURCES.clear()
+
+
+def test_ban_is_a_base_table_datasource(source) -> None:
+    assert isinstance(source, DataSource)
+    assert source.name == "ban"
+    assert source.domain is SourceDomain.BASE
+    assert source.payload is Payload.TABLE
+    assert source.jurisdiction == "FR"
+
+
+def test_search_entry_uses_geoplateforme_rest_table_with_dept63_default(source) -> None:
+    entry = source._entry("addresses-search")
+
+    assert entry.access.protocol is AccessProtocol.REST_TABLE
+    assert entry.access.endpoint == "https://data.geopf.fr/geocodage/search/"
+    assert entry.access.format == "application/json"
+    assert entry.access.params["query"] == {
+        "q": "1 rue abbe Girard Clermont-Ferrand",
+        "citycode": "63113",
+        "limit": 5,
+    }
+    assert entry.access.params["pagination"] == {
+        "data_key": "features",
+        "max_pages": 1,
+        "max_rows": 5,
+    }
+    assert entry.metadata["default_departement"] == "63"
+    assert entry.metadata["default_citycode"] == "63113"
+    assert entry.metadata["api_host"] == "data.geopf.fr/geocodage"
+    assert entry.metadata["legacy_api_host"] == "api-adresse.data.gouv.fr"
+    assert entry.metadata["query_kind"] == "search"
+    assert entry.metadata["join_keys"] == (
+        "properties.id",
+        "properties.banId",
+        "properties.citycode",
+    )
+
+
+def test_reverse_entry_uses_geoplateforme_rest_table_with_clermont_default(source) -> None:
+    entry = source._entry("addresses-reverse")
+
+    assert entry.access.protocol is AccessProtocol.REST_TABLE
+    assert entry.access.endpoint == "https://data.geopf.fr/geocodage/reverse/"
+    assert entry.access.params["query"] == {
+        "lon": 3.087025,
+        "lat": 45.777222,
+        "limit": 1,
+    }
+    assert entry.access.params["pagination"] == {
+        "data_key": "features",
+        "max_pages": 1,
+        "max_rows": 1,
+    }
+    assert entry.metadata["query_kind"] == "reverse"
+    assert entry.metadata["default_lon"] == 3.087025
+    assert entry.metadata["default_lat"] == 45.777222
+
+
+def test_department_bulk_entry_uses_ban_csv_gzip_with_dept63_default(source) -> None:
+    entry = source._entry("addresses-departement")
+
+    assert entry.access.protocol is AccessProtocol.TABLE_FILE
+    assert entry.access.endpoint == (
+        "https://adresse.data.gouv.fr/data/ban/adresses/latest/csv/"
+        "adresses-{departement}.csv.gz"
+    )
+    assert entry.access.params == {
+        "departement": "63",
+        "table_format": "csv",
+        "delimiter": ";",
+    }
+    assert entry.access.format == "text/csv"
+    assert entry.payload is Payload.TABLE
+    assert entry.metadata["default_departement"] == "63"
+    assert entry.metadata["compression"] == "gzip"
+    assert entry.metadata["join_keys"] == (
+        "id",
+        "code_insee",
+        "cad_parcelles",
+    )
+
+
+def test_access_for_search_overrides_query_without_mutating_catalog(source) -> None:
+    access = source.access_for(
+        "addresses-search",
+        q="8 boulevard du port",
+        citycode="95127",
+        limit=1,
+        s3_key="raw/ban/search/cergy.jsonl",
+    )
+    original = source._entry("addresses-search").access
+
+    assert access.params["query"] == {
+        "q": "8 boulevard du port",
+        "citycode": "95127",
+        "limit": 1,
+    }
+    assert access.params["pagination"]["max_rows"] == 1
+    assert access.params["s3_key"] == "raw/ban/search/cergy.jsonl"
+    assert original.params["query"]["citycode"] == "63113"
+
+
+def test_access_for_reverse_replaces_coordinates_and_type_filter(source) -> None:
+    access = source.access_for(
+        "addresses-reverse",
+        lon=2.062821,
+        lat=49.031624,
+        address_type="housenumber",
+        limit=3,
+        local_path="/tmp/ban-reverse.jsonl",
+    )
+
+    assert access.params["query"] == {
+        "lon": 2.062821,
+        "lat": 49.031624,
+        "limit": 3,
+        "type": "housenumber",
+    }
+    assert access.params["pagination"]["max_rows"] == 3
+    assert access.params["local_path"] == "/tmp/ban-reverse.jsonl"
+
+
+def test_access_for_bulk_normalises_department_and_materialization(source) -> None:
+    access = source.access_for(
+        "addresses-departement",
+        departement="1",
+        s3_key="raw/ban/adresses-01.parquet",
+    )
+
+    assert access.params == {
+        "departement": "01",
+        "table_format": "csv",
+        "delimiter": ";",
+        "s3_key": "raw/ban/adresses-01.parquet",
+    }
+
+
+def test_access_for_rejects_invalid_limit_and_department(source) -> None:
+    with pytest.raises(ValueError, match="limit"):
+        source.access_for("addresses-search", limit=21)
+
+    with pytest.raises(ValueError, match="department"):
+        source.access_for("addresses-departement", departement="999")
+
+
+def test_fetch_delegates_search_to_rest_table_adapter() -> None:
+    rest = FakeRestTable()
+    reg = ProtocolRegistry()
+    reg.register(rest)
+    reg.register(FakeTableFile())
+    src = _source_class()(registry=reg)
+
+    result = src.fetch("addresses-search")
+
+    assert result.payload is Payload.TABLE
+    assert result.data == "https://data.geopf.fr/geocodage/search/"
+    assert len(rest.calls) == 1
+    assert rest.calls[0].protocol is AccessProtocol.REST_TABLE
+
+
+def test_fetch_delegates_department_template_to_table_file_adapter() -> None:
+    table_file = FakeTableFile()
+    reg = ProtocolRegistry()
+    reg.register(FakeRestTable())
+    reg.register(table_file)
+    src = _source_class()(registry=reg)
+
+    result = src.fetch("addresses-departement")
+
+    assert result.payload is Payload.TABLE
+    assert result.data.endswith("/adresses-63.csv.gz")
+    assert len(table_file.calls) == 1
+    assert table_file.calls[0].endpoint.endswith("/adresses-63.csv.gz")
+
+
+def test_schema_exposes_search_feature_and_bulk_csv_fields(source) -> None:
+    search_schema = source.schema("addresses-search")
+    bulk_schema = source.schema("addresses-departement")
+
+    assert search_schema["properties.id"] == "str"
+    assert search_schema["properties.banId"] == "str"
+    assert search_schema["properties.citycode"] == "str"
+    assert search_schema["geometry.coordinates"] == "list[float]"
+
+    assert bulk_schema["id"] == "str"
+    assert bulk_schema["code_insee"] == "str"
+    assert bulk_schema["lon"] == "float"
+    assert bulk_schema["lat"] == "float"
+    assert bulk_schema["cad_parcelles"] == "str"
+
+
+def test_revision_is_unknown_for_api_entries(source) -> None:
+    assert source.revision("addresses-search") is None
+    assert source.revision("addresses-reverse") is None


### PR DESCRIPTION
BAN geocoding (Geoplateforme) + departmental export. Zero-network unit tests green, real source probed, adversarial review fixes applied.

Depends on #358 (adds `AccessProtocol.TABLE_FILE`) — CI is red until #358 merges. Sits in the `beta-national` integration branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)