### PR TITLE
feat(capabilities): NetworkGraph reusable routing handle (F)

### DIFF
--- a/src/gispulse/capabilities/network.py
+++ b/src/gispulse/capabilities/network.py
@@ -17,82 +17,13 @@ from __future__ import annotations
 from typing import Any
 
 import geopandas as gpd
-from shapely.geometry import LineString, MultiLineString, Point
+from shapely.geometry import LineString, Point
 
 from gispulse.capabilities.base import Capability
 from gispulse.capabilities.registry import register
 from gispulse.core.crs import is_angular
+from gispulse.core.network_graph_handle import NetworkGraph
 from gispulse.persistence.tier import check_tier
-
-
-def _build_graph(
-    gdf: gpd.GeoDataFrame,
-    weight_col: str | None = None,
-) -> tuple[Any, dict[Any, int]]:
-    """Construit un graphe NetworkX depuis un GeoDataFrame de lignes.
-
-    Chaque extrémité de ligne (arrondie à 6 décimales) devient un nœud.
-    Le poids d'un arc est `weight_col` si fourni, sinon la longueur géographique.
-
-    Returns:
-        (graph, node_index) — le graphe et un dict {(x,y) -> node_id}.
-    """
-    try:
-        import networkx as nx
-    except ImportError as exc:
-        raise ImportError(
-            "Network capabilities require 'networkx'. "
-            "Install with: pip install networkx"
-        ) from exc
-
-    G = nx.Graph()
-    node_idx: dict[tuple[float, float], int] = {}
-
-    def _snap(pt: Point) -> tuple[float, float]:
-        return (round(pt.x, 6), round(pt.y, 6))
-
-    def _node(pt: Point) -> int:
-        key = _snap(pt)
-        if key not in node_idx:
-            nid = len(node_idx)
-            node_idx[key] = nid
-            G.add_node(nid, x=key[0], y=key[1])
-        return node_idx[key]
-
-    for _, row in gdf.iterrows():
-        geom = row.geometry
-        if geom is None or geom.is_empty:
-            continue
-        lines = geom.geoms if isinstance(geom, MultiLineString) else [geom]
-        for line in lines:
-            if not isinstance(line, LineString) or len(line.coords) < 2:
-                continue
-            coords = list(line.coords)
-            start = _node(Point(coords[0]))
-            end = _node(Point(coords[-1]))
-            weight = (
-                float(row[weight_col])
-                if weight_col and weight_col in gdf.columns
-                else line.length
-            )
-            G.add_edge(start, end, weight=weight, geometry=line)
-
-    return G, node_idx
-
-
-def _nearest_node(
-    pt: Point,
-    node_idx: dict[tuple[float, float], int],
-) -> int:
-    """Retourne l'identifiant du nœud le plus proche d'un point."""
-    best_id = -1
-    best_dist = float("inf")
-    for (x, y), nid in node_idx.items():
-        d = (x - pt.x) ** 2 + (y - pt.y) ** 2
-        if d < best_dist:
-            best_dist = d
-            best_id = nid
-    return best_id
 
 
 @register
@@ -152,9 +83,10 @@ class ShortestPathCapability(Capability):
             src_pt = Point(start_x, start_y)
             dst_pt = Point(end_x, end_y)
 
-        G, node_idx = _build_graph(network_m, weight_col)
-        start_node = _nearest_node(src_pt, node_idx)
-        end_node = _nearest_node(dst_pt, node_idx)
+        graph = NetworkGraph.from_lines(network_m, weight_col)
+        G = graph.graph
+        start_node = graph.nearest_node(src_pt)
+        end_node = graph.nearest_node(dst_pt)
 
         try:
             path_nodes = nx.shortest_path(G, start_node, end_node, weight="weight")
@@ -320,8 +252,9 @@ class IsochroneCapability(Capability):
         else:
             network_m = network
 
-        G, node_idx = _build_graph(network_m, weight_col)
-        if len(node_idx) == 0:
+        graph = NetworkGraph.from_lines(network_m, weight_col)
+        G = graph.graph
+        if len(graph) == 0:
             return gpd.GeoDataFrame(columns=["geometry", "cost_budget"], crs=result_crs)
 
         # Collect start nodes — one per source feature (batch) or a single
@@ -333,11 +266,11 @@ class IsochroneCapability(Capability):
                 if geom is None or geom.is_empty:
                     continue
                 pt = geom.centroid if geom.geom_type != "Point" else geom
