### PR TITLE
feat(plugins): gispulse-src-statbel-be (secteurs statistiques + démographie BE)

### DIFF
--- a/plugins/gispulse-src-statbel-be/gispulse_src_statbel_be/__init__.py
+++ b/plugins/gispulse-src-statbel-be/gispulse_src_statbel_be/__init__.py
@@ -1,0 +1,11 @@
+"""GISPulse data-source plugin — Statbel Belgium open statistical data."""
+
+from __future__ import annotations
+
+
+def register() -> None:
+    """Entry-point hook for the ``gispulse.data_sources`` group."""
+    from gispulse.core.sources import SOURCES
+    from gispulse_src_statbel_be.source import StatbelBeSource
+
+    SOURCES.register(StatbelBeSource())

--- a/plugins/gispulse-src-statbel-be/gispulse_src_statbel_be/source.py
+++ b/plugins/gispulse-src-statbel-be/gispulse_src_statbel_be/source.py
@@ -1,0 +1,327 @@
+"""Statbel Belgium DataSource — statistical sectors (contours) and indicators.
+
+Statbel (Belgian Statistical Office) publishes open-data files under the
+Creative Commons Zero (CC0) licence. This plugin is **fully declarative**:
+it only describes *where* data lives (``AccessSpec``) and *what shape* it
+has (``schema()``). Core fetchers own the network code.
+
+Geometry entries use ``AccessProtocol.DOWNLOAD`` (``HttpFileFetcher``).
+Indicator entries also use ``DOWNLOAD`` — the upstream files are
+delimited-text (TXT/CSV) or XLSX joined to the sector code.
+
+CRS note
+--------
+Statbel vector data is natively in Belgian Lambert 72 (EPSG:31370).
+The ``crs`` key in metadata is informational; the core fetcher does no
+reprojection — the downstream pipeline is responsible for that.
+
+URL status
+----------
+All URLs are the canonical Statbel open-data landing pages or their
+direct-download variants as of June 2026.  Some direct-download URLs may
+change between Statbel publication cycles.  Where the exact file URL was
+uncertain, the dataset landing-page URL is used together with a comment
+``# URL directe à vérifier``.  Maintainers should validate these URLs
+against https://statbel.fgov.be/fr/open-data before each release.
+"""
+
+from __future__ import annotations
+
+from gispulse.plugins.api import (
+    AccessProtocol,
+    AccessSpec,
+    DeclarativeSource,
+    Payload,
+    SourceDomain,
+    SourceEntryRef,
+)
+
+# ---------------------------------------------------------------------------
+# Upstream base URLs
+# ---------------------------------------------------------------------------
+
+# Statistical sectors — contours (GeoJSON, EPSG:31370)
+# Direct GeoJSON download from Statbel open data.
+# NOTE: Statbel publishes a new millésime each year; the URL below points to
+# the 2023 release.  Check https://statbel.fgov.be/fr/open-data/secteurs-statistiques
+# for the latest vintage.
+_SECTORS_GEOJSON_URL = (
+    "https://statbel.fgov.be/sites/default/files/files/opendata/statbel/"
+    "secteurs-statistiques/sh_statbel_statistical_sectors_20230101.geojson"
+    # URL directe à vérifier — landing page :
+    # https://statbel.fgov.be/fr/open-data/secteurs-statistiques
+)
+
+# Population by statistical sector (TXT, delimiter "|")
+# Landing: https://statbel.fgov.be/fr/open-data/population-par-secteur-statistique
+_POPULATION_URL = (
+    "https://statbel.fgov.be/sites/default/files/files/opendata/pop/"
+    "TF_SOC_POP_STRUCT_2022.zip"
+    # URL directe à vérifier — landing page :
+    # https://statbel.fgov.be/fr/open-data/population-par-secteur-statistique
+)
+
+# Households by statistical sector (TXT, delimiter "|")
+# Landing: https://statbel.fgov.be/fr/open-data/menages-par-secteur-statistique
+_HOUSEHOLDS_URL = (
+    "https://statbel.fgov.be/sites/default/files/files/opendata/menages/"
+    "TF_SOC_MENAGES_2022.zip"
+    # URL directe à vérifier — landing page :
+    # https://statbel.fgov.be/fr/open-data/menages-par-secteur-statistique
+)
+
+# Average income by statistical sector (TXT, delimiter "|")
+# Landing: https://statbel.fgov.be/fr/open-data/revenus-par-secteur-statistique
+_INCOME_URL = (
+    "https://statbel.fgov.be/sites/default/files/files/opendata/revenu/"
+    "TF_INCOME_2021_SS.zip"
+    # URL directe à vérifier — landing page :
+    # https://statbel.fgov.be/fr/open-data/revenus-fiscaux-par-secteur-statistique
+)
+
+# Car fleet by statistical sector (TXT, delimiter "|")
+# Landing: https://statbel.fgov.be/fr/open-data/parc-automobile-par-secteur-statistique
+_CARS_URL = (
+    "https://statbel.fgov.be/sites/default/files/files/opendata/vehicles/"
+    "TF_VEHICLES_SS_2023.zip"
+    # URL directe à vérifier — landing page :
+    # https://statbel.fgov.be/fr/open-data/parc-automobile-par-secteur-statistique
+)
+
+# Building permits by municipality (XLSX) — Statbel does not publish permits
+# at sector level; the finest grain is municipality (NIS code).
+# Landing: https://statbel.fgov.be/fr/open-data/permis-de-batir
+_PERMITS_URL = (
+    "https://statbel.fgov.be/sites/default/files/files/opendata/permits/"
+    "TF_PERM_BUILDING.xlsx"
+    # URL directe à vérifier — landing page :
+    # https://statbel.fgov.be/fr/open-data/permis-de-batir
+)
+
+_PROVIDER_META = {
+    "provider": "Statbel — Direction générale Statistique, SPF Economie (BE)",
+    "license": "Creative Commons Zero (CC0 1.0)",
+    "jurisdiction": "BE",
+    "join_key": "cd_sector",
+    "crs": "EPSG:31370",  # Belgian Lambert 72 — for geometry entries
+}
+
+# ---------------------------------------------------------------------------
+# Entry definitions
+# ---------------------------------------------------------------------------
+
+_ENTRIES: dict[str, dict] = {
+    # ------------------------------------------------------------------
+    # Geometry — statistical sector contours
+    # ------------------------------------------------------------------
+    "sectors-contours": {
+        "label": "Statbel — statistical sector contours (EPSG:31370)",
+        "payload": Payload.VECTOR,
+        "access": AccessSpec(
+            protocol=AccessProtocol.DOWNLOAD,
+            endpoint=_SECTORS_GEOJSON_URL,
+            params={},
+            format="application/geo+json",
+        ),
+        "metadata": {
+            **_PROVIDER_META,
+            "dataset": "secteurs-statistiques",
+            "geometry_key": "geometry",
+            "sector_code_key": "cd_sector",
+            "note": (
+                "Annual vintage — check landing page for latest release: "
+                "https://statbel.fgov.be/fr/open-data/secteurs-statistiques"
+            ),
+        },
+    },
+    # ------------------------------------------------------------------
+    # Indicator tables — joinable by cd_sector
+    # ------------------------------------------------------------------
+    "indicators-population": {
+        "label": "Statbel — population by statistical sector",
+        "payload": Payload.TABLE,
+        "access": AccessSpec(
+            protocol=AccessProtocol.DOWNLOAD,
+            endpoint=_POPULATION_URL,
+            params={},
+            format="text/plain",
+        ),
+        "metadata": {
+            **_PROVIDER_META,
+            "dataset": "population-par-secteur-statistique",
+            "key_fields": ("cd_sector", "cd_sex", "cd_naty", "ms_pop"),
+        },
+    },
+    "indicators-households": {
+        "label": "Statbel — households by statistical sector",
+        "payload": Payload.TABLE,
+        "access": AccessSpec(
+            protocol=AccessProtocol.DOWNLOAD,
+            endpoint=_HOUSEHOLDS_URL,
+            params={},
+            format="text/plain",
+        ),
+        "metadata": {
+            **_PROVIDER_META,
+            "dataset": "menages-par-secteur-statistique",
+            "key_fields": ("cd_sector", "cd_type_menage", "ms_menages"),
+        },
+    },
+    "indicators-income": {
+        "label": "Statbel — average income by statistical sector",
+        "payload": Payload.TABLE,
+        "access": AccessSpec(
+            protocol=AccessProtocol.DOWNLOAD,
+            endpoint=_INCOME_URL,
+            params={},
+            format="text/plain",
+        ),
+        "metadata": {
+            **_PROVIDER_META,
+            "dataset": "revenus-par-secteur-statistique",
+            "key_fields": ("cd_sector", "ms_mean_total_net_taxable_income", "ms_nb"),
+        },
+    },
+    "indicators-cars": {
+        "label": "Statbel — car fleet by statistical sector",
+        "payload": Payload.TABLE,
+        "access": AccessSpec(
+            protocol=AccessProtocol.DOWNLOAD,
+            endpoint=_CARS_URL,
+            params={},
+            format="text/plain",
+        ),
+        "metadata": {
+            **_PROVIDER_META,
+            "dataset": "parc-automobile-par-secteur-statistique",
+            "key_fields": ("cd_sector", "cd_type_fuel", "ms_nb_vehicles"),
+        },
+    },
+    "indicators-building-permits": {
+        "label": "Statbel — building permits (municipality level)",
+        "payload": Payload.TABLE,
+        "access": AccessSpec(
+            protocol=AccessProtocol.DOWNLOAD,
+            endpoint=_PERMITS_URL,
+            params={},
+            format="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        ),
+        "metadata": {
+            **_PROVIDER_META,
+            "dataset": "permis-de-batir",
+            # Building permits are published at municipality (NIS) granularity,
+            # not at statistical-sector level.
+            "join_key": "cd_nis5",
+            "key_fields": ("cd_nis5", "tx_adm_dstr_descr_fr", "ms_nb_permits"),
+            "granularity": "municipality",
+        },
+    },
+}
+
+# ---------------------------------------------------------------------------
+# Schema definitions
+# ---------------------------------------------------------------------------
+
+_SCHEMAS: dict[str, dict[str, str]] = {
+    "sectors-contours": {
+        "cd_sector": "str",
+        "tx_sector_descr_fr": "str",
+        "tx_sector_descr_nl": "str",
+        "cd_nis5": "str",
+        "tx_munty_descr_fr": "str",
+        "tx_munty_descr_nl": "str",
+        "cd_arr": "str",
+        "cd_prov": "str",
+        "cd_rgn_refnis": "str",
+        "geometry": "geometry",
+        "crs": "EPSG:31370",
+    },
+    "indicators-population": {
+        "cd_sector": "str",
+        "cd_refnis": "str",
+        "cd_sex": "str",
+        "cd_naty": "str",
+        "cd_age": "int",
+        "ms_pop": "int",
+    },
+    "indicators-households": {
+        "cd_sector": "str",
+        "cd_refnis": "str",
+        "cd_type_menage": "str",
+        "ms_menages": "int",
+    },
+    "indicators-income": {
+        "cd_sector": "str",
+        "cd_refnis": "str",
+        "ms_nb": "int",
+        "ms_mean_total_net_taxable_income": "float",
+        "ms_median_total_net_taxable_income": "float",
+    },
+    "indicators-cars": {
+        "cd_sector": "str",
+        "cd_refnis": "str",
+        "cd_type_fuel": "str",
+        "ms_nb_vehicles": "int",
+    },
+    "indicators-building-permits": {
+        "cd_nis5": "str",
+        "tx_adm_dstr_descr_fr": "str",
+        "tx_adm_dstr_descr_nl": "str",
+        "cd_year": "int",
+        "ms_nb_permits": "int",
+    },
+}
+
+
+class StatbelBeSource(DeclarativeSource):
+    """Statbel Belgium open statistical data exposed as a GISPulse source.
+
+    Entries cover:
+    - ``sectors-contours``: polygon contours of Belgium's statistical
+      sectors in EPSG:31370 (Belgian Lambert 72).
+    - ``indicators-population``: population by age/sex/nationality per
+      statistical sector.
+    - ``indicators-households``: household count by type per statistical
+      sector.
+    - ``indicators-income``: average net taxable income per statistical
+      sector.
+    - ``indicators-cars``: car fleet by fuel type per statistical sector.
+    - ``indicators-building-permits``: building permits at municipality
+      level (finest available granularity from Statbel).
+
+    Indicator entries are joined to geometry via the ``cd_sector`` key
+    (or ``cd_nis5`` for building permits).
+    """
+
+    name = "statbel_be"
+    domain = SourceDomain.STATISTIQUE
+    # Default payload — overridden per entry (VECTOR for contours, TABLE for
+    # indicators). The per-entry payload is carried by SourceEntryRef.payload.
+    payload = Payload.TABLE
+    jurisdiction = "BE"
+
+    def entries(self) -> list[SourceEntryRef]:
+        return [
+            SourceEntryRef(
+                id=entry_id,
+                name=spec["label"],
+                access=spec["access"],
+                revision_token=None,
+                domain=self.domain,
+                payload=spec["payload"],
+                jurisdiction=self.jurisdiction,
+                metadata=spec["metadata"],
+            )
+            for entry_id, spec in _ENTRIES.items()
+        ]
+
+    def schema(self, entry_id: str) -> dict[str, str]:
+        """Return the known field names and types for ``entry_id``."""
+        self._entry(entry_id)  # validate the id
+        return dict(_SCHEMAS[entry_id])
+
+    def revision(self, entry_id: str) -> str | None:
+        """Return ``None`` — Statbel does not expose ETag/Last-Modified on
+        its static file downloads; freshness is unknown."""
+        self._entry(entry_id)  # validate the id
+        return None

--- a/plugins/gispulse-src-statbel-be/pyproject.toml
+++ b/plugins/gispulse-src-statbel-be/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gispulse-src-statbel-be"
+version = "0.1.0"
+description = "Statbel Belgium statistical source for GISPulse (secteurs statistiques + démographie)"
+requires-python = ">=3.10"
+license = "AGPL-3.0-or-later"
+authors = [{ name = "GISPulse", email = "dev@gispulse.io" }]
+dependencies = [
+    "gispulse>=2.0.0,<3.0.0",
+]
+
+# Discovered as a data source by core.plugin_hub.PluginHub.
+[project.entry-points."gispulse.data_sources"]
+statbel_be = "gispulse_src_statbel_be:register"
+
+[tool.gispulse.plugin]
+kind = "source"
+protocol = ">=1.0,<2.0"
+domain = "statistique"
+jurisdiction = "BE"
+display_name = "Statbel — Belgium open statistical data"

--- a/tests/unit/test_src_statbel_be.py
+++ b/tests/unit/test_src_statbel_be.py
@@ -1,0 +1,277 @@
+"""Unit tests for the gispulse-src-statbel-be plugin.
+
+Zero-network: the plugin only declares Statbel open-data AccessSpecs.
+Core fetchers own HTTP and materialisation.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+_PKG = (
+    Path(__file__).resolve().parents[2]
+    / "plugins"
+    / "gispulse-src-statbel-be"
+)
+if str(_PKG) not in sys.path:
+    sys.path.insert(0, str(_PKG))
+
+from gispulse.core.plugin_model import (  # noqa: E402
+    AccessProtocol,
+    FetchMode,
+    Payload,
+    SourceDomain,
+    SourceResult,
+)
+from gispulse.core.sources import DataSource, ProtocolRegistry  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fake fetcher — DOWNLOAD protocol
+# ---------------------------------------------------------------------------
+
+
+class FakeDownload:
+    """Records the AccessSpec it is handed and returns a marker result."""
+
+    protocol = AccessProtocol.DOWNLOAD
+
+    def __init__(self) -> None:
+        self.calls: list = []
+
+    def fetch(self, access, *, extent=None, mode=FetchMode.MATERIALIZE):
+        self.calls.append(access)
+        return SourceResult(
+            payload=Payload.VECTOR,
+            mode=mode,
+            data=access.endpoint,
+        )
+
+
+def _source_class():
+    return importlib.import_module(
+        "gispulse_src_statbel_be.source"
+    ).StatbelBeSource
+
+
+@pytest.fixture
+def source():
+    reg = ProtocolRegistry()
+    reg.register(FakeDownload())
+    return _source_class()(registry=reg)
+
+
+# ---------------------------------------------------------------------------
+# Packaging + registration
+# ---------------------------------------------------------------------------
+
+
+def test_pyproject_declares_statbel_be_entrypoint_and_manifest() -> None:
+    tomllib = pytest.importorskip("tomllib")
+    pyproject = tomllib.loads((_PKG / "pyproject.toml").read_text())
+
+    assert pyproject["project"]["entry-points"]["gispulse.data_sources"] == {
+        "statbel_be": "gispulse_src_statbel_be:register"
+    }
+
+    manifest = pyproject["tool"]["gispulse"]["plugin"]
+    assert manifest["kind"] == "source"
+    assert manifest["domain"] == "statistique"
+    assert manifest["jurisdiction"] == "BE"
+
+
+def test_register_adds_statbel_be_source_to_global_registry() -> None:
+    from gispulse.core.sources import SOURCES
+
+    StatbelBeSource = _source_class()
+    register = importlib.import_module("gispulse_src_statbel_be").register
+
+    SOURCES.clear()
+    try:
+        register()
+        registered = SOURCES.get("statbel_be")
+        assert isinstance(registered, StatbelBeSource)
+        expected_ids = {
+            "sectors-contours",
+            "indicators-population",
+            "indicators-households",
+            "indicators-income",
+            "indicators-cars",
+            "indicators-building-permits",
+        }
+        assert {e.id for e in registered.catalog()} == expected_ids
+    finally:
+        SOURCES.clear()
+
+
+# ---------------------------------------------------------------------------
+# Contract conformance + declared axes
+# ---------------------------------------------------------------------------
+
+
+def test_statbel_be_is_a_statistical_datasource(source) -> None:
+    assert isinstance(source, DataSource)
+    assert source.name == "statbel_be"
+    assert source.domain is SourceDomain.STATISTIQUE
+    assert source.jurisdiction == "BE"
+
+
+def test_catalog_lists_all_six_entries(source) -> None:
+    ids = {entry.id for entry in source.catalog()}
+    assert ids == {
+        "sectors-contours",
+        "indicators-population",
+        "indicators-households",
+        "indicators-income",
+        "indicators-cars",
+        "indicators-building-permits",
+    }
+
+
+# ---------------------------------------------------------------------------
+# sectors-contours — geometry entry, VECTOR payload, DOWNLOAD protocol
+# ---------------------------------------------------------------------------
+
+
+def test_sectors_contours_is_vector_download(source) -> None:
+    entry = next(e for e in source.catalog() if e.id == "sectors-contours")
+
+    assert entry.access.protocol is AccessProtocol.DOWNLOAD
+    assert entry.access.endpoint.startswith("https://statbel.fgov.be/")
+    assert entry.access.format == "application/geo+json"
+    assert entry.payload is Payload.VECTOR
+    assert entry.jurisdiction == "BE"
+
+
+def test_sectors_contours_metadata_has_crs_and_join_key(source) -> None:
+    entry = next(e for e in source.catalog() if e.id == "sectors-contours")
+    meta = entry.metadata
+
+    assert meta["crs"] == "EPSG:31370"
+    assert meta["join_key"] == "cd_sector"
+    assert meta["provider"].startswith("Statbel")
+    assert meta["license"] == "Creative Commons Zero (CC0 1.0)"
+
+
+# ---------------------------------------------------------------------------
+# Indicator entries — TABLE payload, DOWNLOAD protocol
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "entry_id",
+    [
+        "indicators-population",
+        "indicators-households",
+        "indicators-income",
+        "indicators-cars",
+    ],
+)
+def test_indicator_entry_is_table_download_keyed_by_cd_sector(
+    source, entry_id: str
+) -> None:
+    entry = next(e for e in source.catalog() if e.id == entry_id)
+
+    assert entry.access.protocol is AccessProtocol.DOWNLOAD
+    assert entry.access.endpoint.startswith("https://statbel.fgov.be/")
+    assert entry.payload is Payload.TABLE
+    assert entry.metadata["join_key"] == "cd_sector"
+    assert entry.metadata["license"] == "Creative Commons Zero (CC0 1.0)"
+
+
+def test_building_permits_is_table_keyed_by_nis5(source) -> None:
+    entry = next(
+        e for e in source.catalog() if e.id == "indicators-building-permits"
+    )
+
+    assert entry.access.protocol is AccessProtocol.DOWNLOAD
+    assert entry.payload is Payload.TABLE
+    # Permits are at municipality level, join key differs
+    assert entry.metadata["join_key"] == "cd_nis5"
+    assert entry.metadata["granularity"] == "municipality"
+
+
+# ---------------------------------------------------------------------------
+# Declarative fetch — delegates to the DOWNLOAD adapter, zero network code
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_sectors_contours_delegates_to_download_adapter() -> None:
+    dl = FakeDownload()
+    reg = ProtocolRegistry()
+    reg.register(dl)
+    src = _source_class()(registry=reg)
+
+    result = src.fetch("sectors-contours")
+
+    assert result.payload is Payload.VECTOR
+    assert result.data.startswith("https://statbel.fgov.be/")
+    assert len(dl.calls) == 1
+    assert dl.calls[0].protocol is AccessProtocol.DOWNLOAD
+
+
+def test_fetch_unknown_entry_raises(source) -> None:
+    with pytest.raises(KeyError, match="unknown entry 'ghost'"):
+        source.fetch("ghost")
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+def test_schema_sectors_contours_has_geometry_and_crs(source) -> None:
+    schema = source.schema("sectors-contours")
+
+    assert schema["cd_sector"] == "str"
+    assert schema["geometry"] == "geometry"
+    assert schema["crs"] == "EPSG:31370"
+    assert schema["cd_nis5"] == "str"
+    assert schema["tx_sector_descr_fr"] == "str"
+
+
+def test_schema_population_has_identity_and_count_fields(source) -> None:
+    schema = source.schema("indicators-population")
+
+    assert schema["cd_sector"] == "str"
+    assert schema["ms_pop"] == "int"
+    assert schema["cd_sex"] == "str"
+
+
+def test_schema_income_has_mean_and_median(source) -> None:
+    schema = source.schema("indicators-income")
+
+    assert schema["ms_mean_total_net_taxable_income"] == "float"
+    assert schema["ms_median_total_net_taxable_income"] == "float"
+    assert schema["cd_sector"] == "str"
+
+
+def test_schema_building_permits_has_nis5_and_permits(source) -> None:
+    schema = source.schema("indicators-building-permits")
+
+    assert schema["cd_nis5"] == "str"
+    assert schema["ms_nb_permits"] == "int"
+
+
+def test_schema_validates_entry_id(source) -> None:
+    with pytest.raises(KeyError, match="unknown entry 'ghost'"):
+        source.schema("ghost")
+
+
+# ---------------------------------------------------------------------------
+# revision()
+# ---------------------------------------------------------------------------
+
+
+def test_revision_is_none_for_all_entries(source) -> None:
+    for entry in source.catalog():
+        assert source.revision(entry.id) is None
+
+
+def test_revision_validates_entry_id(source) -> None:
+    with pytest.raises(KeyError, match="unknown entry 'ghost'"):
+        source.revision("ghost")


### PR DESCRIPTION
## Summary

- Adds `plugins/gispulse-src-statbel-be/`: a declarative `DeclarativeSource` plugin (`StatbelBeSource`) exposing 6 Statbel Belgium open-data entries via `AccessProtocol.DOWNLOAD` (core `HttpFileFetcher`):
  - `sectors-contours` — statistical sector polygon contours (GeoJSON, EPSG:31370, `Payload.VECTOR`)
  - `indicators-population` — population by age/sex/nationality per sector
  - `indicators-households` — household count by type per sector
  - `indicators-income` — average/median net taxable income per sector
  - `indicators-cars` — car fleet by fuel type per sector
  - `indicators-building-permits` — building permits at municipality level (finest Statbel granularity)
- Entry-point: `statbel_be = "gispulse_src_statbel_be:register"` under `gispulse.data_sources`; manifest `kind=source`, `domain=statistique`, `jurisdiction=BE`
- 20 zero-network unit tests (`tests/unit/test_src_statbel_be.py`), ruff clean

## URL uncertainty

Several direct-download URLs are best-effort extrapolations from Statbel open-data landing pages. Statbel's static file paths change between annual publication cycles. The following entries should have their `endpoint` validated against the official landing pages before a production release:

| Entry | Landing page |
|---|---|
| `sectors-contours` | https://statbel.fgov.be/fr/open-data/secteurs-statistiques |
| `indicators-population` | https://statbel.fgov.be/fr/open-data/population-par-secteur-statistique |
| `indicators-households` | https://statbel.fgov.be/fr/open-data/menages-par-secteur-statistique |
| `indicators-income` | https://statbel.fgov.be/fr/open-data/revenus-fiscaux-par-secteur-statistique |
| `indicators-cars` | https://statbel.fgov.be/fr/open-data/parc-automobile-par-secteur-statistique |
| `indicators-building-permits` | https://statbel.fgov.be/fr/open-data/permis-de-batir |

Each URL in `source.py` carries a `# URL directe à vérifier` comment alongside the landing-page reference.

## Test plan

- [x] `uv run python -m pytest tests/unit/test_src_statbel_be.py -v` → 20/20 passed
- [x] `uv run ruff check plugins/gispulse-src-statbel-be/ tests/unit/test_src_statbel_be.py` → all checks passed
- [x] Commit carries `Signed-off-by: Erwan Lee Pesle <erpesle@gmail.com>` (DCO)

Refs #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)