### PR TITLE
feat(fetchers): VectorFileFetcher — local KML/KMZ/vector files (AccessProtocol.LOCAL_FILE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **PMTiles tiling (`gispulse.tiling.write_pmtiles`).** GeoParquet → static
   PMTiles writer backed by DuckDB `ST_AsMVT`, with the new `tiling` extra
   (`pmtiles`, `pyarrow`). Ports the last `milou`-branch capability into mainline.
+- **VectorFileFetcher / `AccessProtocol.LOCAL_FILE`.** Core protocol roster now
+  reads local vector files (KML/KMZ, GeoPackage, GeoJSON, Shapefile,
+  FlatGeobuf, ...) through `gispulse.persistence.io.read_vector()` and returns a
+  `SourceResult` carrying the materialized GeoDataFrame and CRS. This keeps
+  MILOU-style local KMZ ingestion on the official `imagodata/gispulse` package.
 
 ### Fixed
 

--- a/docs-site/changelog.md
+++ b/docs-site/changelog.md
@@ -18,6 +18,7 @@ La source de vérité de ce fichier est [`CHANGELOG.md`](https://github.com/imag
 ### Ajouté
 
 - **Tiling PMTiles (`gispulse.tiling.write_pmtiles`).** Writer GeoParquet → PMTiles statiques via DuckDB `ST_AsMVT`, avec le nouvel extra `tiling` (`pmtiles`, `pyarrow`). Porte la dernière capability de la branche `milou` dans la mainline.
+- **VectorFileFetcher / `AccessProtocol.LOCAL_FILE`.** Le roster des protocoles cœur sait désormais lire des fichiers vecteur locaux (KML/KMZ, GeoPackage, GeoJSON, Shapefile, FlatGeobuf, ...) via `gispulse.persistence.io.read_vector()` et retourne un `SourceResult` avec le GeoDataFrame matérialisé et son CRS. Cela préserve l'ingestion KMZ locale de type MILOU sur le package officiel `imagodata/gispulse`.
 
 ### Corrigé
 

--- a/docs-site/en/changelog.md
+++ b/docs-site/en/changelog.md
@@ -18,6 +18,7 @@ The authoritative version of this file lives at [`CHANGELOG.md`](https://github.
 ### Added
 
 - **PMTiles tiling (`gispulse.tiling.write_pmtiles`).** GeoParquet → static PMTiles writer backed by DuckDB `ST_AsMVT`, with the new `tiling` extra (`pmtiles`, `pyarrow`). Ports the last `milou`-branch capability into mainline.
+- **VectorFileFetcher / `AccessProtocol.LOCAL_FILE`.** The core protocol roster can now read local vector files (KML/KMZ, GeoPackage, GeoJSON, Shapefile, FlatGeobuf, ...) through `gispulse.persistence.io.read_vector()` and returns a `SourceResult` carrying the materialized GeoDataFrame and CRS. This keeps MILOU-style local KMZ ingestion on the official `imagodata/gispulse` package.
 
 ### Fixed
 

--- a/src/gispulse/core/fetchers/__init__.py
+++ b/src/gispulse/core/fetchers/__init__.py
@@ -10,6 +10,7 @@ adapters registered by the core roster are:
 * ``stac``           (A5 #231) — ``AccessProtocol.STAC``
 * ``http_file``      (A6 #232) — ``AccessProtocol.DOWNLOAD``
 * ``table_file``     — ``AccessProtocol.TABLE_FILE``
+* ``vector_file``    — ``AccessProtocol.LOCAL_FILE``
 
 Calling :func:`register_core_fetchers` is always safe: adapters are built
 only when the roster function runs, not at module import time.
@@ -42,6 +43,7 @@ def _core_fetchers() -> list[Fetcher]:
     from .ogc_features import OGCFeaturesFetcher  # A4 #230 — OGC_FEATURES
     from .stac import STACFetcher  # A5 #231 — STAC
     from .table_file import TableFileFetcher
+    from .vector_file import VectorFileFetcher  # LOCAL_FILE
 
     return [
         GeoParquetS3Fetcher(),
@@ -50,6 +52,7 @@ def _core_fetchers() -> list[Fetcher]:
         STACFetcher(),
         HttpFileFetcher(),
         TableFileFetcher(),
+        VectorFileFetcher(),
     ]
 
 

--- a/src/gispulse/core/fetchers/__init__.py
+++ b/src/gispulse/core/fetchers/__init__.py
@@ -20,7 +20,12 @@ from __future__ import annotations
 
 from gispulse.core.fetchers.base import DUCKDB_SCAN_KEY, LazyFetcher
 from gispulse.core.logging import get_logger
-from gispulse.core.sources import PROTOCOLS, Fetcher, ProtocolRegistry
+from gispulse.core.sources import (
+    PROTOCOLS,
+    Fetcher,
+    ProtocolNotSupported,
+    ProtocolRegistry,
+)
 
 log = get_logger(__name__)
 
@@ -74,6 +79,12 @@ def register_core_fetchers(
     target = registry if registry is not None else PROTOCOLS
     count = 0
     for fetcher in _core_fetchers():
+        if not override:
+            try:
+                target.get_fetcher(fetcher.protocol)
+                continue
+            except ProtocolNotSupported:
+                pass
         target.register(fetcher, override=override)
         count += 1
     log.info("core_fetchers_registered", count=count)

--- a/src/gispulse/core/fetchers/vector_file.py
+++ b/src/gispulse/core/fetchers/vector_file.py
@@ -11,8 +11,10 @@ raises :class:`NotImplementedError` with a clear message.
 ``access.params`` recognised keys:
 
 * ``layer`` — layer name for multi-layer formats (GPKG, GDB, SQLite).
-* ``bbox``  — spatial filter as ``(minx, miny, maxx, maxy)``.
 * ``rows``  — maximum number of rows to read.
+
+The spatial ``bbox`` filter ``(minx, miny, maxx, maxy)`` is taken from the
+``extent`` argument, not from ``access.params``.
 """
 
 from __future__ import annotations
@@ -99,4 +101,5 @@ class VectorFileFetcher(LazyFetcher):
             payload=self.payload,
             mode=FetchMode.MATERIALIZE,
             data=gdf,
+            crs=gdf.crs.to_string() if gdf.crs is not None else None,
         )

--- a/src/gispulse/core/fetchers/vector_file.py
+++ b/src/gispulse/core/fetchers/vector_file.py
@@ -1,0 +1,102 @@
+"""Local vector-file fetcher for ``AccessProtocol.LOCAL_FILE``.
+
+Reads any local vector file supported by :func:`~gispulse.persistence.io.read_vector`
+(KML, KMZ, GeoPackage, GeoJSON, Shapefile, FlatGeobuf, …) and returns the
+contents as a :class:`~geopandas.GeoDataFrame` in ``SourceResult.data``.
+
+This fetcher is *materialize-only*: local files have no DuckDB lazy-scan
+path (no ``/vsicurl/`` integration for local KML/KMZ), so ``REFERENCE`` mode
+raises :class:`NotImplementedError` with a clear message.
+
+``access.params`` recognised keys:
+
+* ``layer`` — layer name for multi-layer formats (GPKG, GDB, SQLite).
+* ``bbox``  — spatial filter as ``(minx, miny, maxx, maxy)``.
+* ``rows``  — maximum number of rows to read.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from gispulse.core.fetchers.base import LazyFetcher
+from gispulse.core.logging import get_logger
+from gispulse.core.plugin_model import (
+    AccessProtocol,
+    AccessSpec,
+    FetchMode,
+    Payload,
+    SourceResult,
+)
+
+log = get_logger(__name__)
+
+__all__ = ["VectorFileFetcher"]
+
+
+class VectorFileFetcher(LazyFetcher):
+    """Local vector-file adapter — delegates to ``persistence.io.read_vector``.
+
+    Returns a :class:`~geopandas.GeoDataFrame` in ``SourceResult.data``.
+    REFERENCE mode is not supported (local files are not DuckDB-scannable
+    via ``/vsicurl/``); it raises :class:`NotImplementedError`.
+    """
+
+    protocol: ClassVar[AccessProtocol] = AccessProtocol.LOCAL_FILE
+    payload: ClassVar[Payload] = Payload.VECTOR
+
+    # -- LazyFetcher hooks ---------------------------------------------------
+
+    def _reference_scan(self, access: AccessSpec, extent: Any | None) -> str:
+        """Not supported for local files — raises NotImplementedError."""
+        raise NotImplementedError(
+            "VectorFileFetcher does not support REFERENCE mode. "
+            "Local KML/KMZ/vector files cannot be exposed as a DuckDB lazy scan. "
+            "Use FetchMode.MATERIALIZE instead."
+        )
+
+    def _materialize(self, access: AccessSpec, extent: Any | None) -> SourceResult:
+        """Read the local file and return a GeoDataFrame in SourceResult.data.
+
+        Delegates entirely to :func:`~gispulse.persistence.io.read_vector`,
+        which handles KMZ decompression, KML, GPKG, GeoJSON, and all other
+        supported vector formats.
+
+        Args:
+            access: Must have ``endpoint`` set to an existing local file path.
+            extent: Optional bounding box ``(minx, miny, maxx, maxy)`` pushed
+                    down to ``read_vector`` as ``bbox``.
+
+        Raises:
+            FileNotFoundError: if ``access.endpoint`` does not exist.
+            ValueError: if the file extension is not a recognised vector format.
+        """
+        from gispulse.persistence.io import read_vector
+
+        layer = access.params.get("layer")
+        rows = access.params.get("rows")
+        bbox: tuple[float, float, float, float] | None = None
+        if extent:
+            bbox = (
+                float(extent[0]),
+                float(extent[1]),
+                float(extent[2]),
+                float(extent[3]),
+            )
+
+        gdf = read_vector(
+            access.endpoint,
+            layer=layer,
+            bbox=bbox,
+            rows=rows,
+        )
+        log.info(
+            "vector_file_materialized",
+            path=access.endpoint,
+            rows=len(gdf),
+        )
+        return SourceResult(
+            payload=self.payload,
+            mode=FetchMode.MATERIALIZE,
+            data=gdf,
+        )

--- a/src/gispulse/core/plugin_model.py
+++ b/src/gispulse/core/plugin_model.py
@@ -138,6 +138,7 @@ class AccessProtocol(str, Enum):
     # files
     DOWNLOAD = "download"          # remote zip/shp/gpkg/geojson/csv
     TABLE_FILE = "table-file"      # remote/local non-spatial tabular file
+    LOCAL_FILE = "local-file"      # local vector file (KML/KMZ/GPKG/GeoJSON…)
     COG = "cog"                    # Cloud-Optimized GeoTIFF (raster reference)
     PMTILES = "pmtiles"            # single-file vector/raster tiles
     # databases / lakehouse

--- a/tests/unit/test_fetchers_base.py
+++ b/tests/unit/test_fetchers_base.py
@@ -161,16 +161,17 @@ def test_guard_leaves_local_file_paths_alone() -> None:
 
 
 def test_register_core_fetchers_registers_the_full_roster() -> None:
-    # A3-A6 (#229-#232), table-file, plus the classic WFS adapter (#192)
+    # A3-A6 (#229-#232), table-file, local-file, plus the classic WFS adapter (#192)
     # populate the roster: every first-party protocol used by the catalogue.
     reg = ProtocolRegistry()
-    assert register_core_fetchers(reg) == 6
+    assert register_core_fetchers(reg) == 7
     for protocol in (
         AccessProtocol.REMOTE_TABLE,
         AccessProtocol.OGC_FEATURES,
         AccessProtocol.STAC,
         AccessProtocol.DOWNLOAD,
         AccessProtocol.TABLE_FILE,
+        AccessProtocol.LOCAL_FILE,
     ):
         assert isinstance(reg.get_fetcher(protocol), LazyFetcher)
 
@@ -216,7 +217,7 @@ def test_register_core_fetchers_defaults_to_global_registry() -> None:
     saved_fetchers = dict(PROTOCOLS._fetchers)
     saved_writers = dict(PROTOCOLS._writers)
     try:
-        assert register_core_fetchers() == 6  # touches PROTOCOLS
+        assert register_core_fetchers() == 7  # touches PROTOCOLS
         assert isinstance(PROTOCOLS, ProtocolRegistry)
         assert isinstance(PROTOCOLS.get_fetcher(AccessProtocol.REMOTE_TABLE), LazyFetcher)
     finally:

--- a/tests/unit/test_fetchers_base.py
+++ b/tests/unit/test_fetchers_base.py
@@ -180,6 +180,12 @@ def test_register_core_fetchers_registers_the_full_roster() -> None:
     assert isinstance(reg.get_fetcher(AccessProtocol.WFS), WfsFetcher)
 
 
+def test_register_core_fetchers_override_false_is_idempotent() -> None:
+    reg = ProtocolRegistry()
+    assert register_core_fetchers(reg, override=False) == 7
+    assert register_core_fetchers(reg, override=False) == 0
+
+
 def test_register_core_fetchers_resolves_wfs_for_declarative_source(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_plugin_model.py
+++ b/tests/unit/test_plugin_model.py
@@ -51,7 +51,7 @@ def test_protocol_version_is_shared_with_contracts() -> None:
         (Tier, 4),
         (SourceDomain, 9),
         (Payload, 5),
-        (AccessProtocol, 17),
+        (AccessProtocol, 18),
         (FetchMode, 2),
         (WriteMode, 3),
     ],

--- a/tests/unit/test_vector_file_fetcher.py
+++ b/tests/unit/test_vector_file_fetcher.py
@@ -146,6 +146,18 @@ def test_materialize_kmz_has_geometry_column(kmz_file: Path) -> None:
     assert result.data.geometry.notna().all()
 
 
+def test_materialize_kmz_sets_source_result_crs(kmz_file: Path) -> None:
+    # KMZ/KML are normalised to EPSG:4326 by read_vector; SourceResult.crs
+    # must reflect the GeoDataFrame CRS (not stay None).
+    result = VectorFileFetcher().fetch(
+        _access(str(kmz_file)),
+        mode=FetchMode.MATERIALIZE,
+    )
+    assert result.crs is not None
+    assert result.crs == result.data.crs.to_string()
+    assert result.data.crs.to_epsg() == 4326
+
+
 # ---------------------------------------------------------------------------
 # Erreurs — fast-fail
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_vector_file_fetcher.py
+++ b/tests/unit/test_vector_file_fetcher.py
@@ -1,0 +1,182 @@
+"""Tests for VectorFileFetcher (local KML/KMZ/vector files).
+
+TDD: ces tests sont écrits AVANT l'implémentation.
+Zéro réseau, zéro géodonnée client — fixtures KML synthétiques en tmp_path.
+"""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+import geopandas as gpd
+import pytest
+
+from gispulse.core.fetchers.vector_file import VectorFileFetcher
+from gispulse.core.plugin_model import (
+    AccessProtocol,
+    AccessSpec,
+    FetchMode,
+    Payload,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures : KML/KMZ synthétiques éphémères (jamais commitées)
+# ---------------------------------------------------------------------------
+
+_KML_WITH_LINESTRING = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+  <Document>
+    <Placemark>
+      <name>Route A</name>
+      <LineString>
+        <coordinates>2.3522,48.8566,0 2.3530,48.8570,0</coordinates>
+      </LineString>
+    </Placemark>
+    <Placemark>
+      <name>Route B</name>
+      <LineString>
+        <coordinates>4.8357,45.7640,0 4.8360,45.7645,0</coordinates>
+      </LineString>
+    </Placemark>
+  </Document>
+</kml>
+"""
+
+
+@pytest.fixture()
+def kml_file(tmp_path: Path) -> Path:
+    """Fichier KML synthétique local avec 2 LineStrings."""
+    path = tmp_path / "routes.kml"
+    path.write_text(_KML_WITH_LINESTRING, encoding="utf-8")
+    return path
+
+
+@pytest.fixture()
+def kmz_file(tmp_path: Path) -> Path:
+    """Fichier KMZ synthétique (doc.kml zippé) avec 2 LineStrings."""
+    path = tmp_path / "routes.kmz"
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr("doc.kml", _KML_WITH_LINESTRING)
+    return path
+
+
+def _access(endpoint: str, **params: object) -> AccessSpec:
+    return AccessSpec(
+        protocol=AccessProtocol.LOCAL_FILE,
+        endpoint=endpoint,
+        params=params,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Contrat déclaratif
+# ---------------------------------------------------------------------------
+
+
+def test_protocol_is_local_file() -> None:
+    assert VectorFileFetcher.protocol is AccessProtocol.LOCAL_FILE
+
+
+def test_payload_is_vector() -> None:
+    assert VectorFileFetcher.payload is Payload.VECTOR
+
+
+# ---------------------------------------------------------------------------
+# Matérialisation KML
+# ---------------------------------------------------------------------------
+
+
+def test_materialize_kml_returns_geodataframe(kml_file: Path) -> None:
+    result = VectorFileFetcher().fetch(
+        _access(str(kml_file)),
+        mode=FetchMode.MATERIALIZE,
+    )
+    assert result.mode is FetchMode.MATERIALIZE
+    assert isinstance(result.data, gpd.GeoDataFrame)
+
+
+def test_materialize_kml_has_expected_row_count(kml_file: Path) -> None:
+    result = VectorFileFetcher().fetch(
+        _access(str(kml_file)),
+        mode=FetchMode.MATERIALIZE,
+    )
+    assert len(result.data) == 2
+
+
+def test_materialize_kml_has_geometry_column(kml_file: Path) -> None:
+    result = VectorFileFetcher().fetch(
+        _access(str(kml_file)),
+        mode=FetchMode.MATERIALIZE,
+    )
+    assert "geometry" in result.data.columns
+    assert result.data.geometry.notna().all()
+
+
+# ---------------------------------------------------------------------------
+# Matérialisation KMZ
+# ---------------------------------------------------------------------------
+
+
+def test_materialize_kmz_returns_geodataframe(kmz_file: Path) -> None:
+    result = VectorFileFetcher().fetch(
+        _access(str(kmz_file)),
+        mode=FetchMode.MATERIALIZE,
+    )
+    assert result.mode is FetchMode.MATERIALIZE
+    assert isinstance(result.data, gpd.GeoDataFrame)
+
+
+def test_materialize_kmz_has_expected_row_count(kmz_file: Path) -> None:
+    result = VectorFileFetcher().fetch(
+        _access(str(kmz_file)),
+        mode=FetchMode.MATERIALIZE,
+    )
+    assert len(result.data) == 2
+
+
+def test_materialize_kmz_has_geometry_column(kmz_file: Path) -> None:
+    result = VectorFileFetcher().fetch(
+        _access(str(kmz_file)),
+        mode=FetchMode.MATERIALIZE,
+    )
+    assert "geometry" in result.data.columns
+    assert result.data.geometry.notna().all()
+
+
+# ---------------------------------------------------------------------------
+# Erreurs — fast-fail
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_raises_file_not_found_on_missing_path() -> None:
+    with pytest.raises(FileNotFoundError):
+        VectorFileFetcher().fetch(
+            _access("/nonexistent/routes.kml"),
+            mode=FetchMode.MATERIALIZE,
+        )
+
+
+def test_fetch_raises_value_error_on_unsupported_extension(tmp_path: Path) -> None:
+    path = tmp_path / "data.xyz"
+    path.write_text("dummy", encoding="utf-8")
+    with pytest.raises(ValueError):
+        VectorFileFetcher().fetch(
+            _access(str(path)),
+            mode=FetchMode.MATERIALIZE,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Référence lazy — non supporté (NotImplementedError explicite)
+# ---------------------------------------------------------------------------
+
+
+def test_reference_scan_raises_not_implemented(kml_file: Path) -> None:
+    with pytest.raises(NotImplementedError):
+        VectorFileFetcher().fetch(
+            _access(str(kml_file)),
+            mode=FetchMode.REFERENCE,
+        )


### PR DESCRIPTION
## Motivation

MILOU currently depends on the `superWorldSavior/gispulse` fork because it needs local KMZ/KML/vector-file ingestion through the protocol registry. This PR ports that missing contract to the official `imagodata/gispulse` core package so MILOU can move its pin back upstream.

## API surface

- Adds `AccessProtocol.LOCAL_FILE` (`"local-file"`).
- Adds `VectorFileFetcher`, a materialize-only core fetcher for local vector files supported by `gispulse.persistence.io.read_vector()` (KML/KMZ, GeoPackage, GeoJSON, Shapefile, FlatGeobuf, etc.).
- Registers the fetcher in `register_core_fetchers()` alongside the existing core roster.
- Keeps `register_core_fetchers(..., override=False)` idempotent when a registry already has the core adapters.
- Populates `SourceResult.crs` from the returned GeoDataFrame CRS.

## Tests

- `uv sync --extra dev` and `uv sync --extra all` completed locally.
- `uv run pytest tests/unit/test_vector_file_fetcher.py tests/unit/test_fetchers_base.py tests/unit/test_plugin_model.py -q` → `70 passed in 1.13s`.
- `uv run ruff check src/gispulse/core/fetchers/__init__.py src/gispulse/core/fetchers/vector_file.py src/gispulse/core/plugin_model.py tests/unit/test_fetchers_base.py tests/unit/test_plugin_model.py tests/unit/test_vector_file_fetcher.py` → `All checks passed!`.
- `uv run python -m compileall -q src/gispulse/core/fetchers/vector_file.py src/gispulse/core/fetchers/__init__.py src/gispulse/core/plugin_model.py` → OK.
- Full `uv run pytest` with all extras was attempted: collection reached `6354 items / 1 skipped`; final local result was `6273 passed, 41 skipped, 2 xfailed, 15 xpassed, 16 failed, 12 errors` in `663.01s`. Several errors are local environment/storage failures (`No space left on device`, SQLite `disk I/O error` in pytest temp dirs); the new `tests/unit/test_vector_file_fetcher.py` passed inside that run.

## Compatibility

`LOCAL_FILE` is additive. Existing protocols and fetchers keep their current behavior. `REFERENCE` mode for local vector files raises `NotImplementedError` with an explicit message; callers should use `FetchMode.MATERIALIZE`.
