### PR TITLE
feat(plugins): gispulse-src-gipod-be (travaux planifiés / domaine public, Flandre)

### DIFF
--- a/plugins/gispulse-src-gipod-be/gispulse_src_gipod_be/__init__.py
+++ b/plugins/gispulse-src-gipod-be/gispulse_src_gipod_be/__init__.py
@@ -1,0 +1,11 @@
+"""GISPulse data-source plugin — GIPOD public domain works and occupancies (Flandre/BE)."""
+
+from __future__ import annotations
+
+
+def register() -> None:
+    """Entry-point hook for the ``gispulse.data_sources`` group."""
+    from gispulse.core.sources import SOURCES
+    from gispulse_src_gipod_be.source import GipodBeSource
+
+    SOURCES.register(GipodBeSource())

--- a/plugins/gispulse-src-gipod-be/gispulse_src_gipod_be/source.py
+++ b/plugins/gispulse-src-gipod-be/gispulse_src_gipod_be/source.py
@@ -1,0 +1,238 @@
+"""GIPOD DataSource — travaux planifiés et occupations du domaine public (Flandre/BE).
+
+GIPOD (Generiek InformatiePlatform Openbaar Domein) est la plateforme d'information
+du domaine public de la région flamande (Belgique). Le service OGC publié par
+Digitaal Vlaanderen expose les occupations du domaine public et les perturbations
+de mobilité planifiées, valables aujourd'hui et sur les 6 prochains mois.
+
+Les deux entrées couvertes par ce plugin :
+
+* **inname** — occupations du domaine public (surfaces/polygones). Comprend
+  grondwerken (travaux de génie civil), événements et autres types d'occupation.
+  Co-tranchée (GroundworkPartOfTrenchSynergy) inclus.
+* **hinder** — perturbations de mobilité planifiées (surfaces). Contient les
+  zones de restriction de trafic associées aux occupations.
+
+Endpoints confirmés (2026-06) via GetCapabilities WFS et collection OGC API :
+  WFS    : https://geo.api.vlaanderen.be/GIPOD/wfs
+  OGC AF : https://geo.api.vlaanderen.be/GIPOD/ogc/features/v1
+
+CRS natif : EPSG:31370 (Belgian Lambert 72). WFS version 2.0 supporte la
+demande en EPSG:4326 via le paramètre ``srsname``; le fetcher core utilise
+le ``crs`` des AccessSpec.params (cf. guide WfsFetcher).
+
+Licence : Modellicentie Gratis Hergebruik — Vlaamse overheid
+(https://www.vlaanderen.be/digitaal-vlaanderen/onze-oplossingen/geografische-webdiensten/
+gebruiksrechten-en-privacyverklaring-geografische-webdiensten)
+"""
+
+from __future__ import annotations
+
+from gispulse.plugins.api import (
+    AccessProtocol,
+    AccessSpec,
+    DeclarativeSource,
+    Payload,
+    SourceDomain,
+    SourceEntryRef,
+)
+
+# WFS endpoint (Digitaal Vlaanderen — confirmé via GetCapabilities 2026-06).
+_WFS_ENDPOINT = "https://geo.api.vlaanderen.be/GIPOD/wfs"
+
+# URL GetCapabilities — sonde de fraîcheur pour revision() (HEAD).
+_WFS_CAPABILITIES = (
+    f"{_WFS_ENDPOINT}?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetCapabilities"
+)
+
+# OGC API Features endpoint (alternatif au WFS, même données).
+# Utilisé ici via AccessProtocol.OGC_FEATURES ; collection key = "INNAME".
+_OGC_FEATURES_BASE = "https://geo.api.vlaanderen.be/GIPOD/ogc/features/v1"
+
+# Namespace WFS (confirmé via FeatureType/@Name dans GetCapabilities).
+_NS = "GIPOD"
+
+_COMMON_METADATA = {
+    "provider": "Digitaal Vlaanderen / Vlaamse overheid",
+    "platform": "geo.api.vlaanderen.be/GIPOD",
+    "license": "Modellicentie Gratis Hergebruik — Vlaamse overheid",
+    "region": "Vlaanderen (Flandre)",
+    "crs_native": "EPSG:31370",
+    "temporal_window": "aujourd'hui + 6 mois",
+    "note": (
+        "Horizon temporel : occupations/travaux planifiés ou en cours "
+        "aujourd'hui et durant les 6 prochains mois."
+    ),
+}
+
+# Schéma des propriétés retournées par l'endpoint INNAME (OGC API, GeoJSON).
+# Noms vérifiés sur un item réel via GET .../INNAME/items?limit=1 (2026-06).
+_SCHEMA_INNAME = {
+    "GipodId": "int",
+    "Uri": "str",
+    "Description": "str",
+    "Reference": "str",
+    "Type": "str",
+    "TypeId": "int",
+    "PublicDomainOccupancyTypes": "list[json]",
+    "Status": "str",
+    "StatusId": "int",
+    "Start": "datetime",
+    "End": "datetime",
+    "TimeSchedule": "str",
+    "Owner": "str",
+    "OwnerId": "int",
+    "ContactOrganisations": "list[json]",
+    "MobilityHindrances": "list[json]",
+    "GroundworkCategory": "str",
+    "GroundworkCategoryId": "int",
+    "GroundworkSpecification": "str",
+    "GroundworkPartOfTrenchSynergy": "bool",
+    "CreatedOn": "datetime",
+    "LastModifiedOn": "datetime",
+    "geometry": "geometry",
+}
+
+# Schéma des perturbations de mobilité (HINDER) — champs déduits du modèle GIPOD.
+# Les champs MobilityHindrance-spécifiques (HinderId, OccupancyIds, …) sont
+# documentés dans la page OGC Services de Digitaal Vlaanderen.
+_SCHEMA_HINDER = {
+    "GipodId": "int",
+    "Uri": "str",
+    "Description": "str",
+    "Start": "datetime",
+    "End": "datetime",
+    "Status": "str",
+    "StatusId": "int",
+    "Owner": "str",
+    "OwnerId": "int",
+    "CreatedOn": "datetime",
+    "LastModifiedOn": "datetime",
+    "geometry": "geometry",
+}
+
+_SCHEMAS: dict[str, dict[str, str]] = {
+    "inname": _SCHEMA_INNAME,
+    "hinder": _SCHEMA_HINDER,
+}
+
+
+def _probe_revision_head(url: str) -> str | None:
+    """Retourne un token de fraîcheur par HEAD sur l'URL de capabilities.
+
+    Renvoie ``None`` si le service est inaccessible ou n'expose pas
+    d'en-tête de fraîcheur — le watcher traite ``None`` comme "inconnu"
+    et ne déclenche pas de faux positif.
+    """
+    import httpx  # import local — le module ne fait aucun réseau à l'import
+
+    try:
+        resp = httpx.head(url, timeout=8.0, follow_redirects=True)
+    except Exception:  # noqa: BLE001 — toute erreur réseau → inconnu
+        return None
+    etag = resp.headers.get("etag")
+    if etag:
+        return etag.strip('"')
+    last_modified = resp.headers.get("last-modified")
+    if last_modified:
+        return last_modified
+    return None
+
+
+class GipodBeSource(DeclarativeSource):
+    """GIPOD (Flandre/BE) : occupations domaine public et perturbations de mobilité."""
+
+    name = "gipod_be"
+    domain = SourceDomain.REGLEMENTAIRE  # occupation = autorisation/permis d'occuper
+    payload = Payload.VECTOR
+    jurisdiction = "BE"
+
+    def entries(self) -> list[SourceEntryRef]:
+        return [
+            SourceEntryRef(
+                id="inname",
+                name="GIPOD - inname openbaar domein (occupations du domaine public)",
+                access=AccessSpec(
+                    protocol=AccessProtocol.WFS,
+                    endpoint=_WFS_ENDPOINT,
+                    params={
+                        "typename": f"{_NS}:INNAME",
+                        "version": "2.0.0",
+                        # CRS demandé en sortie : 4326 (WGS84 GeoJSON).
+                        # Le CRS natif du service est EPSG:31370 (Lambert 72) ;
+                        # passer "EPSG:4326" ici déclenche la reprojection côté WFS.
+                        "crs": "EPSG:4326",
+                    },
+                    format="application/json",
+                ),
+                revision_token=None,
+                domain=self.domain,
+                payload=self.payload,
+                jurisdiction=self.jurisdiction,
+                metadata={
+                    **_COMMON_METADATA,
+                    "layer": "INNAME",
+                    "layer_title": "GIPOD - inname openbaar domein",
+                    "description": (
+                        "Occupations du domaine public (zones/polygones) : "
+                        "travaux de génie civil (grondwerken), événements et "
+                        "autres occupations planifiées ou en cours. "
+                        "Inclut GroundworkPartOfTrenchSynergy (co-tranchée)."
+                    ),
+                    "identity_key": "GipodId",
+                    "date_fields": ("Start", "End"),
+                    "cotrench_key": "GroundworkPartOfTrenchSynergy",
+                    "wfs_typename": f"{_NS}:INNAME",
+                    "ogc_features_collection": "INNAME",
+                    "ogc_features_url": f"{_OGC_FEATURES_BASE}/collections/INNAME/items",
+                },
+            ),
+            SourceEntryRef(
+                id="hinder",
+                name="GIPOD - geplande mobiliteitshinder (perturbations de mobilité planifiées)",
+                access=AccessSpec(
+                    protocol=AccessProtocol.WFS,
+                    endpoint=_WFS_ENDPOINT,
+                    params={
+                        "typename": f"{_NS}:HINDER",
+                        "version": "2.0.0",
+                        "crs": "EPSG:4326",
+                    },
+                    format="application/json",
+                ),
+                revision_token=None,
+                domain=self.domain,
+                payload=self.payload,
+                jurisdiction=self.jurisdiction,
+                metadata={
+                    **_COMMON_METADATA,
+                    "layer": "HINDER",
+                    "layer_title": "GIPOD - geplande mobiliteitshinder",
+                    "description": (
+                        "Perturbations de mobilité planifiées (zones/polygones) "
+                        "associées aux occupations GIPOD. Comprend restrictions "
+                        "de circulation et fermetures de voirie validées par les "
+                        "autorités locales."
+                    ),
+                    "identity_key": "GipodId",
+                    "date_fields": ("Start", "End"),
+                    "wfs_typename": f"{_NS}:HINDER",
+                    "ogc_features_collection": "HINDER",
+                    "ogc_features_url": f"{_OGC_FEATURES_BASE}/collections/HINDER/items",
+                },
+            ),
+        ]
+
+    def schema(self, entry_id: str) -> dict[str, str]:
+        """Schéma des attributs de l'entrée GIPOD."""
+        self._entry(entry_id)  # valide l'id
+        return dict(_SCHEMAS[entry_id])
+
+    def revision(self, entry_id: str) -> str | None:
+        """Token de fraîcheur via HEAD sur GetCapabilities WFS.
+
+        Retourne ``None`` si le service est inaccessible — le watcher
+        considère cela comme "inconnu" et ne déclenche pas de faux positif.
+        """
+        self._entry(entry_id)  # valide l'id
+        return _probe_revision_head(_WFS_CAPABILITIES)