-                start_nodes.add(_nearest_node(pt, node_idx))
+                start_nodes.add(graph.nearest_node(pt))
             if not start_nodes:
                 return gpd.GeoDataFrame(columns=["geometry", "cost_budget"], crs=result_crs)
         else:
-            start_nodes = {_nearest_node(Point(start_x, start_y), node_idx)}
+            start_nodes = {graph.nearest_node(Point(start_x, start_y))}
 
         # Single Dijkstra pass for all budgets — cutoff at the largest, then
         # filter reachable nodes per budget. N-budget cost ≈ 1-budget cost.
@@ -512,7 +445,8 @@ class NetworkAllocationCapability(Capability):
             hubs_m = hubs_gdf
             feats_m = gdf
 
-        G, node_idx = _build_graph(net_m, weight_col)
+        graph = NetworkGraph.from_lines(net_m, weight_col)
+        G = graph.graph
 
         # Snap chaque hub sur le graphe
         hub_nodes: list[tuple[int, Any]] = []
@@ -520,7 +454,7 @@ class NetworkAllocationCapability(Capability):
             if hub_row.geometry is None or hub_row.geometry.is_empty:
                 continue
             hub_pt = hub_row.geometry
-            nid = _nearest_node(Point(hub_pt.x, hub_pt.y), node_idx)
+            nid = graph.nearest_node(Point(hub_pt.x, hub_pt.y))
             hub_id_val = hub_row.get(hub_id_col, hub_row.name)
             hub_nodes.append((nid, hub_id_val))
 
@@ -561,7 +495,7 @@ class NetworkAllocationCapability(Capability):
             if not isinstance(feat_pt, Point):
                 feat_pt = feat_pt.centroid
 
-            nearest_nid = _nearest_node(feat_pt, node_idx)
+            nearest_nid = graph.nearest_node(feat_pt)
             if nearest_nid in node_to_hub:
                 hub_val, cost = node_to_hub[nearest_nid]
                 hub_ids.append(hub_val)
@@ -671,7 +605,7 @@ class ConnectivityCheckCapability(Capability):
                 crs=gdf.crs,
             )
 
-        G, node_idx = _build_graph(gdf, weight_col)
+        G = NetworkGraph.from_lines(gdf, weight_col).graph
 
         is_connected = nx.is_connected(G)
         components = list(nx.connected_components(G))
@@ -840,10 +774,11 @@ class ODMatrixCapability(Capability):
         except ImportError as exc:
             raise ImportError("networkx required for od_matrix.") from exc
 
-        G, node_idx = _build_graph(gdf, weight_col=weight_col)
+        graph = NetworkGraph.from_lines(gdf, weight_col=weight_col)
+        G = graph.graph
 
