### PR TITLE
chore(release): 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0]
+
+Feature release adding a coherent set of **generic GIS capabilities** for
+network analysis, linear referencing and clustering (the "A–K" plan), plus a
+unified multi-source data provider. Fully backwards-compatible.
+
+### Added
+
+- **Unified data loader & providers (#374).** `gispulse.load(source, …)` /
+  `app.load()` resolve files (incl. GeoParquet), remote URIs (s3/http),
+  `wfs://` / `stac://` / `ogc-features://`, datamarts (`datamart://`, curated
+  Parquet) and GeoNode instances (`geonode://`, read + `publish()` write) to a
+  GeoDataFrame or a lazy DuckDB scan.
+- **`SpatialIndex` (K) & `NetworkGraph` (F).** Reusable core infrastructure: a
+  thin STRtree wrapper (build once / query many) and a persistent routing
+  handle that builds the NetworkX graph once and snaps points to nodes in
+  O(log n). All network capabilities (`shortest_path`, `isochrone`,
+  `od_matrix`, `mst`, `network_allocation`, `connectivity_check`) now reuse the
+  handle instead of rebuilding the graph and scanning nodes linearly.
+- **`build_network_graph` (A).** Turns a line layer into a tagged node/edge
+  GeoDataFrame with stable ids, degrees and metric lengths.
+- **`snap_points_to_lines` (B)** and **`split_lines_at_points` (C).** Snap a
+  point layer onto a line network; cut lines at a reference point layer.
+- **`planarize` (D)** and **`connected_components` (E).** Attribute-preserving
+  planar noding; label network islands.
+- **`steiner_tree` (G).** Approximate minimum Steiner tree connecting a subset
+  of terminal points at near-minimum total cost.
+- **`cluster_network_dbscan` (H).** DBSCAN using shortest-path distance along a
+  network instead of straight-line distance.
+- **`community_detection` (I).** Partition a network into communities (Louvain
+  / greedy modularity / label propagation); tags each edge with a
+  `community_id`.
+- **`cluster_st_dbscan` (J).** Spatio-temporal DBSCAN combining a spatial
+  (`eps_m`) and a temporal (`eps_time`) threshold.
+
 ## [2.1.0]
 
 Feature release consolidating everything that landed on `main` since `2.0.0`:

--- a/docs-site/changelog.md
+++ b/docs-site/changelog.md
@@ -13,6 +13,23 @@ La source de vérité de ce fichier est [`CHANGELOG.md`](https://github.com/imag
 
 ---
 
+## [2.2.0] — 2026-06-07
+
+Release de fonctionnalités ajoutant un ensemble cohérent de **capacités SIG génériques** pour l'analyse réseau, le linear referencing et le clustering (le plan « A–K »), ainsi qu'un provider de données multi-sources unifié. Entièrement rétro-compatible.
+
+### Ajouts
+
+- **Loader & providers unifiés (#374).** `gispulse.load(source, …)` / `app.load()` résolvent fichiers (dont GeoParquet), URI distants (s3/http), `wfs://` / `stac://` / `ogc-features://`, datamarts (`datamart://`, Parquet curés) et instances GeoNode (`geonode://`, lecture + `publish()`) vers un GeoDataFrame ou un scan DuckDB lazy.
+- **`SpatialIndex` (K) & `NetworkGraph` (F).** Infrastructure cœur réutilisable : wrapper STRtree (build once / query many) et handle de routage persistant qui construit le graphe NetworkX une seule fois et snappe les points aux nœuds en O(log n). Toutes les capacités réseau (`shortest_path`, `isochrone`, `od_matrix`, `mst`, `network_allocation`, `connectivity_check`) le réutilisent.
+- **`build_network_graph` (A), `snap_points_to_lines` (B), `split_lines_at_points` (C).**
+- **`planarize` (D), `connected_components` (E).**
+- **`steiner_tree` (G).** Arbre de Steiner approximé reliant un sous-ensemble de terminaux au moindre coût.
+- **`cluster_network_dbscan` (H).** DBSCAN sur distance plus-court-chemin réseau.
+- **`community_detection` (I).** Partition en communautés (Louvain / greedy modularity / label propagation), annote `community_id`.
+- **`cluster_st_dbscan` (J).** DBSCAN spatio-temporel (seuils `eps_m` + `eps_time`).
+
+---
+
 ## [2.1.0] — 2026-06-05
 
 Release de fonctionnalités consolidant tout ce qui a atterri sur `main` depuis `2.0.0` : une vague de nouveaux plugins sources déclaratifs, le pipeline ELT push-down / manifest-v3, la matérialisation S3 en masse des sources tabulaires, et un object store Garage piloté par l'environnement. Entièrement rétro-compatible — le shim meta-path `_compat` et l'alias `PluginHub = ExtensionHub` restent en place.

--- a/docs-site/en/changelog.md
+++ b/docs-site/en/changelog.md
@@ -13,6 +13,23 @@ The authoritative version of this file lives at [`CHANGELOG.md`](https://github.
 
 ---
 
+## [2.2.0] — 2026-06-07
+
+Feature release adding a coherent set of **generic GIS capabilities** for network analysis, linear referencing and clustering (the "A–K" plan), plus a unified multi-source data provider. Fully backwards-compatible.
+
+### Added
+
+- **Unified data loader & providers (#374).** `gispulse.load(source, …)` / `app.load()` resolve files (incl. GeoParquet), remote URIs (s3/http), `wfs://` / `stac://` / `ogc-features://`, datamarts (`datamart://`, curated Parquet) and GeoNode instances (`geonode://`, read + `publish()`) to a GeoDataFrame or a lazy DuckDB scan.
+- **`SpatialIndex` (K) & `NetworkGraph` (F).** Reusable core infrastructure: a thin STRtree wrapper (build once / query many) and a persistent routing handle building the NetworkX graph once and snapping points in O(log n). All network capabilities reuse it.
+- **`build_network_graph` (A), `snap_points_to_lines` (B), `split_lines_at_points` (C).**
+- **`planarize` (D), `connected_components` (E).**
+- **`steiner_tree` (G).** Approximate minimum Steiner tree connecting a subset of terminals.
+- **`cluster_network_dbscan` (H).** DBSCAN over shortest-path network distance.
+- **`community_detection` (I).** Community partition (Louvain / greedy modularity / label propagation), tags `community_id`.
+- **`cluster_st_dbscan` (J).** Spatio-temporal DBSCAN (`eps_m` + `eps_time`).
+
+---
+
 ## [2.1.0] — 2026-06-05
 
 Feature release consolidating everything that landed on `main` since `2.0.0`: a wave of new declarative source plugins, the ELT push-down / manifest-v3 pipeline, S3 bulk materialisation for tabular sources, and an env-driven Garage object store. Fully backwards-compatible — the `_compat` meta-path shim and the `PluginHub = ExtensionHub` alias stay in place.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gispulse"
-version = "2.1.0"
+version = "2.2.0"
 description = "Modular geospatial engine with business rules, triggers, and dual operating modes (DuckDB/PostGIS)"
 license = "AGPL-3.0-or-later"
 requires-python = ">=3.10"

--- a/qgis_plugin/metadata.txt
+++ b/qgis_plugin/metadata.txt
@@ -4,7 +4,7 @@ qgisMinimumVersion=3.28
 qgisMaximumVersion=3.99
 description=Trigger-driven spatial CDC for QGIS — attach gispulse rules to any layer.
 about=GISPulse turns QGIS layers into reactive datasets. Save a tracked GeoPackage and gispulse fires the rules attached to it: webhooks, downstream layer refresh, validation. The plugin is a thin bridge — it shells out to the gispulse Python CLI (pip install gispulse) and streams its logs into a dock widget. Requires gispulse >= 1.3.0 on the PATH visible to QGIS.
-version=2.1.0
+version=2.2.0
 author=Imagodata
 email=hello@gispulse.dev
 homepage=https://gispulse.dev


### PR DESCRIPTION
## Release 2.2.0

Version bump + CHANGELOG for the **A–K generic GIS capabilities** wave and the unified data provider, all merged to `main`:

- Provider/loader (#374), `SpatialIndex` (K) + `NetworkGraph` handle (#379, F)
- `build_network_graph` (A), `snap_points_to_lines` (B), `split_lines_at_points` (#378, C), `planarize` (D), `connected_components` (#377, E)
- `steiner_tree` (#381, G), `cluster_network_dbscan` (#380, H), `community_detection` (#382, I), `cluster_st_dbscan` (#383, J)

Bumps `pyproject.toml` and `qgis_plugin/metadata.txt` (lockstep) to 2.2.0. After merge, tag `v2.2.0` triggers `release.yml` → PyPI publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)