### PR TITLE
fix: declare requests for WFS adapter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "pydantic-settings>=2.0,<3.0",
     "PyYAML>=6.0,<7.0",
     "httpx>=0.24,<1.0",
+    "requests>=2.28,<3.0",
     "openpyxl>=3.1,<4.0",
 ]
 


### PR DESCRIPTION
Fixes #345.

src/gispulse/adapters/ogc/wfs_client.py imports equests directly, but equests is not declared in the runtime dependencies.

This adds equests>=2.28,<3.0 alongside the existing HTTP client dependency so minimal installs can import and use the WFS/OGC adapter without requiring users to install equests manually.