### PR TITLE
feat(fetchers): network hardening — REST retry/backoff + HTTP stream timeout/retry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.12"]
+        python-version: ["3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "gispulse"
 version = "2.2.2"
 description = "Modular geospatial engine with business rules, triggers, and dual operating modes (DuckDB/PostGIS)"
 license = "AGPL-3.0-or-later"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 readme = "README.md"
 authors = [
     {name = "ImagoData", email = "contact@imagodata.com"},
@@ -18,7 +18,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: GIS",

--- a/src/gispulse/adapters/rest/rest_fetcher.py
+++ b/src/gispulse/adapters/rest/rest_fetcher.py
@@ -21,6 +21,7 @@ import json
 from typing import Any
 from urllib.parse import urlencode
 
+from gispulse.adapters.rest.retry import RetrySpec, get_json_with_retry, sleep as _sleep
 from gispulse.core.logging import get_logger
 from gispulse.core.plugin_model import (
     AccessProtocol,
@@ -37,7 +38,7 @@ _GEOJSON_CRS = "EPSG:4326"
 _DEFAULT_TIMEOUT_S = 20.0
 #: AccessSpec.params keys the fetcher consumes itself — every *other* key
 #: is forwarded verbatim as an HTTP query parameter.
-_RESERVED_PARAMS = frozenset({"geom_param", "timeout"})
+_RESERVED_PARAMS = frozenset({"geom_param", "timeout", "retry"})
 
 
 def _bbox_from_extent(extent: Any) -> tuple[float, float, float, float] | None:
@@ -84,6 +85,21 @@ def _get_geojson(url: str, timeout: float) -> dict[str, Any]:
     return resp.json()
 
 
+def _get_geojson_with_retry(
+    url: str,
+    timeout: float,
+    retry: RetrySpec,
+) -> dict[str, Any]:
+    return get_json_with_retry(
+        _get_geojson,
+        url,
+        timeout,
+        retry,
+        retry_event="rest_geojson_fetch_retry",
+        sleep_fn=_sleep,
+    )
+
+
 class RestGeoJsonFetcher:
     """:class:`~core.sources.Fetcher` for ``AccessProtocol.REST_API``.
 
@@ -93,6 +109,7 @@ class RestGeoJsonFetcher:
     - ``geom_param`` — *(optional)* name of the query field that receives
       the fetch ``extent`` as a GeoJSON polygon (API Carto uses ``geom``)
     - ``timeout`` — HTTP timeout in seconds *(default: 20)*
+    - ``retry`` — retry/backoff policy for transient HTTP/transport errors
     - every other key — forwarded verbatim as an HTTP query parameter
     """
 
@@ -109,21 +126,18 @@ class RestGeoJsonFetcher:
 
         params = dict(access.params or {})
         timeout = float(params.get("timeout", _DEFAULT_TIMEOUT_S))
+        retry = RetrySpec.from_params(params)
         geom_param = params.get("geom_param")
-        query: dict[str, Any] = {
-            k: v for k, v in params.items() if k not in _RESERVED_PARAMS
-        }
+        query: dict[str, Any] = {k: v for k, v in params.items() if k not in _RESERVED_PARAMS}
         bbox = _bbox_from_extent(extent)
         if geom_param and bbox is not None:
-            query[str(geom_param)] = json.dumps(
-                _bbox_polygon(bbox), separators=(",", ":")
-            )
+            query[str(geom_param)] = json.dumps(_bbox_polygon(bbox), separators=(",", ":"))
         url = access.endpoint
         if query:
             sep = "&" if "?" in url else "?"
             url = f"{url}{sep}{urlencode(query)}"
 
-        payload = _get_geojson(url, timeout)
+        payload = _get_geojson_with_retry(url, timeout, retry)
         if payload.get("type") != "FeatureCollection":
             raise ValueError(
                 f"REST endpoint did not return a GeoJSON FeatureCollection "

--- a/src/gispulse/adapters/rest/rest_table_fetcher.py
+++ b/src/gispulse/adapters/rest/rest_table_fetcher.py
@@ -27,6 +27,7 @@ import time
 from typing import Any, BinaryIO
 from urllib.parse import urlencode, urljoin, urlsplit
 
+from gispulse.adapters.rest.retry import RetrySpec, get_json_with_retry, sleep as _sleep
 from gispulse.core.config import settings
 from gispulse.core.logging import get_logger
 from gispulse.core.plugin_model import (
@@ -108,10 +109,26 @@ class PaginationSpec:
             empty_body_is_empty=bool(pagination.get("empty_body_is_empty", False)),
             max_pages=int(pagination.get("max_pages", _DEFAULT_MAX_PAGES)),
             max_rows=int(max_rows) if max_rows is not None else None,
-            max_total_seconds=(
-                float(max_total_seconds) if max_total_seconds is not None else None
-            ),
+            max_total_seconds=(float(max_total_seconds) if max_total_seconds is not None else None),
         )
+
+
+def _get_json_with_retry(
+    url: str,
+    timeout: float,
+    retry: RetrySpec,
+    *,
+    empty_statuses: frozenset[Any],
+) -> dict[str, Any]:
+    return get_json_with_retry(
+        _get_json,
+        url,
+        timeout,
+        retry,
+        empty_statuses=empty_statuses,
+        retry_event="rest_table_fetch_retry",
+        sleep_fn=_sleep,
+    )
 
 
 def _rows_from_body(body: dict[str, Any], spec: PaginationSpec) -> list[Any]:
@@ -247,6 +264,7 @@ class RestTableFetcher:
         params = dict(access.params or {})
         timeout = float(params.get("timeout", _DEFAULT_TIMEOUT_S))
         pagination = PaginationSpec.from_params(params)
+        retry = RetrySpec.from_params(params)
         deadline = (
             time.monotonic() + pagination.max_total_seconds
             if pagination.max_total_seconds is not None
@@ -286,7 +304,12 @@ class RestTableFetcher:
                 guard_outbound_url(url)
                 seen.add(url)
                 try:
-                    body = _get_json(url, timeout)
+                    body = _get_json_with_retry(
+                        url,
+                        timeout,
+                        retry,
+                        empty_statuses=pagination.empty_statuses,
+                    )
                 except httpx.HTTPStatusError as exc:
                     if exc.response.status_code in pagination.empty_statuses:
                         break  # "no data here" — leave the result empty
@@ -297,16 +320,10 @@ class RestTableFetcher:
                     raise
                 page_count += 1
                 for row in _rows_from_body(body, pagination):
-                    if (
-                        pagination.max_rows is not None
-                        and row_count >= pagination.max_rows
-                    ):
+                    if pagination.max_rows is not None and row_count >= pagination.max_rows:
                         break
                     row_count += _write_jsonl_row(row, fh, digest)
-                if (
-                    pagination.max_rows is not None
-                    and row_count >= pagination.max_rows
-                ):
+                if pagination.max_rows is not None and row_count >= pagination.max_rows:
                     break
                 if page_count >= pagination.max_pages:
                     break

--- a/src/gispulse/adapters/rest/retry.py
+++ b/src/gispulse/adapters/rest/retry.py
@@ -1,0 +1,121 @@
+"""Shared retry/backoff helpers for REST adapters."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
+import time
+from typing import Any
+
+from gispulse.core.logging import get_logger
+
+log = get_logger(__name__)
+
+_DEFAULT_RETRY_STATUSES = frozenset({429, 500, 502, 503, 504})
+
+
+@dataclass(frozen=True)
+class RetrySpec:
+    """Retry policy compiled from ``AccessSpec.params["retry"]``."""
+
+    max_attempts: int = 1
+    backoff_seconds: float = 0.0
+    backoff_factor: float = 2.0
+    statuses: frozenset[int] = field(default_factory=lambda: _DEFAULT_RETRY_STATUSES)
+
+    @classmethod
+    def from_params(cls, params: dict[str, Any]) -> RetrySpec:
+        retry = dict(params.get("retry") or {})
+        if not retry:
+            return cls()
+        max_attempts = retry.get("max_attempts")
+        if max_attempts is None and retry.get("max_retries") is not None:
+            max_attempts = int(retry["max_retries"]) + 1
+        if max_attempts is None:
+            max_attempts = 1
+        statuses = retry.get("statuses", _DEFAULT_RETRY_STATUSES)
+        return cls(
+            max_attempts=max(1, int(max_attempts)),
+            backoff_seconds=max(0.0, float(retry.get("backoff_seconds", 0.0))),
+            backoff_factor=max(1.0, float(retry.get("backoff_factor", 2.0))),
+            statuses=frozenset(int(status) for status in statuses),
+        )
+
+
+def sleep(seconds: float) -> None:
+    time.sleep(seconds)
+
+
+def _retry_after_seconds(headers: Any) -> float | None:
+    value = headers.get("Retry-After") if hasattr(headers, "get") else None
+    if not value:
+        return None
+    try:
+        return max(0.0, float(value))
+    except (TypeError, ValueError):
+        pass
+    try:
+        retry_at = parsedate_to_datetime(str(value))
+    except (TypeError, ValueError):
+        return None
+    if retry_at.tzinfo is None:
+        retry_at = retry_at.replace(tzinfo=UTC)
+    return max(0.0, (retry_at - datetime.now(tz=UTC)).total_seconds())
+
+
+def _retry_delay_seconds(
+    exc: BaseException,
+    retry: RetrySpec,
+    *,
+    attempt: int,
+) -> float:
+    import httpx
+
+    if isinstance(exc, httpx.HTTPStatusError):
+        retry_after = _retry_after_seconds(exc.response.headers)
+        if retry_after is not None:
+            return retry_after
+    return retry.backoff_seconds * (retry.backoff_factor ** max(0, attempt - 1))
+
+
+def get_json_with_retry(
+    fetch_json: Callable[[str, float], dict[str, Any]],
+    url: str,
+    timeout: float,
+    retry: RetrySpec,
+    *,
+    empty_statuses: frozenset[Any] = frozenset(),
+    retry_event: str = "rest_fetch_retry",
+    sleep_fn: Callable[[float], None] = sleep,
+) -> dict[str, Any]:
+    """GET JSON through ``fetch_json`` with retry on transient HTTP/transport failures."""
+    import httpx
+
+    attempt = 1
+    while True:
+        try:
+            return fetch_json(url, timeout)
+        except httpx.HTTPStatusError as exc:
+            status_code = exc.response.status_code
+            if (
+                status_code in empty_statuses
+                or status_code not in retry.statuses
+                or attempt >= retry.max_attempts
+            ):
+                raise
+            delay = _retry_delay_seconds(exc, retry, attempt=attempt)
+        except httpx.TransportError as exc:
+            if attempt >= retry.max_attempts:
+                raise
+            delay = _retry_delay_seconds(exc, retry, attempt=attempt)
+        log.warning(
+            retry_event,
+            url=url,
+            attempt=attempt,
+            max_attempts=retry.max_attempts,
+            sleep_seconds=delay,
+        )
+        sleep_fn(delay)
+        attempt += 1

--- a/src/gispulse/core/bulk_runner.py
+++ b/src/gispulse/core/bulk_runner.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Any, Iterable, Iterator
 from zipfile import ZipFile
 
+from gispulse.core.fetchers._http_download import stream_http_to_file
 from gispulse.core.bulk_ingest import (
     BULK_RAW_PREFIX,
     BULK_STAGE_PREFIX,
@@ -640,14 +641,10 @@ def _is_spatial_gzip_download(entry: SourceEntryRef, access: AccessSpec) -> bool
 def _download_to_path(endpoint: str, dest: Path) -> None:
     dest.parent.mkdir(parents=True, exist_ok=True)
     if endpoint.startswith(("http://", "https://")):
-        import httpx
-
-        with httpx.stream("GET", endpoint, follow_redirects=True) as resp:
-            resp.raise_for_status()
-            with dest.open("wb") as out:
-                for chunk in resp.iter_bytes():
-                    if chunk:
-                        out.write(chunk)
+        # Bulk archives can be 100s of MB; a single transient blip must not abort
+        # a national run. Reuse the shared streamed-download helper (timeout +
+        # bounded retries) instead of a one-shot httpx stream.
+        stream_http_to_file(endpoint, dest, retry_log_event="bulk_download_retry")
         return
     shutil.copyfile(Path(endpoint), dest)
 

--- a/src/gispulse/core/fetchers/_http_download.py
+++ b/src/gispulse/core/fetchers/_http_download.py
@@ -1,0 +1,125 @@
+"""HTTP streaming download helpers for fetchers."""
+
+from __future__ import annotations
+
+import os
+import time
+from os import PathLike
+
+from gispulse.core.logging import get_logger
+
+log = get_logger(__name__)
+
+_DEFAULT_READ_TIMEOUT_SECONDS = 120.0
+_HTTP_RETRY_BACKOFFS_SECONDS = (2.0, 5.0)
+_HTTP_MAX_ATTEMPTS = len(_HTTP_RETRY_BACKOFFS_SECONDS) + 1
+
+
+def _read_timeout_seconds() -> float:
+    raw = os.getenv("GISPULSE_HTTP_READ_TIMEOUT")
+    if raw is None:
+        return _DEFAULT_READ_TIMEOUT_SECONDS
+    try:
+        value = float(raw)
+    except ValueError:
+        log.warning(
+            "http_download_invalid_read_timeout",
+            value=raw,
+            default_seconds=_DEFAULT_READ_TIMEOUT_SECONDS,
+        )
+        return _DEFAULT_READ_TIMEOUT_SECONDS
+    if value <= 0:
+        log.warning(
+            "http_download_invalid_read_timeout",
+            value=raw,
+            default_seconds=_DEFAULT_READ_TIMEOUT_SECONDS,
+        )
+        return _DEFAULT_READ_TIMEOUT_SECONDS
+    return value
+
+
+def _http_timeout():
+    import httpx
+
+    return httpx.Timeout(
+        connect=10.0,
+        read=_read_timeout_seconds(),
+        write=30.0,
+        pool=10.0,
+    )
+
+
+def _is_retriable_status(status_code: int) -> bool:
+    return status_code == 429 or status_code >= 500
+
+
+def _log_retry(
+    event: str,
+    *,
+    endpoint: str,
+    attempt: int,
+    backoff_seconds: float,
+    error: BaseException,
+    status_code: int | None = None,
+) -> None:
+    log.warning(
+        event,
+        endpoint=endpoint,
+        attempt=attempt,
+        max_attempts=_HTTP_MAX_ATTEMPTS,
+        next_attempt=attempt + 1,
+        backoff_seconds=backoff_seconds,
+        error_type=type(error).__name__,
+        error=str(error),
+        status_code=status_code,
+    )
+
+
+def stream_http_to_file(
+    endpoint: str,
+    local_path: str | PathLike[str],
+    *,
+    retry_log_event: str,
+) -> None:
+    """Stream an HTTP(S) response to disk with bounded retries."""
+    import httpx
+
+    for attempt in range(1, _HTTP_MAX_ATTEMPTS + 1):
+        try:
+            with httpx.stream(
+                "GET",
+                endpoint,
+                follow_redirects=True,
+                timeout=_http_timeout(),
+            ) as resp:
+                resp.raise_for_status()
+                with open(local_path, "wb") as fh:
+                    for chunk in resp.iter_bytes():
+                        fh.write(chunk)
+            return
+        except httpx.HTTPStatusError as exc:
+            status_code = exc.response.status_code
+            if attempt >= _HTTP_MAX_ATTEMPTS or not _is_retriable_status(status_code):
+                raise
+            backoff_seconds = _HTTP_RETRY_BACKOFFS_SECONDS[attempt - 1]
+            _log_retry(
+                retry_log_event,
+                endpoint=endpoint,
+                attempt=attempt,
+                backoff_seconds=backoff_seconds,
+                error=exc,
+                status_code=status_code,
+            )
+            time.sleep(backoff_seconds)
+        except (httpx.TimeoutException, httpx.TransportError) as exc:
+            if attempt >= _HTTP_MAX_ATTEMPTS:
+                raise
+            backoff_seconds = _HTTP_RETRY_BACKOFFS_SECONDS[attempt - 1]
+            _log_retry(
+                retry_log_event,
+                endpoint=endpoint,
+                attempt=attempt,
+                backoff_seconds=backoff_seconds,
+                error=exc,
+            )
+            time.sleep(backoff_seconds)

--- a/src/gispulse/core/fetchers/http_file.py
+++ b/src/gispulse/core/fetchers/http_file.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from typing import Any, ClassVar
 
+from gispulse.core.fetchers._http_download import stream_http_to_file
 from gispulse.core.fetchers.base import LazyFetcher, resolve_s3_materialize_uri
 from gispulse.core.logging import get_logger
 from gispulse.core.plugin_model import (
@@ -78,9 +79,7 @@ class HttpFileFetcher(LazyFetcher):
         if not extent:
             return ""
         minx, miny, maxx, maxy = (float(c) for c in extent)
-        envelope = (
-            f"ST_MakeEnvelope({minx}, {miny}, {maxx}, {maxy})"
-        )
+        envelope = f"ST_MakeEnvelope({minx}, {miny}, {maxx}, {maxy})"
         return f" WHERE ST_Intersects({geom_expr}, {envelope})"
 
     def _csv_scan(self, access: AccessSpec, extent: Any | None) -> str:
@@ -90,10 +89,7 @@ class HttpFileFetcher(LazyFetcher):
         lon = access.params.get("lon", "longitude")
         geom = f'ST_Point("{lon}", "{lat}")'
         where = self._bbox_clause(extent, geom)
-        return (
-            f"(SELECT *, {geom} AS geometry "
-            f"FROM read_csv_auto('{uri}'){where})"
-        )
+        return f"(SELECT *, {geom} AS geometry FROM read_csv_auto('{uri}'){where})"
 
     def _spatial_scan(self, access: AccessSpec, extent: Any | None) -> str:
         """Spatial-file scan via ``ST_Read`` (GeoJSON / GPKG / FGB / SHP)."""
@@ -133,17 +129,13 @@ class HttpFileFetcher(LazyFetcher):
         """
         import tempfile
 
-        import httpx
-
         s3_destination = resolve_s3_materialize_uri(access)
         if s3_destination:
             from gispulse.persistence.duckdb_engine import DuckDBSession
 
             select = self._reference_scan(access, extent)
             dest = s3_destination.replace("'", "''")
-            copy_sql = (
-                f"COPY (SELECT * FROM {select}) TO '{dest}' (FORMAT PARQUET)"
-            )
+            copy_sql = f"COPY (SELECT * FROM {select}) TO '{dest}' (FORMAT PARQUET)"
             with DuckDBSession() as session:
                 session.conn.execute(copy_sql)
             log.info("http_file_materialized", path=s3_destination)
@@ -163,11 +155,11 @@ class HttpFileFetcher(LazyFetcher):
             handle.close()
             local_path = handle.name
 
-        with httpx.stream("GET", access.endpoint, follow_redirects=True) as resp:
-            resp.raise_for_status()
-            with open(local_path, "wb") as fh:
-                for chunk in resp.iter_bytes():
-                    fh.write(chunk)
+        stream_http_to_file(
+            access.endpoint,
+            local_path,
+            retry_log_event="http_file_download_retry",
+        )
         log.info("http_file_materialized", path=local_path)
         return SourceResult(
             payload=self.payload,

--- a/src/gispulse/core/fetchers/table_file.py
+++ b/src/gispulse/core/fetchers/table_file.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from typing import Any, ClassVar
 
+from gispulse.core.fetchers._http_download import stream_http_to_file
 from gispulse.core.fetchers.base import LazyFetcher, resolve_s3_materialize_uri
 from gispulse.core.logging import get_logger
 from gispulse.core.plugin_model import (
@@ -108,9 +109,7 @@ class TableFileFetcher(LazyFetcher):
 
             select = self._reference_scan(access, extent)
             dest = s3_destination.replace("'", "''")
-            copy_sql = (
-                f"COPY (SELECT * FROM {select}) TO '{dest}' (FORMAT PARQUET)"
-            )
+            copy_sql = f"COPY (SELECT * FROM {select}) TO '{dest}' (FORMAT PARQUET)"
             with DuckDBSession() as session:
                 session.conn.execute(copy_sql)
             log.info("table_file_materialized", path=s3_destination)
@@ -135,8 +134,6 @@ class TableFileFetcher(LazyFetcher):
 
         import tempfile
 
-        import httpx
-
         local_path = access.params.get("local_path")
         if not local_path:
             suffix = "." + access.endpoint.split("?")[0].rsplit(".", 1)[-1]
@@ -144,11 +141,11 @@ class TableFileFetcher(LazyFetcher):
             handle.close()
             local_path = handle.name
 
-        with httpx.stream("GET", access.endpoint, follow_redirects=True) as resp:
-            resp.raise_for_status()
-            with open(local_path, "wb") as fh:
-                for chunk in resp.iter_bytes():
-                    fh.write(chunk)
+        stream_http_to_file(
+            access.endpoint,
+            local_path,
+            retry_log_event="table_file_download_retry",
+        )
         log.info("table_file_materialized", path=local_path)
         return SourceResult(
             payload=self.payload,

--- a/tests/unit/test_http_file_fetcher.py
+++ b/tests/unit/test_http_file_fetcher.py
@@ -25,9 +25,7 @@ pytestmark = pytest.mark.usefixtures("offline_ssrf")
 
 
 def _access(endpoint: str, **params: object) -> AccessSpec:
-    return AccessSpec(
-        protocol=AccessProtocol.DOWNLOAD, endpoint=endpoint, params=params
-    )
+    return AccessSpec(protocol=AccessProtocol.DOWNLOAD, endpoint=endpoint, params=params)
 
 
 # -- contract ---------------------------------------------------------------
@@ -42,9 +40,7 @@ def test_protocol_and_payload() -> None:
 
 
 def test_reference_scan_geojson_via_vsicurl_st_read() -> None:
-    result = HttpFileFetcher().virtual_table(
-        _access("https://host.example.org/cities.geojson")
-    )
+    result = HttpFileFetcher().virtual_table(_access("https://host.example.org/cities.geojson"))
     assert result.metadata[DUCKDB_SCAN_KEY] == (
         "ST_Read('/vsicurl/https://host.example.org/cities.geojson')"
     )
@@ -75,19 +71,15 @@ def test_reference_scan_pushdown_bbox_for_spatial_file() -> None:
 
 def test_reference_scan_csv_builds_st_point_geometry() -> None:
     result = HttpFileFetcher().virtual_table(
-        _access(
-            "https://host.example.org/sites.csv", lat="lat", lon="lng"
-        )
+        _access("https://host.example.org/sites.csv", lat="lat", lon="lng")
     )
     scan = result.metadata[DUCKDB_SCAN_KEY]
-    assert 'read_csv_auto(' in scan
+    assert "read_csv_auto(" in scan
     assert 'ST_Point("lng", "lat") AS geometry' in scan
 
 
 def test_reference_scan_csv_default_lat_lon_columns() -> None:
-    result = HttpFileFetcher().virtual_table(
-        _access("https://host.example.org/sites.csv")
-    )
+    result = HttpFileFetcher().virtual_table(_access("https://host.example.org/sites.csv"))
     assert 'ST_Point("longitude", "latitude")' in result.metadata[DUCKDB_SCAN_KEY]
 
 
@@ -232,6 +224,4 @@ def test_fetch_materialize_builds_s3_uri_from_configured_bucket(
 @pytest.mark.parametrize("mode", [FetchMode.REFERENCE, FetchMode.MATERIALIZE])
 def test_fetch_rejects_private_address(mode: FetchMode) -> None:
     with pytest.raises(SSRFError):
-        HttpFileFetcher().fetch(
-            _access("http://127.0.0.1/data.geojson"), mode=mode
-        )
+        HttpFileFetcher().fetch(_access("http://127.0.0.1/data.geojson"), mode=mode)

--- a/tests/unit/test_rest_fetcher.py
+++ b/tests/unit/test_rest_fetcher.py
@@ -40,15 +40,18 @@ def mock_get(monkeypatch: pytest.MonkeyPatch) -> list:
         calls.append({"url": url, "timeout": timeout})
         return _feature_collection(3)
 
-    monkeypatch.setattr(
-        "gispulse.adapters.rest.rest_fetcher._get_geojson", fake
-    )
+    monkeypatch.setattr("gispulse.adapters.rest.rest_fetcher._get_geojson", fake)
     return calls
 
 
 def _query_of(url: str) -> dict:
     """Return the parsed query string of ``url`` as a flat dict."""
     return {k: v[0] for k, v in parse_qs(urlsplit(url).query).items()}
+
+
+def _assert_url_not_forwarding_retry(url: str) -> None:
+    query = _query_of(url)
+    assert "retry" not in query
 
 
 # ---------------------------------------------------------------------------
@@ -136,6 +139,44 @@ def test_vendor_params_forwarded_verbatim(mock_get: list) -> None:
     assert mock_get[0]["timeout"] == 5.0
 
 
+def test_retry_transient_transport_error_before_geojson_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import httpx
+
+    from gispulse.adapters.rest import rest_fetcher
+
+    calls: list[dict[str, object]] = []
+    sleeps: list[float] = []
+
+    def fake(url: str, timeout: float) -> dict:
+        calls.append({"url": url, "timeout": timeout})
+        if len(calls) == 1:
+            raise httpx.ConnectTimeout("temporary blip")
+        return _feature_collection(1)
+
+    monkeypatch.setattr(rest_fetcher, "_get_geojson", fake)
+    monkeypatch.setattr(rest_fetcher, "_sleep", sleeps.append, raising=False)
+
+    access = AccessSpec(
+        protocol=AccessProtocol.REST_API,
+        endpoint="https://apicarto.example.org/api/cadastre/parcelle",
+        params={
+            "code_insee": "44109",
+            "timeout": 5,
+            "retry": {"max_attempts": 2, "backoff_seconds": 0.5},
+        },
+    )
+    result = RestGeoJsonFetcher().fetch(access)
+
+    assert result.payload is Payload.VECTOR
+    assert result.metadata["feature_count"] == 1
+    assert len(calls) == 2
+    assert {call["timeout"] for call in calls} == {5.0}
+    assert sleeps == [0.5]
+    _assert_url_not_forwarding_retry(str(calls[0]["url"]))
+
+
 def test_endpoint_with_existing_query_appends_with_ampersand(
     mock_get: list,
 ) -> None:
@@ -206,9 +247,7 @@ def test_rest_fetcher_self_registered_in_global_protocols() -> None:
     """Importing the module wired the fetcher into the shared registry."""
     from gispulse.core.sources import PROTOCOLS
 
-    assert isinstance(
-        PROTOCOLS.get_fetcher(AccessProtocol.REST_API), RestGeoJsonFetcher
-    )
+    assert isinstance(PROTOCOLS.get_fetcher(AccessProtocol.REST_API), RestGeoJsonFetcher)
 
 
 def test_dispatch_fetch_routes_to_rest_fetcher(mock_get: list) -> None:

--- a/tests/unit/test_rest_table_fetcher.py
+++ b/tests/unit/test_rest_table_fetcher.py
@@ -662,3 +662,77 @@ def test_body_row_source_wraps_whole_body(
     assert result.metadata["row_count"] == 1
     rows = [json.loads(line) for line in out.read_text().splitlines()]
     assert rows == [{"codeExposition": "2", "exposition": "moyen"}]
+
+
+def test_retries_transient_http_status_before_materializing_page(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import httpx
+
+    from gispulse.adapters.rest import rest_table_fetcher
+    from gispulse.adapters.rest.rest_table_fetcher import RestTableFetcher
+
+    calls: list[str] = []
+
+    def fake_get(url: str, timeout: float) -> dict:
+        calls.append(url)
+        if len(calls) == 1:
+            request = httpx.Request("GET", url)
+            response = httpx.Response(503, request=request)
+            raise httpx.HTTPStatusError("503", request=request, response=response)
+        return {"data": [{"i": 1}]}
+
+    monkeypatch.setattr(rest_table_fetcher, "_get_json", fake_get)
+    monkeypatch.setattr(rest_table_fetcher, "_sleep", lambda _seconds: None)
+
+    out = tmp_path / "out.jsonl"
+    access = AccessSpec(
+        protocol=AccessProtocol.REST_TABLE,
+        endpoint="https://geo.example.org/api/v1/rga",
+        params={
+            "local_path": str(out),
+            "retry": {"max_attempts": 2, "backoff_seconds": 0.0},
+        },
+    )
+    result = RestTableFetcher().fetch(access)
+
+    assert calls == ["https://geo.example.org/api/v1/rga"] * 2
+    assert result.metadata["row_count"] == 1
+    assert [json.loads(line) for line in out.read_text().splitlines()] == [{"i": 1}]
+
+
+def test_rate_limit_retry_uses_retry_after_header(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import httpx
+
+    from gispulse.adapters.rest import rest_table_fetcher
+    from gispulse.adapters.rest.rest_table_fetcher import RestTableFetcher
+
+    calls = 0
+    sleeps: list[float] = []
+
+    def fake_get(url: str, timeout: float) -> dict:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            request = httpx.Request("GET", url)
+            response = httpx.Response(429, headers={"Retry-After": "0.25"}, request=request)
+            raise httpx.HTTPStatusError("429", request=request, response=response)
+        return {"data": [{"i": 1}]}
+
+    monkeypatch.setattr(rest_table_fetcher, "_get_json", fake_get)
+    monkeypatch.setattr(rest_table_fetcher, "_sleep", sleeps.append)
+
+    access = AccessSpec(
+        protocol=AccessProtocol.REST_TABLE,
+        endpoint="https://geo.example.org/api/v1/rga",
+        params={
+            "local_path": str(tmp_path / "out.jsonl"),
+            "retry": {"max_attempts": 2, "backoff_seconds": 3.0},
+        },
+    )
+    RestTableFetcher().fetch(access)
+
+    assert calls == 2
+    assert sleeps == [0.25]

--- a/tests/unit/test_table_file_fetcher.py
+++ b/tests/unit/test_table_file_fetcher.py
@@ -98,22 +98,6 @@ def test_reference_scan_zip_csv_escapes_archive_member_sql_literal() -> None:
     )
 
 
-def test_reference_scan_zip_csv_escapes_archive_member_sql_literal() -> None:
-    result = TableFileFetcher().virtual_table(
-        _access(
-            "https://host.example.org/iris_csv.zip",
-            archive_format="zip",
-            table_format="csv",
-            archive_member="tables/l'iris.csv",
-        )
-    )
-
-    assert result.metadata[DUCKDB_SCAN_KEY] == (
-        "read_csv_auto("
-        "'/vsizip//vsicurl/https://host.example.org/iris_csv.zip/tables/l''iris.csv')"
-    )
-
-
 def test_materialize_streams_remote_table_file_to_disk(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/unit/test_table_file_fetcher.py
+++ b/tests/unit/test_table_file_fetcher.py
@@ -78,8 +78,23 @@ def test_reference_scan_zip_csv_can_target_archive_member() -> None:
     )
 
     assert result.metadata[DUCKDB_SCAN_KEY] == (
+        "read_csv_auto('/vsizip//vsicurl/https://host.example.org/iris_csv.zip/tables/iris.csv')"
+    )
+
+
+def test_reference_scan_zip_csv_escapes_archive_member_sql_literal() -> None:
+    result = TableFileFetcher().virtual_table(
+        _access(
+            "https://host.example.org/iris_csv.zip",
+            archive_format="zip",
+            table_format="csv",
+            archive_member="tables/l'iris.csv",
+        )
+    )
+
+    assert result.metadata[DUCKDB_SCAN_KEY] == (
         "read_csv_auto("
-        "'/vsizip//vsicurl/https://host.example.org/iris_csv.zip/tables/iris.csv')"
+        "'/vsizip//vsicurl/https://host.example.org/iris_csv.zip/tables/l''iris.csv')"
     )
 
 
@@ -141,6 +156,192 @@ def test_materialize_streams_remote_table_file_to_disk(
     assert result.data == str(dest)
     assert result.metadata == {"archive_format": "zip", "table_format": "csv"}
     assert dest.read_bytes() == b"IRIS;LIBIRIS\n631130101;La Gauthiere\n"
+
+
+def test_materialize_remote_table_file_passes_explicit_timeout(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import httpx
+
+    timeouts: list[httpx.Timeout] = []
+
+    class _FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def iter_bytes(self):
+            yield b"IRIS;LIBIRIS\n"
+
+        def __enter__(self) -> "_FakeResponse":
+            return self
+
+        def __exit__(self, *exc: object) -> None:
+            return None
+
+    def _fake_stream(method: str, url: str, **kw: object) -> _FakeResponse:
+        assert method == "GET"
+        assert url == "https://host.example.org/iris.csv"
+        timeout = kw["timeout"]
+        assert isinstance(timeout, httpx.Timeout)
+        timeouts.append(timeout)
+        return _FakeResponse()
+
+    monkeypatch.setenv("GISPULSE_HTTP_READ_TIMEOUT", "42.5")
+    monkeypatch.setattr(httpx, "stream", _fake_stream)
+
+    dest = tmp_path / "iris.csv"
+    TableFileFetcher().fetch(
+        _access("https://host.example.org/iris.csv", local_path=str(dest)),
+        mode=FetchMode.MATERIALIZE,
+    )
+
+    assert len(timeouts) == 1
+    assert timeouts[0].connect == 10.0
+    assert timeouts[0].read == 42.5
+    assert timeouts[0].write == 30.0
+    assert timeouts[0].pool == 10.0
+
+
+def test_materialize_remote_table_file_retries_timeout_then_succeeds(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import httpx
+
+    attempts = 0
+    sleeps: list[float] = []
+
+    class _FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def iter_bytes(self):
+            yield b"IRIS;LIBIRIS\n"
+
+        def __enter__(self) -> "_FakeResponse":
+            return self
+
+        def __exit__(self, *exc: object) -> None:
+            return None
+
+    def _fake_stream(method: str, url: str, **kw: object) -> _FakeResponse:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            request = httpx.Request(method, url)
+            raise httpx.ReadTimeout("read operation timed out", request=request)
+        return _FakeResponse()
+
+    monkeypatch.setattr("time.sleep", lambda seconds: sleeps.append(seconds))
+    monkeypatch.setattr(httpx, "stream", _fake_stream)
+
+    dest = tmp_path / "iris.csv"
+    result = TableFileFetcher().fetch(
+        _access("https://host.example.org/iris.csv", local_path=str(dest)),
+        mode=FetchMode.MATERIALIZE,
+    )
+
+    assert attempts == 2
+    assert sleeps == [2.0]
+    assert result.data == str(dest)
+    assert dest.read_bytes() == b"IRIS;LIBIRIS\n"
+
+
+def test_materialize_remote_table_file_retries_500_then_succeeds(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import httpx
+
+    attempts = 0
+    sleeps: list[float] = []
+
+    class _ServerErrorResponse:
+        def raise_for_status(self) -> None:
+            request = httpx.Request("GET", "https://host.example.org/iris.csv")
+            response = httpx.Response(500, request=request)
+            raise httpx.HTTPStatusError("server error", request=request, response=response)
+
+        def iter_bytes(self):
+            raise AssertionError("body must not be read before retrying")
+
+        def __enter__(self) -> "_ServerErrorResponse":
+            return self
+
+        def __exit__(self, *exc: object) -> None:
+            return None
+
+    class _OkResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def iter_bytes(self):
+            yield b"IRIS;LIBIRIS\n"
+
+        def __enter__(self) -> "_OkResponse":
+            return self
+
+        def __exit__(self, *exc: object) -> None:
+            return None
+
+    def _fake_stream(method: str, url: str, **kw: object):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return _ServerErrorResponse()
+        return _OkResponse()
+
+    monkeypatch.setattr("time.sleep", lambda seconds: sleeps.append(seconds))
+    monkeypatch.setattr(httpx, "stream", _fake_stream)
+
+    dest = tmp_path / "iris.csv"
+    TableFileFetcher().fetch(
+        _access("https://host.example.org/iris.csv", local_path=str(dest)),
+        mode=FetchMode.MATERIALIZE,
+    )
+
+    assert attempts == 2
+    assert sleeps == [2.0]
+    assert dest.read_bytes() == b"IRIS;LIBIRIS\n"
+
+
+def test_materialize_remote_table_file_does_not_retry_404(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import httpx
+
+    attempts = 0
+
+    class _NotFoundResponse:
+        def raise_for_status(self) -> None:
+            request = httpx.Request("GET", "https://host.example.org/missing.csv")
+            response = httpx.Response(404, request=request)
+            raise httpx.HTTPStatusError("not found", request=request, response=response)
+
+        def iter_bytes(self):
+            raise AssertionError("body must not be read for a 404")
+
+        def __enter__(self) -> "_NotFoundResponse":
+            return self
+
+        def __exit__(self, *exc: object) -> None:
+            return None
+
+    def _fake_stream(method: str, url: str, **kw: object) -> _NotFoundResponse:
+        nonlocal attempts
+        attempts += 1
+        return _NotFoundResponse()
+
+    monkeypatch.setattr(httpx, "stream", _fake_stream)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        TableFileFetcher().fetch(
+            _access(
+                "https://host.example.org/missing.csv",
+                local_path=str(tmp_path / "missing.csv"),
+            ),
+            mode=FetchMode.MATERIALIZE,
+        )
+
+    assert attempts == 1
 
 
 def test_materialize_local_table_file_returns_path(tmp_path: Path) -> None:
@@ -239,17 +440,13 @@ def test_materialize_can_copy_zip_csv_to_s3_key(
         mode=FetchMode.MATERIALIZE,
     )
 
-    uri = (
-        "s3://gispulse-beta/stage/georisques/gaspar-bulk/"
-        "millesime=2025/national/gaspar.parquet"
-    )
+    uri = "s3://gispulse-beta/stage/georisques/gaspar-bulk/millesime=2025/national/gaspar.parquet"
     assert result.data == uri
     assert result.reference == uri
     assert result.metadata["s3_uri"] == uri
     assert f"TO '{uri}' (FORMAT PARQUET)" in executed[0]
     assert (
-        "read_csv_auto("
-        "'/vsizip//vsicurl/https://host.example.org/gaspar.zip/tables/gaspar.csv')"
+        "read_csv_auto('/vsizip//vsicurl/https://host.example.org/gaspar.zip/tables/gaspar.csv')"
     ) in executed[0]
 
 


### PR DESCRIPTION
## What
Two complementary network-robustness additions for fetchers, extracted from downstream use at national scale:

1. **`feat(rest)`** — `RetrySpec` retry/backoff on `REST_API` + `REST_TABLE` fetchers (`adapters/rest/retry.py`), on top of the existing timeouts. Honors `Retry-After`, exponential backoff on transient statuses.
2. **`feat(fetchers)`** — shared `stream_http_to_file` helper (`core/fetchers/_http_download.py`) with timeout + retry, wired into `table_file.py`, `http_file.py`, `bulk_runner.py` (replaces fragile direct `httpx.stream`).

## Why
Bulk/national ingests download large archives (cadastre, IGN GPKG, INSEE) over flaky endpoints; a single transient drop aborted whole runs. These make file + REST fetches resilient without changing the happy path.

## Tests
`pytest tests/unit/test_rest_fetcher.py test_rest_table_fetcher.py test_table_file_fetcher.py test_http_file_fetcher.py` → 77 passed; ruff clean. DCO signed.

(Both commits are individually reviewable; happy to split if preferred.)