-        origin_nodes = [_nearest_node(Point(g.x, g.y) if g.geom_type == "Point" else g.centroid, node_idx) for g in ref_gdf.geometry]
-        dest_nodes = [_nearest_node(Point(g.x, g.y) if g.geom_type == "Point" else g.centroid, node_idx) for g in dest_gdf.geometry]
+        origin_nodes = [graph.nearest_node(Point(g.x, g.y) if g.geom_type == "Point" else g.centroid) for g in ref_gdf.geometry]
+        dest_nodes = [graph.nearest_node(Point(g.x, g.y) if g.geom_type == "Point" else g.centroid) for g in dest_gdf.geometry]
 
         origin_ids = (
             list(ref_gdf[origin_id_col])
@@ -957,7 +892,7 @@ class MinimumSpanningTreeCapability(Capability):
         if gdf.empty:
             return gdf.copy()
 
-        G, _ = _build_graph(gdf, weight_col=weight_col)
+        G = NetworkGraph.from_lines(gdf, weight_col=weight_col).graph
         if G.number_of_edges() == 0:
             return gpd.GeoDataFrame(geometry=[], crs=gdf.crs)
 

--- a/src/gispulse/core/network_graph_handle.py
+++ b/src/gispulse/core/network_graph_handle.py
@@ -1,0 +1,175 @@
+"""Reusable routing handle — build a network graph once, query it many times.
+
+Capability F of the network/linear-referencing track. Today every network
+capability (``shortest_path``, ``isochrone``, ``od_matrix``,
+``network_allocation``, ``mst``, ``connectivity_check``) rebuilds a NetworkX
+graph from scratch on each call *and* snaps query points to nodes with an
+O(n) linear scan (the old ``network._nearest_node``). For a workflow that
+fires many routing queries against the same network that is wasteful twice
+over.
+
+:class:`NetworkGraph` is the persistent handle that fixes both:
+
+* **build once** — :meth:`NetworkGraph.from_lines` constructs the
+  ``networkx.Graph`` a single time (endpoints fused on 6-decimal rounding,
+  byte-for-byte the behaviour of the legacy ``network._build_graph``, so
+  existing results are unchanged);
+* **query many** — :meth:`nearest_node` snaps a point to the closest node in
+  **O(log n)** through a lazily-built
+  :class:`~gispulse.core.spatial_index.SpatialIndex` (K) instead of the
+  linear scan.
+
+The handle is geometry-only and CRS-agnostic: callers reproject to a metric
+CRS *before* building so edge weights and snap distances are in meters.
+
+Example::
+
+    graph = NetworkGraph.from_lines(network_m, weight_col="travel_time")
+    src = graph.nearest_node(Point(x0, y0))   # O(log n)
+    dst = graph.nearest_node(Point(x1, y1))
+    path = networkx.shortest_path(graph.graph, src, dst, weight="weight")
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Iterable
+
+from shapely.geometry import LineString, MultiLineString, Point
+
+from gispulse.core.spatial_index import SpatialIndex
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    import geopandas as gpd
+    import networkx as nx
+
+
+class NetworkGraph:
+    """A NetworkX graph over a line layer, plus O(log n) point snapping.
+
+    Wraps the ``networkx.Graph`` together with the ``{(x, y) -> node_id}``
+    index the legacy code exposed, and adds a spatial index over the node
+    geometries so :meth:`nearest_node` is sub-linear. Build once with
+    :meth:`from_lines`, then reuse the same instance across every routing
+    query on that network.
+    """
+
+    __slots__ = ("_graph", "_node_index", "_node_points", "_index")
+
+    def __init__(
+        self,
+        graph: "nx.Graph",
+        node_index: dict[tuple[float, float], int],
+    ) -> None:
+        self._graph = graph
+        self._node_index = node_index
+        # node_points[node_id] = Point(rounded coords) — dense 0..K-1 because
+        # from_lines assigns ids as ``len(node_index)`` in encounter order.
+        points: list[Point] = [Point(0, 0)] * len(node_index)
+        for (x, y), nid in node_index.items():
+            points[nid] = Point(x, y)
+        self._node_points = points
+        self._index: SpatialIndex | None = None  # built lazily on first snap
+
+    @classmethod
+    def from_lines(
+        cls,
+        gdf: "gpd.GeoDataFrame",
+        weight_col: str | None = None,
+        *,
+        snap_decimals: int = 6,
+    ) -> "NetworkGraph":
+        """Build a handle from a GeoDataFrame of lines.
+
+        Each line endpoint, rounded to *snap_decimals* decimals, becomes a
+        node; each (Multi)LineString part becomes an edge. The edge
+        ``weight`` is ``weight_col`` when present, else the geometric length.
+
+        Args:
+            gdf:           Line network (LineString / MultiLineString).
+            weight_col:    Column used as edge weight; geometric length if
+                           absent or ``None``.
+            snap_decimals: Coordinate rounding used to fuse coincident
+                           endpoints (default 6, matching the legacy snap).
+        """
+        try:
+            import networkx as nx
+        except ImportError as exc:  # pragma: no cover - exercised via callers
+            raise ImportError(
+                "Network capabilities require 'networkx'. "
+                "Install with: pip install networkx"
+            ) from exc
+
+        graph = nx.Graph()
+        node_index: dict[tuple[float, float], int] = {}
+        has_weight = weight_col is not None and weight_col in gdf.columns
+
+        def _node(pt: Point) -> int:
+            key = (round(pt.x, snap_decimals), round(pt.y, snap_decimals))
+            nid = node_index.get(key)
+            if nid is None:
+                nid = len(node_index)
+                node_index[key] = nid
+                graph.add_node(nid, x=key[0], y=key[1])
+            return nid
+
+        for _, row in gdf.iterrows():
+            geom = row.geometry
+            if geom is None or geom.is_empty:
+                continue
+            lines = geom.geoms if isinstance(geom, MultiLineString) else [geom]
+            for line in lines:
+                if not isinstance(line, LineString) or len(line.coords) < 2:
+                    continue
+                coords = list(line.coords)
+                start = _node(Point(coords[0]))
+                end = _node(Point(coords[-1]))
+                weight = float(row[weight_col]) if has_weight else line.length
+                graph.add_edge(start, end, weight=weight, geometry=line)
+
+        return cls(graph, node_index)
+
+    @property
+    def graph(self) -> "nx.Graph":
+        """The underlying ``networkx.Graph`` (nodes carry ``x``/``y``)."""
+        return self._graph
+
+    @property
+    def node_index(self) -> dict[tuple[float, float], int]:
+        """The legacy ``{(x, y) -> node_id}`` mapping (rounded coords)."""
+        return self._node_index
+
+    def __len__(self) -> int:
+        return self._graph.number_of_nodes()
+
+    def node_point(self, node_id: int) -> Point:
+        """Return the ``Point`` of node *node_id* (rounded coords)."""
+        return self._node_points[node_id]
+
+    def nearest_node(self, point: Point) -> int:
+        """Return the id of the node closest to *point* in O(log n).
+
+        Uses a :class:`SpatialIndex` over the node geometries (built lazily
+        on first call). Returns ``-1`` for an empty graph, mirroring the
+        legacy ``network._nearest_node`` contract.
+        """
+        if not self._node_points:
+            return -1
+        if self._index is None:
+            self._index = SpatialIndex(self._node_points)
+        hit = self._index.nearest(point)
+        return hit[0] if hit else -1
+
+    def nearest_nodes(self, points: "Iterable[Point]") -> list[int]:
+        """Snap several points at once; returns one node id per point."""
+        if not self._node_points:
+            return [-1 for _ in points]
+        if self._index is None:
+            self._index = SpatialIndex(self._node_points)
+        out: list[int] = []
+        for pt in points:
+            hit = self._index.nearest(pt)
+            out.append(hit[0] if hit else -1)
+        return out
+
+
+__all__ = ["NetworkGraph"]

--- a/tests/unit/test_network_graph_handle.py
+++ b/tests/unit/test_network_graph_handle.py
@@ -1,0 +1,130 @@
+"""Unit tests for NetworkGraph — the reusable routing handle (capability F)."""
+
+from __future__ import annotations
+
+import geopandas as gpd
+import pytest
+from shapely.geometry import LineString, MultiLineString, Point
+
+pytest.importorskip("networkx", reason="networkx not installed")
+
+from gispulse.core.network_graph_handle import NetworkGraph
+
+
+@pytest.fixture
+def y_network() -> gpd.GeoDataFrame:
+    # A Y: two arms meeting at (10, 0), third arm going right.
+    return gpd.GeoDataFrame(
+        {"rid": ["a", "b", "c"], "w": [1.0, 2.0, 3.0]},
+        geometry=[
+            LineString([(0, 0), (10, 0)]),
+            LineString([(10, 10), (10, 0)]),
+            LineString([(10, 0), (20, 0)]),
+        ],
+        crs="EPSG:3857",
+    )
+
+
+def _brute_nearest(points, pt) -> int:
+    """Reference O(n) nearest used to pin the handle's snapping."""
+    best_id, best = -1, float("inf")
+    for nid, p in enumerate(points):
+        d = (p.x - pt.x) ** 2 + (p.y - pt.y) ** 2
+        if d < best:
+            best, best_id = d, nid
+    return best_id
+
+
+def test_node_and_edge_counts(y_network):
+    g = NetworkGraph.from_lines(y_network)
+    # 4 distinct endpoints: (0,0),(20,0),(10,10) and the shared (10,0)
+    assert len(g) == 4
+    assert g.graph.number_of_edges() == 3
+
+
+def test_shared_node_fused(y_network):
+    g = NetworkGraph.from_lines(y_network)
+    # the (10,0) junction is incident to all three edges → degree 3
+    assert max(dict(g.graph.degree()).values()) == 3
+
+
+def test_node_index_is_rounded_mapping(y_network):
+    g = NetworkGraph.from_lines(y_network)
+    assert (10.0, 0.0) in g.node_index
+    junction = g.node_index[(10.0, 0.0)]
+    assert g.node_point(junction).equals(Point(10.0, 0.0))
+
+
+def test_weight_col_used(y_network):
+    g = NetworkGraph.from_lines(y_network, weight_col="w")
+    weights = sorted(data["weight"] for _, _, data in g.graph.edges(data=True))
+    assert weights == [1.0, 2.0, 3.0]
+
+
+def test_default_weight_is_length(y_network):
+    g = NetworkGraph.from_lines(y_network)  # no weight_col
+    weights = sorted(data["weight"] for _, _, data in g.graph.edges(data=True))
+    # every arm is 10 m long
+    assert weights == pytest.approx([10.0, 10.0, 10.0])
+
+
+def test_nearest_node_matches_brute_force(y_network):
+    g = NetworkGraph.from_lines(y_network)
+    points = [g.node_point(i) for i in range(len(g))]
+    for probe in (Point(0.4, 0.1), Point(9.6, 0.2), Point(19.0, -1.0), Point(10.1, 9.0)):
+        assert g.nearest_node(probe) == _brute_nearest(points, probe)
+
+
+def test_nearest_nodes_batch(y_network):
+    g = NetworkGraph.from_lines(y_network)
+    probes = [Point(0, 0), Point(20, 0), Point(10, 10)]
+    got = g.nearest_nodes(probes)
+    assert got == [g.nearest_node(p) for p in probes]
+
+
+def test_empty_graph_returns_minus_one():
+    empty = gpd.GeoDataFrame({"x": []}, geometry=[], crs="EPSG:3857")
+    g = NetworkGraph.from_lines(empty)
+    assert len(g) == 0
+    assert g.nearest_node(Point(0, 0)) == -1
+    assert g.nearest_nodes([Point(0, 0), Point(1, 1)]) == [-1, -1]
+
+
+def test_multilinestring_splits_into_edges():
+    gdf = gpd.GeoDataFrame(
+        {"id": [1]},
+        geometry=[
+            MultiLineString(
+                [
+                    LineString([(0, 0), (1, 0)]),
+                    LineString([(1, 0), (2, 0)]),
+                ]
+            )
+        ],
+        crs="EPSG:3857",
+    )
+    g = NetworkGraph.from_lines(gdf)
+    assert g.graph.number_of_edges() == 2
+    assert len(g) == 3  # (0,0),(1,0),(2,0)
+
+
+def test_empty_and_none_geometry_skipped():
+    gdf = gpd.GeoDataFrame(
+        {"id": [1, 2, 3]},
+        geometry=[
+            LineString([(0, 0), (1, 0)]),
+            None,
+            LineString(),
+        ],
+        crs="EPSG:3857",
+    )
+    g = NetworkGraph.from_lines(gdf)
+    assert g.graph.number_of_edges() == 1
+
+
+def test_index_built_once_and_reused(y_network):
+    g = NetworkGraph.from_lines(y_network)
+    g.nearest_node(Point(0, 0))
+    first = g._index
+    g.nearest_node(Point(20, 0))
+    assert g._index is first  # lazily built, then cached


### PR DESCRIPTION
## Feature F — graph handle persistant

Capability F of the network/linear-referencing track (A–K plan). A persistent, reusable routing handle that fixes the transverse weak point shared by A/F/K: every network capability used to **rebuild** the NetworkX graph on each call *and* snap query points with an **O(n) linear scan** (`network._nearest_node`).

### What changed
- **`core/network_graph_handle.py`** — new `NetworkGraph` class (infra core, like `SpatialIndex` K; not a registered capability):
  - `from_lines(gdf, weight_col=None, snap_decimals=6)` — builds the graph once. Endpoint fusion on 6-decimal rounding is **byte-for-byte the legacy `_build_graph`**, so existing routing results are unchanged.
  - `nearest_node` / `nearest_nodes` — **O(log n)** snapping through a lazily-built `SpatialIndex` (K), replacing the O(n) scan.
  - `graph` / `node_index` / `node_point` / `__len__` accessors (`node_index` mirrors the legacy `{(x,y) -> node_id}` mapping).
- **`capabilities/network.py`** — `shortest_path`, `isochrone`, `network_allocation`, `od_matrix`, `mst`, `connectivity_check` now delegate to the handle; the private `_build_graph` / `_nearest_node` helpers are removed (no external importers).

### Tests
- 11 new unit tests (`test_network_graph_handle.py`): node/edge counts, endpoint fusion, weighting (col vs length), nearest-node **vs brute-force reference**, empty/None geometry, MultiLineString split, lazy-index reuse.
- Full network suite green (98 passed): `test_network_capabilities`, `_s11`, `test_network_graph`, `test_network_topology_capabilities`, `test_graph_executor`.

### Notes
- Infra core (not registered) → **capability matrix unchanged**, no drift gate to touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)