### PR TITLE
fix(fetchers): require explicit table zip member

### DIFF
--- a/plugins/gispulse-src-georisques/gispulse_src_georisques/source.py
+++ b/plugins/gispulse-src-georisques/gispulse_src_georisques/source.py
@@ -159,7 +159,11 @@ _BULK_ENTRIES: dict[str, dict[str, Any]] = {
         "join_keys": ("code_insee",),
         "echelle": "nationale",
         "department_param": None,
-        "params": {"archive_format": "zip", "table_format": "csv"},
+        "params": {
+            "archive_format": "zip",
+            "table_format": "csv",
+            "archive_member": "risq_gaspar.csv",
+        },
     },
 }
 

--- a/plugins/gispulse-src-insee/README.md
+++ b/plugins/gispulse-src-insee/README.md
@@ -104,7 +104,11 @@ from gispulse.plugins.api import get_catalog_entry
 entry = get_catalog_entry("insee", "iris_population_2022")
 # entry.access.protocol -> AccessProtocol.TABLE_FILE
 # entry.payload          -> Payload.TABLE
-# entry.access.params    -> {"archive_format": "zip", "table_format": "csv"}
+# entry.access.params    -> {
+#     "archive_format": "zip",
+#     "table_format": "csv",
+#     "archive_member": "base-ic-evol-struct-pop-2022.CSV",
+# }
 
 bulk = get_catalog_entry("insee", "iris_bulk")
 # bulk.access.protocol -> AccessProtocol.DOWNLOAD