--- a/plugins/gispulse-src-gipod-be/pyproject.toml
+++ b/plugins/gispulse-src-gipod-be/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gispulse-src-gipod-be"
+version = "0.1.0"
+description = "GIPOD (Flandre/BE) public domain works and occupancies source for GISPulse"
+requires-python = ">=3.10"
+license = "AGPL-3.0-or-later"
+authors = [{ name = "GISPulse", email = "dev@gispulse.io" }]
+dependencies = [
+    "gispulse>=2.0.0,<3.0.0",
+]
+
+# Registered as a data source — discovered by core.plugin_hub.PluginHub.
+[project.entry-points."gispulse.data_sources"]
+gipod_be = "gispulse_src_gipod_be:register"
+
+[tool.gispulse.plugin]
+kind = "source"
+protocol = ">=1.0,<2.0"
+domain = "reglementaire"
+jurisdiction = "BE"
+display_name = "GIPOD - Travaux planifiés et occupations du domaine public (Flandre)"

--- a/tests/unit/test_src_gipod_be.py
+++ b/tests/unit/test_src_gipod_be.py
@@ -1,0 +1,282 @@
+"""Unit tests for the gispulse-src-gipod-be plugin.
+
+Zero-network : le plugin déclare des AccessSpec WFS/OGC et ne fait aucun réseau.
+Les fetchers core possèdent HTTP, pagination et matérialisation.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_PKG = Path(__file__).resolve().parents[2] / "plugins" / "gispulse-src-gipod-be"
+_PKG_PATH = str(_PKG)
+if _PKG_PATH in sys.path:
+    sys.path.remove(_PKG_PATH)
+sys.path.insert(0, _PKG_PATH)
+for _module in ("gispulse_src_gipod_be.source", "gispulse_src_gipod_be"):
+    sys.modules.pop(_module, None)
+
+from gispulse_src_gipod_be.source import GipodBeSource  # noqa: E402
+
+from gispulse.core.plugin_model import (  # noqa: E402
+    AccessProtocol,
+    Payload,
+    SourceDomain,
+)
+from gispulse.core.sources import DataSource  # noqa: E402
+
+pytestmark = pytest.mark.usefixtures("offline_ssrf")
+
+
+@pytest.fixture
+def source() -> GipodBeSource:
+    return GipodBeSource()
+
+
+# ---------------------------------------------------------------------------
+# pyproject.toml — déclaration entry-point et manifest
+# ---------------------------------------------------------------------------
+
+
+def test_pyproject_declares_gipod_be_entrypoint_and_manifest() -> None:
+    tomllib = pytest.importorskip("tomllib")
+    pyproject = tomllib.loads((_PKG / "pyproject.toml").read_text())
+
+    assert pyproject["project"]["entry-points"]["gispulse.data_sources"] == {
+        "gipod_be": "gispulse_src_gipod_be:register"
+    }
+
+    manifest = pyproject["tool"]["gispulse"]["plugin"]
+    assert manifest["kind"] == "source"
+    assert manifest["domain"] == "reglementaire"
+    assert manifest["jurisdiction"] == "BE"
+
+
+# ---------------------------------------------------------------------------
+# Conformité contrat DataSource
+# ---------------------------------------------------------------------------
+
+
+def test_is_a_reglementaire_vector_datasource(source: GipodBeSource) -> None:
+    assert isinstance(source, DataSource)
+    assert source.name == "gipod_be"
+    assert source.domain is SourceDomain.REGLEMENTAIRE
+    assert source.payload is Payload.VECTOR
+    assert source.jurisdiction == "BE"
+
+
+# ---------------------------------------------------------------------------
+# entries() — couverture des deux concepts du brief
+# ---------------------------------------------------------------------------
+
+
+def test_declares_inname_and_hinder_entries(source: GipodBeSource) -> None:
+    ids = {entry.id for entry in source.entries()}
+    assert ids == {"inname", "hinder"}
+
+
+def test_all_entries_use_wfs_protocol(source: GipodBeSource) -> None:
+    for entry in source.entries():
+        assert entry.access.protocol is AccessProtocol.WFS
+
+
+def test_all_entries_target_geo_api_vlaanderen(source: GipodBeSource) -> None:
+    for entry in source.entries():
+        assert entry.access.endpoint == "https://geo.api.vlaanderen.be/GIPOD/wfs"
+
+
+# ---------------------------------------------------------------------------
+# Entrée inname — occupations du domaine public
+# ---------------------------------------------------------------------------
+
+
+def test_inname_entry_wfs_typename_and_format(source: GipodBeSource) -> None:
+    entry = next(e for e in source.entries() if e.id == "inname")
+
+    assert entry.access.params["typename"] == "GIPOD:INNAME"
+    assert entry.access.params["version"] == "2.0.0"
+    assert entry.access.params["crs"] == "EPSG:4326"
+    assert entry.access.format == "application/json"
+
+
+def test_inname_entry_metadata_identity_and_cotrench(source: GipodBeSource) -> None:
+    entry = next(e for e in source.entries() if e.id == "inname")
+
+    assert entry.metadata["provider"] == "Digitaal Vlaanderen / Vlaamse overheid"
+    assert entry.metadata["identity_key"] == "GipodId"
+    assert entry.metadata["cotrench_key"] == "GroundworkPartOfTrenchSynergy"
+    assert entry.metadata["region"] == "Vlaanderen (Flandre)"
+    assert entry.metadata["crs_native"] == "EPSG:31370"
+    assert "6 mois" in entry.metadata["temporal_window"]
+
+
+def test_inname_entry_carries_jurisdiction_and_domain(source: GipodBeSource) -> None:
+    entry = next(e for e in source.entries() if e.id == "inname")
+
+    assert entry.jurisdiction == "BE"
+    assert entry.domain is SourceDomain.REGLEMENTAIRE
+    assert entry.payload is Payload.VECTOR
+
+
+def test_inname_entry_exposes_ogc_features_url_in_metadata(
+    source: GipodBeSource,
+) -> None:
+    entry = next(e for e in source.entries() if e.id == "inname")
+
+    ogc_url = entry.metadata["ogc_features_url"]
+    assert "geo.api.vlaanderen.be/GIPOD/ogc/features" in ogc_url
+    assert "INNAME" in ogc_url
+
+
+# ---------------------------------------------------------------------------
+# Entrée hinder — perturbations de mobilité planifiées
+# ---------------------------------------------------------------------------
+
+
+def test_hinder_entry_wfs_typename(source: GipodBeSource) -> None:
+    entry = next(e for e in source.entries() if e.id == "hinder")
+
+    assert entry.access.params["typename"] == "GIPOD:HINDER"
+    assert entry.access.params["crs"] == "EPSG:4326"
+
+
+def test_hinder_entry_metadata_provider_and_temporal_window(
+    source: GipodBeSource,
+) -> None:
+    entry = next(e for e in source.entries() if e.id == "hinder")
+
+    assert entry.metadata["provider"] == "Digitaal Vlaanderen / Vlaamse overheid"
+    assert "6 mois" in entry.metadata["temporal_window"]
+    assert entry.metadata["identity_key"] == "GipodId"
+
+
+# ---------------------------------------------------------------------------
+# schema()
+# ---------------------------------------------------------------------------
+
+
+def test_schema_inname_exposes_key_fields(source: GipodBeSource) -> None:
+    schema = source.schema("inname")
+
+    assert schema["GipodId"] == "int"
+    assert schema["Start"] == "datetime"
+    assert schema["End"] == "datetime"
+    assert schema["GroundworkPartOfTrenchSynergy"] == "bool"
+    assert schema["geometry"] == "geometry"
+    assert schema["Status"] == "str"
+    assert schema["Owner"] == "str"
+
+
+def test_schema_hinder_exposes_key_fields(source: GipodBeSource) -> None:
+    schema = source.schema("hinder")
+
+    assert schema["GipodId"] == "int"
+    assert schema["Start"] == "datetime"
+    assert schema["End"] == "datetime"
+    assert schema["geometry"] == "geometry"
+
+
+def test_schema_raises_for_unknown_entry(source: GipodBeSource) -> None:
+    with pytest.raises(KeyError, match="unknown entry 'ghost'"):
+        source.schema("ghost")
+
+
+# ---------------------------------------------------------------------------
+# revision() — sonde HEAD GetCapabilities (monkeypatched)
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, *, headers: dict[str, str] | None = None) -> None:
+        self.headers = headers or {}
+
+
+def test_revision_returns_etag_when_present(
+    source: GipodBeSource, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "httpx.head",
+        lambda *_a, **_kw: _FakeResponse(headers={"etag": '"2026-06-01"'}),
+    )
+    assert source.revision("inname") == "2026-06-01"
+    assert source.revision("hinder") == "2026-06-01"
+
+
+def test_revision_falls_back_to_last_modified(
+    source: GipodBeSource, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "httpx.head",
+        lambda *_a, **_kw: _FakeResponse(
+            headers={"last-modified": "Mon, 01 Jun 2026 00:00:00 GMT"}
+        ),
+    )
+    assert source.revision("inname") == "Mon, 01 Jun 2026 00:00:00 GMT"
+
+
+def test_revision_returns_none_on_network_error(
+    source: GipodBeSource, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "httpx.head",
+        lambda *_a, **_kw: (_ for _ in ()).throw(RuntimeError("offline")),
+    )
+    assert source.revision("inname") is None
+
+
+def test_revision_returns_none_without_freshness_header(
+    source: GipodBeSource, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "httpx.head",
+        lambda *_a, **_kw: _FakeResponse(headers={}),
+    )
+    assert source.revision("hinder") is None
+
+
+def test_revision_raises_for_unknown_entry(
+    source: GipodBeSource, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "httpx.head",
+        lambda *_a, **_kw: _FakeResponse(headers={}),
+    )
+    with pytest.raises(KeyError, match="unknown entry 'ghost'"):
+        source.revision("ghost")
+
+
+def test_revision_probes_wfs_capabilities_url(
+    source: GipodBeSource, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: list[str] = []
+
+    def fake_head(url: str, **_kw: object) -> _FakeResponse:
+        captured.append(url)
+        return _FakeResponse(headers={"etag": '"test"'})
+
+    monkeypatch.setattr("httpx.head", fake_head)
+    source.revision("inname")
+
+    assert captured
+    assert "geo.api.vlaanderen.be/GIPOD/wfs" in captured[0]
+    assert "GetCapabilities" in captured[0]
+
+
+# ---------------------------------------------------------------------------
+# register() — intégration registre
+# ---------------------------------------------------------------------------
+
+
+def test_register_adds_source_to_registry() -> None:
+    from gispulse.core.sources import SOURCES
+    from gispulse_src_gipod_be import register
+
+    SOURCES.clear()
+    try:
+        register()
+        assert SOURCES.get("gipod_be") is not None
+    finally:
+        SOURCES.clear()


### PR DESCRIPTION
## Summary

- Ajoute le plugin source `gispulse-src-gipod-be` pour **GIPOD** (Generiek InformatiePlatform Openbaar Domein, Flandre/BE) : travaux planifiés et occupations du domaine public, utile pour co-tranchée et planning réseau.
- Deux entrées WFS via `geo.api.vlaanderen.be/GIPOD/wfs` (Digitaal Vlaanderen, confirmé via GetCapabilities 2026-06) :
  - `inname` — `GIPOD:INNAME` : occupations du domaine public (polygones), avec champ `GroundworkPartOfTrenchSynergy` (co-tranchée).
  - `hinder` — `GIPOD:HINDER` : perturbations de mobilité planifiées (polygones).
- Horizon temporel : aujourd'hui + 6 mois (contrainte service côté Digitaal Vlaanderen).
- CRS natif EPSG:31370 (Lambert 72), sortie EPSG:4326 via paramètre `crs` WFS.
- Licence : Modellicentie Gratis Hergebruik — Vlaamse overheid.
- Premier plugin `jurisdiction = "BE"` du repo.

## Test plan

- [x] 21 tests zero-network (`tests/unit/test_src_gipod_be.py`) — tous verts.
- [x] ruff : aucune erreur.
- [x] Commit `--signoff` (DCO, auteur `erpesle@gmail.com`).
- [ ] Vérifier que `uv run python -m pytest tests/unit/test_src_gipod_be.py -v` passe en CI.

## Notes d'incertitude

Les URLs WFS et OGC API Features sont **confirmées** via GetCapabilities live (`geo.api.vlaanderen.be/GIPOD/wfs?REQUEST=GetCapabilities`) et landing page OGC (`geo.api.vlaanderen.be/GIPOD/ogc/features`). Les typenames `GIPOD:INNAME` et `GIPOD:HINDER` sont les valeurs exactes retournées par le service.

Le champ `GroundworkPartOfTrenchSynergy` (co-tranchée) est vérifié sur un item réel via OGC API Features (`/INNAME/items?limit=1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)