### PR TITLE
feat(tiling): add PMTiles batch writer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,8 +68,9 @@ scheduling = ["croniter>=1.3,<7.0"]
 sso = ["PyJWT[crypto]>=2.8,<3.0", "httpx>=0.24,<1.0"]
 billing = ["stripe>=7.0,<16.0"]
 parquet = ["pyarrow>=14,<25"]
-dev = ["pytest>=9.0.3,<10.0", "pytest-cov>=4.0,<8.0", "pytest-asyncio>=1.0,<2.0", "pytest-rerunfailures>=14.0,<17.0", "ruff>=0.1,<1.0", "httpx>=0.24,<1.0", "pip-audit>=2.7,<3.0"]
-all = ["gispulse[postgis,api,mcp,raster,network,classification,pointcloud,redis,s3,scheduling,sso,billing,parquet,dev]"]
+tiling = ["pmtiles>=3.7,<4.0", "pyarrow>=14,<25"]
+dev = ["pytest>=9.0.3,<10.0", "pytest-cov>=4.0,<8.0", "pytest-asyncio>=1.0,<2.0", "pytest-rerunfailures>=14.0,<17.0", "ruff>=0.1,<1.0", "httpx>=0.24,<1.0", "pip-audit>=2.7,<3.0", "pmtiles>=3.7,<4.0", "pyarrow>=14,<25"]
+all = ["gispulse[postgis,api,mcp,raster,network,classification,pointcloud,redis,s3,scheduling,sso,billing,parquet,tiling,dev]"]
 
 [project.urls]
 Homepage = "https://gispulse.dev"

--- a/src/gispulse/tiling/__init__.py
+++ b/src/gispulse/tiling/__init__.py
@@ -1,0 +1,11 @@
+"""Batch tiling helpers for static tile artifacts."""
+
+from __future__ import annotations
+
+from gispulse.tiling.write_pmtiles import (
+    PmtilesWriter,
+    register_pmtiles_writer,
+    write_pmtiles,
+)
+
+__all__ = ["PmtilesWriter", "register_pmtiles_writer", "write_pmtiles"]

