### PR TITLE
chore(release): 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.1]
+
+### Added
+
+- **DuckDB-file datamarts (DP2b).** A datamart can now be backed by a single
+  DuckDB database file (`kind="duckdb"`) instead of one Parquet file per
+  table: `datamart://<mart>/<table>` attaches the `.duckdb` file read-only
+  and selects the table, with bbox push-down via `ST_Intersects`.
+  `GISPULSE_DATAMARTS` accepts `"kind": "duckdb"`.
+
 ## [2.2.0]
 
 Feature release adding a coherent set of **generic GIS capabilities** for

--- a/docs-site/changelog.md
+++ b/docs-site/changelog.md
@@ -13,6 +13,14 @@ La source de vérité de ce fichier est [`CHANGELOG.md`](https://github.com/imag
 
 ---
 
+## [2.2.1] — 2026-06-07
+
+### Ajouts
+
+- **Datamarts sur fichier DuckDB (DP2b).** Un datamart peut désormais être adossé à un **fichier base DuckDB unique** (`kind="duckdb"`) au lieu d'un Parquet par table : `datamart://<mart>/<table>` attache le fichier `.duckdb` en lecture seule et sélectionne la table, avec push-down du bbox via `ST_Intersects`. `GISPULSE_DATAMARTS` accepte `"kind": "duckdb"`.
+
+---
+
 ## [2.2.0] — 2026-06-07
 
 Release de fonctionnalités ajoutant un ensemble cohérent de **capacités SIG génériques** pour l'analyse réseau, le linear referencing et le clustering (le plan « A–K »), ainsi qu'un provider de données multi-sources unifié. Entièrement rétro-compatible.

--- a/docs-site/en/changelog.md
+++ b/docs-site/en/changelog.md
@@ -13,6 +13,14 @@ The authoritative version of this file lives at [`CHANGELOG.md`](https://github.
 
 ---
 
+## [2.2.1] — 2026-06-07
+
+### Added
+
+- **DuckDB-file datamarts (DP2b).** A datamart can now be backed by a single DuckDB database file (`kind="duckdb"`) instead of one Parquet file per table: `datamart://<mart>/<table>` attaches the `.duckdb` file read-only and selects the table, with bbox push-down via `ST_Intersects`. `GISPULSE_DATAMARTS` accepts `"kind": "duckdb"`.
+
+---
+
 ## [2.2.0] — 2026-06-07
 
 Feature release adding a coherent set of **generic GIS capabilities** for network analysis, linear referencing and clustering (the "A–K" plan), plus a unified multi-source data provider. Fully backwards-compatible.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gispulse"
-version = "2.2.0"
+version = "2.2.1"
 description = "Modular geospatial engine with business rules, triggers, and dual operating modes (DuckDB/PostGIS)"
 license = "AGPL-3.0-or-later"
 requires-python = ">=3.10"

--- a/qgis_plugin/metadata.txt
+++ b/qgis_plugin/metadata.txt
@@ -4,7 +4,7 @@ qgisMinimumVersion=3.28
 qgisMaximumVersion=3.99
 description=Trigger-driven spatial CDC for QGIS — attach gispulse rules to any layer.
 about=GISPulse turns QGIS layers into reactive datasets. Save a tracked GeoPackage and gispulse fires the rules attached to it: webhooks, downstream layer refresh, validation. The plugin is a thin bridge — it shells out to the gispulse Python CLI (pip install gispulse) and streams its logs into a dock widget. Requires gispulse >= 1.3.0 on the PATH visible to QGIS.
-version=2.2.0
+version=2.2.1
 author=Imagodata
 email=hello@gispulse.dev
 homepage=https://gispulse.dev


### PR DESCRIPTION
## Release 2.2.1

Patch release shipping **DuckDB-file datamarts (DP2b)** (#385): a datamart can now be backed by a single `.duckdb` database file (`kind="duckdb"`) instead of one Parquet file per table.

Bumps `pyproject.toml` + `qgis_plugin/metadata.txt` (lockstep) to 2.2.1 and adds the 2.2.1 section to all changelogs (root + docs-site FR/EN). After merge, tag `v2.2.1` triggers `release.yml` → PyPI publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)