### PR TITLE
feat(milou): socle client gispulse — S3/R2 DuckDB + ingestion KMZ/XLSX Lambert 72

### DIFF
--- a/docs/milou-client-plan.md
+++ b/docs/milou-client-plan.md
@@ -17,9 +17,9 @@
 - Pattern de référence (NE PAS importer en bloc) : cube DuckDB de `gispulse-foncier` — scan Parquet paramétré, `read_parquet(..., union_by_name=true)`, géométrie normalisée.
 
 ## 2. À durcir / ajouter côté gispulse
-- [ ] **KMZ réel** dans `persistence.io` : `.kmz` → unzip → `doc.kml` (fallback 1er `.kml`) → GeoDataFrame WGS84. Aujourd'hui `.kmz` n'est qu'inféré côté engine CDC, pas lu par `read_vector`.
-- [ ] **XLSX projeté CRS-explicite** : ajouter `x_col` / `y_col` / `source_crs` / `target_crs` ; **refuser l'inférence naïve `X/Y → EPSG:4326`** (les fichiers Orange ont des **X/Y en Lambert 72 / EPSG:31370**).
-- [ ] **Déclarer `openpyxl`** (extra `xlsx` ou dépendance directe) — `pandas.read_excel` est utilisé mais la dépendance n'est pas déclarée.
+- [x] **KMZ réel** dans `persistence.io` : `.kmz` → unzip → `doc.kml` (fallback 1er `.kml`) → GeoDataFrame WGS84. Aujourd'hui `.kmz` n'est qu'inféré côté engine CDC, pas lu par `read_vector`.
+- [x] **XLSX projeté CRS-explicite** : ajouter `x_col` / `y_col` / `source_crs` / `target_crs` ; **refuser l'inférence naïve `X/Y → EPSG:4326`** (les fichiers Orange ont des **X/Y en Lambert 72 / EPSG:31370**).
+- [x] **Déclarer `openpyxl`** (extra `xlsx` ou dépendance directe) — `pandas.read_excel` est utilisé mais la dépendance n'est pas déclarée.
 - [ ] **Helpers DuckDB/R2** : builders sûrs `read_parquet('s3://…')` (+ `union_by_name`), matérialisation GPKG distante en cache local, helper `ST_DWithin` métrique.
 - [ ] **Conventions GPKG de pipeline** : helper de noms de couches + manifest (`feature_count`, `source`, `crs`, `params_hash`).
 - [ ] **Doc API cliente minimale** (exemples sans règles métier MILOU).

--- a/docs/milou-client-plan.md
+++ b/docs/milou-client-plan.md
@@ -20,7 +20,7 @@
 - [x] **KMZ réel** dans `persistence.io` : `.kmz` → unzip → `doc.kml` (fallback 1er `.kml`) → GeoDataFrame WGS84. Aujourd'hui `.kmz` n'est qu'inféré côté engine CDC, pas lu par `read_vector`.
 - [x] **XLSX projeté CRS-explicite** : ajouter `x_col` / `y_col` / `source_crs` / `target_crs` ; **refuser l'inférence naïve `X/Y → EPSG:4326`** (les fichiers Orange ont des **X/Y en Lambert 72 / EPSG:31370**).
 - [x] **Déclarer `openpyxl`** (extra `xlsx` ou dépendance directe) — `pandas.read_excel` est utilisé mais la dépendance n'est pas déclarée.
-- [ ] **Helpers DuckDB/R2** : builders sûrs `read_parquet('s3://…')` (+ `union_by_name`), matérialisation GPKG distante en cache local, helper `ST_DWithin` métrique.
+- [x] **Helpers DuckDB/R2** : builders sûrs `read_parquet('s3://…')` (+ `union_by_name`), matérialisation GPKG distante en cache local, helper `ST_DWithin` métrique.
 - [ ] **Conventions GPKG de pipeline** : helper de noms de couches + manifest (`feature_count`, `source`, `crs`, `params_hash`).
 - [ ] **Doc API cliente minimale** (exemples sans règles métier MILOU).
 

--- a/docs/milou-client-plan.md
+++ b/docs/milou-client-plan.md
@@ -1,0 +1,62 @@
+# Plan de travail — gispulse comme socle de MILOU (branche `milou`)
+
+> Objectif : MILOU (moteur de pré-dimensionnement réseau fibre belge) devient **client
+> hybride de gispulse**. gispulse fournit l'**I/O géo, la persistence GeoPackage, DuckDB/
+> spatial et la lecture R2/S3** ; MILOU garde la **logique fibre** (terrain, oil-slick, rings,
+> costing, livrables, confidentiel `input_client`).
+>
+> Branche `milou` créée depuis `main` + cherry-pick `c451a64` (config secret S3/R2 → DuckDB).
+> Workflow : push sur `origin` (fork `superWorldSavior/gispulse`) → PR vers `imagodata/gispulse`.
+> Issues côté MILOU : `imagodata/milou#5`→`#10`.
+
+## 1. Déjà utilisable (rien à coder)
+- `gispulse.persistence.io.read_vector` — GPKG/GeoJSON/SHP/FGB/KML/CSV/XLSX/Parquet (`bbox`, `rows`, `layer`, `crs`).
+- `gispulse.persistence.gpkg` — `list_layers`, `read_gpkg`, `write_gpkg`, `read_all_layers`, `write_all_layers`.
+- `gispulse.persistence.duckdb_engine.DuckDBSession` — `spatial` + `httpfs` + **secret S3/R2** (déjà testé : endpoint Garage/R2, credentials, escaping, scope bucket).
+- Config R2 via `GISPULSE_S3_*` (`gispulse.core.config`).
+- Pattern de référence (NE PAS importer en bloc) : cube DuckDB de `gispulse-foncier` — scan Parquet paramétré, `read_parquet(..., union_by_name=true)`, géométrie normalisée.
+
+## 2. À durcir / ajouter côté gispulse
+- [ ] **KMZ réel** dans `persistence.io` : `.kmz` → unzip → `doc.kml` (fallback 1er `.kml`) → GeoDataFrame WGS84. Aujourd'hui `.kmz` n'est qu'inféré côté engine CDC, pas lu par `read_vector`.
+- [ ] **XLSX projeté CRS-explicite** : ajouter `x_col` / `y_col` / `source_crs` / `target_crs` ; **refuser l'inférence naïve `X/Y → EPSG:4326`** (les fichiers Orange ont des **X/Y en Lambert 72 / EPSG:31370**).
+- [ ] **Déclarer `openpyxl`** (extra `xlsx` ou dépendance directe) — `pandas.read_excel` est utilisé mais la dépendance n'est pas déclarée.
+- [ ] **Helpers DuckDB/R2** : builders sûrs `read_parquet('s3://…')` (+ `union_by_name`), matérialisation GPKG distante en cache local, helper `ST_DWithin` métrique.
+- [ ] **Conventions GPKG de pipeline** : helper de noms de couches + manifest (`feature_count`, `source`, `crs`, `params_hash`).
+- [ ] **Doc API cliente minimale** (exemples sans règles métier MILOU).
+
+## 3. API cliente cible (ce que MILOU importera)
+```python
+from gispulse.persistence import read_vector, write_vector, DuckDBSession
+from gispulse.persistence.gpkg import (
+    list_layers, read_gpkg, write_gpkg, read_all_layers, write_all_layers,
+)
+from gispulse.persistence.duckdb_relations import (   # à créer
+    parquet_scan, materialize_remote_gpkg, st_dwithin_join_sql,
+)
+
+# Sites Orange (X/Y Lambert 72) :
+sites = read_vector(path_xlsx, x_col="X", y_col="Y", source_crs="EPSG:31370")
+network = read_vector(path_kmz)  # WGS84
+with DuckDBSession() as db:
+    companies = parquet_scan("s3://milou-data/data/processed/companies_be.parquet", union_by_name=True)
+    sql = st_dwithin_join_sql("sites", companies, distance_m=200)
+```
+
+## 4. Frontière générique (gispulse) / métier (MILOU)
+- **gispulse** (générique, dual-license) : KMZ/KML/XLSX projeté, CRS explicite, GPKG pipeline, DuckDB spatial, S3/R2/httpfs, relations Parquet/GPKG, `ST_DWithin`.
+- **MILOU** (métier, confidentiel) : mapping Orange, règles d'anneaux, re-homing IC, coût marginal, TPR savings, Infrabel 10/20/40 ans, cashflow/MRC, `input_client`.
+
+## 5. Plan ordonné (cible 13/14 juin)
+| Quand | Lot |
+|---|---|
+| 5-7 juin | **P0** : `read_vector(.kmz)` + XLSX Lambert 72 + tests fixtures |
+| 8 juin | API importable stabilisée + dépendance `openpyxl` |
+| 9-10 juin | Helpers DuckDB/R2 (Parquet) + `ST_DWithin` |
+| 10-11 juin | Conventions GPKG pipeline + manifest |
+| 12 juin | Brancher MILOU en dépendance editable ; remplacer `kmz_reader`/lectures XLSX maison |
+| 13-14 juin | Buffer livraison ; smoke : sites Orange + companies R2 + GPKG pipeline |
+
+## 6. Note licence
+MILOU (propriétaire) dépend de gispulse (AGPL-3.0 + dual-license commercial) sous **exception/
+licence commerciale ImagoData**. Le générique reversé ici reste dual-licensé ; le métier
+confidentiel reste côté MILOU.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "pydantic-settings>=2.0,<3.0",
     "PyYAML>=6.0,<7.0",
     "httpx>=0.24,<1.0",
