### PR TITLE
feat(tiling): integrate PMTiles writer (2.2.3) + fix line-volume & type bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.3]
+
+### Added
+
+- **PMTiles tiling (`gispulse.tiling.write_pmtiles`).** GeoParquet → static
+  PMTiles writer backed by DuckDB `ST_AsMVT`, with the new `tiling` extra
+  (`pmtiles`, `pyarrow`). Ports the last `milou`-branch capability into mainline.
+
+### Fixed
+
+- **Line-volume memory corruption in tiling.** Tile encoding ran one `ST_AsMVT`
+  query per coverage tile on a single DuckDB connection; past a few hundred line
+  features the spatial extension corrupted memory → non-deterministic segfault or
+  `ST_AsMVTGeom: tile width and height must be positive`. Rewritten as a single
+  grouped query (features × tiles spatial join → `GROUP BY` tile). Robust and much
+  faster.
+- **Unsupported MVT property types.** A `DATE`/`TIMESTAMP` (or other non-numeric)
+  column made tiling fail (`ST_AsMVT` accepts only VARCHAR/FLOAT/DOUBLE/INTEGER/
+  BIGINT/BOOLEAN). Properties are now coerced (wide ints → BIGINT, decimals →
+  DOUBLE, everything else → VARCHAR).
+
 ## [2.2.2]
 
 ### Changed

