### PR TITLE
fix(plugins): statbel-be corrections (materialize_only, payload, schema)

### DIFF
--- a/plugins/gispulse-src-statbel-be/gispulse_src_statbel_be/source.py
+++ b/plugins/gispulse-src-statbel-be/gispulse_src_statbel_be/source.py
@@ -7,7 +7,10 @@ has (``schema()``). Core fetchers own the network code.
 
 Geometry entries use ``AccessProtocol.DOWNLOAD`` (``HttpFileFetcher``).
 Indicator entries also use ``DOWNLOAD`` — the upstream files are
-delimited-text (TXT/CSV) or XLSX joined to the sector code.
+ZIP-wrapped delimited text or XLSX joined to the sector code. They are
+declared ``Payload.TABLE``, but the current ``HttpFileFetcher`` materializes
+DOWNLOAD entries as ``Payload.VECTOR`` and cannot scan ZIP/XLSX tabular
+members. Downstream pipelines must decompress/parse these table files.
 
 CRS note
 --------
@@ -20,9 +23,9 @@ URL status
 All URLs are the canonical Statbel open-data landing pages or their
 direct-download variants as of June 2026.  Some direct-download URLs may
 change between Statbel publication cycles.  Where the exact file URL was
-uncertain, the dataset landing-page URL is used together with a comment
-``# URL directe à vérifier``.  Maintainers should validate these URLs
-against https://statbel.fgov.be/fr/open-data before each release.
+uncertain, entry metadata carries the official dataset landing page as a
+fallback. Maintainers should validate these URLs against
+https://statbel.fgov.be/fr/open-data before each release.
 """
 
 from __future__ import annotations
@@ -45,6 +48,7 @@ from gispulse.plugins.api import (
 # NOTE: Statbel publishes a new millésime each year; the URL below points to
 # the 2023 release.  Check https://statbel.fgov.be/fr/open-data/secteurs-statistiques
 # for the latest vintage.
+_SECTORS_LANDING_URL = "https://statbel.fgov.be/fr/open-data/secteurs-statistiques"
 _SECTORS_GEOJSON_URL = (
     "https://statbel.fgov.be/sites/default/files/files/opendata/statbel/"
     "secteurs-statistiques/sh_statbel_statistical_sectors_20230101.geojson"
@@ -54,6 +58,9 @@ _SECTORS_GEOJSON_URL = (
 
 # Population by statistical sector (TXT, delimiter "|")
 # Landing: https://statbel.fgov.be/fr/open-data/population-par-secteur-statistique
+_POPULATION_LANDING_URL = (
+    "https://statbel.fgov.be/fr/open-data/population-par-secteur-statistique"
+)
 _POPULATION_URL = (
     "https://statbel.fgov.be/sites/default/files/files/opendata/pop/"
     "TF_SOC_POP_STRUCT_2022.zip"
@@ -63,6 +70,9 @@ _POPULATION_URL = (
 
 # Households by statistical sector (TXT, delimiter "|")
 # Landing: https://statbel.fgov.be/fr/open-data/menages-par-secteur-statistique
+_HOUSEHOLDS_LANDING_URL = (
+    "https://statbel.fgov.be/fr/open-data/menages-par-secteur-statistique"
+)
 _HOUSEHOLDS_URL = (
     "https://statbel.fgov.be/sites/default/files/files/opendata/menages/"
     "TF_SOC_MENAGES_2022.zip"
@@ -72,6 +82,9 @@ _HOUSEHOLDS_URL = (
 
 # Average income by statistical sector (TXT, delimiter "|")
 # Landing: https://statbel.fgov.be/fr/open-data/revenus-par-secteur-statistique
+_INCOME_LANDING_URL = (
+    "https://statbel.fgov.be/fr/open-data/revenus-fiscaux-par-secteur-statistique"
+)
 _INCOME_URL = (
     "https://statbel.fgov.be/sites/default/files/files/opendata/revenu/"
     "TF_INCOME_2021_SS.zip"
@@ -81,6 +94,9 @@ _INCOME_URL = (
 
 # Car fleet by statistical sector (TXT, delimiter "|")
 # Landing: https://statbel.fgov.be/fr/open-data/parc-automobile-par-secteur-statistique
+_CARS_LANDING_URL = (
+    "https://statbel.fgov.be/fr/open-data/parc-automobile-par-secteur-statistique"
+)
 _CARS_URL = (
     "https://statbel.fgov.be/sites/default/files/files/opendata/vehicles/"
     "TF_VEHICLES_SS_2023.zip"
@@ -91,6 +107,7 @@ _CARS_URL = (
 # Building permits by municipality (XLSX) — Statbel does not publish permits
 # at sector level; the finest grain is municipality (NIS code).
 # Landing: https://statbel.fgov.be/fr/open-data/permis-de-batir
+_PERMITS_LANDING_URL = "https://statbel.fgov.be/fr/open-data/permis-de-batir"
 _PERMITS_URL = (
     "https://statbel.fgov.be/sites/default/files/files/opendata/permits/"
     "TF_PERM_BUILDING.xlsx"
@@ -104,6 +121,24 @@ _PROVIDER_META = {
     "jurisdiction": "BE",
     "join_key": "cd_sector",
     "crs": "EPSG:31370",  # Belgian Lambert 72 — for geometry entries
+}
+
+# Current core limitation: HttpFileFetcher scans vector-like file formats only
+# and returns Payload.VECTOR even when a plugin entry is declared Payload.TABLE.
+# TODO(core): teach DOWNLOAD table materialization to return Payload.TABLE for
+# ZIP/XLSX tabular inputs, including ZIP member selection. A related ZIP harden
+# branch exists at codex/harden-table-file-zip-members; this plugin does not
+# depend on it.
+_TABLE_DOWNLOAD_CORE_LIMIT_META = {
+    "fetch_mode": "materialize_only",
+    "fetch_doc": (
+        "Direct ZIP/XLSX table downloads are materialized only; decompression "
+        "and parsing are the responsibility of the downstream pipeline."
+    ),
+    "payload_note": (
+        "Declared as Payload.TABLE for the plugin contract, but the current "
+        "core HttpFileFetcher returns Payload.VECTOR for DOWNLOAD results."
+    ),
 }
 
 # ---------------------------------------------------------------------------
@@ -128,9 +163,11 @@ _ENTRIES: dict[str, dict] = {
             "dataset": "secteurs-statistiques",
             "geometry_key": "geometry",
             "sector_code_key": "cd_sector",
+            "landing_page_url": _SECTORS_LANDING_URL,
+            "fallback_url": _SECTORS_LANDING_URL,
             "note": (
                 "Annual vintage — check landing page for latest release: "
-                "https://statbel.fgov.be/fr/open-data/secteurs-statistiques"
+                f"{_SECTORS_LANDING_URL}"
             ),
         },
     },
@@ -148,8 +185,11 @@ _ENTRIES: dict[str, dict] = {
         ),
         "metadata": {
             **_PROVIDER_META,
+            **_TABLE_DOWNLOAD_CORE_LIMIT_META,
             "dataset": "population-par-secteur-statistique",
             "key_fields": ("cd_sector", "cd_sex", "cd_naty", "ms_pop"),
+            "landing_page_url": _POPULATION_LANDING_URL,
+            "fallback_url": _POPULATION_LANDING_URL,
         },
     },
     "indicators-households": {
@@ -163,8 +203,11 @@ _ENTRIES: dict[str, dict] = {
         ),
         "metadata": {
             **_PROVIDER_META,
+            **_TABLE_DOWNLOAD_CORE_LIMIT_META,
             "dataset": "menages-par-secteur-statistique",
             "key_fields": ("cd_sector", "cd_type_menage", "ms_menages"),
+            "landing_page_url": _HOUSEHOLDS_LANDING_URL,
+            "fallback_url": _HOUSEHOLDS_LANDING_URL,
         },
     },
     "indicators-income": {
@@ -178,8 +221,11 @@ _ENTRIES: dict[str, dict] = {
         ),
         "metadata": {
             **_PROVIDER_META,
+            **_TABLE_DOWNLOAD_CORE_LIMIT_META,
             "dataset": "revenus-par-secteur-statistique",
             "key_fields": ("cd_sector", "ms_mean_total_net_taxable_income", "ms_nb"),
+            "landing_page_url": _INCOME_LANDING_URL,
+            "fallback_url": _INCOME_LANDING_URL,
         },
     },
     "indicators-cars": {
@@ -193,8 +239,11 @@ _ENTRIES: dict[str, dict] = {
         ),
         "metadata": {
             **_PROVIDER_META,
+            **_TABLE_DOWNLOAD_CORE_LIMIT_META,
             "dataset": "parc-automobile-par-secteur-statistique",
             "key_fields": ("cd_sector", "cd_type_fuel", "ms_nb_vehicles"),
+            "landing_page_url": _CARS_LANDING_URL,
+            "fallback_url": _CARS_LANDING_URL,
         },
     },
     "indicators-building-permits": {
@@ -208,12 +257,15 @@ _ENTRIES: dict[str, dict] = {
         ),
         "metadata": {
             **_PROVIDER_META,
+            **_TABLE_DOWNLOAD_CORE_LIMIT_META,
             "dataset": "permis-de-batir",
             # Building permits are published at municipality (NIS) granularity,
             # not at statistical-sector level.
             "join_key": "cd_nis5",
             "key_fields": ("cd_nis5", "tx_adm_dstr_descr_fr", "ms_nb_permits"),
             "granularity": "municipality",
+            "landing_page_url": _PERMITS_LANDING_URL,
+            "fallback_url": _PERMITS_LANDING_URL,
         },
     },
 }
@@ -234,7 +286,6 @@ _SCHEMAS: dict[str, dict[str, str]] = {
         "cd_prov": "str",
         "cd_rgn_refnis": "str",
         "geometry": "geometry",
-        "crs": "EPSG:31370",
     },
     "indicators-population": {
         "cd_sector": "str",

--- a/plugins/gispulse-src-statbel-be/pyproject.toml
+++ b/plugins/gispulse-src-statbel-be/pyproject.toml
@@ -23,3 +23,4 @@ protocol = ">=1.0,<2.0"
 domain = "statistique"
 jurisdiction = "BE"
 display_name = "Statbel — Belgium open statistical data"
+urls_verified = false

--- a/tests/unit/test_src_statbel_be.py
+++ b/tests/unit/test_src_statbel_be.py
@@ -82,6 +82,7 @@ def test_pyproject_declares_statbel_be_entrypoint_and_manifest() -> None:
     assert manifest["kind"] == "source"
     assert manifest["domain"] == "statistique"
     assert manifest["jurisdiction"] == "BE"
+    assert manifest["urls_verified"] is False
 
 
 def test_register_adds_statbel_be_source_to_global_registry() -> None:
@@ -155,6 +156,9 @@ def test_sectors_contours_metadata_has_crs_and_join_key(source) -> None:
     assert meta["join_key"] == "cd_sector"
     assert meta["provider"].startswith("Statbel")
     assert meta["license"] == "Creative Commons Zero (CC0 1.0)"
+    assert meta["landing_page_url"] == (
+        "https://statbel.fgov.be/fr/open-data/secteurs-statistiques"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -181,6 +185,13 @@ def test_indicator_entry_is_table_download_keyed_by_cd_sector(
     assert entry.payload is Payload.TABLE
     assert entry.metadata["join_key"] == "cd_sector"
     assert entry.metadata["license"] == "Creative Commons Zero (CC0 1.0)"
+    assert entry.metadata["fetch_mode"] == "materialize_only"
+    assert "downstream pipeline" in entry.metadata["fetch_doc"]
+    assert "Payload.TABLE" in entry.metadata["payload_note"]
+    assert "Payload.VECTOR" in entry.metadata["payload_note"]
+    assert entry.metadata["landing_page_url"].startswith(
+        "https://statbel.fgov.be/fr/open-data/"
+    )
 
 
 def test_building_permits_is_table_keyed_by_nis5(source) -> None:
@@ -193,6 +204,35 @@ def test_building_permits_is_table_keyed_by_nis5(source) -> None:
     # Permits are at municipality level, join key differs
     assert entry.metadata["join_key"] == "cd_nis5"
     assert entry.metadata["granularity"] == "municipality"
+    assert entry.metadata["fetch_mode"] == "materialize_only"
+    assert "downstream pipeline" in entry.metadata["fetch_doc"]
+    assert "Payload.TABLE" in entry.metadata["payload_note"]
+    assert "Payload.VECTOR" in entry.metadata["payload_note"]
+    assert entry.metadata["landing_page_url"] == (
+        "https://statbel.fgov.be/fr/open-data/permis-de-batir"
+    )
+
+
+def test_table_entries_are_materialize_only_but_contours_remain_scannable(
+    source,
+) -> None:
+    entries = {entry.id: entry for entry in source.catalog()}
+    table_ids = {
+        "indicators-population",
+        "indicators-households",
+        "indicators-income",
+        "indicators-cars",
+        "indicators-building-permits",
+    }
+
+    for entry_id in table_ids:
+        assert entries[entry_id].metadata["fetch_mode"] == "materialize_only"
+
+    assert "fetch_mode" not in entries["sectors-contours"].metadata
+
+
+def test_sectors_contours_schema_does_not_include_metadata_crs(source) -> None:
+    assert "crs" not in source.schema("sectors-contours")
 
 
 # ---------------------------------------------------------------------------
@@ -224,12 +264,12 @@ def test_fetch_unknown_entry_raises(source) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_schema_sectors_contours_has_geometry_and_crs(source) -> None:
+def test_schema_sectors_contours_has_geometry_without_metadata_crs(source) -> None:
     schema = source.schema("sectors-contours")
 
     assert schema["cd_sector"] == "str"
     assert schema["geometry"] == "geometry"
-    assert schema["crs"] == "EPSG:31370"
+    assert "crs" not in schema
     assert schema["cd_nis5"] == "str"
     assert schema["tx_sector_descr_fr"] == "str"
 


### PR DESCRIPTION
## Summary
- mark Statbel ZIP/XLSX table entries as materialize_only and document downstream parsing
- document the current Payload.TABLE declaration vs HttpFileFetcher Payload.VECTOR result
- move sectors-contours CRS out of schema and into metadata only
- mark Statbel URLs as unverified in the plugin manifest and expose official landing-page fallbacks in metadata

## Checks
- uv run ruff check
- uv run pytest tests/unit/test_src_statbel_be.py -q
- uv run pytest (fails on unrelated existing config_loader/raster tests; see PR notes)