+    "openpyxl>=3.1,<4.0",
 ]
 
 [project.scripts]

--- a/src/gispulse/persistence/__init__.py
+++ b/src/gispulse/persistence/__init__.py
@@ -30,12 +30,20 @@ try:
     from gispulse.persistence.duckdb_engine import DuckDBSession
     # Lot 3: change-log adapter wrapping DuckDBSession for live-sync.
     from gispulse.persistence.duckdb_engine_adapter import DuckDBSpatialEngine
+    from gispulse.persistence.duckdb_relations import (
+        materialize_remote_gpkg,
+        parquet_scan,
+        st_dwithin_join_sql,
+    )
 
     _DUCKDB_AVAILABLE = True
 except ImportError:
     _DUCKDB_AVAILABLE = False
     DuckDBSession = None  # type: ignore[assignment,misc]
     DuckDBSpatialEngine = None  # type: ignore[assignment,misc]
+    materialize_remote_gpkg = None  # type: ignore[assignment,misc]
+    parquet_scan = None  # type: ignore[assignment,misc]
+    st_dwithin_join_sql = None  # type: ignore[assignment,misc]
 
 # DuckDB-PostGIS hybrid bridge (Phase 4).
 try:
@@ -147,6 +155,9 @@ __all__ = [
     # DuckDB (Phase 1)
     "DuckDBSession",
     "DuckDBSpatialEngine",
+    "parquet_scan",
+    "materialize_remote_gpkg",
+    "st_dwithin_join_sql",
     "_DUCKDB_AVAILABLE",
     # Hybrid bridge (Phase 4)
     "DuckDBPostGISBridge",

--- a/src/gispulse/persistence/duckdb_engine.py
+++ b/src/gispulse/persistence/duckdb_engine.py
@@ -13,15 +13,82 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 import duckdb
 import geopandas as gpd
 from shapely import wkb
 
+from gispulse.core.config import settings
 from gispulse.core.logging import get_logger
 from gispulse.persistence.engine import SpatialEngine
 
 log = get_logger(__name__)
+
+
+def _sql_literal(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _normalise_s3_endpoint(endpoint: str) -> tuple[str, bool]:
+    """Return DuckDB's ENDPOINT value and whether it should use TLS."""
+    endpoint = endpoint.strip().rstrip("/")
+    parsed = urlparse(endpoint if "://" in endpoint else f"https://{endpoint}")
+    host = parsed.netloc or parsed.path
+    return host, parsed.scheme != "http"
+
+
+def _configure_s3_secret(conn: duckdb.DuckDBPyConnection, s3: Any) -> None:
+    """Configure DuckDB httpfs from ``GISPULSE_S3_*`` settings."""
+    raw_endpoint = str(getattr(s3, "endpoint", "") or "").strip()
+    if not raw_endpoint:
+        return
+
+    endpoint, use_ssl = _normalise_s3_endpoint(raw_endpoint)
+    bucket = str(getattr(s3, "bucket", "") or "").strip() or "gispulse"
+    region = str(getattr(s3, "region", "") or "").strip() or "us-east-1"
+    access_key = str(getattr(s3, "access_key", "") or "").strip()
+    secret_key = str(getattr(s3, "secret_key", "") or "").strip()
+
+    clauses = [
+        "TYPE s3",
+        "PROVIDER config",
+    ]
+    if access_key and secret_key:
+        clauses.extend([
+            f"KEY_ID {_sql_literal(access_key)}",
+            f"SECRET {_sql_literal(secret_key)}",
+        ])
+    elif access_key or secret_key:
+        log.warning("duckdb_s3_secret_credentials_incomplete", bucket=bucket)
+
+    clauses.extend([
+        f"REGION {_sql_literal(region)}",
+        f"ENDPOINT {_sql_literal(endpoint)}",
+        "URL_STYLE 'path'",
+        f"USE_SSL {'true' if use_ssl else 'false'}",
+        f"SCOPE {_sql_literal(f's3://{bucket}')}",
+    ])
+
+    sql = "CREATE OR REPLACE SECRET gispulse_s3 (\n    "
+    sql += ",\n    ".join(clauses)
+    sql += "\n);"
+
+    try:
+        conn.execute(sql)
+        log.debug(
+            "duckdb_s3_secret_configured",
+            endpoint=endpoint,
+            bucket=bucket,
+            region=region,
+        )
+    except Exception as exc:
+        log.warning(
+            "duckdb_s3_secret_failed",
+            endpoint=endpoint,
+            bucket=bucket,
+            error_type=type(exc).__name__,
+        )
 
 
 class DuckDBSession(SpatialEngine):
@@ -59,6 +126,7 @@ class DuckDBSession(SpatialEngine):
         # effort — a missing httpfs (no network, locked-down host) must not
         # break the offline GPKG path, which goes through GeoPandas/Fiona.
         self._load_extension("httpfs")
+        _configure_s3_secret(self.conn, settings.s3)
         log.debug("duckdb_session_opened", database=self.database)
 
     def _load_extension(self, name: str) -> None:

--- a/src/gispulse/persistence/duckdb_engine.py
+++ b/src/gispulse/persistence/duckdb_engine.py
@@ -34,7 +34,9 @@ def _normalise_s3_endpoint(endpoint: str) -> tuple[str, bool]:
     """Return DuckDB's ENDPOINT value and whether it should use TLS."""
     endpoint = endpoint.strip().rstrip("/")
     parsed = urlparse(endpoint if "://" in endpoint else f"https://{endpoint}")
-    host = parsed.netloc or parsed.path
+    host = parsed.hostname or parsed.path
+    if parsed.port is not None:
+        host = f"{host}:{parsed.port}"
     return host, parsed.scheme != "http"
 
 

--- a/src/gispulse/persistence/duckdb_relations.py
+++ b/src/gispulse/persistence/duckdb_relations.py
@@ -1,0 +1,271 @@
+"""Safe DuckDB relation builders for Parquet/R2 and metric spatial joins."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import math
+import tempfile
+import threading
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+from gispulse.core.fetchers.http_file import HttpFileFetcher
+from gispulse.core.plugin_model import AccessProtocol, AccessSpec, FetchMode
+from gispulse.persistence.storage import StorageError, create_storage
+
+_PARQUET_SCAN_PREFIX = "read_parquet("
+_SAFE_RELATION_CHARS = set(
+    "abcdefghijklmnopqrstuvwxyz"
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    "0123456789"
+    "_ ."
+)
+_SAFE_IDENTIFIER_CHARS = set(
+    "abcdefghijklmnopqrstuvwxyz"
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    "0123456789"
+    "_ "
+)
+
+
+def parquet_scan(uri: str | Path, *, union_by_name: bool = True) -> str:
+    """Return a safe DuckDB ``read_parquet`` relation expression.
+
+    The expression is only built, never executed. ``uri`` may be a local path
+    or an ``s3://`` R2/S3 URI; credentials remain owned by ``DuckDBSession``.
+    """
+    return (
+        f"read_parquet({_sql_literal(str(uri))}, "
+        f"union_by_name={'true' if union_by_name else 'false'})"
+    )
+
+
+def materialize_remote_gpkg(
+    uri: str | Path,
+    *,
+    layer: str | None = None,
+    cache_dir: str | Path | None = None,
+) -> Path:
+    """Materialize a remote GeoPackage to local cache and return its path.
+
+    Local paths are returned as-is after existence and optional layer checks.
+    ``http(s)://`` downloads reuse ``HttpFileFetcher``. ``s3://`` downloads use
+    the configured storage backend, so S3/R2 credentials stay centralized.
+    """
+    uri_text = str(uri)
+    parsed = urlparse(uri_text)
+
+    if parsed.scheme in ("", "file"):
+        path = Path(unquote(parsed.path) if parsed.scheme == "file" else uri_text)
+        if not path.exists():
+            raise FileNotFoundError(f"GPKG file not found: {path}")
+        _validate_gpkg_layer(path, layer)
+        return path
+
+    if parsed.scheme not in ("http", "https", "s3"):
+        raise ValueError(f"Unsupported GPKG URI scheme: {parsed.scheme!r}")
+
+    dest = _cached_gpkg_path(uri_text, cache_dir)
+    if not dest.exists():
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        if parsed.scheme in ("http", "https"):
+            access = AccessSpec(
+                protocol=AccessProtocol.DOWNLOAD,
+                endpoint=uri_text,
+                params={"local_path": str(dest), "layer": layer} if layer else {"local_path": str(dest)},
+            )
+            HttpFileFetcher().fetch(access, mode=FetchMode.MATERIALIZE)
+        else:
+            _download_s3_uri(parsed, dest)
+
+    _validate_gpkg_layer(dest, layer)
+    return dest
+
+
+def st_dwithin_join_sql(
+    left: str,
+    right: str,
+    *,
+    distance_m: float,
+    left_geom: str = "geom",
+    right_geom: str = "geom",
+    select: str = "*",
+) -> str:
+    """Build a metric ``ST_DWithin`` join SQL statement for projected CRS data."""
+    distance = float(distance_m)
+    if not math.isfinite(distance) or distance < 0:
+        raise ValueError("distance_m must be a finite non-negative number")
+
+    left_relation = _relation_sql(left)
+    right_relation = _relation_sql(right)
+    left_geom_sql = _qualified_identifier("l", left_geom)
+    right_geom_sql = _qualified_identifier("r", right_geom)
+    select_sql = _select_sql(select)
+
+    return (
+        f"SELECT {select_sql} "
+        f"FROM {left_relation} AS l "
+        f"JOIN {right_relation} AS r "
+        f"ON ST_DWithin({left_geom_sql}, {right_geom_sql}, {distance})"
+    )
+
+
+def _sql_literal(value: str) -> str:
+    if "\x00" in value:
+        raise ValueError("SQL literals cannot contain null bytes")
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _quote_identifier(identifier: str) -> str:
+    if not identifier or "\x00" in identifier:
+        raise ValueError("Unsafe identifier")
+    if any(char not in _SAFE_IDENTIFIER_CHARS for char in identifier):
+        raise ValueError(f"Unsafe identifier: {identifier!r}")
+    return '"' + identifier.replace('"', '""') + '"'
+
+
+def _qualified_identifier(alias: str, identifier: str) -> str:
+    return f"{alias}.{_quote_identifier(identifier)}"
+
+
+def _relation_sql(relation: str) -> str:
+    if _is_parquet_scan_expression(relation):
+        return relation
+    parts = relation.split(".")
+    if not parts or any(not part for part in parts):
+        raise ValueError(f"Unsafe relation: {relation!r}")
+    if any(char not in _SAFE_RELATION_CHARS for char in relation):
+        raise ValueError(f"Unsafe relation: {relation!r}")
+    return ".".join(_quote_identifier(part) for part in parts)
+
+
+def _is_parquet_scan_expression(value: str) -> bool:
+    if not value.startswith(_PARQUET_SCAN_PREFIX) or not value.endswith(")"):
+        return False
+    return value == parquet_scan(_extract_parquet_scan_uri(value), union_by_name=True) or value == parquet_scan(
+        _extract_parquet_scan_uri(value),
+        union_by_name=False,
+    )
+
+
+def _extract_parquet_scan_uri(scan: str) -> str:
+    true_suffix = ", union_by_name=true)"
+    false_suffix = ", union_by_name=false)"
+    if scan.endswith(true_suffix):
+        literal = scan[len(_PARQUET_SCAN_PREFIX) : -len(true_suffix)]
+    elif scan.endswith(false_suffix):
+        literal = scan[len(_PARQUET_SCAN_PREFIX) : -len(false_suffix)]
+    else:
+        raise ValueError("Unsafe relation")
+    return _parse_sql_literal(literal)
+
+
+def _parse_sql_literal(literal: str) -> str:
+    if len(literal) < 2 or literal[0] != "'" or literal[-1] != "'":
+        raise ValueError("Unsafe relation")
+    value_chars: list[str] = []
+    i = 1
+    while i < len(literal) - 1:
+        char = literal[i]
+        if char == "'":
+            if i + 1 < len(literal) - 1 and literal[i + 1] == "'":
+                value_chars.append("'")
+                i += 2
+                continue
+            raise ValueError("Unsafe relation")
+        value_chars.append(char)
+        i += 1
+    return "".join(value_chars)
+
+
+def _select_sql(select: str) -> str:
+    if select.strip() == "*":
+        return "*"
+    columns = [part.strip() for part in select.split(",")]
+    if not columns or any(not part for part in columns):
+        raise ValueError("Unsafe select")
+
+    rendered: list[str] = []
+    for column in columns:
+        if column in ("l.*", "r.*"):
+            rendered.append(column)
+            continue
+        if column == "*" or "*" in column:
+            raise ValueError(f"Unsafe select: {select!r}")
+        parts = column.split(".")
+        try:
+            if len(parts) == 1:
+                rendered.append(_quote_identifier(parts[0]))
+            elif len(parts) == 2 and parts[0] in ("l", "r"):
+                rendered.append(_qualified_identifier(parts[0], parts[1]))
+            else:
+                raise ValueError
+        except ValueError:
+            raise ValueError(f"Unsafe select: {select!r}")
+    return ", ".join(rendered)
+
+
+def _cached_gpkg_path(uri: str, cache_dir: str | Path | None) -> Path:
+    parsed = urlparse(uri)
+    base = (
+        Path(cache_dir)
+        if cache_dir is not None
+        else Path(tempfile.gettempdir()) / "gispulse-duckdb-gpkg-cache"
+    )
+    name = Path(unquote(parsed.path)).name or "remote.gpkg"
+    if not name.lower().endswith(".gpkg"):
+        name += ".gpkg"
+    digest = hashlib.sha256(uri.encode("utf-8")).hexdigest()[:16]
+    return base / f"{digest}-{name}"
+
+
+def _download_s3_uri(parsed, dest: Path) -> None:  # noqa: ANN001
+    bucket = parsed.netloc
+    key = unquote(parsed.path.lstrip("/"))
+    if not bucket or not key:
+        raise ValueError("s3:// GPKG URI must include bucket and key")
+
+    storage = create_storage()
+    if not hasattr(storage, "_bucket"):
+        raise StorageError("S3/R2 storage is not configured")
+    configured_bucket = getattr(storage, "_bucket")
+    if configured_bucket != bucket:
+        raise StorageError(
+            "Configured S3/R2 bucket does not match requested s3:// URI bucket"
+        )
+    data = _run_async(storage.download(key))
+    dest.write_bytes(data)
+
+
+def _run_async(coro):
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+
+    result: list[object] = []
+    error: list[BaseException] = []
+
+    def runner() -> None:
+        try:
+            result.append(asyncio.run(coro))
+        except BaseException as exc:  # noqa: BLE001
+            error.append(exc)
+
+    thread = threading.Thread(target=runner)
+    thread.start()
+    thread.join()
+    if error:
+        raise error[0]
+    return result[0]
+
+
+def _validate_gpkg_layer(path: Path, layer: str | None) -> None:
+    if layer is None:
+        return
+    from gispulse.persistence.gpkg import list_layers
+
+    layers = list_layers(str(path))
+    if layer not in layers:
+        raise ValueError(f"Layer {layer!r} not found in {path}")

--- a/src/gispulse/persistence/io.py
+++ b/src/gispulse/persistence/io.py
@@ -58,6 +58,9 @@ VECTOR_DRIVERS: dict[str, str] = {
 #: Formats that support multiple layers.
 MULTI_LAYER_FORMATS = {".gpkg", ".gdb", ".sqlite"}
 
+#: Maximum uncompressed KML member size accepted from a KMZ archive.
+KMZ_KML_MAX_BYTES = 50 * 1024 * 1024
+
 #: Formats that are write-capable via GeoPandas/Fiona.
 WRITABLE_FORMATS = {
     ".gpkg", ".geojson", ".json", ".shp", ".fgb",
@@ -223,8 +226,14 @@ def _read_kmz_geo(
 
             preferred = next(
                 (name for name in kml_names if Path(name).name.lower() == "doc.kml"),
-                sorted(kml_names)[0],
+                kml_names[0],
             )
+            kml_info = archive.getinfo(preferred)
+            if kml_info.file_size > KMZ_KML_MAX_BYTES:
+                raise ValueError(
+                    f"KMZ KML member '{preferred}' exceeds maximum size "
+                    f"({kml_info.file_size} bytes > {KMZ_KML_MAX_BYTES} bytes)."
+                )
             kml_bytes = archive.read(preferred)
     except zipfile.BadZipFile as exc:
         raise ValueError(f"Invalid KMZ file '{path}': not a valid zip archive.") from exc

--- a/src/gispulse/persistence/io.py
+++ b/src/gispulse/persistence/io.py
@@ -20,6 +20,8 @@ Usage::
 
 from __future__ import annotations
 
+import tempfile
+import zipfile
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any, Optional
@@ -43,6 +45,7 @@ VECTOR_DRIVERS: dict[str, str] = {
     ".fgb": "FlatGeobuf",
     ".gml": "GML",
     ".kml": "KML",
+    ".kmz": "KML",
     ".dxf": "DXF",
     ".sqlite": "SQLite",
     ".gdb": "OpenFileGDB",
@@ -101,6 +104,10 @@ def read_vector(
     crs: Optional[str] = None,
     bbox: Optional[tuple[float, float, float, float]] = None,
     rows: Optional[int] = None,
+    x_col: str | None = None,
+    y_col: str | None = None,
+    source_crs: str | None = None,
+    target_crs: str = "EPSG:4326",
     **kwargs: Any,
 ) -> gpd.GeoDataFrame:
     """Read a vector/tabular-geo file into a GeoDataFrame.
@@ -111,6 +118,10 @@ def read_vector(
         crs:   Force a CRS if the file has none (e.g. CSV without .prj).
         bbox:  Spatial filter (minx, miny, maxx, maxy).
         rows:  Read only the first N rows.
+        x_col: X/easting column for tabular-geo XLSX inputs.
+        y_col: Y/northing column for tabular-geo XLSX inputs.
+        source_crs: Source CRS for projected XLSX coordinates.
+        target_crs: Target CRS when reprojecting from ``source_crs``.
         **kwargs: Extra arguments passed to geopandas.read_file / read_parquet.
 
     Returns:
@@ -150,7 +161,26 @@ def read_vector(
 
     # --- XLSX: pandas then geopandas ---
     if ext == ".xlsx":
-        return _read_xlsx_geo(path, crs=crs, rows=rows, **kwargs)
+        return _read_xlsx_geo(
+            path,
+            crs=crs,
+            rows=rows,
+            x_col=x_col,
+            y_col=y_col,
+            source_crs=source_crs,
+            target_crs=target_crs,
+            **kwargs,
+        )
+
+    if ext == ".kmz":
+        return _read_kmz_geo(
+            path,
+            layer=layer,
+            crs=crs,
+            bbox=bbox,
+            rows=rows,
+            **kwargs,
+        )
 
     # --- Standard Fiona-based formats ---
     read_kwargs: dict[str, Any] = {}
@@ -170,6 +200,54 @@ def read_vector(
         gdf = gdf.set_crs(crs)
 
     return gdf
+
+
+def _read_kmz_geo(
+    path: str,
+    layer: Optional[str] = None,
+    crs: Optional[str] = None,
+    bbox: Optional[tuple[float, float, float, float]] = None,
+    rows: Optional[int] = None,
+    **kwargs: Any,
+) -> gpd.GeoDataFrame:
+    """Read a KMZ archive by loading ``doc.kml`` or the first KML member."""
+    try:
+        with zipfile.ZipFile(path) as archive:
+            kml_names = [
+                name
+                for name in archive.namelist()
+                if not name.endswith("/") and name.lower().endswith(".kml")
+            ]
+            if not kml_names:
+                raise ValueError(f"KMZ file '{path}' does not contain a KML file.")
+
+            preferred = next(
+                (name for name in kml_names if Path(name).name.lower() == "doc.kml"),
+                sorted(kml_names)[0],
+            )
+            kml_bytes = archive.read(preferred)
+    except zipfile.BadZipFile as exc:
+        raise ValueError(f"Invalid KMZ file '{path}': not a valid zip archive.") from exc
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        kml_path = Path(tmp_dir) / "doc.kml"
+        kml_path.write_bytes(kml_bytes)
+
+        read_kwargs: dict[str, Any] = {"driver": "KML"}
+        if layer:
+            read_kwargs["layer"] = layer
+        if bbox:
+            read_kwargs["bbox"] = bbox
+        if rows:
+            read_kwargs["rows"] = rows
+        read_kwargs.update(kwargs)
+
+        gdf = gpd.read_file(kml_path, **read_kwargs)
+
+    if gdf.crs is None:
+        gdf = gdf.set_crs(crs or "EPSG:4326")
+
+    return gdf.to_crs("EPSG:4326")
 
 
 def read_vector_chunked(
@@ -314,6 +392,10 @@ def _read_xlsx_geo(
     rows: Optional[int] = None,
     lat_col: str | None = None,
     lon_col: str | None = None,
+    x_col: str | None = None,
+    y_col: str | None = None,
+    source_crs: str | None = None,
+    target_crs: str = "EPSG:4326",
     sheet_name: int | str = 0,
     **kwargs: Any,
 ) -> gpd.GeoDataFrame:
@@ -321,36 +403,75 @@ def _read_xlsx_geo(
     import pandas as pd
 
     nrows = rows if rows else None
-    df = pd.read_excel(path, sheet_name=sheet_name, nrows=nrows, **kwargs)
+    try:
+        df = pd.read_excel(path, sheet_name=sheet_name, nrows=nrows, **kwargs)
+    except ImportError as exc:
+        raise ImportError(
+            "Reading XLSX files requires openpyxl. Install gispulse with its declared "
+            "dependencies, or install openpyxl>=3.1,<4.0."
+        ) from exc
 
     # Reuse the CSV geo logic on the dataframe
     # Auto-detect lat/lon
     lat_candidates = ("lat", "latitude", "y", "LAT", "Latitude")
     lon_candidates = ("lon", "lng", "longitude", "x", "LON", "Longitude")
+    projected_candidates = (("X", "Y"),)
 
-    if lat_col is None:
+    coord_x_col = x_col or lon_col
+    coord_y_col = y_col or lat_col
+
+    if coord_y_col is None:
         for c in lat_candidates:
             if c in df.columns:
-                lat_col = c
+                coord_y_col = c
                 break
-    if lon_col is None:
+    if coord_x_col is None:
         for c in lon_candidates:
             if c in df.columns:
-                lon_col = c
+                coord_x_col = c
+                break
+    if coord_x_col is None or coord_y_col is None:
+        for candidate_x, candidate_y in projected_candidates:
+            if candidate_x in df.columns and candidate_y in df.columns:
+                coord_x_col = candidate_x
+                coord_y_col = candidate_y
                 break
 
-    if lat_col is None or lon_col is None:
+    if coord_y_col is None or coord_x_col is None:
         raise ValueError(
             f"Cannot detect lat/lon columns in XLSX. "
-            f"Columns found: {list(df.columns)}. Provide lat_col/lon_col."
+            f"Columns found: {list(df.columns)}. Provide lat_col/lon_col or x_col/y_col."
         )
 
+    if source_crs is None and _looks_like_projected_xy(df, coord_x_col, coord_y_col):
+        raise ValueError(
+            f"XLSX columns '{coord_x_col}'/'{coord_y_col}' look like projected coordinates. "
+            "Provide source_crs, for example source_crs='EPSG:31370', instead of assuming "
+            "EPSG:4326."
+        )
+
+    input_crs = source_crs or crs or target_crs
     gdf = gpd.GeoDataFrame(
         df,
-        geometry=gpd.points_from_xy(df[lon_col], df[lat_col]),
-        crs=crs or "EPSG:4326",
+        geometry=gpd.points_from_xy(df[coord_x_col], df[coord_y_col]),
+        crs=input_crs,
     )
+    if source_crs:
+        gdf = gdf.to_crs(target_crs)
     return gdf
+
+
+def _looks_like_projected_xy(df: Any, x_col: str, y_col: str) -> bool:
+    if x_col == "X" and y_col == "Y":
+        return True
+
+    import pandas as pd
+
+    x_values = pd.to_numeric(df[x_col], errors="coerce").dropna()
+    y_values = pd.to_numeric(df[y_col], errors="coerce").dropna()
+    if x_values.empty or y_values.empty:
+        return False
+    return bool((x_values.abs() > 180).any() or (y_values.abs() > 90).any())
 
 
 # ---------------------------------------------------------------------------

--- a/tests/persistence/test_duckdb_relations.py
+++ b/tests/persistence/test_duckdb_relations.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import geopandas as gpd
+import pytest
+from shapely.geometry import Point
+
+from gispulse.core.fetchers.http_file import HttpFileFetcher
+from gispulse.persistence import DuckDBSession
+from gispulse.persistence.duckdb_relations import (
+    materialize_remote_gpkg,
+    parquet_scan,
+    st_dwithin_join_sql,
+)
+
+
+def test_duckdb_relation_helpers_are_exported_from_persistence() -> None:
+    from gispulse import persistence
+
+    assert persistence.parquet_scan is parquet_scan
+    assert persistence.materialize_remote_gpkg is materialize_remote_gpkg
+    assert persistence.st_dwithin_join_sql is st_dwithin_join_sql
+
+
+def test_parquet_scan_escapes_uri_and_controls_union_by_name() -> None:
+    assert parquet_scan("s3://milou-data/path/companies.parquet") == (
+        "read_parquet('s3://milou-data/path/companies.parquet', union_by_name=true)"
+    )
+    assert parquet_scan("/tmp/o'hara.parquet", union_by_name=False) == (
+        "read_parquet('/tmp/o''hara.parquet', union_by_name=false)"
+    )
+
+
+def test_parquet_scan_expression_reads_synthetic_local_parquet(tmp_path: Path) -> None:
+    path = tmp_path / "companies.parquet"
+    gpd.GeoDataFrame(
+        {"company": ["a", "b"], "geometry": [Point(0, 0), Point(1, 1)]},
+        crs="EPSG:4326",
+    ).to_parquet(path)
+
+    with DuckDBSession() as session:
+        rows = session.execute_sql(f"SELECT count(*) AS n FROM {parquet_scan(path)}")
+
+    assert rows == [{"n": 2}]
+
+
+def test_st_dwithin_join_sql_quotes_identifiers_and_accepts_parquet_relation() -> None:
+    companies = parquet_scan("s3://milou-data/data/processed/companies_be.parquet")
+
+    sql = st_dwithin_join_sql(
+        "project.sites",
+        companies,
+        distance_m=200,
+        left_geom="site geom",
+        right_geom="geom",
+        select="l.id, r.company_name",
+    )
+
+    assert sql == (
+        "SELECT l.\"id\", r.\"company_name\" "
+        "FROM \"project\".\"sites\" AS l "
+        "JOIN read_parquet('s3://milou-data/data/processed/companies_be.parquet', "
+        "union_by_name=true) AS r "
+        "ON ST_DWithin(l.\"site geom\", r.\"geom\", 200.0)"
+    )
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"left": "sites; DROP TABLE sites"}, "Unsafe relation"),
+        ({"right": "companies WHERE 1=1"}, "Unsafe relation"),
+        ({"left_geom": "geom) OR true --"}, "Unsafe identifier"),
+        ({"select": "*, now()"}, "Unsafe select"),
+        ({"distance_m": -1}, "distance_m"),
+    ],
+)
+def test_st_dwithin_join_sql_rejects_unsafe_sql(kwargs: dict[str, object], match: str) -> None:
+    params: dict[str, object] = {
+        "left": "sites",
+        "right": "companies",
+        "distance_m": 10,
+    }
+    params.update(kwargs)
+
+    with pytest.raises(ValueError, match=match):
+        st_dwithin_join_sql(**params)  # type: ignore[arg-type]
+
+
+def test_materialize_remote_gpkg_returns_existing_local_file(tmp_path: Path) -> None:
+    path = tmp_path / "sites.gpkg"
+    gpd.GeoDataFrame(
+        {"name": ["site"], "geometry": [Point(0, 0)]},
+        crs="EPSG:4326",
+    ).to_file(path, layer="sites", driver="GPKG")
+
+    result = materialize_remote_gpkg(path, layer="sites")
+
+    assert result == path
+
+
+def test_materialize_remote_gpkg_uses_cache_for_http_download(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source.gpkg"
+    gpd.GeoDataFrame(
+        {"name": ["site"], "geometry": [Point(0, 0)]},
+        crs="EPSG:4326",
+    ).to_file(source, layer="sites", driver="GPKG")
+    calls: list[tuple[str, str]] = []
+
+    def fake_fetch(self: HttpFileFetcher, access, *, mode, extent=None):  # noqa: ANN001
+        calls.append((access.endpoint, access.params["local_path"]))
+        Path(access.params["local_path"]).write_bytes(source.read_bytes())
+        return type("Result", (), {"data": access.params["local_path"]})()
+
+    monkeypatch.setattr(HttpFileFetcher, "fetch", fake_fetch)
+
+    uri = "https://data.example.test/sites.gpkg?sig=secret"
+    first = materialize_remote_gpkg(uri, layer="sites", cache_dir=tmp_path / "cache")
+    second = materialize_remote_gpkg(uri, layer="sites", cache_dir=tmp_path / "cache")
+
+    assert first == second
+    assert first.exists()
+    assert calls == [(uri, str(first))]

--- a/tests/unit/test_duckdb_engine.py
+++ b/tests/unit/test_duckdb_engine.py
@@ -1,11 +1,14 @@
 """Tests for the DuckDB session engine."""
 
 
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
 import geopandas as gpd
 import pytest
 from shapely.geometry import Point
 
-from gispulse.persistence.duckdb_engine import DuckDBSession
+from gispulse.persistence.duckdb_engine import DuckDBSession, _configure_s3_secret
 
 
 @pytest.fixture
@@ -50,6 +53,77 @@ class TestDuckDBSession:
                 pytest.skip("httpfs unavailable in this environment (no network)")
             # httpfs present — remote scan functions are wired.
             assert session._conn is not None
+
+    def test_configure_s3_secret_uses_garage_endpoint(self):
+        conn = MagicMock()
+        s3 = SimpleNamespace(
+            endpoint="https://garage.casys.ai",
+            bucket="gispulse",
+            access_key="dev-key",
+            secret_key="dev-secret",
+            region="garage",
+        )
+
+        _configure_s3_secret(conn, s3)
+
+        sql = conn.execute.call_args.args[0]
+        assert "CREATE OR REPLACE SECRET gispulse_s3" in sql
+        assert "TYPE s3" in sql
+        assert "PROVIDER config" in sql
+        assert "KEY_ID 'dev-key'" in sql
+        assert "SECRET 'dev-secret'" in sql
+        assert "REGION 'garage'" in sql
+        assert "ENDPOINT 'garage.casys.ai'" in sql
+        assert "URL_STYLE 'path'" in sql
+        assert "USE_SSL true" in sql
+        assert "SCOPE 's3://gispulse'" in sql
+
+    def test_configure_s3_secret_uses_http_for_compose_endpoint(self):
+        conn = MagicMock()
+        s3 = SimpleNamespace(
+            endpoint="http://garage:3900",
+            bucket="gispulse",
+            access_key="dev-key",
+            secret_key="dev-secret",
+            region="garage",
+        )
+
+        _configure_s3_secret(conn, s3)
+
+        sql = conn.execute.call_args.args[0]
+        assert "ENDPOINT 'garage:3900'" in sql
+        assert "USE_SSL false" in sql
+
+    def test_configure_s3_secret_escapes_sql_literals(self):
+        conn = MagicMock()
+        s3 = SimpleNamespace(
+            endpoint="https://garage.casys.ai",
+            bucket="bucket'one",
+            access_key="key'one",
+            secret_key="secret'one",
+            region="garage",
+        )
+
+        _configure_s3_secret(conn, s3)
+
+        sql = conn.execute.call_args.args[0]
+        assert "KEY_ID 'key''one'" in sql
+        assert "SECRET 'secret''one'" in sql
+        assert "SCOPE 's3://bucket''one'" in sql
+
+    def test_configure_s3_secret_skips_empty_endpoint(self):
+        conn = MagicMock()
+        s3 = SimpleNamespace(
+            endpoint="",
+            bucket="gispulse",
+            access_key="dev-key",
+            secret_key="dev-secret",
+            region="garage",
+        )
+
+        _configure_s3_secret(conn, s3)
+
+        conn.execute.assert_not_called()
 
     def test_open_survives_missing_extension(self):
         # A missing/failed extension must not break the offline GPKG path.

--- a/tests/unit/test_duckdb_engine.py
+++ b/tests/unit/test_duckdb_engine.py
@@ -94,6 +94,26 @@ class TestDuckDBSession:
         assert "ENDPOINT 'garage:3900'" in sql
         assert "USE_SSL false" in sql
 
+    def test_configure_s3_secret_strips_endpoint_userinfo_before_sql_and_logs(self, caplog):
+        conn = MagicMock()
+        conn.execute.side_effect = RuntimeError("boom")
+        s3 = SimpleNamespace(
+            endpoint="https://user:pass@garage.casys.ai",
+            bucket="gispulse",
+            access_key="dev-key",
+            secret_key="dev-secret",
+            region="garage",
+        )
+
+        _configure_s3_secret(conn, s3)
+
+        sql = conn.execute.call_args.args[0]
+        assert "ENDPOINT 'garage.casys.ai'" in sql
+        assert "user" not in sql
+        assert "pass" not in sql
+        assert "user" not in caplog.text
+        assert "pass" not in caplog.text
+
     def test_configure_s3_secret_escapes_sql_literals(self):
         conn = MagicMock()
         s3 = SimpleNamespace(

--- a/tests/unit/test_persistence_io.py
+++ b/tests/unit/test_persistence_io.py
@@ -4,10 +4,13 @@ Unit tests for persistence.io — format detection, read/write vector, dataset_f
 
 from __future__ import annotations
 
+import zipfile
 from pathlib import Path
 
 import geopandas as gpd
+import pandas as pd
 import pytest
+from pyproj import Transformer
 from shapely.geometry import Point
 
 from gispulse.persistence.io import (
@@ -48,6 +51,10 @@ class TestFormatDetection:
         assert ".geojson" in exts
         assert ".shp" in exts
 
+    def test_detect_kmz_as_kml(self) -> None:
+        assert detect_format("data/sites.kmz") == "KML"
+        assert ".kmz" in supported_extensions()
+
 
 class TestReadWriteVector:
     @pytest.fixture()
@@ -81,6 +88,101 @@ class TestReadWriteVector:
     def test_read_nonexistent_raises(self) -> None:
         with pytest.raises(Exception):
             read_vector("/nonexistent/file.gpkg")
+
+
+class TestReadKmz:
+    def test_read_kmz_doc_kml_as_epsg_4326(self, tmp_path: Path) -> None:
+        path = tmp_path / "site.kmz"
+        with zipfile.ZipFile(path, "w") as archive:
+            archive.writestr(
+                "doc.kml",
+                """<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+  <Document>
+    <Placemark>
+      <name>Orange site</name>
+      <Point><coordinates>4.3517,50.8503,0</coordinates></Point>
+    </Placemark>
+  </Document>
+</kml>
+""",
+            )
+
+        result = read_vector(str(path))
+
+        assert len(result) == 1
+        assert result.crs.to_epsg() == 4326
+        assert result.geometry.iloc[0].x == pytest.approx(4.3517)
+        assert result.geometry.iloc[0].y == pytest.approx(50.8503)
+
+    def test_read_kmz_uses_doc_kml_when_multiple_kml_files_exist(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        path = tmp_path / "network.kmz"
+        with zipfile.ZipFile(path, "w") as archive:
+            archive.writestr(
+                "other.kml",
+                """<kml xmlns="http://www.opengis.net/kml/2.2">
+<Placemark><name>Other</name><Point><coordinates>5,51,0</coordinates></Point></Placemark>
+</kml>""",
+            )
+            archive.writestr(
+                "doc.kml",
+                """<kml xmlns="http://www.opengis.net/kml/2.2">
+<Placemark><name>Doc</name><Point><coordinates>4,50,0</coordinates></Point></Placemark>
+</kml>""",
+            )
+
+        result = read_vector(str(path))
+
+        assert result.geometry.iloc[0].x == pytest.approx(4)
+        assert result.geometry.iloc[0].y == pytest.approx(50)
+
+    def test_read_kmz_raises_clear_error_for_invalid_zip(self, tmp_path: Path) -> None:
+        path = tmp_path / "broken.kmz"
+        path.write_text("not a zip")
+
+        with pytest.raises(ValueError, match="Invalid KMZ"):
+            read_vector(str(path))
+
+    def test_read_kmz_raises_clear_error_when_no_kml_exists(self, tmp_path: Path) -> None:
+        path = tmp_path / "empty.kmz"
+        with zipfile.ZipFile(path, "w") as archive:
+            archive.writestr("readme.txt", "no kml here")
+
+        with pytest.raises(ValueError, match="does not contain a KML"):
+            read_vector(str(path))
+
+
+class TestReadXlsxGeo:
+    def test_read_xlsx_lambert_72_reprojects_to_epsg_4326(self, tmp_path: Path) -> None:
+        path = tmp_path / "orange-sites.xlsx"
+        lon, lat = 4.3517, 50.8503
+        x, y = Transformer.from_crs("EPSG:4326", "EPSG:31370", always_xy=True).transform(lon, lat)
+        pd.DataFrame({"name": ["Orange site"], "X": [x], "Y": [y]}).to_excel(path, index=False)
+
+        result = read_vector(
+            str(path),
+            x_col="X",
+            y_col="Y",
+            source_crs="EPSG:31370",
+        )
+
+        assert len(result) == 1
+        assert result.crs.to_epsg() == 4326
+        assert result.geometry.iloc[0].x == pytest.approx(lon, abs=1e-6)
+        assert result.geometry.iloc[0].y == pytest.approx(lat, abs=1e-6)
+
+    def test_read_xlsx_rejects_projected_xy_without_source_crs(self, tmp_path: Path) -> None:
+        path = tmp_path / "orange-sites.xlsx"
+        pd.DataFrame({"name": ["Orange site"], "X": [149_000], "Y": [171_000]}).to_excel(
+            path,
+            index=False,
+        )
+
+        with pytest.raises(ValueError, match="source_crs"):
+            read_vector(str(path))
 
 
 class TestDatasetFromFile:

--- a/tests/unit/test_persistence_io.py
+++ b/tests/unit/test_persistence_io.py
@@ -13,6 +13,7 @@ import pytest
 from pyproj import Transformer
 from shapely.geometry import Point
 
+from gispulse.persistence import io as io_mod
 from gispulse.persistence.io import (
     dataset_from_file,
     detect_format,
@@ -139,6 +140,43 @@ class TestReadKmz:
         assert result.geometry.iloc[0].x == pytest.approx(4)
         assert result.geometry.iloc[0].y == pytest.approx(50)
 
+    def test_read_kmz_falls_back_to_first_kml_in_archive_order(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        path = tmp_path / "network.kmz"
+        with zipfile.ZipFile(path, "w") as archive:
+            archive.writestr(
+                "z-first.kml",
+                """<kml xmlns="http://www.opengis.net/kml/2.2">
+<Placemark><name>Archive first</name><Point><coordinates>1,49,0</coordinates></Point></Placemark>
+</kml>""",
+            )
+            archive.writestr(
+                "a-second.kml",
+                """<kml xmlns="http://www.opengis.net/kml/2.2">
+<Placemark><name>Sorted first</name><Point><coordinates>2,50,0</coordinates></Point></Placemark>
+</kml>""",
+            )
+
+        result = read_vector(str(path))
+
+        assert result.geometry.iloc[0].x == pytest.approx(1)
+        assert result.geometry.iloc[0].y == pytest.approx(49)
+
+    def test_read_kmz_rejects_oversized_kml_member(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        path = tmp_path / "oversized.kmz"
+        monkeypatch.setattr(io_mod, "KMZ_KML_MAX_BYTES", 64, raising=False)
+        with zipfile.ZipFile(path, "w") as archive:
+            archive.writestr("doc.kml", "x" * 65)
+
+        with pytest.raises(ValueError, match="KMZ KML member .* exceeds maximum size"):
+            read_vector(str(path))
+
     def test_read_kmz_raises_clear_error_for_invalid_zip(self, tmp_path: Path) -> None:
         path = tmp_path / "broken.kmz"
         path.write_text("not a zip")
@@ -182,6 +220,22 @@ class TestReadXlsxGeo:
         )
 
         with pytest.raises(ValueError, match="source_crs"):
+            read_vector(str(path))
+
+    def test_read_xlsx_reports_missing_openpyxl_clearly(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        path = tmp_path / "orange-sites.xlsx"
+        path.write_bytes(b"not used")
+
+        def raise_missing_openpyxl(*args: object, **kwargs: object) -> pd.DataFrame:
+            raise ImportError("Missing optional dependency 'openpyxl'")
+
+        monkeypatch.setattr(pd, "read_excel", raise_missing_openpyxl)
+
+        with pytest.raises(ImportError, match="requires openpyxl.*declared"):
             read_vector(str(path))
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -981,7 +981,7 @@ wheels = [
 
 [[package]]
 name = "gispulse"
-version = "1.6.2"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },

--- a/uv.lock
+++ b/uv.lock
@@ -846,6 +846,15 @@ wheels = [
 ]
 
 [[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -987,6 +996,7 @@ dependencies = [
     { name = "duckdb" },
     { name = "geopandas" },
     { name = "httpx" },
+    { name = "openpyxl" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyogrio" },
@@ -1117,6 +1127,7 @@ requires-dist = [
     { name = "laspy", marker = "extra == 'pointcloud'", specifier = ">=2.5,<3.0" },
     { name = "mapclassify", marker = "extra == 'classification'", specifier = ">=2.5,<3.0" },
     { name = "networkx", marker = "extra == 'network'", specifier = ">=3.0,<4.0" },
+    { name = "openpyxl", specifier = ">=3.1,<4.0" },
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.7,<3.0" },
     { name = "psycopg2-binary", marker = "extra == 'postgis'", specifier = ">=2.9,<3.0" },
     { name = "pyarrow", marker = "extra == 'parquet'", specifier = ">=14,<25" },
@@ -1870,6 +1881,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892, upload-time = "2025-01-08T19:29:27.083Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/cf/03675d8bd8ecbf4445504d8071adab19f5f993676795708e36402ab38263/openapi_pydantic-0.5.1-py3-none-any.whl", hash = "sha256:a3a09ef4586f5bd760a8df7f43028b60cafb6d9f61de2acba9574766255ab146", size = 96381, upload-time = "2025-01-08T19:29:25.275Z" },
+]
+
+[[package]]
+name = "openpyxl"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "et-xmlfile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Objet
Première brique pour faire de **MILOU** (pré-dimensionnement réseau fibre belge) un **client de gispulse**. Branche `milou` (depuis `main`).

## Contenu
- `feat(duckdb)` : config secret S3/R2 → DuckDB (cherry-pick `c451a64`) — permet la lecture directe de parquet depuis un bucket S3-compatible (R2).
- `docs(milou)` : `docs/milou-client-plan.md` — plan de travail (frontière MILOU/gispulse, API cible, ordre).
- `feat(io)` : **lecture KMZ réelle** (`read_vector('.kmz')` → unzip `doc.kml` → WGS84) + **XLSX en CRS projeté** (`x_col/y_col/source_crs/target_crs`, neutralise l'inférence naïve `X/Y → 4326`, reprojette Lambert 72). `openpyxl` déclaré. Rétrocompat préservée.

## Vérif
- ruff vert ; tests ciblés `tests/unit/test_persistence_io.py` : 21 passed.
- Review Codex du P0 : SHIP, aucun P0/P1.
- (Les 3 échecs raster en suite globale sont le flaky connu #191, indépendant de ce diff.)

## Suite (hors PR)
Helpers DuckDB/R2 (`parquet_scan`, `ST_DWithin`), conventions GPKG de pipeline, puis branchement de MILOU en dépendance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)