### PR TITLE
feat(provider): unified data loader + datamart & GeoNode providers (DP0–DP3)

### DIFF
--- a/docs/DATA_LOADING.md
+++ b/docs/DATA_LOADING.md
@@ -1,0 +1,85 @@
+# Data loading — `gispulse.load` & `gispulse.publish`
+
+GISPulse reads **any supported source** behind a single verb and returns a
+plain `GeoDataFrame`, so every capability runs on the result unchanged:
+
+```python
+import gispulse
+
+gdf = gispulse.load("data/parcels.parquet")
+out = gispulse.apply("buffer", gdf, distance=25.0)
+```
+
+`load` reconciles the three reading paths the engine already owned —
+local files, remote protocol sources, and lazy DuckDB scans — and
+normalises their heterogeneous results into one GeoDataFrame.
+
+## Sources
+
+| Form | Example | Resolves to |
+|------|---------|-------------|
+| Local file | `load("parcels.gpkg")`, `load("x.parquet")` | `read_vector` (GPKG, GeoJSON, GeoParquet w/ bbox, Shapefile, FlatGeobuf, CSV, XLSX, KMZ, …) |
+| Remote table | `load("s3://bucket/x.parquet")`, `load("https://h/x.fgb")` | `remote-table` fetcher (DuckDB scan) |
+| Remote file | `load("https://h/export.geojson")` | `download` fetcher |
+| OGC / WFS / STAC | `load("ogc-features://h/collections/x")`, `load("wfs://h/wfs")` | the matching protocol fetcher |
+| Datamart | `load("datamart://ref/parcels")` | a curated table (see below) |
+| GeoNode | `load("geonode://prod/roads")` | the instance's GeoServer WFS (see below) |
+| Descriptor | `load({"protocol": "wfs", "endpoint": "https://h/wfs", "params": {...}})` | explicit `AccessSpec` |
+
+Common options: `bbox=(minx, miny, maxx, maxy)` (pushed down to the
+reader/fetcher), `layer=` (multi-layer files), `crs=` (forced when the
+source declares none), `lazy=True` (remote sources → a `LazyDataset`).
+
+### Lazy sources
+
+`load(src, lazy=True)` on a remote source returns a `LazyDataset` wrapping
+a DuckDB scan — no bytes move until you materialise:
+
+```python
+handle = gispulse.load("s3://bucket/huge.parquet", lazy=True)
+gdf = handle.to_geodataframe(bbox=(2.2, 48.8, 2.5, 48.9))  # only the rows in the bbox
+gispulse.apply("cluster_dbscan", gdf, eps=100.0)
+```
+
+## Datamarts
+
+A **datamart** is a named collection of curated Parquet/GeoParquet tables
+(local, S3 or HTTP) scanned by DuckDB. It adds a naming indirection so
+pipelines reference stable logical names instead of storage paths:
+
+```python
+from gispulse.persistence.datamart import DATAMARTS, Datamart
+
+DATAMARTS.register(Datamart(name="ref", location="s3://bucket/marts/ref"))
+gispulse.load("datamart://ref/parcels")          # → s3://bucket/marts/ref/parcels.parquet
+```
+
+Or declare them with `GISPULSE_DATAMARTS` (JSON):
+
+```bash
+export GISPULSE_DATAMARTS='{"ref": {"location": "s3://bucket/marts/ref"}}'
+```
+
+## GeoNode (read + write)
+
+GeoNode datasets are addressed as `geonode://<instance>/<dataset>`.
+
+**Read** resolves to the instance's GeoServer WFS endpoint:
+
+```python
+from gispulse.persistence.geonode import GEONODES, GeoNode
+
+GEONODES.register(GeoNode(name="prod", host="https://geo.example.org"))
+gispulse.load("geonode://prod/roads", bbox=(2.2, 48.8, 2.5, 48.9))
+```
+
+An unregistered authority is treated as a bare host with default paths, so
+`load("geonode://geo.example.org/roads")` works without prior declaration.
+Instances can also be declared via `GISPULSE_GEONODE` (JSON).
+
+**Write** packages a GeoDataFrame as a GeoPackage and uploads it through
+the GeoNode REST API v2:
+
+```python
+gispulse.publish(result, "geonode://prod/roads", auth="<token>")
+```

--- a/src/gispulse/__init__.py
+++ b/src/gispulse/__init__.py
@@ -31,10 +31,10 @@ from gispulse import _compat as _compat
 
 _compat.install()
 
-__all__ = ["__version__", "GISPulseApp", "get_app", "apply", "run"]
+__all__ = ["__version__", "GISPulseApp", "get_app", "apply", "load", "run"]
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
-    from gispulse.app import GISPulseApp, apply, get_app, run
+    from gispulse.app import GISPulseApp, apply, get_app, load, run
 
 
 def __getattr__(name: str):
@@ -43,7 +43,7 @@ def __getattr__(name: str):
     Keeps ``import gispulse`` free of heavy imports — ``gispulse.app`` and
     its subsystems are pulled only when the façade is first accessed.
     """
-    if name in {"GISPulseApp", "get_app", "apply", "run"}:
+    if name in {"GISPulseApp", "get_app", "apply", "load", "run"}:
         from gispulse import app as _app
 
         return getattr(_app, name)

--- a/src/gispulse/__init__.py
+++ b/src/gispulse/__init__.py
@@ -31,10 +31,18 @@ from gispulse import _compat as _compat
 
 _compat.install()
 
-__all__ = ["__version__", "GISPulseApp", "get_app", "apply", "load", "run"]
+__all__ = [
+    "__version__",
+    "GISPulseApp",
+    "get_app",
+    "apply",
+    "load",
+    "publish",
+    "run",
+]
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
-    from gispulse.app import GISPulseApp, apply, get_app, load, run
+    from gispulse.app import GISPulseApp, apply, get_app, load, publish, run
 
 
 def __getattr__(name: str):
@@ -43,7 +51,7 @@ def __getattr__(name: str):
     Keeps ``import gispulse`` free of heavy imports — ``gispulse.app`` and
     its subsystems are pulled only when the façade is first accessed.
     """
-    if name in {"GISPulseApp", "get_app", "apply", "load", "run"}:
+    if name in {"GISPulseApp", "get_app", "apply", "load", "publish", "run"}:
         from gispulse import app as _app
 
         return getattr(_app, name)

--- a/src/gispulse/app.py
+++ b/src/gispulse/app.py
@@ -150,6 +150,44 @@ class GISPulseApp:
     # ------------------------------------------------------------------
     # Datasets
     # ------------------------------------------------------------------
+    def load(
+        self,
+        source: "str | Path | Any",
+        *,
+        bbox: "tuple[float, float, float, float] | None" = None,
+        layer: str | None = None,
+        lazy: bool = False,
+        crs: str | None = None,
+        **opts: Any,
+    ) -> "gpd.GeoDataFrame | Any":
+        """Load any supported source into a GeoDataFrame.
+
+        The unified entry point over every reader GISPulse owns — local
+        files (GeoPackage, GeoJSON, GeoParquet, Shapefile, …) and remote
+        protocol sources (GeoParquet on S3/HTTP, OGC API Features, WFS,
+        STAC, …). The result is a plain GeoDataFrame, so any capability
+        runs on it directly: ``app.apply(verb, app.load(src), ...)``.
+
+        Args:
+            source: A path, a ``s3://`` / ``https://`` / named-protocol
+                URI, an :class:`~gispulse.core.plugin_model.AccessSpec`,
+                or an access-descriptor ``dict``.
+            bbox:   Spatial filter ``(minx, miny, maxx, maxy)`` pushed
+                    down to the reader/fetcher when supported.
+            layer:  Layer name for multi-layer file formats.
+            lazy:   Return a :class:`~gispulse.persistence.loader.LazyDataset`
+                    handle for remote sources instead of materialising.
+            crs:    Force this CRS when the source declares none.
+            **opts: Extra options forwarded to the underlying reader.
+
+        Returns:
+            A GeoDataFrame, or a ``LazyDataset`` when ``lazy=True`` on a
+            remote source.
+        """
+        from gispulse.persistence.loader import load as _load
+
+        return _load(source, bbox=bbox, layer=layer, lazy=lazy, crs=crs, **opts)
+
     def load_dataset(
         self, path: "str | Path", layer: str | None = None
     ) -> "gpd.GeoDataFrame":