--- a/docs-site/changelog.md
+++ b/docs-site/changelog.md
@@ -13,6 +13,19 @@ La source de vérité de ce fichier est [`CHANGELOG.md`](https://github.com/imag
 
 ---
 
+## [2.2.3] — 2026-06-09
+
+### Ajouté
+
+- **Tiling PMTiles (`gispulse.tiling.write_pmtiles`).** Writer GeoParquet → PMTiles statiques via DuckDB `ST_AsMVT`, avec le nouvel extra `tiling` (`pmtiles`, `pyarrow`). Porte la dernière capability de la branche `milou` dans la mainline.
+
+### Corrigé
+
+- **Corruption mémoire sur volume de lignes.** L'encodage faisait un appel `ST_AsMVT` par tuile de couverture sur une même connexion DuckDB ; au-delà de quelques centaines de features lignes, l'extension spatiale corrompait la mémoire → segfault non-déterministe ou `ST_AsMVTGeom: tile width and height must be positive`. Réécrit en une seule requête groupée (jointure spatiale features × tuiles → `GROUP BY` tuile). Robuste et bien plus rapide.
+- **Types de propriété MVT non supportés.** Une colonne `DATE`/`TIMESTAMP` (ou autre type non numérique) faisait échouer le tiling (`ST_AsMVT` n'accepte que VARCHAR/FLOAT/DOUBLE/INTEGER/BIGINT/BOOLEAN). Les propriétés sont désormais castées (entiers larges → BIGINT, décimaux → DOUBLE, reste → VARCHAR).
+
+---
+
 ## [2.2.2] — 2026-06-07
 
 ### Modifié

--- a/docs-site/en/changelog.md
+++ b/docs-site/en/changelog.md
@@ -13,6 +13,19 @@ The authoritative version of this file lives at [`CHANGELOG.md`](https://github.
 
 ---
 
+## [2.2.3] — 2026-06-09
+
+### Added
+
+- **PMTiles tiling (`gispulse.tiling.write_pmtiles`).** GeoParquet → static PMTiles writer backed by DuckDB `ST_AsMVT`, with the new `tiling` extra (`pmtiles`, `pyarrow`). Ports the last `milou`-branch capability into mainline.
+
+### Fixed
+
+- **Line-volume memory corruption.** Tile encoding ran one `ST_AsMVT` query per coverage tile on a single DuckDB connection; past a few hundred line features the spatial extension corrupted memory → non-deterministic segfault or `ST_AsMVTGeom: tile width and height must be positive`. Rewritten as a single grouped query (features × tiles spatial join → `GROUP BY` tile). Robust and much faster.
+- **Unsupported MVT property types.** A `DATE`/`TIMESTAMP` (or other non-numeric) column made tiling fail (`ST_AsMVT` accepts only VARCHAR/FLOAT/DOUBLE/INTEGER/BIGINT/BOOLEAN). Properties are now coerced (wide ints → BIGINT, decimals → DOUBLE, everything else → VARCHAR).
+
+---
+
 ## [2.2.2] — 2026-06-07
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gispulse"
-version = "2.2.2"
+version = "2.2.3"
 description = "Modular geospatial engine with business rules, triggers, and dual operating modes (DuckDB/PostGIS)"
 license = "AGPL-3.0-or-later"
 requires-python = ">=3.11"

--- a/qgis_plugin/metadata.txt
+++ b/qgis_plugin/metadata.txt
@@ -4,7 +4,7 @@ qgisMinimumVersion=3.28
 qgisMaximumVersion=3.99
 description=Trigger-driven spatial CDC for QGIS — attach gispulse rules to any layer.
 about=GISPulse turns QGIS layers into reactive datasets. Save a tracked GeoPackage and gispulse fires the rules attached to it: webhooks, downstream layer refresh, validation. The plugin is a thin bridge — it shells out to the gispulse Python CLI (pip install gispulse) and streams its logs into a dock widget. Requires gispulse >= 1.3.0 on the PATH visible to QGIS.
-version=2.2.2
+version=2.2.3
 author=Imagodata
 email=hello@gispulse.dev
 homepage=https://gispulse.dev

--- a/src/gispulse/tiling/write_pmtiles.py
+++ b/src/gispulse/tiling/write_pmtiles.py
@@ -333,7 +333,7 @@ def _materialize_features(
 ) -> int:
     _cleanup_temp_relation(session)
     properties = [column for column in columns if column.name != geometry.name]
-    select_properties = ", ".join(_quote_identifier(column.name) for column in properties)
+    select_properties = ", ".join(_property_select_expr(column) for column in properties)
     if select_properties:
         select_properties += ", "
     geom_expr = _geometry_expression(geometry)
@@ -354,6 +354,33 @@ def _materialize_features(
         f"SELECT COUNT(*) FROM {_quote_identifier(_TEMP_FEATURES)}"
     ).fetchone()
     return int(row[0]) if row else 0
+
+
+# Types de propriete encodables tels quels par ``ST_AsMVT``.
+_MVT_DIRECT_TYPES = frozenset({"VARCHAR", "FLOAT", "DOUBLE", "INTEGER", "BIGINT", "BOOLEAN"})
+_MVT_INTEGER_TYPES = frozenset(
+    {"TINYINT", "SMALLINT", "UTINYINT", "USMALLINT", "UINTEGER", "UBIGINT", "HUGEINT", "UHUGEINT"}
+)
+_MVT_DOUBLE_TYPES = frozenset({"DECIMAL", "NUMERIC", "REAL"})
+
+
+def _property_select_expr(column: _Column) -> str:
+    """Expression SELECT d'une propriete, castee vers un type encodable MVT.
+
+    ``ST_AsMVT`` n'accepte que VARCHAR / FLOAT / DOUBLE / INTEGER / BIGINT / BOOLEAN.
+    Les autres types (DATE, TIMESTAMP, UUID, listes, …) sont caste : les entiers
+    elargis vers BIGINT, les decimaux vers DOUBLE, le reste vers VARCHAR. Sans cela
+    une colonne date/timestamp fait echouer l'encodage de la tuile.
+    """
+    identifier = _quote_identifier(column.name)
+    base = column.type_name.upper().split("(", 1)[0].strip()
+    if base in _MVT_DIRECT_TYPES:
+        return identifier
+    if base in _MVT_INTEGER_TYPES:
+        return f"CAST({identifier} AS BIGINT) AS {identifier}"
+    if base in _MVT_DOUBLE_TYPES:
+        return f"CAST({identifier} AS DOUBLE) AS {identifier}"
+    return f"CAST({identifier} AS VARCHAR) AS {identifier}"
 
 
 def _cleanup_temp_relation(session: DuckDBSession) -> None:
@@ -458,6 +485,9 @@ def _lonlat_to_tile(lon: float, lat: float, z: int) -> tuple[int, int]:
     return (max(0, min(n - 1, x)), max(0, min(n - 1, y)))
 
 
+_TEMP_TILES = "__gispulse_pmtiles_tiles"
+
+
 def _write_archive(
     session: DuckDBSession,
     out_path: Path,
@@ -470,35 +500,90 @@ def _write_archive(
     extent: int,
     buffer: int,
 ) -> int:
-    from pmtiles.tile import Compression, TileType
+    from pmtiles.tile import Compression, TileType, zxy_to_tileid
     from pmtiles.writer import Writer
 
-    tile_count = 0
+    # Encodage MVT en UNE seule requete groupee (jointure spatiale features x tuiles
+    # -> ST_AsMVTGeom -> GROUP BY tuile -> ST_AsMVT) au lieu d'un appel ST_AsMVT par
+    # tuile. La boucle par tuile (N appels successifs sur la meme connexion DuckDB)
+    # corrompt la memoire de l'extension spatiale au-dela de quelques centaines de
+    # features lignes (segfault / "tile width and height must be positive" non
+    # deterministe). La forme groupee evite cette accumulation et est nettement plus
+    # rapide.
+    geom_expr = "features.__geom_3857"
+    if simplify_tolerance is not None and simplify_tolerance > 0:
+        geom_expr = f"ST_SimplifyPreserveTopology({geom_expr}, {float(simplify_tolerance)})"
+
+    tiles_table = _quote_identifier(_TEMP_TILES)
+    session.conn.execute(f"DROP TABLE IF EXISTS {tiles_table}")
+    session.conn.execute(
+        f"CREATE TEMP TABLE {tiles_table} "
+        "(z INTEGER, x INTEGER, y INTEGER, "
+        "xmin DOUBLE, ymin DOUBLE, xmax DOUBLE, ymax DOUBLE)"
+    )
+    tile_rows = []
+    for _tile_id, z, x, y in tile_coords:
+        xmin, ymin, xmax, ymax = _tile_bounds_3857(z, x, y)
+        tile_rows.append((z, x, y, xmin, ymin, xmax, ymax))
+    if not tile_rows:
+        return 0
+    session.conn.executemany(f"INSERT INTO {tiles_table} VALUES (?, ?, ?, ?, ?, ?, ?)", tile_rows)
+
+    box_expr = "ST_MakeBox2D(ST_Point(tiles.xmin, tiles.ymin), ST_Point(tiles.xmax, tiles.ymax))"
+    struct_fields = ", ".join(
+        f"{_quote_identifier(name)}: {_quote_identifier(name)}" for name in field_types
+    )
+    feature_struct = "{" + (struct_fields + ", " if struct_fields else "") + "geom: geom}"
+
+    sql = f"""
+        WITH mvtgeom AS (
+            SELECT
+                tiles.z AS __z,
+                tiles.x AS __x,
+                tiles.y AS __y,
+                ST_AsMVTGeom(
+                    {geom_expr},
+                    {box_expr},
+                    {int(extent)},
+                    {int(buffer)},
+                    true
+                ) AS geom,
+                features.* EXCLUDE (__geom_3857, __geom_4326)
+            FROM {tiles_table} AS tiles
+            JOIN {_quote_identifier(_TEMP_FEATURES)} AS features
+              ON ST_Intersects(features.__geom_3857, {box_expr})
+        )
+        SELECT
+            __z, __x, __y,
+            ST_AsMVT({feature_struct}, {_sql_literal(layer)}, {int(extent)}, 'geom') AS tile
+        FROM mvtgeom
+        WHERE geom IS NOT NULL
+        GROUP BY __z, __x, __y
+    """
+    result = session.conn.execute(sql).fetchall()
+    session.conn.execute(f"DROP TABLE IF EXISTS {tiles_table}")
+
+    encoded: list[tuple[int, bytes]] = []
+    for z, x, y, tile in result:
+        if tile is None:
+            continue
+        data = bytes(tile)
+        if data:
+            encoded.append((zxy_to_tileid(int(z), int(x), int(y)), data))
+    if not encoded:
+        return 0
+    encoded.sort(key=lambda item: item[0])
+
     with out_path.open("wb") as fh:
         writer = Writer(fh)
-        for tile_id, z, x, y in tile_coords:
-            tile = _mvt_tile(
-                session,
-                z,
-                x,
-                y,
-                layer=layer,
-                simplify_tolerance=simplify_tolerance,
-                extent=extent,
-                buffer=buffer,
-            )
-            if not tile:
-                continue
-            writer.write_tile(tile_id, tile)
-            tile_count += 1
-        if tile_count == 0:
-            return 0
+        for tile_id, data in encoded:
+            writer.write_tile(tile_id, data)
         with _deterministic_gzip():
             writer.finalize(
                 _pmtiles_header(bounds_4326, Compression.NONE, TileType.MVT),
                 _pmtiles_metadata(layer, bounds_4326, field_types),
             )
-    return tile_count
+    return len(encoded)
 
 
 def _mvt_tile(

--- a/tests/unit/test_tiling_pmtiles.py
+++ b/tests/unit/test_tiling_pmtiles.py
@@ -118,3 +118,58 @@ def test_coverage_spans_all_features_not_just_the_first(tmp_path: Path) -> None:
     written = {zxy for zxy, _data in tiles}
     expected = {(8, 129, 88), (8, 131, 91)}
     assert expected.issubset(written), f"couverture incomplete: {sorted(written)}"
+
+
+def _grid_lines(n: int) -> list:
+    """``n`` LineStrings reparties sur une grille (densite multi-tuiles)."""
+    from shapely.geometry import LineString
+
+    lines = []
+    for i in range(n):
+        x = 2.5 + (i % 50) * 0.06
+        y = 49.5 + (i // 50) * 0.04
+        lines.append(LineString([(x, y), (x + 0.05, y + 0.03)]))
+    return lines
+
+
+def test_write_pmtiles_handles_many_line_features(tmp_path: Path) -> None:
+    """Regression : un volume de lignes ne doit plus corrompre l'encodeur MVT.
+
+    La forme « un appel ST_AsMVT par tuile » segfaultait (corruption memoire de
+    l'extension spatiale DuckDB) au-dela de quelques centaines de lignes. La forme
+    groupee (une requete, GROUP BY tuile) doit produire une archive valide.
+    """
+    write_pmtiles = import_module("gispulse.tiling").write_pmtiles
+    path = tmp_path / "lines.parquet"
+    gpd.GeoDataFrame(
+        {"id": list(range(600))},
+        geometry=_grid_lines(600),
+        crs="EPSG:4326",
+    ).to_parquet(path)
+
+    out = tmp_path / "lines.pmtiles"
+    report = write_pmtiles(path, out, layer="lines", min_zoom=0, max_zoom=10)
+    assert report.rows_written > 0
+    _, _, tiles = _read_pmtiles(out)
+    assert len(tiles) > 0
+
+
+def test_write_pmtiles_coerces_unsupported_property_types(tmp_path: Path) -> None:
+    """Regression : une colonne DATE/timestamp ne doit pas casser l'encodage.
+
+    ``ST_AsMVT`` n'accepte que VARCHAR/FLOAT/DOUBLE/INTEGER/BIGINT/BOOLEAN ; les
+    autres types doivent etre castes (ici DATE -> VARCHAR) au lieu de lever.
+    """
+    import datetime as _dt
+
+    write_pmtiles = import_module("gispulse.tiling").write_pmtiles
+    path = tmp_path / "dated.parquet"
+    gpd.GeoDataFrame(
+        {"id": [1, 2], "target_date": [_dt.date(2030, 7, 1), _dt.date(2031, 1, 15)]},
+        geometry=[Point(4.35, 50.85), Point(4.40, 50.80)],
+        crs="EPSG:4326",
+    ).to_parquet(path)
+
+    out = tmp_path / "dated.pmtiles"
+    report = write_pmtiles(path, out, layer="dated", min_zoom=0, max_zoom=10)
+    assert report.rows_written > 0

--- a/uv.lock
+++ b/uv.lock
@@ -990,7 +990,7 @@ wheels = [
 
 [[package]]
 name = "gispulse"
-version = "2.2.2"
+version = "2.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
## Objet

Intègre le **writer PMTiles** (`gispulse.tiling.write_pmtiles`) depuis la branche `milou` dans la mainline — **la dernière capability `milou` non encore mergée** — et **corrige deux bugs** révélés sur de vraies couches lignes (~30k features). Prépare la **2.2.3** (publiable sur PyPI) pour que les consommateurs (MILOU) sortent du pin git `milou`.

## Changements

- **Port** `src/gispulse/tiling/{__init__,write_pmtiles}.py` + extra `tiling = ["pmtiles>=3.7,<4.0", "pyarrow>=14,<25"]`.
- **Fix #1 — corruption mémoire sur volume de lignes.** L'encodage faisait **un appel `ST_AsMVT` par tuile** (des milliers) sur une même connexion DuckDB ; au-delà de quelques centaines de features lignes, l'extension spatiale corrompt la mémoire → **segfault non-déterministe** ou `ST_AsMVTGeom: tile width and height must be positive`. Réécrit en **une seule requête groupée** (jointure spatiale features × tuiles → `ST_AsMVTGeom` → `GROUP BY` tuile → `ST_AsMVT`). Robuste **et bien plus rapide**.
- **Fix #2 — types de propriété non supportés.** `ST_AsMVT` n'encode que VARCHAR/FLOAT/DOUBLE/INTEGER/BIGINT/BOOLEAN ; une colonne `DATE`/`TIMESTAMP` faisait échouer le tiling. Coercition ajoutée (entiers larges→BIGINT, décimaux→DOUBLE, reste→VARCHAR).
- **Tests** : suite portée + 2 régressions (grille de 600 lignes ; couche à colonne DATE). Bump **2.2.2 → 2.2.3** + CHANGELOG.

## Vérification

- `pytest tests/unit/test_tiling_pmtiles.py` → **4 passed**.
- Tuilé sur données réelles (fichiers MILOU bruts) : sites 1564 (colonne date), IC 181, **réseau 29 849 lignes 3D**, anneaux 1522 — **tous OK** là où l'ancien writer segfaultait.
- `ruff check` + `ruff format` verts.

## Suite

Après merge + release 2.2.3 sur PyPI, MILOU bascule `gispulse[s3,tiling]>=2.2.3` (fin du pin git `milou`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)