--- a/plugins/gispulse-src-insee/gispulse_src_insee/source.py
+++ b/plugins/gispulse-src-insee/gispulse_src_insee/source.py
@@ -55,6 +55,7 @@ _ENTRIES: dict[str, tuple[str, str]] = {
 class _TableEntrySpec:
     label: str
     endpoint: str
+    archive_member: str
     revision: str
     source_page: str
     millesime: str
@@ -79,6 +80,7 @@ _TABLE_ENTRIES: dict[str, _TableEntrySpec] = {
     "iris_population_2022": _TableEntrySpec(
         label="IRIS — population 2022",
         endpoint=f"{_INSEE_FILE_BASE}/8647014/base-ic-evol-struct-pop-2022_csv.zip",
+        archive_member="base-ic-evol-struct-pop-2022.CSV",
         revision="insee-rp-iris-population-2022-geo-2024-01-01",
         source_page="https://www.insee.fr/fr/statistiques/8647014",
         millesime="2022",
@@ -97,6 +99,7 @@ _TABLE_ENTRIES: dict[str, _TableEntrySpec] = {
     "iris_logement_2022": _TableEntrySpec(
         label="IRIS — logement 2022",
         endpoint=f"{_INSEE_FILE_BASE}/8647012/base-ic-logement-2022_csv.zip",
+        archive_member="base-ic-logement-2022.CSV",
         revision="insee-rp-iris-logement-2022-geo-2024-01-01",
         source_page="https://www.insee.fr/fr/statistiques/8647012",
         millesime="2022",
@@ -116,6 +119,7 @@ _TABLE_ENTRIES: dict[str, _TableEntrySpec] = {
             f"{_INSEE_FILE_BASE}/8647008/"
             "base-ic-couples-familles-menages-2022_csv.zip"
         ),
+        archive_member="base-ic-couples-familles-menages-2022.CSV",
         revision="insee-rp-iris-menages-2022-geo-2024-01-01",
         source_page="https://www.insee.fr/fr/statistiques/8647008",
         millesime="2022",
@@ -131,6 +135,7 @@ _TABLE_ENTRIES: dict[str, _TableEntrySpec] = {
     "iris_activite_2022": _TableEntrySpec(
         label="IRIS — activite des residents 2022",
         endpoint=f"{_INSEE_FILE_BASE}/8647006/base-ic-activite-residents-2022_csv.zip",
+        archive_member="base-ic-activite-residents-2022.CSV",
         revision="insee-rp-iris-activite-2022-geo-2024-01-01",
         source_page="https://www.insee.fr/fr/statistiques/8647006",
         millesime="2022",
@@ -145,6 +150,7 @@ _TABLE_ENTRIES: dict[str, _TableEntrySpec] = {
     "iris_diplomes_2022": _TableEntrySpec(
         label="IRIS — diplomes et formation 2022",
         endpoint=f"{_INSEE_FILE_BASE}/8647010/base-ic-diplomes-formation-2022_csv.zip",
+        archive_member="base-ic-diplomes-formation-2022.CSV",
         revision="insee-rp-iris-diplomes-2022-geo-2024-01-01",
         source_page="https://www.insee.fr/fr/statistiques/8647010",
         millesime="2022",
@@ -159,6 +165,7 @@ _TABLE_ENTRIES: dict[str, _TableEntrySpec] = {
     "iris_filosofi_revenus_declares_2021": _TableEntrySpec(
         label="IRIS — Filosofi revenus declares 2021",
         endpoint=f"{_INSEE_FILE_BASE}/8229323/BASE_TD_FILO_IRIS_2021_DEC_CSV.zip",
+        archive_member="BASE_TD_FILO_IRIS_2021_DEC.csv",
         revision="insee-filosofi-iris-revenus-declares-2021-geo-2022-01-01",
         source_page="https://www.insee.fr/fr/statistiques/8229323",
         millesime="2021",
@@ -173,6 +180,7 @@ _TABLE_ENTRIES: dict[str, _TableEntrySpec] = {
     "iris_filosofi_revenus_disponibles_2021": _TableEntrySpec(
         label="IRIS — Filosofi revenus disponibles 2021",
         endpoint=f"{_INSEE_FILE_BASE}/8229323/BASE_TD_FILO_IRIS_2021_DISP_CSV.zip",
+        archive_member="BASE_TD_FILO_IRIS_2021_DISP.csv",
         revision="insee-filosofi-iris-revenus-disponibles-2021-geo-2022-01-01",
         source_page="https://www.insee.fr/fr/statistiques/8229323",
         millesime="2021",
@@ -279,7 +287,11 @@ class InseeSource(DeclarativeSource):
                 access=AccessSpec(
                     protocol=AccessProtocol.TABLE_FILE,
                     endpoint=spec.endpoint,
-                    params={"archive_format": "zip", "table_format": "csv"},
+                    params={
+                        "archive_format": "zip",
+                        "table_format": "csv",
+                        "archive_member": spec.archive_member,
+                    },
                     format="application/zip",
                 ),
                 revision_token=spec.revision,
@@ -295,6 +307,7 @@ class InseeSource(DeclarativeSource):
                     "geography_date": spec.geography_date,
                     "source_page": spec.source_page,
                     "archive_format": "zip",
+                    "archive_member": spec.archive_member,
                     "table_format": "csv",
                 },
             )

--- a/src/gispulse/core/bulk_runner.py
+++ b/src/gispulse/core/bulk_runner.py
@@ -1045,7 +1045,16 @@ def _table_file_scan(table_path: Path, access: AccessSpec) -> str:
         )
     uri = str(table_path)
     if _is_table_zip(access):
-        member = str(access.params.get("archive_member", "*.csv")).lstrip("/")
+        raw_member = access.params.get("archive_member")
+        if not raw_member:
+            raise ValueError(
+                "TABLE_FILE zip archives require access.params.archive_member"
+            )
+        member = str(raw_member).lstrip("/")
+        if not member or "*" in member:
+            raise ValueError(
+                "TABLE_FILE zip archive_member must name one concrete member"
+            )
         uri = f"/vsizip/{uri}/{member}"
     return f"read_csv_auto({_sql_literal(uri)})"
 

--- a/src/gispulse/core/fetchers/table_file.py
+++ b/src/gispulse/core/fetchers/table_file.py
@@ -32,8 +32,26 @@ def _vsicurl(endpoint: str) -> str:
 
 
 def _metadata(access: AccessSpec) -> dict[str, str]:
-    keys = ("archive_format", "table_format")
+    keys = ("archive_format", "archive_member", "table_format")
     return {key: str(access.params[key]) for key in keys if key in access.params}
+
+
+def _sql_literal(value: object) -> str:
+    return "'" + str(value).replace("'", "''") + "'"
+
+
+def _archive_member(access: AccessSpec) -> str:
+    raw_member = access.params.get("archive_member")
+    if not raw_member:
+        raise ValueError(
+            "TABLE_FILE zip archives require access.params.archive_member"
+        )
+    member = str(raw_member).lstrip("/")
+    if not member or "*" in member:
+        raise ValueError(
+            "TABLE_FILE zip archive_member must name one concrete member"
+        )
+    return member
 
 
 class TableFileFetcher(LazyFetcher):
@@ -63,24 +81,24 @@ class TableFileFetcher(LazyFetcher):
 
     @staticmethod
     def _table_uri(access: AccessSpec) -> str:
-        uri = _vsicurl(access.endpoint).replace("'", "''")
+        uri = _vsicurl(access.endpoint)
         if TableFileFetcher._is_zip(access):
-            member = str(access.params.get("archive_member", "*.csv")).lstrip("/")
+            member = _archive_member(access)
             return f"/vsizip/{uri}/{member}"
         return uri
 
     def _reference_scan(self, access: AccessSpec, extent: Any | None) -> str:
         """Lazy scan for CSV tables.
 
-        ZIP archives use GDAL's ``/vsizip/`` virtual path and default to all
-        CSV members. Callers can narrow the member path via ``archive_member``.
+        ZIP archives use GDAL's ``/vsizip/`` virtual path and require
+        ``archive_member`` so multiple CSV members are never read silently.
         """
         if not self._is_csv(access):
             raise NotImplementedError(
                 "TABLE_FILE reference mode currently supports plain CSV files only"
             )
         uri = self._table_uri(access)
-        return f"read_csv_auto('{uri}')"
+        return f"read_csv_auto({_sql_literal(uri)})"
 
     def _materialize(self, access: AccessSpec, extent: Any | None) -> SourceResult:
         """Return a table file path, or write a parsed Parquet copy to S3."""

--- a/tests/unit/test_bulk_runner.py
+++ b/tests/unit/test_bulk_runner.py
@@ -199,6 +199,41 @@ def test_runner_materializes_table_file_entry_to_stage_s3_key(
     assert result.fetch_result.reference == result.manifest["stage_s3_uri"]
 
 
+def test_runner_rejects_zip_table_file_without_archive_member(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gispulse.core.bulk_runner import BulkIngestRunner
+
+    _patch_duckdb(monkeypatch)
+    fetcher = _FakeTableFetcher()
+    registry = ProtocolRegistry()
+    registry.register(fetcher)
+    source = _StaticSource(
+        SourceEntryRef(
+            id="gaspar-bulk",
+            name="GASPAR bulk",
+            access=AccessSpec(
+                protocol=AccessProtocol.TABLE_FILE,
+                endpoint="https://host.example.org/gaspar.zip",
+                params={"archive_format": "zip", "table_format": "csv"},
+            ),
+            payload=Payload.TABLE,
+            metadata={"base_key": "gaspar", "data_format": "csv"},
+        ),
+        registry=registry,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="TABLE_FILE zip archives require access.params.archive_member",
+    ):
+        BulkIngestRunner(registry=registry).run_entry(
+            source,
+            "gaspar-bulk",
+            revision="gaspar-2026",
+        )
+
+
 def test_runner_can_prefix_and_upload_raw_table_file_entry(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_src_georisques.py
+++ b/tests/unit/test_src_georisques.py
@@ -134,6 +134,7 @@ def test_table_bulk_entries_use_table_file_and_keep_georisques_metadata(
     assert by_id["gaspar-bulk"].access.params == {
         "archive_format": "zip",
         "table_format": "csv",
+        "archive_member": "risq_gaspar.csv",
     }
     assert by_id["gaspar-bulk"].payload is Payload.TABLE
     assert by_id["gaspar-bulk"].metadata["base_key"] == "gaspar"

--- a/tests/unit/test_src_insee.py
+++ b/tests/unit/test_src_insee.py
@@ -208,6 +208,8 @@ def test_iris_sociodemo_entries_are_table_files(source) -> None:
         )
         assert entry.access.params["archive_format"] == "zip"
         assert entry.access.params["table_format"] == "csv"
+        assert entry.access.params["archive_member"].lower().endswith(".csv")
+        assert entry.metadata["archive_member"] == entry.access.params["archive_member"]
 
 
 def test_iris_sociodemo_entries_keep_official_download_urls(source) -> None:

--- a/tests/unit/test_table_file_fetcher.py
+++ b/tests/unit/test_table_file_fetcher.py
@@ -38,20 +38,33 @@ def test_reference_scan_plain_csv_uses_duckdb_read_csv() -> None:
     )
 
 
-def test_reference_scan_zip_csv_uses_duckdb_read_csv() -> None:
-    result = TableFileFetcher().virtual_table(
-        _access(
-            "https://host.example.org/iris_csv.zip",
-            archive_format="zip",
-            table_format="csv",
+def test_reference_scan_zip_csv_requires_explicit_archive_member() -> None:
+    with pytest.raises(
+        ValueError,
+        match="TABLE_FILE zip archives require access.params.archive_member",
+    ):
+        TableFileFetcher().virtual_table(
+            _access(
+                "https://host.example.org/iris_csv.zip",
+                archive_format="zip",
+                table_format="csv",
+            )
         )
-    )
 
-    assert result.payload is Payload.TABLE
-    assert result.mode is FetchMode.REFERENCE
-    assert result.metadata[DUCKDB_SCAN_KEY] == (
-        "read_csv_auto('/vsizip//vsicurl/https://host.example.org/iris_csv.zip/*.csv')"
-    )
+
+def test_reference_scan_zip_csv_rejects_wildcard_archive_member() -> None:
+    with pytest.raises(
+        ValueError,
+        match="TABLE_FILE zip archive_member must name one concrete member",
+    ):
+        TableFileFetcher().virtual_table(
+            _access(
+                "https://host.example.org/iris_csv.zip",
+                archive_format="zip",
+                table_format="csv",
+                archive_member="*.csv",
+            )
+        )
 
 
 def test_reference_scan_zip_csv_can_target_archive_member() -> None:
@@ -67,6 +80,22 @@ def test_reference_scan_zip_csv_can_target_archive_member() -> None:
     assert result.metadata[DUCKDB_SCAN_KEY] == (
         "read_csv_auto("
         "'/vsizip//vsicurl/https://host.example.org/iris_csv.zip/tables/iris.csv')"
+    )
+
+
+def test_reference_scan_zip_csv_escapes_archive_member_sql_literal() -> None:
+    result = TableFileFetcher().virtual_table(
+        _access(
+            "https://host.example.org/iris_csv.zip",
+            archive_format="zip",
+            table_format="csv",
+            archive_member="tables/l'iris.csv",
+        )
+    )
+
+    assert result.metadata[DUCKDB_SCAN_KEY] == (
+        "read_csv_auto("
+        "'/vsizip//vsicurl/https://host.example.org/iris_csv.zip/tables/l''iris.csv')"
     )
 
 


### PR DESCRIPTION
## Summary
- require TABLE_FILE ZIP sources to declare a concrete archive_member instead of silently scanning *.csv
- add explicit CSV members for INSEE IRIS table ZIPs and Georisques GASPAR bulk
- apply the same guard in the N3 bulk runner and keep TABLE_FILE S3 materialization intact
- escape the generated DuckDB SQL literal for ZIP member paths

## Why
PR #356 is obsolete as a branch, but it surfaced one valid issue: ZIP TABLE_FILE scans should not silently read an arbitrary CSV member. This isolates that hardening on top of current main without reintroducing the old branch.

## Validation
- .venv/bin/pytest tests/unit/test_table_file_fetcher.py tests/unit/test_bulk_runner.py tests/unit/test_src_insee.py tests/unit/test_src_georisques.py -q
- .venv/bin/pytest tests/unit/test_src_bdnb.py tests/unit/test_src_ban.py tests/unit/test_src_loyers.py tests/unit/test_src_rnb.py tests/unit/test_n3_smoke.py -q
- .venv/bin/ruff check src/gispulse/core/fetchers/table_file.py src/gispulse/core/bulk_runner.py plugins/gispulse-src-insee/gispulse_src_insee/source.py plugins/gispulse-src-georisques/gispulse_src_georisques/source.py tests/unit/test_table_file_fetcher.py tests/unit/test_bulk_runner.py tests/unit/test_src_insee.py tests/unit/test_src_georisques.py
- git diff --check