@@ -535,4 +573,19 @@ def run(
     return get_app().run_pipeline(spec, inputs, params)
 
 
-__all__ = ["GISPulseApp", "get_app", "apply", "run"]
+def load(
+    source: "str | Path | Any",
+    *,
+    bbox: "tuple[float, float, float, float] | None" = None,
+    layer: str | None = None,
+    lazy: bool = False,
+    crs: str | None = None,
+    **opts: Any,
+) -> "gpd.GeoDataFrame | Any":
+    """Load any supported source — shortcut for ``get_app().load``."""
+    return get_app().load(
+        source, bbox=bbox, layer=layer, lazy=lazy, crs=crs, **opts
+    )
+
+
+__all__ = ["GISPulseApp", "get_app", "apply", "load", "run"]

--- a/src/gispulse/app.py
+++ b/src/gispulse/app.py
@@ -188,6 +188,40 @@ class GISPulseApp:
 
         return _load(source, bbox=bbox, layer=layer, lazy=lazy, crs=crs, **opts)
 
+    def publish(
+        self,
+        gdf: "gpd.GeoDataFrame",
+        target: str,
+        *,
+        auth: str | None = None,
+        overwrite: bool = True,
+        **opts: Any,
+    ) -> dict:
+        """Publish a GeoDataFrame to a writable destination.
+
+        Currently supports GeoNode (``geonode://<instance>/<dataset>``),
+        the write counterpart of :meth:`load`. The frame is packaged and
+        uploaded through the destination's native publish API.
+
+        Args:
+            gdf:       The GeoDataFrame to publish.
+            target:    Destination URI (``geonode://…``).
+            auth:      Credential/token; falls back to the instance config.
+            overwrite: Replace an existing dataset of the same name.
+            **opts:    Extra options forwarded to the writer.
+
+        Returns:
+            The writer's response payload.
+        """
+        from gispulse.persistence.geonode import GEONODE_SCHEME, publish as _publish
+
+        if str(target).partition("://")[0].lower() == GEONODE_SCHEME:
+            return _publish(gdf, target, auth=auth, overwrite=overwrite, **opts)
+        raise ValueError(
+            f"unsupported publish target {target!r}; "
+            "supported schemes: geonode://"
+        )
+
     def load_dataset(
         self, path: "str | Path", layer: str | None = None
     ) -> "gpd.GeoDataFrame":
@@ -588,4 +622,18 @@ def load(
     )
 
 
-__all__ = ["GISPulseApp", "get_app", "apply", "load", "run"]
+def publish(
+    gdf: "gpd.GeoDataFrame",
+    target: str,
+    *,
+    auth: str | None = None,
+    overwrite: bool = True,
+    **opts: Any,
+) -> dict:
+    """Publish a GeoDataFrame — shortcut for ``get_app().publish``."""
+    return get_app().publish(
+        gdf, target, auth=auth, overwrite=overwrite, **opts
+    )
+
+
+__all__ = ["GISPulseApp", "get_app", "apply", "load", "publish", "run"]

--- a/src/gispulse/persistence/datamart.py
+++ b/src/gispulse/persistence/datamart.py
@@ -1,0 +1,184 @@
+"""Datamart provider — named, curated table stores addressable by URI.
+
+DP2 of the *generic data provider* track. A *datamart* is a named
+collection of curated tables backed by Parquet/GeoParquet (local, S3 or
+HTTP), scanned by DuckDB. It adds a thin **naming indirection** on top of
+:func:`gispulse.persistence.loader.load`:
+
+    datamart://<mart>/<table>
+
+resolves a logical ``(mart, table)`` pair to a concrete source URI through
+a :class:`DatamartRegistry`, so pipelines reference stable logical names
+(``datamart://referentiel/parcelles``) instead of hard-coded storage
+paths. Because resolution yields an ordinary source the loader already
+understands, every capability runs on the result unchanged and bbox
+push-down still applies.
+
+Marts are declared programmatically (:meth:`DatamartRegistry.register`) or
+from the ``GISPULSE_DATAMARTS`` environment variable (a JSON object), e.g.::
+
+    GISPULSE_DATAMARTS='{
+      "referentiel": {"location": "s3://bucket/marts/referentiel"},
+      "local": {"location": "/data/marts/local", "table_pattern": "{table}.parquet"}
+    }'
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from dataclasses import dataclass, field
+from typing import Any
+
+from gispulse.core.logging import get_logger
+
+log = get_logger(__name__)
+
+#: Environment variable carrying a JSON map of datamart declarations.
+DATAMARTS_ENV = "GISPULSE_DATAMARTS"
+
+#: URI scheme that addresses a datamart table.
+DATAMART_SCHEME = "datamart"
+
+
+@dataclass(frozen=True)
+class Datamart:
+    """Declaration of one curated table store.
+
+    Args:
+        name:          Logical mart name used in ``datamart://<name>/…``.
+        location:      Base location of the tables — a directory path or
+                       an ``s3://`` / ``https://`` prefix. Joined with
+                       ``table_pattern`` to address a single table.
+        table_pattern: Filename pattern for a table, ``{table}`` being the
+                       table name. Defaults to ``"{table}.parquet"``.
+        crs:           Optional CRS to force on tables that declare none.
+        metadata:      Free-form descriptive metadata.
+    """
+
+    name: str
+    location: str
+    table_pattern: str = "{table}.parquet"
+    crs: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def uri_for(self, table: str) -> str:
+        """Return the concrete source URI for *table* in this mart."""
+        if not table:
+            raise ValueError(f"datamart '{self.name}': empty table name")
+        filename = self.table_pattern.format(table=table)
+        base = self.location.rstrip("/")
+        return f"{base}/{filename}"
+
+
+class DatamartRegistry:
+    """Thread-safe registry of declared :class:`Datamart` stores."""
+
+    def __init__(self) -> None:
+        self._marts: dict[str, Datamart] = {}
+        self._lock = threading.Lock()
+        self._env_loaded = False
+
+    def register(self, mart: Datamart, *, override: bool = False) -> None:
+        """Record *mart* under its name (raises on a taken slot unless override)."""
+        with self._lock:
+            if mart.name in self._marts and not override:
+                raise ValueError(
+                    f"datamart '{mart.name}' already registered; "
+                    f"pass override=True to replace"
+                )
+            self._marts[mart.name] = mart
+        log.debug("datamart_registered", name=mart.name, location=mart.location)
+
+    def get(self, name: str) -> Datamart:
+        """Return the mart registered as *name* or raise ``KeyError``."""
+        self._ensure_env_loaded()
+        try:
+            return self._marts[name]
+        except KeyError:
+            raise KeyError(
+                f"no datamart named {name!r} is registered "
+                f"(available: {', '.join(self.names()) or 'none'}); "
+                f"declare it via DatamartRegistry.register or {DATAMARTS_ENV}"
+            ) from None
+
+    def names(self) -> list[str]:
+        return sorted(self._marts)
+
+    def clear(self) -> None:
+        """Drop every declaration and reset env loading — used by tests."""
+        with self._lock:
+            self._marts.clear()
+            self._env_loaded = False
+
+    def resolve(self, mart_name: str, table: str) -> str:
+        """Resolve ``(mart, table)`` to a concrete source URI."""
+        return self.get(mart_name).uri_for(table)
+
+    def _ensure_env_loaded(self) -> None:
+        """Lazily merge ``GISPULSE_DATAMARTS`` declarations (env never overrides)."""
+        if self._env_loaded:
+            return
+        with self._lock:
+            if self._env_loaded:
+                return
+            self._env_loaded = True
+            raw = os.environ.get(DATAMARTS_ENV, "").strip()
+            if not raw:
+                return
+            try:
+                decls = json.loads(raw)
+            except json.JSONDecodeError as exc:
+                log.warning("datamart_env_invalid_json", error=str(exc))
+                return
+            if not isinstance(decls, dict):
+                log.warning("datamart_env_not_object", got=type(decls).__name__)
+                return
+            for name, spec in decls.items():
+                if name in self._marts:  # explicit registration wins
+                    continue
+                if not isinstance(spec, dict) or "location" not in spec:
+                    log.warning("datamart_env_bad_decl", name=name)
+                    continue
+                self._marts[name] = Datamart(
+                    name=name,
+                    location=str(spec["location"]),
+                    table_pattern=str(spec.get("table_pattern", "{table}.parquet")),
+                    crs=spec.get("crs"),
+                    metadata=dict(spec.get("metadata") or {}),
+                )
+
+
+def parse_datamart_uri(uri: str) -> tuple[str, str]:
+    """Split ``datamart://<mart>/<table>`` into ``(mart, table)``.
+
+    The table part may itself contain slashes (nested layout); it is kept
+    verbatim after the first path separator.
+
+    Raises:
+        ValueError: if *uri* is not a well-formed datamart URI.
+    """
+    scheme, sep, rest = uri.partition("://")
+    if not sep or scheme.lower() != DATAMART_SCHEME:
+        raise ValueError(f"not a datamart URI: {uri!r}")
+    mart, slash, table = rest.partition("/")
+    if not mart or not slash or not table:
+        raise ValueError(
+            f"datamart URI must be 'datamart://<mart>/<table>', got {uri!r}"
+        )
+    return mart, table
+
+
+#: Process-wide datamart registry consulted by the unified loader.
+DATAMARTS = DatamartRegistry()
+
+
+__all__ = [
+    "DATAMARTS",
+    "DATAMARTS_ENV",
+    "DATAMART_SCHEME",
+    "Datamart",
+    "DatamartRegistry",
+    "parse_datamart_uri",
+]

--- a/src/gispulse/persistence/geonode.py
+++ b/src/gispulse/persistence/geonode.py
@@ -1,0 +1,287 @@
+"""GeoNode provider — read and write GeoNode-hosted datasets.
+
+DP1 of the *generic data provider* track. `GeoNode <https://geonode.org>`_
+publishes spatial datasets through an embedded GeoServer (OGC WFS/WMS) plus
+its own REST API v2. This module wires both directions behind stable URIs:
+
+    geonode://<instance>/<dataset>
+
+**Read** resolves to the instance's GeoServer **WFS** endpoint and reuses
+the existing OGC fetcher — ``gispulse.load("geonode://prod/roads")`` returns
+a GeoDataFrame with bbox push-down, no GeoNode-specific transport code.
+
+**Write** (:func:`publish`) packages a GeoDataFrame as a GeoPackage and
+uploads it through the GeoNode **REST API v2 uploads** endpoint, creating or
+replacing the dataset.
+
+Instances are declared programmatically (:meth:`GeoNodeRegistry.register`)
+or from the ``GISPULSE_GEONODE`` environment variable (a JSON object). When
+the URI authority is not a registered alias it is treated as a bare host
+with default paths, so ``geonode://geo.example.org/roads`` works without any
+prior declaration.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from dataclasses import dataclass, field
+from typing import Any
+
+from gispulse.core.logging import get_logger
+from gispulse.core.plugin_model import AccessProtocol, AccessSpec
+
+log = get_logger(__name__)
+
+#: Environment variable carrying a JSON map of GeoNode instance declarations.
+GEONODE_ENV = "GISPULSE_GEONODE"
+
+#: URI scheme that addresses a GeoNode dataset.
+GEONODE_SCHEME = "geonode"
+
+
+@dataclass(frozen=True)
+class GeoNode:
+    """Declaration of one GeoNode instance.
+
+    Args:
+        name:           Logical alias used in ``geonode://<name>/…``.
+        host:           Base URL of the instance (``https://geo.example.org``).
+        geoserver_path: OWS endpoint path under *host* for WFS reads.
+        workspace:      GeoServer workspace the datasets live in.
+        version:        WFS version requested.
+        crs:            CRS requested from the server.
+        upload_path:    REST API v2 uploads endpoint path for writes.
+        auth:           Token/credential name resolved by the licence layer
+                        (or a literal token); forwarded to read/write.
+        metadata:       Free-form descriptive metadata.
+    """
+
+    name: str
+    host: str
+    geoserver_path: str = "/geoserver/ows"
+    workspace: str = "geonode"
+    version: str = "2.0.0"
+    crs: str = "EPSG:4326"
+    upload_path: str = "/api/v2/uploads"
+    auth: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def wfs_endpoint(self) -> str:
+        return f"{self.host.rstrip('/')}{self.geoserver_path}"
+
+    def upload_endpoint(self) -> str:
+        return f"{self.host.rstrip('/')}{self.upload_path}"
+
+    def typename(self, dataset: str) -> str:
+        """The WFS typeName for *dataset* (``<workspace>:<dataset>`` unless qualified)."""
+        return dataset if ":" in dataset else f"{self.workspace}:{dataset}"
+
+    def read_access(self, dataset: str) -> AccessSpec:
+        """Build the read :class:`AccessSpec` for *dataset* (WFS via GeoServer)."""
+        return AccessSpec(
+            protocol=AccessProtocol.OGC_FEATURES,
+            endpoint=self.wfs_endpoint(),
+            params={
+                "collection": self.typename(dataset),
+                "source_type": "wfs",
+                "version": self.version,
+                "crs": self.crs,
+                **({"auth": self.auth} if self.auth else {}),
+            },
+        )
+
+
+class GeoNodeRegistry:
+    """Thread-safe registry of declared :class:`GeoNode` instances."""
+
+    def __init__(self) -> None:
+        self._nodes: dict[str, GeoNode] = {}
+        self._lock = threading.Lock()
+        self._env_loaded = False
+
+    def register(self, node: GeoNode, *, override: bool = False) -> None:
+        with self._lock:
+            if node.name in self._nodes and not override:
+                raise ValueError(
+                    f"geonode '{node.name}' already registered; "
+                    f"pass override=True to replace"
+                )
+            self._nodes[node.name] = node
+        log.debug("geonode_registered", name=node.name, host=node.host)
+
+    def get(self, name: str) -> GeoNode:
+        self._ensure_env_loaded()
+        try:
+            return self._nodes[name]
+        except KeyError:
+            raise KeyError(
+                f"no geonode instance named {name!r} is registered "
+                f"(available: {', '.join(self.names()) or 'none'})"
+            ) from None
+
+    def names(self) -> list[str]:
+        return sorted(self._nodes)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._nodes.clear()
+            self._env_loaded = False
+
+    def resolve(self, authority: str) -> GeoNode:
+        """Resolve a URI authority to a :class:`GeoNode`.
+
+        A registered alias wins; otherwise the authority is taken as a bare
+        host (``https://<authority>``) with default GeoServer/upload paths.
+        """
+        self._ensure_env_loaded()
+        if authority in self._nodes:
+            return self._nodes[authority]
+        host = authority if "://" in authority else f"https://{authority}"
+        return GeoNode(name=authority, host=host)
+
+    def _ensure_env_loaded(self) -> None:
+        if self._env_loaded:
+            return
+        with self._lock:
+            if self._env_loaded:
+                return
+            self._env_loaded = True
+            raw = os.environ.get(GEONODE_ENV, "").strip()
+            if not raw:
+                return
+            try:
+                decls = json.loads(raw)
+            except json.JSONDecodeError as exc:
+                log.warning("geonode_env_invalid_json", error=str(exc))
+                return
+            if not isinstance(decls, dict):
+                log.warning("geonode_env_not_object", got=type(decls).__name__)
+                return
+            for name, spec in decls.items():
+                if name in self._nodes:  # explicit registration wins
+                    continue
+                if not isinstance(spec, dict) or "host" not in spec:
+                    log.warning("geonode_env_bad_decl", name=name)
+                    continue
+                self._nodes[name] = GeoNode(
+                    name=name,
+                    host=str(spec["host"]),
+                    geoserver_path=str(spec.get("geoserver_path", "/geoserver/ows")),
+                    workspace=str(spec.get("workspace", "geonode")),
+                    version=str(spec.get("version", "2.0.0")),
+                    crs=str(spec.get("crs", "EPSG:4326")),
+                    upload_path=str(spec.get("upload_path", "/api/v2/uploads")),
+                    auth=spec.get("auth"),
+                    metadata=dict(spec.get("metadata") or {}),
+                )
+
+
+def parse_geonode_uri(uri: str) -> tuple[str, str]:
+    """Split ``geonode://<instance>/<dataset>`` into ``(instance, dataset)``.
+
+    Raises:
+        ValueError: if *uri* is not a well-formed geonode URI.
+    """
+    scheme, sep, rest = uri.partition("://")
+    if not sep or scheme.lower() != GEONODE_SCHEME:
+        raise ValueError(f"not a geonode URI: {uri!r}")
+    inst, slash, dataset = rest.partition("/")
+    if not inst or not slash or not dataset:
+        raise ValueError(
+            f"geonode URI must be 'geonode://<instance>/<dataset>', got {uri!r}"
+        )
+    return inst, dataset
+
+
+def read_access(uri: str, *, registry: "GeoNodeRegistry | None" = None) -> AccessSpec:
+    """Resolve a ``geonode://`` read URI to an :class:`AccessSpec`."""
+    inst, dataset = parse_geonode_uri(uri)
+    reg = registry if registry is not None else GEONODES
+    return reg.resolve(inst).read_access(dataset)
+
+
+# ---------------------------------------------------------------------------
+# Write — GeoNode REST API v2 upload
+# ---------------------------------------------------------------------------
+
+
+def publish(
+    gdf: Any,
+    target: str,
+    *,
+    auth: str | None = None,
+    overwrite: bool = True,
+    registry: "GeoNodeRegistry | None" = None,
+    timeout: float = 120.0,
+) -> dict[str, Any]:
+    """Publish a GeoDataFrame to GeoNode as a dataset (REST API v2 uploads).
+
+    The frame is packaged as a GeoPackage and POSTed to the instance's
+    uploads endpoint. The dataset name is the ``<dataset>`` part of
+    *target* (``geonode://<instance>/<dataset>``).
+
+    Args:
+        gdf:       The GeoDataFrame to publish.
+        target:    ``geonode://<instance>/<dataset>`` destination URI.
+        auth:      Bearer token; falls back to the instance's declared auth.
+        overwrite: Replace an existing dataset of the same name.
+        registry:  GeoNode registry. Defaults to the process-wide one.
+        timeout:   HTTP timeout in seconds.
+
+    Returns:
+        The parsed JSON upload response (or ``{"status": ...}`` on a
+        non-JSON body).
+
+    Raises:
+        ValueError: on a malformed target.
+        httpx.HTTPStatusError: on a non-2xx response.
+    """
+    import tempfile
+    from pathlib import Path
+
+    import httpx
+
+    inst, dataset = parse_geonode_uri(target)
+    reg = registry if registry is not None else GEONODES
+    node = reg.resolve(inst)
+    token = auth or node.auth
+
+    with tempfile.TemporaryDirectory() as tmp:
+        gpkg = Path(tmp) / f"{dataset}.gpkg"
+        gdf.to_file(gpkg, layer=dataset, driver="GPKG")
+
+        headers = {"Authorization": f"Bearer {token}"} if token else {}
+        data = {"dataset_title": dataset, "overwrite_existing_layer": str(overwrite).lower()}
+        with gpkg.open("rb") as fh:
+            files = {"base_file": (gpkg.name, fh, "application/geopackage+sqlite3")}
+            resp = httpx.post(
+                node.upload_endpoint(),
+                headers=headers,
+                data=data,
+                files=files,
+                timeout=timeout,
+            )
+    resp.raise_for_status()
+    log.info("geonode_published", target=target, status=resp.status_code)
+    try:
+        return resp.json()
+    except Exception:  # noqa: BLE001 - non-JSON body is still a success
+        return {"status": resp.status_code, "text": resp.text[:500]}
+
+
+#: Process-wide GeoNode registry consulted by the unified loader.
+GEONODES = GeoNodeRegistry()
+
+
+__all__ = [
+    "GEONODES",
+    "GEONODE_ENV",
+    "GEONODE_SCHEME",
+    "GeoNode",
+    "GeoNodeRegistry",
+    "parse_geonode_uri",
+    "publish",
+    "read_access",
+]

--- a/src/gispulse/persistence/loader.py
+++ b/src/gispulse/persistence/loader.py
@@ -1,0 +1,416 @@
+"""Unified data loader — one entry point for every source GISPulse can read.
+
+DP0 of the *generic data provider* track. A single :func:`load` reconciles
+the three reading paths that already exist in the codebase but were never
+wired behind one verb:
+
+* **local / file** — any format handled by
+  :func:`gispulse.persistence.io.read_vector` (GeoPackage, GeoJSON,
+  Shapefile, FlatGeobuf, **GeoParquet** with bbox push-down, CSV, XLSX,
+  KMZ, …);
+* **remote / protocol** — anything reachable through a registered
+  transport adapter in :data:`gispulse.core.sources.PROTOCOLS`
+  (GeoParquet on S3/HTTP via ``remote-table``, OGC API Features, WFS,
+  STAC, plain HTTP download, …), via the ``s3://`` / ``https://`` URI
+  forms or an explicit access descriptor;
+* **lazy / referenced** — the same remote sources as a DuckDB scan handle
+  (:class:`LazyDataset`) that materialises to a GeoDataFrame on demand,
+  so a project only ever reads the rows a bbox selects.
+
+Whatever the source, :func:`load` returns a plain
+:class:`geopandas.GeoDataFrame` (or a :class:`LazyDataset` when
+``lazy=True``), so **every capability runs on the result unchanged** —
+``gispulse.apply(verb, gispulse.load(src), ...)`` just works.
+
+This module owns no transport code of its own: it resolves a source to a
+:class:`~gispulse.core.plugin_model.AccessSpec` and delegates to the
+protocol registry, then normalises the heterogeneous
+:class:`~gispulse.core.plugin_model.SourceResult` (already-a-GeoDataFrame,
+a materialised file path, or a DuckDB scan) into one GeoDataFrame.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+import geopandas as gpd
+
+from gispulse.core.logging import get_logger
+from gispulse.core.plugin_model import (
+    AccessProtocol,
+    AccessSpec,
+    FetchMode,
+    SourceResult,
+)
+from gispulse.core.sources import PROTOCOLS, ProtocolRegistry
+
+log = get_logger(__name__)
+
+#: Bounding box as ``(minx, miny, maxx, maxy)`` in the source CRS.
+BBox = tuple[float, float, float, float]
+
+#: URI schemes that are *transports* (resolved by extension), as opposed to
+#: a named :class:`AccessProtocol`. A Windows drive letter (``c:``) is one
+#: char long and never matches, so ``C:\path`` stays a local file.
+_TRANSPORT_SCHEMES = {"http", "https", "s3", "ftp", "ftps"}
+
+#: File extensions DuckDB can scan zero-copy as a remote table.
+_REMOTE_TABLE_EXTS = {".parquet", ".pq", ".fgb"}
+
+_fetchers_lock = threading.Lock()
+_fetchers_registered = False
+
+
+def _ensure_fetchers_registered(registry: ProtocolRegistry) -> None:
+    """Register the core protocol fetchers into *registry* exactly once.
+
+    The worldwide-aggregator fetchers (``remote-table``, ``ogc-features``,
+    ``wfs``, ``stac``, ``download``, ``table-file``) self-register through
+    :func:`~gispulse.core.fetchers.register_core_fetchers`, kept lazy so a
+    bare ``import gispulse`` never pulls DuckDB/httpx. We only trigger it
+    for the process-wide :data:`PROTOCOLS`; a caller-supplied registry is
+    assumed to be populated as the caller sees fit.
+    """
+    global _fetchers_registered
+    if registry is not PROTOCOLS or _fetchers_registered:
+        return
+    with _fetchers_lock:
+        if _fetchers_registered:
+            return
+        from gispulse.core.fetchers import register_core_fetchers
+
+        register_core_fetchers(registry, override=False)
+        _fetchers_registered = True
+
+
+# ---------------------------------------------------------------------------
+# Lazy handle
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class LazyDataset:
+    """A referenced (not-yet-read) remote source backed by a DuckDB scan.
+
+    Returned by :func:`load` with ``lazy=True``. Holds the DuckDB scan
+    expression a fetcher produced in :attr:`FetchMode.REFERENCE` mode
+    (``read_parquet(…)``, ``ST_Read(…)``, …) without moving any bytes.
+    Call :meth:`to_geodataframe` to materialise — optionally narrowed to a
+    bbox so only the needed rows are read.
+    """
+
+    scan_sql: str
+    crs: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_geodataframe(self, bbox: BBox | None = None) -> gpd.GeoDataFrame:
+        """Run the scan through an ephemeral DuckDB session into a GeoDataFrame.
+
+        Args:
+            bbox: Optional ``(minx, miny, maxx, maxy)`` filter applied in
+                SQL via ``ST_Intersects`` against the scanned geometry.
+        """
+        return _scan_to_gdf(self.scan_sql, crs=self.crs, bbox=bbox)
+
+
+# ---------------------------------------------------------------------------
+# Source resolution
+# ---------------------------------------------------------------------------
+
+
+def resolve_source(source: "str | Path | AccessSpec | dict[str, Any]") -> "Path | AccessSpec":
+    """Resolve a user-supplied source into a local path or an access spec.
+
+    Accepted forms:
+
+    * :class:`~gispulse.core.plugin_model.AccessSpec` — returned as-is.
+    * ``dict`` — built into an ``AccessSpec`` (keys: ``protocol``,
+      ``endpoint``, ``params``, ``format``, ``auth``). ``protocol`` may be
+      an :class:`AccessProtocol` or its string value.
+    * ``str`` / :class:`~pathlib.Path` with a transport scheme
+      (``s3://``, ``https://``, …) — mapped to ``remote-table`` when the
+      path ends in a DuckDB-scannable extension (``.parquet`` / ``.fgb``),
+      otherwise ``download``.
+    * ``str`` with a named-protocol scheme (``wfs://``, ``stac://``,
+      ``ogc-features://``) — that protocol, the remainder taken as an
+      ``https`` endpoint. ``proto+https://host`` forces the transport.
+    * anything else — a local filesystem :class:`~pathlib.Path`.
+
+    Raises:
+        ValueError: on an unknown named protocol scheme.
+    """
+    if isinstance(source, AccessSpec):
+        return source
+
+    if isinstance(source, dict):
+        return _access_from_dict(source)
+
+    raw = str(source)
+
+    # Split on "://" directly rather than via urlparse.scheme — the latter
+    # rejects schemes with underscores (``ogc_features``), and a Windows
+    # drive (``C:\path``) has no "://" so it stays a local path.
+    head, sep, _ = raw.partition("://")
+    if not sep:
+        return Path(raw)
+    scheme = head.lower()
+
+    # "<proto>+<transport>://…" — explicit transport override.
+    proto_name, _, _ = scheme.partition("+")
+
+    if scheme in _TRANSPORT_SCHEMES:
+        return _transport_access(raw, scheme)
+
+    # Named AccessProtocol (wfs, stac, ogc-features, remote-table, …).
+    try:
+        protocol = AccessProtocol(proto_name.replace("_", "-"))
+    except ValueError:
+        # Unknown two-plus-char scheme that is not a transport — most
+        # likely a local path on an exotic FS; let read_vector decide.
+        return Path(raw)
+
+    endpoint = _strip_scheme_to_https(raw)
+    return AccessSpec(protocol=protocol, endpoint=endpoint)
+
+
+def _access_from_dict(spec: dict[str, Any]) -> AccessSpec:
+    """Build an :class:`AccessSpec` from a plain descriptor dict."""
+    try:
+        protocol = spec["protocol"]
+        endpoint = spec["endpoint"]
+    except KeyError as exc:  # pragma: no cover - defensive
+        raise ValueError(
+            "source descriptor requires 'protocol' and 'endpoint' keys"
+        ) from exc
+    if not isinstance(protocol, AccessProtocol):
+        protocol = AccessProtocol(str(protocol).replace("_", "-"))
+    return AccessSpec(
+        protocol=protocol,
+        endpoint=str(endpoint),
+        params=dict(spec.get("params") or {}),
+        format=spec.get("format"),
+        auth=spec.get("auth"),
+    )
+
+
+def _transport_access(uri: str, scheme: str) -> AccessSpec:
+    """Map an ``s3``/``http(s)`` URI to a transport ``AccessSpec`` by extension."""
+    ext = Path(urlparse(uri).path).suffix.lower()
+    if ext in _REMOTE_TABLE_EXTS or (scheme == "s3" and not ext):
+        return AccessSpec(protocol=AccessProtocol.REMOTE_TABLE, endpoint=uri)
+    return AccessSpec(protocol=AccessProtocol.DOWNLOAD, endpoint=uri)
+
+
+def _strip_scheme_to_https(uri: str) -> str:
+    """Rewrite ``proto://rest`` (or ``proto+transport://rest``) as an https URL."""
+    scheme, sep, rest = uri.partition("://")
+    if not sep:
+        return uri
+    _, plus, transport = scheme.partition("+")
+    proto = transport if plus else "https"
+    if proto not in {"http", "https", "ftp", "ftps", "s3"}:
+        proto = "https"
+    return f"{proto}://{rest}"
+
+
+# ---------------------------------------------------------------------------
+# Result normalisation
+# ---------------------------------------------------------------------------
+
+
+def _result_to_gdf(
+    result: SourceResult,
+    *,
+    bbox: BBox | None,
+    layer: str | None,
+) -> gpd.GeoDataFrame:
+    """Normalise a heterogeneous :class:`SourceResult` into a GeoDataFrame.
+
+    ``SourceResult.data`` is intentionally untyped — depending on the
+    fetcher it is already a GeoDataFrame (OGC Features), a materialised
+    file path (GeoParquet/S3, HTTP download), or ``None`` in
+    :attr:`FetchMode.REFERENCE` mode with a DuckDB scan in ``metadata``.
+    """
+    from gispulse.core.fetchers import DUCKDB_SCAN_KEY
+
+    data = result.data
+    scan = result.metadata.get(DUCKDB_SCAN_KEY)
+
+    if isinstance(data, gpd.GeoDataFrame):
+        gdf = data
+    elif result.mode is FetchMode.REFERENCE or (data is None and scan):
+        if not scan:
+            if result.reference:
+                gdf = _read_path(result.reference, bbox=bbox, layer=layer)
+            else:  # pragma: no cover - defensive
+                raise ValueError(
+                    "referenced SourceResult carries neither a DuckDB scan "
+                    "nor a reference URL to read"
+                )
+        else:
+            gdf = _scan_to_gdf(scan, crs=result.crs, bbox=bbox)
+    elif isinstance(data, (str, Path)):
+        gdf = _read_path(str(data), bbox=bbox, layer=layer)
+    else:  # pragma: no cover - defensive
+        raise TypeError(
+            f"cannot turn SourceResult.data of type {type(data).__name__} "
+            "into a GeoDataFrame"
+        )
+
+    if result.crs and gdf.crs is None:
+        gdf = gdf.set_crs(result.crs)
+    return gdf
+
+
+def _read_path(
+    path: str, *, bbox: BBox | None, layer: str | None
+) -> gpd.GeoDataFrame:
+    """Read a local/materialised file through the unified file reader."""
+    from gispulse.persistence.io import read_vector
+
+    kwargs: dict[str, Any] = {}
+    if bbox is not None:
+        kwargs["bbox"] = bbox
+    if layer is not None:
+        kwargs["layer"] = layer
+    return read_vector(path, **kwargs)
+
+
+def _scan_to_gdf(
+    scan_sql: str, *, crs: str | None, bbox: BBox | None
+) -> gpd.GeoDataFrame:
+    """Materialise a DuckDB scan expression into a GeoDataFrame.
+
+    *scan_sql* is a relation expression such as ``read_parquet('s3://…')``
+    or ``ST_Read('…')`` (the form fetchers emit under
+    :data:`~gispulse.core.fetchers.DUCKDB_SCAN_KEY`). When *bbox* is given,
+    an ``ST_Intersects`` envelope predicate is pushed into the query so
+    only intersecting rows are read.
+    """
+    from gispulse.persistence.duckdb_engine import DuckDBSession
+
+    query = f"SELECT * FROM {scan_sql}"
+    if bbox is not None:
+        minx, miny, maxx, maxy = bbox
+        query = (
+            f"SELECT * FROM ({query}) AS _src "
+            f"WHERE ST_Intersects(geom, ST_MakeEnvelope("
+            f"{minx}, {miny}, {maxx}, {maxy}))"
+        )
+
+    session = DuckDBSession()
+    try:
+        gdf = session.sql(query)
+    finally:
+        session.close()
+
+    if crs and gdf.crs is None:
+        gdf = gdf.set_crs(crs)
+    return gdf
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def load(
+    source: "str | Path | AccessSpec | dict[str, Any] | SourceResult",
+    *,
+    bbox: BBox | None = None,
+    layer: str | None = None,
+    lazy: bool = False,
+    crs: str | None = None,
+    registry: ProtocolRegistry | None = None,
+    **read_opts: Any,
+) -> "gpd.GeoDataFrame | LazyDataset":
+    """Load any supported source into a GeoDataFrame (or a lazy handle).
+
+    Args:
+        source: A local path, a ``s3://`` / ``https://`` URI, a
+            named-protocol URI (``wfs://…``, ``stac://…``), an explicit
+            :class:`AccessSpec`, an access-descriptor ``dict``, or a
+            ready :class:`SourceResult`.
+        bbox: Spatial filter ``(minx, miny, maxx, maxy)`` in the source
+            CRS, pushed down to the reader/fetcher when supported.
+        layer: Layer name for multi-layer file formats (GPKG/GDB/SQLite).
+        lazy: When True, remote sources return a :class:`LazyDataset`
+            handle instead of being materialised. Ignored (with a debug
+            log) for local files, which are read eagerly.
+        crs: Force this CRS on the result when the source declares none.
+        registry: Protocol registry to dispatch through. Defaults to the
+            process-wide :data:`PROTOCOLS`.
+        **read_opts: Extra options forwarded to
+            :func:`~gispulse.persistence.io.read_vector` for file sources.
+
+    Returns:
+        A :class:`geopandas.GeoDataFrame`, or a :class:`LazyDataset` when
+        ``lazy=True`` and the source is remote.
+
+    Raises:
+        FileNotFoundError: If a local file source does not exist.
+        ValueError: On an unresolvable source or an unreadable result.
+    """
+    if isinstance(source, SourceResult):
+        gdf = _result_to_gdf(source, bbox=bbox, layer=layer)
+        if crs and gdf.crs is None:
+            gdf = gdf.set_crs(crs)
+        return gdf
+
+    resolved = resolve_source(source)
+
+    # --- Local file path ---------------------------------------------------
+    if isinstance(resolved, Path):
+        if lazy:
+            log.debug("loader_lazy_ignored_for_file", path=str(resolved))
+        from gispulse.persistence.io import read_vector
+
+        opts = dict(read_opts)
+        if bbox is not None:
+            opts["bbox"] = bbox
+        if layer is not None:
+            opts["layer"] = layer
+        if crs is not None:
+            opts["crs"] = crs
+        return read_vector(str(resolved), **opts)
+
+    # --- Remote / protocol source -----------------------------------------
+    target = registry if registry is not None else PROTOCOLS
+    _ensure_fetchers_registered(target)
+
+    mode = FetchMode.REFERENCE if lazy else FetchMode.MATERIALIZE
+    result = target.dispatch_fetch(resolved, extent=bbox, mode=mode)
+
+    if lazy:
+        from gispulse.core.fetchers import DUCKDB_SCAN_KEY
+
+        scan = result.metadata.get(DUCKDB_SCAN_KEY)
+        if not scan:
+            # The fetcher could not produce a lazy scan (e.g. a pure
+            # download protocol) — fall back to an eager read so the
+            # caller still gets data rather than an empty handle.
+            log.debug(
+                "loader_lazy_unsupported_falling_back",
+                protocol=resolved.protocol.value,
+            )
+            gdf = _result_to_gdf(result, bbox=bbox, layer=layer)
+            if crs and gdf.crs is None:
+                gdf = gdf.set_crs(crs)
+            return gdf
+        return LazyDataset(
+            scan_sql=scan,
+            crs=crs or result.crs,
+            metadata=dict(result.metadata),
+        )
+
+    gdf = _result_to_gdf(result, bbox=bbox, layer=layer)
+    if crs and gdf.crs is None:
+        gdf = gdf.set_crs(crs)
+    return gdf
+
+
+__all__ = ["BBox", "LazyDataset", "load", "resolve_source"]

--- a/src/gispulse/persistence/loader.py
+++ b/src/gispulse/persistence/loader.py
@@ -48,6 +48,7 @@ from gispulse.core.plugin_model import (
 )
 from gispulse.core.sources import PROTOCOLS, ProtocolRegistry
 from gispulse.persistence.datamart import DATAMART_SCHEME
+from gispulse.persistence.geonode import GEONODE_SCHEME
 
 log = get_logger(__name__)
 
@@ -167,6 +168,13 @@ def resolve_source(source: "str | Path | AccessSpec | dict[str, Any]") -> "Path 
 
         mart, table = parse_datamart_uri(raw)
         return resolve_source(DATAMARTS.resolve(mart, table))
+
+    # GeoNode: geonode://<instance>/<dataset> reads via the instance's
+    # GeoServer WFS endpoint (reuses the OGC fetcher).
+    if scheme == GEONODE_SCHEME:
+        from gispulse.persistence.geonode import read_access
+
+        return read_access(raw)
 
     # "<proto>+<transport>://…" — explicit transport override.
     proto_name, _, _ = scheme.partition("+")

--- a/src/gispulse/persistence/loader.py
+++ b/src/gispulse/persistence/loader.py
@@ -47,6 +47,7 @@ from gispulse.core.plugin_model import (
     SourceResult,
 )
 from gispulse.core.sources import PROTOCOLS, ProtocolRegistry
+from gispulse.persistence.datamart import DATAMART_SCHEME
 
 log = get_logger(__name__)
 
@@ -158,6 +159,14 @@ def resolve_source(source: "str | Path | AccessSpec | dict[str, Any]") -> "Path 
     if not sep:
         return Path(raw)
     scheme = head.lower()
+
+    # Datamart indirection: resolve datamart://<mart>/<table> to its
+    # concrete source URI, then resolve that recursively.
+    if scheme == DATAMART_SCHEME:
+        from gispulse.persistence.datamart import DATAMARTS, parse_datamart_uri
+
+        mart, table = parse_datamart_uri(raw)
+        return resolve_source(DATAMARTS.resolve(mart, table))
 
     # "<proto>+<transport>://…" — explicit transport override.
     proto_name, _, _ = scheme.partition("+")

--- a/tests/unit/test_datamart.py
+++ b/tests/unit/test_datamart.py
@@ -1,0 +1,168 @@
+"""Unit tests for the datamart provider (DP2)."""
+
+from __future__ import annotations
+
+import geopandas as gpd
+import pytest
+from shapely.geometry import Point
+
+from gispulse.persistence.datamart import (
+    DATAMARTS,
+    Datamart,
+    DatamartRegistry,
+    parse_datamart_uri,
+)
+from gispulse.persistence.loader import load, resolve_source
+
+
+@pytest.fixture
+def points_gdf() -> gpd.GeoDataFrame:
+    return gpd.GeoDataFrame(
+        {"name": ["a", "b"]},
+        geometry=[Point(0, 0), Point(1, 1)],
+        crs="EPSG:4326",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clean_default_registry():
+    DATAMARTS.clear()
+    yield
+    DATAMARTS.clear()
+
+
+# ---------------------------------------------------------------------------
+# Datamart.uri_for
+# ---------------------------------------------------------------------------
+
+
+def test_uri_for_default_pattern():
+    m = Datamart(name="m", location="s3://bucket/marts/m")
+    assert m.uri_for("parcels") == "s3://bucket/marts/m/parcels.parquet"
+
+
+def test_uri_for_trailing_slash_normalised():
+    m = Datamart(name="m", location="s3://bucket/marts/m/")
+    assert m.uri_for("parcels") == "s3://bucket/marts/m/parcels.parquet"
+
+
+def test_uri_for_custom_pattern():
+    m = Datamart(name="m", location="/data/m", table_pattern="{table}/data.fgb")
+    assert m.uri_for("roads") == "/data/m/roads/data.fgb"
+
+
+def test_uri_for_empty_table_raises():
+    m = Datamart(name="m", location="/data/m")
+    with pytest.raises(ValueError):
+        m.uri_for("")
+
+
+# ---------------------------------------------------------------------------
+# parse_datamart_uri
+# ---------------------------------------------------------------------------
+
+
+def test_parse_uri_ok():
+    assert parse_datamart_uri("datamart://ref/parcels") == ("ref", "parcels")
+
+
+def test_parse_uri_nested_table():
+    assert parse_datamart_uri("datamart://ref/cadastre/parcels") == (
+        "ref",
+        "cadastre/parcels",
+    )
+
+
+@pytest.mark.parametrize(
+    "uri",
+    ["datamart://ref", "datamart://ref/", "datamart:///x", "wfs://h/x"],
+)
+def test_parse_uri_invalid(uri):
+    with pytest.raises(ValueError):
+        parse_datamart_uri(uri)
+
+
+# ---------------------------------------------------------------------------
+# DatamartRegistry
+# ---------------------------------------------------------------------------
+
+
+def test_register_get_names():
+    reg = DatamartRegistry()
+    reg.register(Datamart(name="a", location="/x"))
+    reg.register(Datamart(name="b", location="/y"))
+    assert reg.names() == ["a", "b"]
+    assert reg.get("a").location == "/x"
+
+
+def test_register_duplicate_raises():
+    reg = DatamartRegistry()
+    reg.register(Datamart(name="a", location="/x"))
+    with pytest.raises(ValueError):
+        reg.register(Datamart(name="a", location="/y"))
+    reg.register(Datamart(name="a", location="/y"), override=True)
+    assert reg.get("a").location == "/y"
+
+
+def test_get_unknown_raises():
+    reg = DatamartRegistry()
+    with pytest.raises(KeyError):
+        reg.get("nope")
+
+
+def test_resolve_returns_uri():
+    reg = DatamartRegistry()
+    reg.register(Datamart(name="m", location="s3://b/m"))
+    assert reg.resolve("m", "t") == "s3://b/m/t.parquet"
+
+
+# ---------------------------------------------------------------------------
+# Environment loading
+# ---------------------------------------------------------------------------
+
+
+def test_env_declarations_loaded(monkeypatch):
+    monkeypatch.setenv(
+        "GISPULSE_DATAMARTS",
+        '{"ref": {"location": "s3://b/ref", "table_pattern": "{table}.fgb"}}',
+    )
+    reg = DatamartRegistry()
+    assert reg.get("ref").uri_for("x") == "s3://b/ref/x.fgb"
+
+
+def test_env_invalid_json_ignored(monkeypatch):
+    monkeypatch.setenv("GISPULSE_DATAMARTS", "{not json")
+    reg = DatamartRegistry()
+    assert reg.names() == []
+
+
+def test_explicit_registration_wins_over_env(monkeypatch):
+    monkeypatch.setenv(
+        "GISPULSE_DATAMARTS", '{"m": {"location": "s3://env/m"}}'
+    )
+    reg = DatamartRegistry()
+    reg.register(Datamart(name="m", location="s3://explicit/m"))
+    assert reg.get("m").location == "s3://explicit/m"
+
+
+# ---------------------------------------------------------------------------
+# Integration with resolve_source / load
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_source_datamart_indirection(tmp_path):
+    from pathlib import Path
+
+    DATAMARTS.register(Datamart(name="m", location=str(tmp_path)))
+    resolved = resolve_source("datamart://m/pts")
+    assert resolved == Path(str(tmp_path / "pts.parquet"))
+
+
+def test_load_via_datamart(tmp_path, points_gdf):
+    (points_gdf).to_parquet(tmp_path / "pts.parquet")
+    DATAMARTS.register(Datamart(name="m", location=str(tmp_path)))
+
+    out = load("datamart://m/pts")
+    assert isinstance(out, gpd.GeoDataFrame)
+    assert len(out) == 2
+    assert list(out["name"]) == ["a", "b"]

--- a/tests/unit/test_geonode.py
+++ b/tests/unit/test_geonode.py
@@ -1,0 +1,200 @@
+"""Unit tests for the GeoNode provider (DP1)."""
+
+from __future__ import annotations
+
+import geopandas as gpd
+import httpx
+import pytest
+from shapely.geometry import Point
+
+from gispulse.core.plugin_model import AccessProtocol
+from gispulse.persistence.geonode import (
+    GEONODES,
+    GeoNode,
+    GeoNodeRegistry,
+    parse_geonode_uri,
+    publish,
+    read_access,
+)
+from gispulse.persistence.loader import resolve_source
+
+
+@pytest.fixture
+def points_gdf() -> gpd.GeoDataFrame:
+    return gpd.GeoDataFrame(
+        {"name": ["a", "b"]},
+        geometry=[Point(0, 0), Point(1, 1)],
+        crs="EPSG:4326",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clean_default_registry():
+    GEONODES.clear()
+    yield
+    GEONODES.clear()
+
+
+# ---------------------------------------------------------------------------
+# GeoNode helpers
+# ---------------------------------------------------------------------------
+
+
+def test_endpoints():
+    n = GeoNode(name="p", host="https://geo.example.org/")
+    assert n.wfs_endpoint() == "https://geo.example.org/geoserver/ows"
+    assert n.upload_endpoint() == "https://geo.example.org/api/v2/uploads"
+
+
+def test_typename_qualified_vs_default():
+    n = GeoNode(name="p", host="https://h", workspace="geonode")
+    assert n.typename("roads") == "geonode:roads"
+    assert n.typename("other:roads") == "other:roads"
+
+
+def test_read_access_spec():
+    n = GeoNode(name="p", host="https://h", crs="EPSG:2154", auth="tok")
+    spec = n.read_access("roads")
+    assert spec.protocol is AccessProtocol.OGC_FEATURES
+    assert spec.endpoint == "https://h/geoserver/ows"
+    assert spec.params["collection"] == "geonode:roads"
+    assert spec.params["source_type"] == "wfs"
+    assert spec.params["crs"] == "EPSG:2154"
+    assert spec.params["auth"] == "tok"
+
+
+# ---------------------------------------------------------------------------
+# parse_geonode_uri
+# ---------------------------------------------------------------------------
+
+
+def test_parse_uri_ok():
+    assert parse_geonode_uri("geonode://prod/roads") == ("prod", "roads")
+
+
+@pytest.mark.parametrize("uri", ["geonode://prod", "geonode://prod/", "wfs://h/x"])
+def test_parse_uri_invalid(uri):
+    with pytest.raises(ValueError):
+        parse_geonode_uri(uri)
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+def test_register_and_resolve_alias():
+    reg = GeoNodeRegistry()
+    reg.register(GeoNode(name="prod", host="https://prod.example.org"))
+    assert reg.resolve("prod").host == "https://prod.example.org"
+
+
+def test_resolve_bare_host_defaults():
+    reg = GeoNodeRegistry()
+    node = reg.resolve("geo.example.org")
+    assert node.host == "https://geo.example.org"
+    assert node.wfs_endpoint() == "https://geo.example.org/geoserver/ows"
+
+
+def test_register_duplicate_raises():
+    reg = GeoNodeRegistry()
+    reg.register(GeoNode(name="p", host="https://a"))
+    with pytest.raises(ValueError):
+        reg.register(GeoNode(name="p", host="https://b"))
+    reg.register(GeoNode(name="p", host="https://b"), override=True)
+    assert reg.resolve("p").host == "https://b"
+
+
+def test_env_declarations(monkeypatch):
+    monkeypatch.setenv(
+        "GISPULSE_GEONODE",
+        '{"prod": {"host": "https://prod.org", "workspace": "ws"}}',
+    )
+    reg = GeoNodeRegistry()
+    assert reg.get("prod").typename("x") == "ws:x"
+
+
+def test_env_invalid_json_ignored(monkeypatch):
+    monkeypatch.setenv("GISPULSE_GEONODE", "nope{")
+    reg = GeoNodeRegistry()
+    assert reg.names() == []
+
+
+# ---------------------------------------------------------------------------
+# read_access / resolve_source integration
+# ---------------------------------------------------------------------------
+
+
+def test_read_access_uri():
+    GEONODES.register(GeoNode(name="prod", host="https://prod.org"))
+    spec = read_access("geonode://prod/roads")
+    assert spec.endpoint == "https://prod.org/geoserver/ows"
+    assert spec.params["collection"] == "geonode:roads"
+
+
+def test_resolve_source_geonode():
+    spec = resolve_source("geonode://geo.example.org/parcels")
+    assert spec.protocol is AccessProtocol.OGC_FEATURES
+    assert spec.endpoint == "https://geo.example.org/geoserver/ows"
+    assert spec.params["collection"] == "geonode:parcels"
+
+
+# ---------------------------------------------------------------------------
+# publish (write) — httpx mocked
+# ---------------------------------------------------------------------------
+
+
+def test_publish_uploads_geopackage(points_gdf, monkeypatch):
+    captured: dict = {}
+
+    class _Resp:
+        status_code = 201
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"id": 42, "name": "roads"}
+
+    def _fake_post(url, *, headers=None, data=None, files=None, timeout=None):
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["data"] = data
+        # The file handle is live here — read a byte to prove it is a real gpkg.
+        name, fh, mime = files["base_file"]
+        captured["filename"] = name
+        captured["mime"] = mime
+        captured["head"] = fh.read(4)
+        return _Resp()
+
+    monkeypatch.setattr(httpx, "post", _fake_post)
+
+    reg = GeoNodeRegistry()
+    reg.register(GeoNode(name="prod", host="https://prod.org"))
+
+    out = publish(points_gdf, "geonode://prod/roads", auth="tok", registry=reg)
+
+    assert out == {"id": 42, "name": "roads"}
+    assert captured["url"] == "https://prod.org/api/v2/uploads"
+    assert captured["headers"]["Authorization"] == "Bearer tok"
+    assert captured["data"]["dataset_title"] == "roads"
+    assert captured["data"]["overwrite_existing_layer"] == "true"
+    assert captured["filename"] == "roads.gpkg"
+    # GeoPackage files begin with the SQLite magic header.
+    assert captured["head"] == b"SQLi"
+
+
+def test_publish_raises_on_http_error(points_gdf, monkeypatch):
+    class _Resp:
+        status_code = 500
+
+        def raise_for_status(self):
+            raise httpx.HTTPStatusError("boom", request=None, response=None)
+
+    monkeypatch.setattr(
+        httpx, "post", lambda *a, **k: _Resp()
+    )
+    reg = GeoNodeRegistry()
+    reg.register(GeoNode(name="prod", host="https://prod.org"))
+    with pytest.raises(httpx.HTTPStatusError):
+        publish(points_gdf, "geonode://prod/roads", registry=reg)

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -1,0 +1,255 @@
+"""Unit tests for the unified data loader (DP0)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import geopandas as gpd
+import pytest
+from shapely.geometry import Point
+
+from gispulse.core.plugin_model import (
+    AccessProtocol,
+    AccessSpec,
+    FetchMode,
+    Payload,
+    SourceResult,
+)
+from gispulse.core.sources import ProtocolRegistry
+from gispulse.persistence.loader import (
+    LazyDataset,
+    load,
+    resolve_source,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def points_gdf() -> gpd.GeoDataFrame:
+    return gpd.GeoDataFrame(
+        {"name": ["a", "b", "c"]},
+        geometry=[Point(0, 0), Point(1, 1), Point(2, 2)],
+        crs="EPSG:4326",
+    )
+
+
+class _StubFetcher:
+    """A minimal structural Fetcher returning a canned SourceResult."""
+
+    def __init__(self, protocol: AccessProtocol, result: SourceResult) -> None:
+        self.protocol = protocol
+        self._result = result
+        self.calls: list[tuple[AccessSpec, object, FetchMode]] = []
+
+    def fetch(self, access, *, extent=None, mode=FetchMode.MATERIALIZE):
+        self.calls.append((access, extent, mode))
+        return self._result
+
+
+# ---------------------------------------------------------------------------
+# resolve_source
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_local_path():
+    assert resolve_source("data/x.geojson") == Path("data/x.geojson")
+    assert resolve_source(Path("/abs/x.gpkg")) == Path("/abs/x.gpkg")
+
+
+def test_resolve_windows_drive_stays_path():
+    # Single-char scheme ("c") must not be mistaken for a protocol.
+    assert resolve_source("C:\\data\\x.shp") == Path("C:\\data\\x.shp")
+
+
+@pytest.mark.parametrize(
+    "uri",
+    ["s3://bucket/dir/data.parquet", "https://host/data.fgb", "s3://bucket/folder"],
+)
+def test_resolve_remote_table_by_extension(uri):
+    spec = resolve_source(uri)
+    assert isinstance(spec, AccessSpec)
+    assert spec.protocol is AccessProtocol.REMOTE_TABLE
+    assert spec.endpoint == uri
+
+
+def test_resolve_http_non_table_is_download():
+    spec = resolve_source("https://host/api/export.geojson")
+    assert isinstance(spec, AccessSpec)
+    assert spec.protocol is AccessProtocol.DOWNLOAD
+
+
+def test_resolve_named_protocol_uri():
+    spec = resolve_source("wfs://geo.example.org/wfs?typename=roads")
+    assert isinstance(spec, AccessSpec)
+    assert spec.protocol is AccessProtocol.WFS
+    assert spec.endpoint == "https://geo.example.org/wfs?typename=roads"
+
+
+def test_resolve_ogc_features_underscore_normalised():
+    spec = resolve_source("ogc_features://host/collections/x")
+    assert spec.protocol is AccessProtocol.OGC_FEATURES
+
+
+def test_resolve_dict_descriptor():
+    spec = resolve_source(
+        {
+            "protocol": "wfs",
+            "endpoint": "https://host/wfs",
+            "params": {"typename": "t"},
+            "format": "geojson",
+        }
+    )
+    assert isinstance(spec, AccessSpec)
+    assert spec.protocol is AccessProtocol.WFS
+    assert spec.params == {"typename": "t"}
+    assert spec.format == "geojson"
+
+
+def test_resolve_accessspec_passthrough():
+    spec = AccessSpec(protocol=AccessProtocol.STAC, endpoint="https://h/stac")
+    assert resolve_source(spec) is spec
+
+
+# ---------------------------------------------------------------------------
+# load — local files
+# ---------------------------------------------------------------------------
+
+
+def test_load_geojson_roundtrip(tmp_path, points_gdf):
+    path = tmp_path / "pts.geojson"
+    points_gdf.to_file(path, driver="GeoJSON")
+
+    out = load(str(path))
+    assert isinstance(out, gpd.GeoDataFrame)
+    assert len(out) == 3
+    assert list(out["name"]) == ["a", "b", "c"]
+
+
+def test_load_geoparquet_roundtrip(tmp_path, points_gdf):
+    path = tmp_path / "pts.parquet"
+    points_gdf.to_parquet(path)
+
+    out = load(str(path))
+    assert isinstance(out, gpd.GeoDataFrame)
+    assert len(out) == 3
+    assert out.crs is not None
+
+
+def test_load_missing_file_raises(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        load(str(tmp_path / "nope.gpkg"))
+
+
+def test_load_lazy_ignored_for_file(tmp_path, points_gdf):
+    path = tmp_path / "pts.parquet"
+    points_gdf.to_parquet(path)
+    # lazy on a local file is a no-op: returns the eager GeoDataFrame.
+    out = load(str(path), lazy=True)
+    assert isinstance(out, gpd.GeoDataFrame)
+
+
+# ---------------------------------------------------------------------------
+# load — SourceResult normalisation
+# ---------------------------------------------------------------------------
+
+
+def test_load_sourceresult_with_geodataframe(points_gdf):
+    result = SourceResult(payload=Payload.VECTOR, data=points_gdf, crs="EPSG:4326")
+    out = load(result)
+    assert out is points_gdf
+
+
+def test_load_sourceresult_with_path(tmp_path, points_gdf):
+    path = tmp_path / "pts.geojson"
+    points_gdf.to_file(path, driver="GeoJSON")
+    result = SourceResult(payload=Payload.VECTOR, data=str(path))
+    out = load(result)
+    assert isinstance(out, gpd.GeoDataFrame)
+    assert len(out) == 3
+
+
+def test_load_sourceresult_sets_crs_when_missing(points_gdf):
+    bare = points_gdf.set_crs(None, allow_override=True)
+    result = SourceResult(payload=Payload.VECTOR, data=bare, crs="EPSG:2154")
+    out = load(result)
+    assert out.crs is not None
+    assert "2154" in str(out.crs)
+
+
+# ---------------------------------------------------------------------------
+# load — remote via a stub fetcher registry
+# ---------------------------------------------------------------------------
+
+
+def test_load_remote_materialize_returns_gdf(points_gdf, monkeypatch):
+    monkeypatch.setenv("GISPULSE_FETCH_ALLOW_PRIVATE", "1")
+    reg = ProtocolRegistry()
+    result = SourceResult(payload=Payload.VECTOR, data=points_gdf)
+    stub = _StubFetcher(AccessProtocol.OGC_FEATURES, result)
+    reg.register(stub)
+
+    out = load(
+        {"protocol": "ogc-features", "endpoint": "https://host/collections/x"},
+        registry=reg,
+        bbox=(0, 0, 1, 1),
+    )
+    assert isinstance(out, gpd.GeoDataFrame)
+    # bbox is forwarded to the fetcher as extent.
+    assert stub.calls[0][1] == (0, 0, 1, 1)
+    assert stub.calls[0][2] is FetchMode.MATERIALIZE
+
+
+def test_load_remote_path_result_reads_file(tmp_path, points_gdf):
+    path = tmp_path / "mat.geojson"
+    points_gdf.to_file(path, driver="GeoJSON")
+    reg = ProtocolRegistry()
+    result = SourceResult(payload=Payload.VECTOR, data=str(path))
+    # endpoint is a local path → SSRF guard skips it.
+    stub = _StubFetcher(AccessProtocol.DOWNLOAD, result)
+    reg.register(stub)
+
+    out = load(
+        AccessSpec(protocol=AccessProtocol.DOWNLOAD, endpoint=str(path)),
+        registry=reg,
+    )
+    assert isinstance(out, gpd.GeoDataFrame)
+    assert len(out) == 3
+
+
+def test_load_lazy_returns_handle():
+    reg = ProtocolRegistry()
+    result = SourceResult(
+        payload=Payload.VECTOR,
+        mode=FetchMode.REFERENCE,
+        data=None,
+        crs="EPSG:4326",
+        metadata={"duckdb_scan": "read_parquet('s3://b/x.parquet')"},
+    )
+    stub = _StubFetcher(AccessProtocol.REMOTE_TABLE, result)
+    reg.register(stub)
+
+    handle = load("s3://b/x.parquet", registry=reg, lazy=True)
+    assert isinstance(handle, LazyDataset)
+    assert handle.scan_sql == "read_parquet('s3://b/x.parquet')"
+    assert handle.crs == "EPSG:4326"
+    assert stub.calls[0][2] is FetchMode.REFERENCE
+
+
+def test_load_lazy_falls_back_when_no_scan(points_gdf, monkeypatch):
+    monkeypatch.setenv("GISPULSE_FETCH_ALLOW_PRIVATE", "1")
+    # A protocol that cannot produce a lazy scan still yields data.
+    reg = ProtocolRegistry()
+    result = SourceResult(payload=Payload.VECTOR, data=points_gdf)
+    stub = _StubFetcher(AccessProtocol.OGC_FEATURES, result)
+    reg.register(stub)
+
+    out = load(
+        {"protocol": "ogc-features", "endpoint": "https://host/x"},
+        registry=reg,
+        lazy=True,
+    )
+    assert isinstance(out, gpd.GeoDataFrame)

--- a/tests/unit/test_loader_capability_integration.py
+++ b/tests/unit/test_loader_capability_integration.py
@@ -1,0 +1,74 @@
+"""Integration: any source loaded via load() feeds any capability (DP3).
+
+The promise of the data-provider track is that ``gispulse.load`` returns a
+plain GeoDataFrame, so ``gispulse.apply`` runs on its output unchanged —
+whatever the source was (file, datamart, remote). These tests pin that
+contract end-to-end.
+"""
+
+from __future__ import annotations
+
+import geopandas as gpd
+import pytest
+from shapely.geometry import Point
+
+import gispulse
+from gispulse.persistence.datamart import DATAMARTS, Datamart
+from gispulse.persistence.loader import LazyDataset, load
+
+
+@pytest.fixture
+def points_gdf() -> gpd.GeoDataFrame:
+    return gpd.GeoDataFrame(
+        {"v": [1, 2, 3]},
+        geometry=[Point(0, 0), Point(10, 10), Point(20, 20)],
+        crs="EPSG:3857",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clean_datamarts():
+    DATAMARTS.clear()
+    yield
+    DATAMARTS.clear()
+
+
+def test_load_file_then_apply_buffer(tmp_path, points_gdf):
+    path = tmp_path / "pts.parquet"
+    points_gdf.to_parquet(path)
+
+    gdf = load(str(path))
+    out = gispulse.apply("buffer", gdf, distance=1.0)
+
+    assert isinstance(out, gpd.GeoDataFrame)
+    assert len(out) == 3
+    assert set(out.geometry.geom_type) == {"Polygon"}
+
+
+def test_load_datamart_then_apply_cluster(tmp_path, points_gdf):
+    points_gdf.to_parquet(tmp_path / "sites.parquet")
+    DATAMARTS.register(Datamart(name="ref", location=str(tmp_path)))
+
+    gdf = load("datamart://ref/sites")
+    out = gispulse.apply("cluster_dbscan", gdf, eps=5.0, min_samples=1)
+
+    assert isinstance(out, gpd.GeoDataFrame)
+    assert "cluster" in out.columns
+    assert len(out) == 3
+
+
+def test_lazy_handle_materialises_then_applies(monkeypatch, points_gdf):
+    # A LazyDataset materialises to a GeoDataFrame on demand; the result
+    # feeds a capability exactly like an eagerly-loaded frame. We stub the
+    # DuckDB scan so the contract is exercised without a live backend.
+    handle = LazyDataset(scan_sql="read_parquet('s3://b/x.parquet')", crs="EPSG:3857")
+    monkeypatch.setattr(
+        "gispulse.persistence.loader._scan_to_gdf",
+        lambda scan_sql, *, crs, bbox: points_gdf,
+    )
+
+    gdf = handle.to_geodataframe()
+    out = gispulse.apply("buffer", gdf, distance=2.0)
+
+    assert isinstance(out, gpd.GeoDataFrame)
+    assert set(out.geometry.geom_type) == {"Polygon"}


### PR DESCRIPTION
## Volet provider de données unifié (DP0–DP3)

Une seule porte d'entrée pour lire **toute** source et la brancher sur **toute** capability. `load()` renvoie un `GeoDataFrame` ordinaire, donc `apply(verbe, load(src))` fonctionne sans rien changer aux capabilities.

### Commits / étapes

- **DP0** `feat(loader)` — `gispulse.load(source, *, bbox, layer, lazy, crs)` réconcilie les trois chemins de lecture (fichiers via `read_vector` incl. GeoParquet+bbox ; sources protocole distantes via `PROTOCOLS.dispatch_fetch` ; scans DuckDB lazy). `resolve_source()` mappe chemins locaux, `s3://`/`https://` (remote-table par extension, sinon download), URI nommées (`wfs://`, `stac://`, `ogc-features://`), dict descriptor, `AccessSpec`. `LazyDataset` matérialise à la demande (bbox poussé en SQL). Façade `gispulse.load` / `GISPulseApp.load`.
- **DP2** `feat(datamart)` — `datamart://<mart>/<table>` : stores de tables Parquet/GeoParquet curées scannées par DuckDB, indirection de nommage au-dessus de `load()`. `DatamartRegistry` + env `GISPULSE_DATAMARTS`.
- **DP1** `feat(geonode)` — `geonode://<instance>/<dataset>` : **lecture** via le WFS GeoServer de l'instance (réutilise le fetcher OGC, bbox pushdown) ; **écriture** `gispulse.publish(gdf, "geonode://…")` empaquette un GeoPackage et l'envoie via la REST API v2 uploads. `GeoNodeRegistry` + env `GISPULSE_GEONODE` ; une authority non déclarée = host nu avec chemins par défaut.
- **DP3** `test`/`docs` — tests d'intégration `load → apply` (buffer/cluster, materialisation lazy) + `docs/DATA_LOADING.md`.

### Tests

**59 tests** ajoutés (loader 21, datamart 19, geonode 16, intégration 3), tous verts ; `ruff` clean.

> Échecs CI éventuels sur `test_persistence_io` (XLSX), `test_cli_mcp`, `test_rules_loader::test_minimal_rule` : **préexistants sur `main`** (environnement), sans rapport avec cette PR — vérifié via worktree détaché sur `origin/main`.

### Portée / suites

- Datamart = Parquet curés (DuckDB = moteur de scan). Cas *fichier .duckdb attaché* laissé en suivi (DP2b).
- GeoNode write via upload API v2 (plus natif que WFS-T).

🤖 Generated with [Claude Code](https://claude.com/claude-code)