--- a/src/gispulse/tiling/write_pmtiles.py
+++ b/src/gispulse/tiling/write_pmtiles.py
@@ -1,0 +1,654 @@
+"""GeoParquet to PMTiles batch writer backed by DuckDB spatial."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from gispulse.core.fetchers import DUCKDB_SCAN_KEY
+from gispulse.core.logging import get_logger
+from gispulse.core.plugin_model import (
+    AccessProtocol,
+    Payload,
+    SourceResult,
+    WriteReport,
+    WriteSpec,
+)
+from gispulse.core.sources import PROTOCOLS, ProtocolRegistry
+from gispulse.persistence.duckdb_engine import DuckDBSession
+from gispulse.persistence.duckdb_relations import parquet_scan
+
+log = get_logger(__name__)
+
+_WEB_MERCATOR_LIMIT = 85.0511287798066
+_WEB_MERCATOR_HALF_WORLD = 20037508.3427892
+_GEOM_NAMES = {"geom", "geometry", "wkb_geometry", "the_geom", "shape", "__wkb"}
+_TEMP_FEATURES = "__gispulse_pmtiles_features"
+
+
+@dataclass(frozen=True)
+class _Column:
+    name: str
+    type_name: str
+
+
+@dataclass(frozen=True)
+class _PreparedSource:
+    relation: str
+    geometry_column: str
+    source_crs: str | None
+
+
+def write_pmtiles(
+    source: str | Path | SourceResult,
+    out_path: str | Path,
+    *,
+    layer: str,
+    min_zoom: int,
+    max_zoom: int,
+    geometry_column: str | None = None,
+    source_crs: str | None = None,
+    simplify_tolerance: float | None = None,
+    extent: int = 4096,
+    buffer: int = 256,
+    session: DuckDBSession | None = None,
+) -> WriteReport:
+    """Write static PMTiles from a GeoParquet source with DuckDB ``ST_AsMVT``.
+
+    ``source`` may be a local GeoParquet path or a vector ``SourceResult``
+    carrying either a materialized path or a DuckDB scan expression under
+    ``metadata['duckdb_scan']``. Geometries are projected to EPSG:3857 for
+    MVT generation; pass ``source_crs`` when the input relation does not
+    carry CRS metadata.
+    """
+    _validate_options(
+        layer=layer,
+        min_zoom=min_zoom,
+        max_zoom=max_zoom,
+        simplify_tolerance=simplify_tolerance,
+        extent=extent,
+        buffer=buffer,
+    )
+    destination = Path(out_path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+
+    owns_session = session is None
+    duck = session or DuckDBSession()
+    if owns_session:
+        duck.open()
+
+    try:
+        report = _write_with_session(
+            duck,
+            source,
+            destination,
+            layer=layer,
+            min_zoom=min_zoom,
+            max_zoom=max_zoom,
+            geometry_column=geometry_column,
+            source_crs=source_crs,
+            simplify_tolerance=simplify_tolerance,
+            extent=extent,
+            buffer=buffer,
+        )
+    finally:
+        if owns_session:
+            duck.close()
+    return report
+
+
+class PmtilesWriter:
+    """Protocol writer for ``AccessProtocol.PMTILES`` static tile artifacts."""
+
+    protocol = AccessProtocol.PMTILES
+
+    def write(self, result: SourceResult, spec: WriteSpec) -> WriteReport:
+        if spec.protocol is not AccessProtocol.PMTILES:
+            raise ValueError(f"PmtilesWriter cannot handle protocol {spec.protocol.value!r}")
+        layer = spec.layer or _required_option(spec, "layer")
+        min_zoom = int(_required_option(spec, "min_zoom"))
+        max_zoom = int(_required_option(spec, "max_zoom"))
+        return write_pmtiles(
+            result,
+            spec.destination,
+            layer=layer,
+            min_zoom=min_zoom,
+            max_zoom=max_zoom,
+            geometry_column=_optional_str(spec.options.get("geometry_column")),
+            source_crs=_optional_str(spec.options.get("source_crs")),
+            simplify_tolerance=_optional_float(
+                spec.options.get("simplify_tolerance", spec.options.get("simplification"))
+            ),
+            extent=int(spec.options.get("extent", 4096)),
+            buffer=int(spec.options.get("buffer", 256)),
+        )
+
+
+def register_pmtiles_writer(
+    registry: ProtocolRegistry | None = None, *, override: bool = True
+) -> int:
+    """Register the PMTiles writer in a protocol registry."""
+    target = registry if registry is not None else PROTOCOLS
+    target.register(PmtilesWriter(), override=override)
+    log.info("pmtiles_writer_registered")
+    return 1
+
+
+def _write_with_session(
+    session: DuckDBSession,
+    source: str | Path | SourceResult,
+    out_path: Path,
+    *,
+    layer: str,
+    min_zoom: int,
+    max_zoom: int,
+    geometry_column: str | None,
+    source_crs: str | None,
+    simplify_tolerance: float | None,
+    extent: int,
+    buffer: int,
+) -> WriteReport:
+    prepared = _prepare_source(
+        session,
+        source,
+        geometry_column=geometry_column,
+        source_crs=source_crs,
+    )
+    columns = _describe_relation(session, prepared.relation)
+    geometry = _resolve_geometry_column(columns, prepared.geometry_column)
+    feature_count = _materialize_features(session, prepared, columns, geometry)
+    if feature_count == 0:
+        raise ValueError("PMTiles source contains no geometries")
+
+    bounds_4326 = _features_bounds_4326(session)
+    field_types = _metadata_field_types(columns, geometry.name)
+    tile_coords = _coverage_tiles(bounds_4326, min_zoom, max_zoom)
+    tmp_path = out_path.with_name(f".{out_path.name}.tmp")
+    if tmp_path.exists():
+        tmp_path.unlink()
+
+    tile_count = 0
+    try:
+        tile_count = _write_archive(
+            session,
+            tmp_path,
+            tile_coords,
+            layer=layer,
+            bounds_4326=bounds_4326,
+            field_types=field_types,
+            simplify_tolerance=simplify_tolerance,
+            extent=extent,
+            buffer=buffer,
+        )
+        if tile_count == 0:
+            raise ValueError("PMTiles source produced no non-empty MVT tiles")
+        os.replace(tmp_path, out_path)
+    finally:
+        _cleanup_temp_relation(session)
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+    detail = json.dumps(
+        {
+            "features_read": feature_count,
+            "tiles_written": tile_count,
+            "min_zoom": min_zoom,
+            "max_zoom": max_zoom,
+            "layer": layer,
+        },
+        sort_keys=True,
+    )
+    return WriteReport(
+        destination=str(out_path),
+        rows_written=tile_count,
+        created=True,
+        detail=detail,
+    )
+
+
+def _validate_options(
+    *,
+    layer: str,
+    min_zoom: int,
+    max_zoom: int,
+    simplify_tolerance: float | None,
+    extent: int,
+    buffer: int,
+) -> None:
+    if not layer:
+        raise ValueError("layer is required")
+    if not (0 <= min_zoom <= max_zoom <= 31):
+        raise ValueError("zoom range must satisfy 0 <= min_zoom <= max_zoom <= 31")
+    if extent <= 0:
+        raise ValueError("extent must be positive")
+    if buffer < 0:
+        raise ValueError("buffer must be non-negative")
+    if simplify_tolerance is not None and simplify_tolerance < 0:
+        raise ValueError("simplify_tolerance must be non-negative")
+
+
+def _prepare_source(
+    session: DuckDBSession,
+    source: str | Path | SourceResult,
+    *,
+    geometry_column: str | None,
+    source_crs: str | None,
+) -> _PreparedSource:
+    if isinstance(source, SourceResult):
+        if source.payload is not Payload.VECTOR:
+            raise ValueError("PMTiles writer expects a vector SourceResult")
+        return _prepare_source_result(
+            session,
+            source,
+            geometry_column=geometry_column,
+            source_crs=source_crs,
+        )
+    return _PreparedSource(
+        relation=parquet_scan(Path(source)),
+        geometry_column=geometry_column or "",
+        source_crs=source_crs,
+    )
+
+
+def _prepare_source_result(
+    session: DuckDBSession,
+    result: SourceResult,
+    *,
+    geometry_column: str | None,
+    source_crs: str | None,
+) -> _PreparedSource:
+    scan = result.metadata.get(DUCKDB_SCAN_KEY)
+    result_crs = source_crs or result.crs
+    if isinstance(scan, str) and scan:
+        return _PreparedSource(
+            relation=scan,
+            geometry_column=geometry_column or "",
+            source_crs=result_crs,
+        )
+    if isinstance(result.data, (str, Path)):
+        return _PreparedSource(
+            relation=parquet_scan(Path(result.data)),
+            geometry_column=geometry_column or "",
+            source_crs=result_crs,
+        )
+    if result.data is None and result.reference:
+        return _PreparedSource(
+            relation=parquet_scan(Path(result.reference)),
+            geometry_column=geometry_column or "",
+            source_crs=result_crs,
+        )
+
+    try:
+        import geopandas as gpd
+    except Exception as exc:  # pragma: no cover - geopandas is a base dependency
+        raise TypeError("GeoDataFrame SourceResult data requires geopandas") from exc
+
+    if isinstance(result.data, gpd.GeoDataFrame):
+        table = "__gispulse_pmtiles_source_gdf"
+        session.conn.execute(f"DROP VIEW IF EXISTS {_quote_identifier(table)}")
+        session.conn.execute(f"DROP TABLE IF EXISTS {_quote_identifier(table)}")
+        session.register_gdf(table, result.data)
+        gdf_crs = str(result.data.crs) if result.data.crs else None
+        return _PreparedSource(
+            relation=_quote_identifier(table),
+            geometry_column=geometry_column or "__wkb",
+            source_crs=result_crs or gdf_crs,
+        )
+    raise TypeError(
+        f"cannot write PMTiles from SourceResult.data of type {type(result.data).__name__}"
+    )
+
+
+def _describe_relation(session: DuckDBSession, relation: str) -> list[_Column]:
+    rows = session.conn.execute(f"DESCRIBE SELECT * FROM {relation}").fetchall()
+    return [_Column(str(row[0]), str(row[1]).upper()) for row in rows]
+
+
+def _resolve_geometry_column(columns: Sequence[_Column], requested: str | None) -> _Column:
+    if requested:
+        for column in columns:
+            if column.name == requested:
+                return column
+        raise ValueError(f"geometry column {requested!r} not found")
+    for column in columns:
+        if column.type_name.startswith("GEOMETRY"):
+            return column
+    for column in columns:
+        if column.name.lower() in _GEOM_NAMES:
+            return column
+    raise ValueError("could not infer geometry column")
+
+
+def _materialize_features(
+    session: DuckDBSession,
+    prepared: _PreparedSource,
+    columns: Sequence[_Column],
+    geometry: _Column,
+) -> int:
+    _cleanup_temp_relation(session)
+    properties = [column for column in columns if column.name != geometry.name]
+    select_properties = ", ".join(_quote_identifier(column.name) for column in properties)
+    if select_properties:
+        select_properties += ", "
+    geom_expr = _geometry_expression(geometry)
+    geom_3857 = _transform_expression(geom_expr, "EPSG:3857", prepared.source_crs)
+    geom_4326 = _transform_expression(geom_expr, "EPSG:4326", prepared.source_crs)
+    session.conn.execute(
+        f"""
+        CREATE TEMP TABLE {_quote_identifier(_TEMP_FEATURES)} AS
+        SELECT
+            {select_properties}
+            {geom_3857} AS __geom_3857,
+            {geom_4326} AS __geom_4326
+        FROM {prepared.relation}
+        WHERE {geom_expr} IS NOT NULL
+        """
+    )
+    row = session.conn.execute(
+        f"SELECT COUNT(*) FROM {_quote_identifier(_TEMP_FEATURES)}"
+    ).fetchone()
+    return int(row[0]) if row else 0
+
+
+def _cleanup_temp_relation(session: DuckDBSession) -> None:
+    session.conn.execute(f"DROP TABLE IF EXISTS {_quote_identifier(_TEMP_FEATURES)}")
+
+
+def _geometry_expression(geometry: _Column) -> str:
+    identifier = _quote_identifier(geometry.name)
+    if geometry.type_name.startswith("GEOMETRY"):
+        return identifier
+    if geometry.type_name == "BLOB" or geometry.name.lower() in {"__wkb", "wkb_geometry"}:
+        return f"ST_GeomFromWKB({identifier})"
+    raise ValueError(
+        f"geometry column {geometry.name!r} has unsupported DuckDB type {geometry.type_name!r}"
+    )
+
+
+def _transform_expression(geom_expr: str, target_crs: str, source_crs: str | None) -> str:
+    target = _sql_literal(target_crs)
+    if source_crs:
+        return f"ST_Transform({geom_expr}, {_sql_literal(source_crs)}, {target}, true)"
+    return f"ST_Transform({geom_expr}, {target}, true)"
+
+
+def _features_bounds_4326(session: DuckDBSession) -> tuple[float, float, float, float]:
+    row = session.conn.execute(
+        f"""
+        SELECT
+            ST_XMin(bounds) AS minx,
+            ST_YMin(bounds) AS miny,
+            ST_XMax(bounds) AS maxx,
+            ST_YMax(bounds) AS maxy
+        FROM (
+            -- ST_Envelope_Agg agrege l'enveloppe de TOUTES les features
+            -- (nom compatible DuckDB 1.0+ ; ST_Extent_Agg existe aussi en 1.5).
+            -- ST_Extent est scalaire (bbox d'une seule geometrie) : dans un
+            -- SELECT sans GROUP BY, .fetchone() ne lisait que la 1re feature,
+            -- effondrant les bounds de couverture sur un point.
+            SELECT ST_Envelope_Agg(__geom_4326) AS bounds
+            FROM {_quote_identifier(_TEMP_FEATURES)}
+        )
+        """
+    ).fetchone()
+    if row is None or row[0] is None:
+        raise ValueError("PMTiles source has no finite bounds")
+    bounds = tuple(float(value) for value in row)
+    minx, miny, maxx, maxy = bounds
+    return (
+        max(-180.0, min(180.0, minx)),
+        max(-_WEB_MERCATOR_LIMIT, min(_WEB_MERCATOR_LIMIT, miny)),
+        max(-180.0, min(180.0, maxx)),
+        max(-_WEB_MERCATOR_LIMIT, min(_WEB_MERCATOR_LIMIT, maxy)),
+    )
+
+
+def _metadata_field_types(columns: Sequence[_Column], geometry_name: str) -> dict[str, str]:
+    fields: dict[str, str] = {}
+    for column in columns:
+        if column.name == geometry_name:
+            continue
+        fields[column.name] = _tilejson_field_type(column.type_name)
+    return fields
+
+
+def _tilejson_field_type(type_name: str) -> str:
+    if any(token in type_name for token in ("INT", "DOUBLE", "FLOAT", "DECIMAL", "REAL")):
+        return "Number"
+    if "BOOL" in type_name:
+        return "Boolean"
+    return "String"
+
+
+def _coverage_tiles(
+    bounds: tuple[float, float, float, float],
+    min_zoom: int,
+    max_zoom: int,
+) -> list[tuple[int, int, int, int]]:
+    from pmtiles.tile import zxy_to_tileid
+
+    min_lon, min_lat, max_lon, max_lat = bounds
+    tiles: list[tuple[int, int, int, int]] = []
+    for z in range(min_zoom, max_zoom + 1):
+        min_x, max_y = _lonlat_to_tile(min_lon, min_lat, z)
+        max_x, min_y = _lonlat_to_tile(max_lon, max_lat, z)
+        if max_x < min_x:
+            min_x, max_x = max_x, min_x
+        if max_y < min_y:
+            min_y, max_y = max_y, min_y
+        for x in range(min_x, max_x + 1):
+            for y in range(min_y, max_y + 1):
+                tiles.append((zxy_to_tileid(z, x, y), z, x, y))
+    return sorted(tiles)
+
+
+def _lonlat_to_tile(lon: float, lat: float, z: int) -> tuple[int, int]:
+    lat = max(-_WEB_MERCATOR_LIMIT, min(_WEB_MERCATOR_LIMIT, lat))
+    lon = max(-180.0, min(180.0, lon))
+    n = 1 << z
+    x = int((lon + 180.0) / 360.0 * n)
+    lat_rad = math.radians(lat)
+    y = int((1.0 - math.asinh(math.tan(lat_rad)) / math.pi) / 2.0 * n)
+    return (max(0, min(n - 1, x)), max(0, min(n - 1, y)))
+
+
+def _write_archive(
+    session: DuckDBSession,
+    out_path: Path,
+    tile_coords: Sequence[tuple[int, int, int, int]],
+    *,
+    layer: str,
+    bounds_4326: tuple[float, float, float, float],
+    field_types: dict[str, str],
+    simplify_tolerance: float | None,
+    extent: int,
+    buffer: int,
+) -> int:
+    from pmtiles.tile import Compression, TileType
+    from pmtiles.writer import Writer
+
+    tile_count = 0
+    with out_path.open("wb") as fh:
+        writer = Writer(fh)
+        for tile_id, z, x, y in tile_coords:
+            tile = _mvt_tile(
+                session,
+                z,
+                x,
+                y,
+                layer=layer,
+                simplify_tolerance=simplify_tolerance,
+                extent=extent,
+                buffer=buffer,
+            )
+            if not tile:
+                continue
+            writer.write_tile(tile_id, tile)
+            tile_count += 1
+        if tile_count == 0:
+            return 0
+        with _deterministic_gzip():
+            writer.finalize(
+                _pmtiles_header(bounds_4326, Compression.NONE, TileType.MVT),
+                _pmtiles_metadata(layer, bounds_4326, field_types),
+            )
+    return tile_count
+
+
+def _mvt_tile(
+    session: DuckDBSession,
+    z: int,
+    x: int,
+    y: int,
+    *,
+    layer: str,
+    simplify_tolerance: float | None,
+    extent: int,
+    buffer: int,
+) -> bytes | None:
+    xmin, ymin, xmax, ymax = _tile_bounds_3857(z, x, y)
+    geom_expr = "__geom_3857"
+    if simplify_tolerance is not None and simplify_tolerance > 0:
+        geom_expr = f"ST_SimplifyPreserveTopology({geom_expr}, {float(simplify_tolerance)})"
+    sql = f"""
+        WITH bounds AS (
+            SELECT ST_MakeBox2D(
+                ST_Point({xmin}, {ymin}),
+                ST_Point({xmax}, {ymax})
+            ) AS geom
+        ),
+        raw_mvtgeom AS (
+            SELECT
+                ST_AsMVTGeom(
+                    {geom_expr},
+                    bounds.geom,
+                    {int(extent)},
+                    {int(buffer)},
+                    true
+                ) AS geom,
+                features.* EXCLUDE (__geom_3857, __geom_4326)
+            FROM {_quote_identifier(_TEMP_FEATURES)} AS features, bounds
+            WHERE ST_Intersects(features.__geom_3857, bounds.geom)
+        )
+        -- ST_AsMVT ignore nativement les lignes a geometrie NULL : pas besoin
+        -- d'une CTE intermediaire de filtre. Le filtre `WHERE geom IS NOT NULL`
+        -- declenchait un SIGBUS DuckDB 1.5.3 (ST_AsMVT sur MULTILINESTRING -> NULL
+        -- a bas zoom + colonnes de proprietes jointes).
+        SELECT ST_AsMVT(
+            raw_mvtgeom,
+            {_sql_literal(layer)},
+            {int(extent)},
+            'geom'
+        ) AS tile
+        FROM raw_mvtgeom
+    """
+    row = session.conn.execute(sql).fetchone()
+    if row is None or row[0] is None:
+        return None
+    tile = bytes(row[0])
+    return tile or None
+
+
+def _tile_bounds_3857(z: int, x: int, y: int) -> tuple[float, float, float, float]:
+    n = 2.0**z
+    xmin = (x / n) * 2 * _WEB_MERCATOR_HALF_WORLD - _WEB_MERCATOR_HALF_WORLD
+    xmax = ((x + 1) / n) * 2 * _WEB_MERCATOR_HALF_WORLD - _WEB_MERCATOR_HALF_WORLD
+    ymax = _WEB_MERCATOR_HALF_WORLD - (y / n) * 2 * _WEB_MERCATOR_HALF_WORLD
+    ymin = _WEB_MERCATOR_HALF_WORLD - ((y + 1) / n) * 2 * _WEB_MERCATOR_HALF_WORLD
+    return (xmin, ymin, xmax, ymax)
+
+
+def _pmtiles_header(
+    bounds_4326: tuple[float, float, float, float],
+    compression: Any,
+    tile_type: Any,
+) -> dict[str, Any]:
+    min_lon, min_lat, max_lon, max_lat = bounds_4326
+    center_lon = (min_lon + max_lon) / 2.0
+    center_lat = (min_lat + max_lat) / 2.0
+    return {
+        "tile_compression": compression,
+        "tile_type": tile_type,
+        "min_lon_e7": round(min_lon * 10_000_000),
+        "min_lat_e7": round(min_lat * 10_000_000),
+        "max_lon_e7": round(max_lon * 10_000_000),
+        "max_lat_e7": round(max_lat * 10_000_000),
+        "center_lon_e7": round(center_lon * 10_000_000),
+        "center_lat_e7": round(center_lat * 10_000_000),
+    }
+
+
+def _pmtiles_metadata(
+    layer: str,
+    bounds_4326: tuple[float, float, float, float],
+    fields: dict[str, str],
+) -> dict[str, Any]:
+    min_lon, min_lat, max_lon, max_lat = bounds_4326
+    center_lon = (min_lon + max_lon) / 2.0
+    center_lat = (min_lat + max_lat) / 2.0
+    return {
+        "name": layer,
+        "type": "overlay",
+        "version": "1",
+        "scheme": "xyz",
+        "bounds": f"{min_lon},{min_lat},{max_lon},{max_lat}",
+        "center": f"{center_lon},{center_lat},0",
+        "vector_layers": [{"id": layer, "fields": fields}],
+    }
+
+
+@contextmanager
+def _deterministic_gzip() -> Iterator[None]:
+    import gzip
+
+    original = gzip.compress
+
+    def compress(data: bytes, compresslevel: int = 9, *, mtime: int | None = None) -> bytes:
+        return original(data, compresslevel=compresslevel, mtime=0)
+
+    gzip.compress = compress  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        gzip.compress = original  # type: ignore[assignment]
+
+
+def _required_option(spec: WriteSpec, name: str) -> Any:
+    try:
+        value = spec.options[name]
+    except KeyError:
+        raise ValueError(f"WriteSpec.options[{name!r}] is required for PMTiles writes") from None
+    if value is None or value == "":
+        raise ValueError(f"WriteSpec.options[{name!r}] is required for PMTiles writes")
+    return value
+
+
+def _optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value)
+    return text or None
+
+
+def _optional_float(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    return float(value)
+
+
+def _quote_identifier(identifier: str) -> str:
+    if not identifier or "\x00" in identifier:
+        raise ValueError("unsafe SQL identifier")
+    return '"' + identifier.replace('"', '""') + '"'
+
+
+def _sql_literal(value: str) -> str:
+    if "\x00" in value:
+        raise ValueError("SQL literals cannot contain null bytes")
+    return "'" + value.replace("'", "''") + "'"

--- a/tests/unit/test_tiling_pmtiles.py
+++ b/tests/unit/test_tiling_pmtiles.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import time
+from importlib import import_module
+from importlib.util import find_spec
+from pathlib import Path
+
+import geopandas as gpd
+from pmtiles.reader import MmapSource, Reader, all_tiles
+from pmtiles.tile import Compression, TileType
+from shapely.geometry import Point
+
+from gispulse.core.plugin_model import AccessProtocol, Payload, SourceResult, WriteSpec
+from gispulse.core.sources import ProtocolRegistry
+
+
+def _toy_geoparquet(tmp_path: Path) -> Path:
+    path = tmp_path / "toy.parquet"
+    gdf = gpd.GeoDataFrame(
+        {"id": [1, 2], "name": ["paris", "lyon"]},
+        geometry=[Point(2.35, 48.85), Point(4.84, 45.76)],
+        crs="EPSG:4326",
+    )
+    gdf.to_parquet(path)
+    return path
+
+
+def _read_pmtiles(path: Path) -> tuple[dict[str, object], dict[str, object], list[tuple]]:
+    with path.open("rb") as fh:
+        get_bytes = MmapSource(fh)
+        reader = Reader(get_bytes)
+        header = reader.header()
+        metadata = reader.metadata()
+        tiles = list(all_tiles(get_bytes))
+        if tiles:
+            first_zxy, first_tile = tiles[0]
+            assert reader.get(*first_zxy) == first_tile
+        return header, metadata, tiles
+
+
+def test_write_pmtiles_writes_valid_readable_deterministic_archive(tmp_path: Path) -> None:
+    assert find_spec("gispulse.tiling") is not None
+    write_pmtiles = import_module("gispulse.tiling").write_pmtiles
+    source = _toy_geoparquet(tmp_path)
+    out_a = tmp_path / "toy-a.pmtiles"
+    out_b = tmp_path / "toy-b.pmtiles"
+
+    report = write_pmtiles(source, out_a, layer="places", min_zoom=5, max_zoom=5)
+    time.sleep(1.1)
+    write_pmtiles(source, out_b, layer="places", min_zoom=5, max_zoom=5)
+
+    assert out_a.read_bytes()[:7] == b"PMTiles"
+    header, metadata, tiles = _read_pmtiles(out_a)
+    assert header["tile_type"] is TileType.MVT
+    assert header["tile_compression"] is Compression.NONE
+    assert header["min_zoom"] == 5
+    assert header["max_zoom"] == 5
+    assert header["addressed_tiles_count"] >= 1
+    assert len(tiles) == header["addressed_tiles_count"]
+    assert len(tiles[0][1]) > 0
+    assert metadata["vector_layers"] == [
+        {"id": "places", "fields": {"id": "Number", "name": "String"}}
+    ]
+    assert report.destination == str(out_a)
+    assert report.rows_written == header["addressed_tiles_count"]
+    assert report.created is True
+    assert out_a.read_bytes() == out_b.read_bytes()
+
+
+def test_pmtiles_writer_dispatches_write_spec_with_result_crs(tmp_path: Path) -> None:
+    tiling = import_module("gispulse.tiling")
+    registry = ProtocolRegistry()
+    tiling.register_pmtiles_writer(registry)
+    writer = registry.get_writer(AccessProtocol.PMTILES)
+    gdf = gpd.GeoDataFrame(
+        {"id": [1], "name": ["paris"]},
+        geometry=[Point(2.35, 48.85)],
+        crs=None,
+    )
+    result = SourceResult(payload=Payload.VECTOR, data=gdf, crs="EPSG:4326")
+    spec = WriteSpec(
+        protocol=AccessProtocol.PMTILES,
+        destination=str(tmp_path / "writer.pmtiles"),
+        layer="places",
+        options={"min_zoom": 5, "max_zoom": 5},
+    )
+
+    report = writer.write(result, spec)
+
+    header, metadata, tiles = _read_pmtiles(Path(report.destination))
+    assert header["addressed_tiles_count"] == 1
+    assert metadata["vector_layers"] == [
+        {"id": "places", "fields": {"id": "Number", "name": "String"}}
+    ]
+    assert len(tiles[0][1]) > 0
+
+
+def test_coverage_spans_all_features_not_just_the_first(tmp_path: Path) -> None:
+    """Regression: la couverture de tuiles doit englober TOUTES les features.
+
+    ``_features_bounds_4326`` utilisait ``ST_Extent`` (scalaire, bbox d'une
+    seule geometrie) dans un ``SELECT`` sans ``GROUP BY`` ; ``.fetchone()`` ne
+    lisait que la 1re feature et le bounds de couverture s'effondrait sur un
+    point -> une seule tuile par zoom (la colonne de cette feature), la couche
+    se retrouvant tronquee a la frontiere de cette tuile. ``ST_Envelope_Agg``
+    agrege l'enveloppe de toutes les features.
+
+    Source = 2 points distants (paris -> tuile (129, 88), lyon -> (131, 91) a
+    z8) : la couche doit ecrire les deux tuiles. Avec le bug, une seule.
+    """
+    write_pmtiles = import_module("gispulse.tiling").write_pmtiles
+    source = _toy_geoparquet(tmp_path)  # Point(2.35, 48.85), Point(4.84, 45.76)
+    out = tmp_path / "coverage.pmtiles"
+
+    write_pmtiles(source, out, layer="places", min_zoom=8, max_zoom=8)
+
+    _, _, tiles = _read_pmtiles(out)
+    written = {zxy for zxy, _data in tiles}
+    expected = {(8, 129, 88), (8, 131, 91)}
+    assert expected.issubset(written), f"couverture incomplete: {sorted(written)}"

--- a/uv.lock
+++ b/uv.lock
@@ -990,7 +990,7 @@ wheels = [
 
 [[package]]
 name = "gispulse"
-version = "2.1.0"
+version = "2.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },
@@ -1024,6 +1024,7 @@ all = [
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pip-audit" },
+    { name = "pmtiles" },
     { name = "psycopg2-binary" },
     { name = "pyarrow" },
     { name = "pyjwt", extra = ["crypto"] },
@@ -1063,6 +1064,8 @@ classification = [
 dev = [
     { name = "httpx" },
     { name = "pip-audit" },
+    { name = "pmtiles" },
+    { name = "pyarrow" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -1107,6 +1110,10 @@ sso = [
     { name = "httpx" },
     { name = "pyjwt", extra = ["crypto"] },
 ]
+tiling = [
+    { name = "pmtiles" },
+    { name = "pyarrow" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -1119,7 +1126,7 @@ requires-dist = [
     { name = "fiona", marker = "extra == 'mcp'", specifier = ">=1.9,<2.0" },
     { name = "geoalchemy2", marker = "extra == 'postgis'", specifier = ">=0.14,<1.0" },
     { name = "geopandas", specifier = ">=0.14,<2.0" },
-    { name = "gispulse", extras = ["postgis", "api", "mcp", "raster", "network", "classification", "pointcloud", "redis", "s3", "scheduling", "sso", "billing", "parquet", "dev"], marker = "extra == 'all'" },
+    { name = "gispulse", extras = ["postgis", "api", "mcp", "raster", "network", "classification", "pointcloud", "redis", "s3", "scheduling", "sso", "billing", "parquet", "tiling", "dev"], marker = "extra == 'all'" },
     { name = "httpx", specifier = ">=0.24,<1.0" },
     { name = "httpx", marker = "extra == 'api'", specifier = ">=0.24,<1.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.24,<1.0" },
@@ -1129,8 +1136,12 @@ requires-dist = [
     { name = "networkx", marker = "extra == 'network'", specifier = ">=3.0,<4.0" },
     { name = "openpyxl", specifier = ">=3.1,<4.0" },
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.7,<3.0" },
+    { name = "pmtiles", marker = "extra == 'dev'", specifier = ">=3.7,<4.0" },
+    { name = "pmtiles", marker = "extra == 'tiling'", specifier = ">=3.7,<4.0" },
     { name = "psycopg2-binary", marker = "extra == 'postgis'", specifier = ">=2.9,<3.0" },
+    { name = "pyarrow", marker = "extra == 'dev'", specifier = ">=14,<25" },
     { name = "pyarrow", marker = "extra == 'parquet'", specifier = ">=14,<25" },
+    { name = "pyarrow", marker = "extra == 'tiling'", specifier = ">=14,<25" },
     { name = "pydantic", specifier = ">=2.0,<3.0" },
     { name = "pydantic-settings", specifier = ">=2.0,<3.0" },
     { name = "pyjwt", extras = ["crypto"], marker = "extra == 'sso'", specifier = ">=2.8,<3.0" },
@@ -1156,7 +1167,7 @@ requires-dist = [
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'api'", specifier = ">=0.23,<1.0" },
     { name = "watchfiles", marker = "extra == 'api'", specifier = ">=0.21,<2.0" },
 ]
-provides-extras = ["postgis", "api", "mcp", "raster", "network", "classification", "pointcloud", "redis", "s3", "scheduling", "sso", "billing", "parquet", "dev", "all"]
+provides-extras = ["postgis", "api", "mcp", "raster", "network", "classification", "pointcloud", "redis", "s3", "scheduling", "sso", "billing", "parquet", "tiling", "dev", "all"]
 
 [[package]]
 name = "greenlet"
@@ -2141,6 +2152,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pmtiles"
+version = "3.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/3e/47e371add5ba09615c95c5ef72d8c3be471819d6dce07bae26c8e15d0687/pmtiles-3.7.0.tar.gz", hash = "sha256:ed8b04d550d104c81a759c9cc07bfc5743750f62e751f840425f4b9f4bb903df", size = 14582, upload-time = "2026-02-10T16:00:22Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/de/c0f177fd73818e0d671903ed986d4541674b0fad4365c7ecfd5a0af23a6d/pmtiles-3.7.0-py3-none-any.whl", hash = "sha256:d1a7a7a166ce3c5c8756cc2c8e4b0aa55e3d854fbd4517c963de16c39b631b14", size = 16848, upload-time = "2026-02-10T16:00:20.925Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds a DuckDB-based PMTiles writer for GeoDataFrame layers.
- Includes metadata/tilejson generation and deterministic tile coverage enumeration.
- Carries forward the two MILOU hardening fixes before upstream review: no redundant MVT NULL-filter CTE, and aggregate coverage bounds with `ST_Envelope_Agg` instead of scalar `ST_Extent`.

## Why

The fork PRs #16/#17/#18 were stacked against `superWorldSavior:gispulse` and #18 was accidentally opened against the fork `main`. Since upstream does not yet have `src/gispulse/tiling/write_pmtiles.py`, the bbox fix from #18 cannot be a standalone upstream PR. This PR introduces the writer directly in its already-hardened form.

## Validation

- `uv run pytest tests/unit/test_tiling_pmtiles.py -q` -> 3 passed
- `uv run ruff check src/gispulse/tiling/write_pmtiles.py tests/unit/test_tiling_pmtiles.py` -> passed
- `uv run ruff format --check src/gispulse/tiling/write_pmtiles.py tests/unit/test_tiling_pmtiles.py` -> already formatted
- `git diff --check upstream/main..HEAD` -> clean
