### PR TITLE
chore(release): 2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.2]
+
 ### Changed
 
 - **`snap_points_to_lines` hardening.** `ref_id_col` is now **required**: a

--- a/docs-site/changelog.md
+++ b/docs-site/changelog.md
@@ -13,6 +13,14 @@ La source de vérité de ce fichier est [`CHANGELOG.md`](https://github.com/imag
 
 ---
 
+## [2.2.2] — 2026-06-07
+
+### Modifié
+
+- **Durcissement de `snap_points_to_lines`.** `ref_id_col` est désormais **requis** : une colonne absente lève un `ValueError` clair au lieu d'un fallback silencieux sur l'index positionnel. Les ex æquo entre lignes équidistantes sont départagés de façon **déterministe** sur le plus petit `edge_id` (mêmes entrées → mêmes sorties). Le contrat des lignes non-snappées est inchangé (au-delà de `max_distance_m` : `snapped=False`, `edge_id`/`measure` nuls, géométrie d'origine conservée, seul `offset_distance` reporté) — les consommateurs aval (ex. `build_site_network_candidates` de MILOU) ne nécessitent aucune modification.
+
+---
+
 ## [2.2.1] — 2026-06-07
 
 ### Ajouts

--- a/docs-site/en/changelog.md
+++ b/docs-site/en/changelog.md
@@ -13,6 +13,14 @@ The authoritative version of this file lives at [`CHANGELOG.md`](https://github.
 
 ---
 
+## [2.2.2] — 2026-06-07
+
+### Changed
+
+- **`snap_points_to_lines` hardening.** `ref_id_col` is now **required**: a missing column raises a clear `ValueError` instead of silently falling back to a positional index. Ties between equidistant lines break **deterministically** on the smallest `edge_id` (same inputs → same outputs). The unsnapped-row contract is unchanged (beyond `max_distance_m`: `snapped=False`, null `edge_id`/`measure`, original geometry kept, only `offset_distance` reported) — downstream consumers (e.g. MILOU's `build_site_network_candidates`) need no changes.
+
+---
+
 ## [2.2.1] — 2026-06-07
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gispulse"
-version = "2.2.1"
+version = "2.2.2"
 description = "Modular geospatial engine with business rules, triggers, and dual operating modes (DuckDB/PostGIS)"
 license = "AGPL-3.0-or-later"
 requires-python = ">=3.10"

--- a/qgis_plugin/metadata.txt
+++ b/qgis_plugin/metadata.txt
@@ -4,7 +4,7 @@ qgisMinimumVersion=3.28
 qgisMaximumVersion=3.99
 description=Trigger-driven spatial CDC for QGIS — attach gispulse rules to any layer.
 about=GISPulse turns QGIS layers into reactive datasets. Save a tracked GeoPackage and gispulse fires the rules attached to it: webhooks, downstream layer refresh, validation. The plugin is a thin bridge — it shells out to the gispulse Python CLI (pip install gispulse) and streams its logs into a dock widget. Requires gispulse >= 1.3.0 on the PATH visible to QGIS.
-version=2.2.1
+version=2.2.2
 author=Imagodata
 email=hello@gispulse.dev
 homepage=https://gispulse.dev


### PR DESCRIPTION
Patch release **2.2.2**.

## Contenu
Durcissement de `snap_points_to_lines` (capability B), suite à #388 :
- `ref_id_col` **requis** (plus de fallback positionnel silencieux) ;
- ex æquo départagés de façon **déterministe** sur le plus petit `edge_id`.

Le contrat des lignes non-snappées est **inchangé** → les consommateurs aval (`build_site_network_candidates` de MILOU) ne nécessitent aucune modification. Vérifié bout-en-bout : les 10 tests de `milou/tests/network/test_candidates.py` passent contre cette version.

## Bump
- `pyproject.toml` + `qgis_plugin/metadata.txt` (lockstep) → 2.2.2
- `CHANGELOG.md` + `docs-site/{,en/}changelog.md` : section 2.2.2

Le tag `v2.2.2` déclenchera la publication PyPI (Trusted Publisher) + GH Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)