### PR TITLE
feat(plugins): gispulse-src-business-parks-be (parcs d'activité BE)

### DIFF
--- a/plugins/gispulse-src-business-parks-be/gispulse_src_business_parks_be/__init__.py
+++ b/plugins/gispulse-src-business-parks-be/gispulse_src_business_parks_be/__init__.py
@@ -1,0 +1,11 @@
+"""GISPulse data-source plugin - Belgian business parks."""
+
+from __future__ import annotations
+
+
+def register() -> None:
+    """Entry-point hook for the ``gispulse.data_sources`` group."""
+    from gispulse.core.sources import SOURCES
+    from gispulse_src_business_parks_be.source import BusinessParksBeSource
+
+    SOURCES.register(BusinessParksBeSource())

--- a/plugins/gispulse-src-business-parks-be/gispulse_src_business_parks_be/source.py
+++ b/plugins/gispulse-src-business-parks-be/gispulse_src_business_parks_be/source.py
@@ -1,0 +1,187 @@
+"""Belgian business parks DataSource.
+
+This plugin only declares the three upstream inventories used for Belgian
+business parks. GISPulse core fetchers own WFS, HTTP download and
+materialization; harmonisation/scoring stays outside the source plugin.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any
+
+from gispulse.plugins.api import (
+    AccessProtocol,
+    AccessSpec,
+    DeclarativeSource,
+    Payload,
+    SourceDomain,
+    SourceEntryRef,
+)
+
+VLAIO_WFS_ENDPOINT = "https://geo.api.vlaanderen.be/Bedrijventerreinen/wfs"
+SPW_PRE_GEOJSON_ENDPOINT = (
+    "https://www.odwb.be/api/explore/v2.1/catalog/datasets/"
+    "perimetres-de-reconnaissance-economique-wallonie/exports/geojson"
+    "?lang=fr&timezone=Europe%2FBrussels"
+)
+WALSPACE_GEOJSON_ENDPOINT = (
+    "https://www.odwb.be/api/explore/v2.1/catalog/datasets/"
+    "walspace/exports/geojson?lang=fr&timezone=Europe%2FBrussels"
+)
+
+_TARGET_CRS = "EPSG:31370"
+
+_SCHEMA = {
+    "source": "str",
+    "region": "str",
+    "park_id": "str",
+    "name": "str",
+    "municipality": "str",
+    "use": "str",
+    "area_ha": "float",
+    "geometry": f"geometry[{_TARGET_CRS}]",
+}
+
+_COMMON_METADATA = {
+    "license": "open data",
+    "jurisdiction": "BE",
+    "target_crs": _TARGET_CRS,
+    "schema_columns": tuple(_SCHEMA),
+}
+
+_ENTRIES: dict[str, dict[str, Any]] = {
+    "vlaio-bedrijventerreinen": {
+        "label": "VLAIO GIS-Bedrijventerreinen",
+        "provider": "VLAIO",
+        "platform": "Digitaal Vlaanderen WFS Bedrijventerreinen",
+        "region": "VL",
+        "endpoint": VLAIO_WFS_ENDPOINT,
+        "access": AccessSpec(
+            protocol=AccessProtocol.WFS,
+            endpoint=VLAIO_WFS_ENDPOINT,
+            params={
+                "typename": "Bedrijventerreinen:Bedrter",
+                "version": "2.0.0",
+                "crs": _TARGET_CRS,
+            },
+            format="application/json",
+        ),
+        "canonical_field_map": {
+            "source": "literal:VLAIO",
+            "region": "literal:VL",
+            "park_id": "IDBEDR",
+            "name": "NAAM",
+            "municipality": "GEMEENTE",
+            "use": "TYPE",
+            "area_ha": "geometry.area / 10000",
+            "geometry": "geometry",
+        },
+        "source_crs": _TARGET_CRS,
+    },
+    "spw-economic-perimeters": {
+        "label": "SPW perimetres de reconnaissance economique",
+        "provider": "SPW",
+        "platform": "Open Data Wallonie-Bruxelles",
+        "region": "WAL",
+        "endpoint": SPW_PRE_GEOJSON_ENDPOINT,
+        "access": AccessSpec(
+            protocol=AccessProtocol.DOWNLOAD,
+            endpoint=SPW_PRE_GEOJSON_ENDPOINT,
+            params={
+                "source_crs": "EPSG:4326",
+                "target_crs": _TARGET_CRS,
+            },
+            format="application/geo+json",
+        ),
+        "canonical_field_map": {
+            "source": "literal:SPW",
+            "region": "literal:WAL",
+            "park_id": "codecarto",
+            "name": "libelle",
+            "municipality": "commune",
+            "use": "affectatio",
+            "area_ha": "superfha",
+            "geometry": "geometry",
+        },
+        "source_crs": "EPSG:4326",
+    },
+    "walspace": {
+        "label": "WalSpace business park points",
+        "provider": "WalSpace",
+        "platform": "Open Data Wallonie-Bruxelles",
+        "region": "WAL",
+        "endpoint": WALSPACE_GEOJSON_ENDPOINT,
+        "access": AccessSpec(
+            protocol=AccessProtocol.DOWNLOAD,
+            endpoint=WALSPACE_GEOJSON_ENDPOINT,
+            params={
+                "source_crs": "EPSG:4326",
+                "target_crs": _TARGET_CRS,
+            },
+            format="application/geo+json",
+        ),
+        "canonical_field_map": {
+            "source": "literal:WalSpace",
+            "region": "literal:WAL",
+            "park_id": "pae_id",
+            "name": "pae_denom",
+            "municipality": "pae_commune",
+            "use": "pae_theme",
+            "area_ha": "pae_superf_utile",
+            "geometry": "pae_geo",
+        },
+        "source_crs": "EPSG:4326",
+    },
+}
+
+
+def _copy_params(params: dict[str, Any]) -> dict[str, Any]:
+    return dict(params)
+
+
+class BusinessParksBeSource(DeclarativeSource):
+    """Belgian business park upstream inventories."""
+
+    name = "business_parks_be"
+    domain = SourceDomain.FONCIER
+    payload = Payload.VECTOR
+    jurisdiction = "BE"
+
+    def entries(self) -> list[SourceEntryRef]:
+        return [self._entry_ref(entry_id) for entry_id in _ENTRIES]
+
+    def _entry_ref(self, entry_id: str) -> SourceEntryRef:
+        spec = _ENTRIES[entry_id]
+        access = spec["access"]
+        return SourceEntryRef(
+            id=entry_id,
+            name=spec["label"],
+            access=replace(access, params=_copy_params(access.params)),
+            revision_token=None,
+            domain=self.domain,
+            payload=self.payload,
+            jurisdiction=self.jurisdiction,
+            metadata={
+                **_COMMON_METADATA,
+                "provider": spec["provider"],
+                "platform": spec["platform"],
+                "region": spec["region"],
+                "source_crs": spec["source_crs"],
+                "canonical_field_map": dict(spec["canonical_field_map"]),
+                "endpoint": spec["endpoint"],
+            },
+        )
+
+    def access_for(self, entry_id: str) -> AccessSpec:
+        """Return the declared AccessSpec without network access."""
+        entry = self._entry(entry_id)
+        return replace(entry.access, params=_copy_params(entry.access.params))
+
+    def schema(self, entry_id: str) -> dict[str, str]:
+        self._entry(entry_id)  # validates the id
+        return dict(_SCHEMA)
+
+    def revision(self, entry_id: str) -> str | None:
+        self._entry(entry_id)  # validates the id
+        return None

--- a/plugins/gispulse-src-business-parks-be/pyproject.toml
+++ b/plugins/gispulse-src-business-parks-be/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gispulse-src-business-parks-be"
+version = "0.1.0"
+description = "Belgian business parks source for GISPulse"
+requires-python = ">=3.10"
+license = "AGPL-3.0-or-later"
+authors = [{ name = "GISPulse", email = "dev@gispulse.io" }]
+dependencies = [
+    "gispulse>=2.0.0,<3.0.0",
+]
+
+# Registered as a data source - discovered by core.plugin_hub.PluginHub.
+[project.entry-points."gispulse.data_sources"]
+business_parks_be = "gispulse_src_business_parks_be:register"
+
+[tool.gispulse.plugin]
+kind = "source"
+protocol = ">=1.0,<2.0"
+domain = "foncier"
+jurisdiction = "BE"
+display_name = "Business Parks Belgium"

--- a/tests/unit/test_src_business_parks_be.py
+++ b/tests/unit/test_src_business_parks_be.py
@@ -1,0 +1,172 @@
+"""Unit tests for the gispulse-src-business-parks-be plugin.
+
+Zero-network: the plugin declares Belgian business-park upstreams only.
+Core fetchers own HTTP, WFS dispatch and file materialization.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_PKG = Path(__file__).resolve().parents[2] / "plugins" / "gispulse-src-business-parks-be"
+_PKG_PATH = str(_PKG)
+if _PKG_PATH in sys.path:
+    sys.path.remove(_PKG_PATH)
+sys.path.insert(0, _PKG_PATH)
+for _module in (
+    "gispulse_src_business_parks_be.source",
+    "gispulse_src_business_parks_be",
+):
+    sys.modules.pop(_module, None)
+
+from gispulse_src_business_parks_be.source import BusinessParksBeSource  # noqa: E402
+
+from gispulse.core.plugin_model import AccessProtocol, Payload, SourceDomain  # noqa: E402
+from gispulse.core.sources import DataSource  # noqa: E402
+
+pytestmark = pytest.mark.usefixtures("offline_ssrf")
+
+
+@pytest.fixture
+def source() -> BusinessParksBeSource:
+    return BusinessParksBeSource()
+
+
+def test_pyproject_declares_business_parks_entrypoint_and_manifest() -> None:
+    tomllib = pytest.importorskip("tomllib")
+    pyproject = tomllib.loads((_PKG / "pyproject.toml").read_text())
+
+    assert pyproject["project"]["entry-points"]["gispulse.data_sources"] == {
+        "business_parks_be": "gispulse_src_business_parks_be:register"
+    }
+
+    manifest = pyproject["tool"]["gispulse"]["plugin"]
+    assert manifest["kind"] == "source"
+    assert manifest["domain"] == "foncier"
+    assert manifest["jurisdiction"] == "BE"
+
+
+def test_is_a_belgian_foncier_vector_datasource(source: BusinessParksBeSource) -> None:
+    assert isinstance(source, DataSource)
+    assert source.name == "business_parks_be"
+    assert source.domain is SourceDomain.FONCIER
+    assert source.payload is Payload.VECTOR
+    assert source.jurisdiction == "BE"
+
+
+def test_declares_three_real_business_park_upstreams(
+    source: BusinessParksBeSource,
+) -> None:
+    ids = {entry.id for entry in source.entries()}
+
+    assert ids == {
+        "vlaio-bedrijventerreinen",
+        "spw-economic-perimeters",
+        "walspace",
+    }
+
+
+def test_vlaio_entry_uses_registered_wfs_protocol(source: BusinessParksBeSource) -> None:
+    entry = {entry.id: entry for entry in source.entries()}["vlaio-bedrijventerreinen"]
+
+    assert entry.access.protocol is AccessProtocol.WFS
+    assert entry.access.endpoint == "https://geo.api.vlaanderen.be/Bedrijventerreinen/wfs"
+    assert entry.access.format == "application/json"
+    assert entry.access.params == {
+        "typename": "Bedrijventerreinen:Bedrter",
+        "version": "2.0.0",
+        "crs": "EPSG:31370",
+    }
+    assert entry.metadata["provider"] == "VLAIO"
+    assert entry.metadata["region"] == "VL"
+    assert entry.metadata["canonical_field_map"]["park_id"] == "IDBEDR"
+
+
+def test_spw_entry_uses_registered_download_protocol(source: BusinessParksBeSource) -> None:
+    entry = {entry.id: entry for entry in source.entries()}["spw-economic-perimeters"]
+
+    assert entry.access.protocol is AccessProtocol.DOWNLOAD
+    assert entry.access.endpoint == (
+        "https://www.odwb.be/api/explore/v2.1/catalog/datasets/"
+        "perimetres-de-reconnaissance-economique-wallonie/exports/geojson"
+        "?lang=fr&timezone=Europe%2FBrussels"
+    )
+    assert entry.access.format == "application/geo+json"
+    assert entry.access.params == {
+        "source_crs": "EPSG:4326",
+        "target_crs": "EPSG:31370",
+    }
+    assert entry.metadata["provider"] == "SPW"
+    assert entry.metadata["region"] == "WAL"
+    assert entry.metadata["canonical_field_map"]["park_id"] == "codecarto"
+
+
+def test_walspace_entry_uses_registered_download_protocol(
+    source: BusinessParksBeSource,
+) -> None:
+    entry = {entry.id: entry for entry in source.entries()}["walspace"]
+
+    assert entry.access.protocol is AccessProtocol.DOWNLOAD
+    assert entry.access.endpoint == (
+        "https://www.odwb.be/api/explore/v2.1/catalog/datasets/"
+        "walspace/exports/geojson?lang=fr&timezone=Europe%2FBrussels"
+    )
+    assert entry.access.format == "application/geo+json"
+    assert entry.access.params == {
+        "source_crs": "EPSG:4326",
+        "target_crs": "EPSG:31370",
+    }
+    assert entry.metadata["provider"] == "WalSpace"
+    assert entry.metadata["region"] == "WAL"
+    assert entry.metadata["canonical_field_map"]["park_id"] == "pae_id"
+
+
+def test_access_for_returns_declared_access_without_mutating_catalog(
+    source: BusinessParksBeSource,
+) -> None:
+    access = source.access_for("spw-economic-perimeters")
+    access.params["target_crs"] = "EPSG:4326"
+
+    original = source._entry("spw-economic-perimeters").access
+    assert access.protocol is AccessProtocol.DOWNLOAD
+    assert original.params["target_crs"] == "EPSG:31370"
+
+
+def test_schema_exposes_canonical_business_parks_contract(
+    source: BusinessParksBeSource,
+) -> None:
+    schema = source.schema("vlaio-bedrijventerreinen")
+
+    assert schema == {
+        "source": "str",
+        "region": "str",
+        "park_id": "str",
+        "name": "str",
+        "municipality": "str",
+        "use": "str",
+        "area_ha": "float",
+        "geometry": "geometry[EPSG:31370]",
+    }
+
+
+def test_revision_is_unknown_for_business_park_upstreams(
+    source: BusinessParksBeSource,
+) -> None:
+    assert source.revision("vlaio-bedrijventerreinen") is None
+    assert source.revision("spw-economic-perimeters") is None
+    assert source.revision("walspace") is None
+
+
+def test_register_adds_source_to_registry() -> None:
+    from gispulse.core.sources import SOURCES
+    from gispulse_src_business_parks_be import register
+
+    SOURCES.clear()
+    try:
+        register()
+        assert SOURCES.get("business_parks_be") is not None
+    finally:
+        SOURCES.clear()


### PR DESCRIPTION
Source déclarative des parcs d'activité belges (jurisdiction BE) : VLAIO Bedrijventerreinen (WFS), SPW périmètres + WalSpace (ODWB GeoJSON). Zero-network, suit SOURCE_PLUGIN_GUIDE + modèle src-rnb. 10 tests. URLs upstream vérifiées (200).

À noter : `schema()` reflète la cible harmonisée (EPSG:31370) ; l'harmonisation VLAIO/SPW/WalSpace reste côté consommateur (MILOU), le plugin déclare les upstreams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)