### PR TITLE
feat(plugins): src-sup — add acte_sup catalog entry

### DIFF
--- a/plugins/gispulse-src-sup/README.md
+++ b/plugins/gispulse-src-sup/README.md
@@ -27,6 +27,7 @@ All entries use `AccessProtocol.WFS`, endpoint
 | id | WFS typename | CQL filter |
 |----|--------------|------------|
 | `servitude` | `wfs_sup:servitude` | |
+| `acte` | `wfs_sup:acte_sup` | |
 | `assiette-surf` | `wfs_sup:assiette_sup_s` | |
 | `assiette-lin` | `wfs_sup:assiette_sup_l` | |
 | `assiette-pct` | `wfs_sup:assiette_sup_p` | |

--- a/plugins/gispulse-src-sup/gispulse_src_sup/source.py
+++ b/plugins/gispulse-src-sup/gispulse_src_sup/source.py
@@ -46,6 +46,11 @@ _ENTRIES: dict[str, tuple[str, str, str | None]] = {
         "wfs_sup:servitude",
         None,
     ),
+    "acte": (
+        "SUP — actes",
+        "wfs_sup:acte_sup",
+        None,
+    ),
     "assiette-surf": (
         "SUP — assiettes surfaciques",
         "wfs_sup:assiette_sup_s",

--- a/tests/unit/test_src_sup.py
+++ b/tests/unit/test_src_sup.py
@@ -85,6 +85,7 @@ def test_catalog_lists_raw_layers_and_filtered_views(source: SupSource) -> None:
     ids = {e.id for e in source.catalog()}
     assert ids == {
         "servitude",
+        "acte",
         "assiette-surf",
         "assiette-lin",
         "assiette-pct",
@@ -123,6 +124,7 @@ def test_every_entry_carries_classification_axes(source: SupSource) -> None:
 def test_every_entry_targets_wfs_sup_typename(source: SupSource) -> None:
     expected = {
         "servitude": ("wfs_sup:servitude", None),
+        "acte": ("wfs_sup:acte_sup", None),
         "assiette-surf": ("wfs_sup:assiette_sup_s", None),
         "assiette-lin": ("wfs_sup:assiette_sup_l", None),
         "assiette-pct": ("wfs_sup:assiette_sup_p", None),


### PR DESCRIPTION
Adds the missing `acte` entry (`wfs_sup:acte_sup`) to `gispulse-src-sup`'s catalog. The SUP WFS exposes `acte_sup` (actes) alongside servitudes/assiettes/générateurs, but the plugin catalog omitted it (`tests/unit/test_catalog.py` already references `wfs_sup:acte_sup`). One catalog entry + README + tests. `pytest tests/unit/test_src_sup.py` → 21 passed. DCO signed.