### PR TITLE
fix(security): audit 2026-06-09 — SQLi, auth HTTP, zip-slip, SSRF, DoS + CSV/XLSX write + COG

### DIFF
--- a/src/gispulse/adapters/http/app.py
+++ b/src/gispulse/adapters/http/app.py
@@ -12,6 +12,7 @@ variable (comma-separated list of valid keys). Absent or empty = auth disabled
 
 from __future__ import annotations
 
+import hmac
 import inspect
 import os
 from contextlib import asynccontextmanager
@@ -770,7 +771,7 @@ def create_app(
         def metrics(request: Request) -> PlainTextResponse:
             if _metrics_token:
                 auth = request.headers.get("Authorization", "")
-                if auth != f"Bearer {_metrics_token}":
+                if not hmac.compare_digest(auth, f"Bearer {_metrics_token}"):
                     from fastapi.responses import JSONResponse
                     return JSONResponse(
                         status_code=401,
@@ -851,22 +852,24 @@ def create_app(
         app.include_router(relations_router, **write_protected)
         app.include_router(sessions_router, **protected)
         app.include_router(portal_router, **protected)
-        app.include_router(catalog_router)
-        app.include_router(filter_router)
+        app.include_router(catalog_router, **protected)
+        app.include_router(filter_router, **protected)
         app.include_router(schedules_router, **write_protected)
         app.include_router(pipelines_router, **write_protected)
         app.include_router(system_router, **protected)
         app.include_router(watchers_router, **read_protected)
 
-        # Marketplace (read endpoints open, install/uninstall admin-gated internally)
-        app.include_router(marketplace_router)
+        # Marketplace: require a valid API key. Read endpoints stay usable for
+        # any authenticated caller; install/uninstall are additionally fail-closed
+        # behind RBAC admin role inside the router.
+        app.include_router(marketplace_router, **protected)
 
         # Admin (RBAC) and Billing (Stripe) routers ship in the gispulse-enterprise
         # plugin and are mounted by the ExtensionHub block below via
         # ``gispulse.routers`` entry-points — no legacy try/except needed.
 
         from gispulse.adapters.http.routers.ogc_features_router import router as ogc_features_router
-        app.include_router(ogc_features_router)
+        app.include_router(ogc_features_router, **read_protected)
 
         if cfg.engine.backend == "postgis":
             from gispulse.adapters.http.routers.tiles_router import router as tiles_router

--- a/src/gispulse/adapters/http/middleware/read_only.py
+++ b/src/gispulse/adapters/http/middleware/read_only.py
@@ -14,6 +14,7 @@ Health/metrics/options/preflight always pass through.
 
 from __future__ import annotations
 
+import hmac
 import re
 from typing import Iterable
 
@@ -35,7 +36,10 @@ _COMPUTE_ALLOWLIST: tuple[re.Pattern[str], ...] = tuple(
         r"^/pipelines/execute-steps$",
         r"^/rules/[^/]+/validate$",
         r"^/rules/from-node$",
-        r"^/filter/(apply|preview|validate|chain)$",
+        # The filter router is mounted under the ``/api`` prefix
+        # (``APIRouter(prefix="/api/filter")``), so the real compute-only
+        # routes are ``/api/filter/...`` — not ``/filter/...``.
+        r"^/api/filter/(apply|preview|validate|chain)$",
         r"^/triggers/[^/]+/evaluate$",
         r"^/scenarios/[^/]+/run-node$",
         r"^/projects/[^/]+/detect-relations$",
@@ -78,7 +82,17 @@ class ReadOnlyMiddleware(BaseHTTPMiddleware):
             auth = request.headers.get("Authorization", "")
             if auth.startswith("Bearer "):
                 provided = auth[7:].strip()
-        return bool(provided) and provided in self._admin_keys
+        if not provided:
+            return False
+        provided_bytes = provided.encode("utf-8")
+        # Constant-time comparison against every configured key. We do not
+        # short-circuit on the first match nor on length mismatch so the
+        # response time does not leak which (if any) key was hit.
+        matched = False
+        for key in self._admin_keys:
+            if hmac.compare_digest(provided_bytes, key.encode("utf-8")):
+                matched = True
+        return matched
 
     async def dispatch(self, request: Request, call_next):
         method = request.method.upper()

--- a/src/gispulse/adapters/http/routers/marketplace_router.py
+++ b/src/gispulse/adapters/http/routers/marketplace_router.py
@@ -22,12 +22,34 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 
 from gispulse.adapters.http.auth import require_role
 
 router = APIRouter(prefix="/marketplace", tags=["marketplace"])
+
+
+def require_rbac_enabled(request: Request) -> None:
+    """Fail-closed guard for privileged marketplace operations.
+
+    ``require_role("admin")`` is a no-op when RBAC is disabled (no
+    ``AuthRepository`` attached to the app), which would otherwise let any
+    caller install/uninstall packages (pip, arbitrary code execution).  This
+    dependency rejects the request unless RBAC is actually configured, so the
+    admin role check that follows can be meaningfully enforced.
+
+    Raises:
+        HTTPException(403): When RBAC is not configured.
+    """
+    if getattr(request.app.state, "auth_repo", None) is None:
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                "Plugin install/uninstall requires RBAC to be configured "
+                "(set GISPULSE_RBAC=1 and provision an admin user)."
+            ),
+        )
 
 _PLUGIN_PREFIX = "gispulse-cap-"
 _SAFE_NAME_RE = re.compile(r"^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$")
@@ -264,7 +286,7 @@ def search_plugins(q: str = Query(..., min_length=1, description="Search term"))
     "/plugins/{plugin_id}/install",
     summary="Install a plugin by ID (admin only)",
     response_model=PluginActionResponse,
-    dependencies=[Depends(require_role("admin"))],
+    dependencies=[Depends(require_rbac_enabled), Depends(require_role("admin"))],
 )
 def install_plugin_by_id(plugin_id: str) -> PluginActionResponse:
     """Install a plugin using its registry ID (e.g. ``gispulse-cap-ftth``).
@@ -305,7 +327,7 @@ def install_plugin_by_id(plugin_id: str) -> PluginActionResponse:
     "/install",
     summary="Install a plugin (admin only)",
     response_model=PluginActionResponse,
-    dependencies=[Depends(require_role("admin"))],
+    dependencies=[Depends(require_rbac_enabled), Depends(require_role("admin"))],
 )
 def install_plugin(body: PluginAction) -> PluginActionResponse:
     """Install a GISPulse capability plugin via pip.
@@ -339,7 +361,7 @@ def install_plugin(body: PluginAction) -> PluginActionResponse:
     "/plugins/{plugin_id}/uninstall",
     summary="Uninstall a plugin by ID (admin only)",
     response_model=PluginActionResponse,
-    dependencies=[Depends(require_role("admin"))],
+    dependencies=[Depends(require_rbac_enabled), Depends(require_role("admin"))],
 )
 def uninstall_plugin_by_id(plugin_id: str) -> PluginActionResponse:
     """Uninstall a plugin using its registry ID."""
@@ -379,7 +401,7 @@ def uninstall_plugin_by_id(plugin_id: str) -> PluginActionResponse:
     "/uninstall",
     summary="Uninstall a plugin (admin only)",
     response_model=PluginActionResponse,
-    dependencies=[Depends(require_role("admin"))],
+    dependencies=[Depends(require_rbac_enabled), Depends(require_role("admin"))],
 )
 def uninstall_plugin(body: PluginAction) -> PluginActionResponse:
     """Uninstall a GISPulse capability plugin via pip.

--- a/src/gispulse/adapters/http/routers/portal_sql_router.py
+++ b/src/gispulse/adapters/http/routers/portal_sql_router.py
@@ -20,9 +20,14 @@ from gispulse.core.logging import get_logger
 
 log = get_logger(__name__)
 
-# SQL keywords forbidden in user SQL to prevent DDL/DCL via the SQL endpoint
+# SQL keywords forbidden in user SQL to prevent DDL/DCL/DML via the SQL endpoint.
+# These endpoints are read-only ("Only SELECT queries are allowed"), so data
+# mutation verbs (DELETE/INSERT/UPDATE/MERGE/UPSERT) are blocked alongside DDL/DCL.
+# Detection is token-based (\b boundaries) to avoid false positives on column or
+# table names that merely contain a keyword substring (e.g. "update_ts", "deleted").
 _SQL_DDL_BLOCKLIST = re.compile(
     r"\b(DROP|ALTER|CREATE|TRUNCATE|GRANT|REVOKE|COPY|"
+    r"DELETE|INSERT|UPDATE|MERGE|UPSERT|"
     r"pg_read_file|pg_write_file|lo_import|lo_export|"
     r"pg_terminate_backend|pg_cancel_backend|"
     r"set\s+role|reset\s+role)\b",
@@ -190,7 +195,11 @@ def sql_export(
 
         rendered = _render_and_clean(body.sql, body.params)
 
+        # Defence in depth: even though the blocklist rejects DML/DDL, run the
+        # export query inside a READ ONLY transaction so PostGIS itself refuses
+        # any data mutation that slips past the keyword filter.
         with engine.connect() as conn:
+            conn.execute(text("SET TRANSACTION READ ONLY"))
             result = conn.execute(text(rendered))
             columns = list(result.keys())
             raw_rows = result.fetchall()

--- a/src/gispulse/adapters/http/routers/portal_upload_router.py
+++ b/src/gispulse/adapters/http/routers/portal_upload_router.py
@@ -148,13 +148,28 @@ async def upload_dataset(
 
     dataset_id = str(uuid.uuid4())
 
+    # Enforce upload size limit (default 500 MB, max 5000 MB)
+    from gispulse.core.config import settings as _cfg
+    _max_mb = _cfg.api.max_upload_mb
+    _MAX_UPLOAD_SIZE = _max_mb * 1024 * 1024
+
     # Write to a temp file for format detection and metadata extraction
     # (these operations require local filesystem access)
     tmp_dir = Path(tempfile.mkdtemp(prefix="gispulse_upload_"))
     tmp_dest = tmp_dir / safe_filename
     try:
+        total_written = 0
         with open(tmp_dest, "wb") as f:
-            shutil.copyfileobj(file.file, f)
+            while chunk := await file.read(1024 * 1024):  # 1 MB chunks
+                total_written += len(chunk)
+                if total_written > _MAX_UPLOAD_SIZE:
+                    f.close()
+                    shutil.rmtree(tmp_dir, ignore_errors=True)
+                    raise HTTPException(
+                        413,
+                        f"File too large. Maximum upload size: {_MAX_UPLOAD_SIZE // (1024 * 1024)} MB.",
+                    )
+                f.write(chunk)
 
         driver = detect_format(str(tmp_dest))
         if driver is None:

--- a/src/gispulse/adapters/webhooks/http_client.py
+++ b/src/gispulse/adapters/webhooks/http_client.py
@@ -103,7 +103,7 @@ class HttpWebhookClient:
             WebhookSecurityError: URL fails the SSRF / scheme policy.
             WebhookDeliveryError: 5xx or network error persists after retries.
         """
-        self._validate_target(url)
+        pinned_ip = self._validate_target(url)
         body = json.dumps(payload, separators=(",", ":"), default=str).encode("utf-8")
         headers = {"Content-Type": "application/json"}
         signature = self._sign(body)
@@ -113,7 +113,7 @@ class HttpWebhookClient:
         last_exc: Exception | None = None
         for attempt in range(self._max_retries + 1):
             try:
-                response = self._send(url, body, headers)
+                response = self._send(url, body, headers, pinned_ip)
             except (httpx.ConnectError, httpx.ReadTimeout, httpx.ConnectTimeout) as exc:
                 last_exc = exc
                 self._sleep_for_retry(attempt)
@@ -158,13 +158,71 @@ class HttpWebhookClient:
         url: str,
         body: bytes,
         headers: dict[str, str],
+        pinned_ip: str | None = None,
     ) -> httpx.Response:
+        # When a client is injected (tests / DI) we honour the original URL so
+        # the supplied transport sees the request as configured.
         if self._client is not None:
             return self._client.post(url, content=body, headers=headers, timeout=self._timeout)
-        with httpx.Client(timeout=self._timeout) as client:
-            return client.post(url, content=body, headers=headers)
 
-    def _validate_target(self, url: str) -> None:
+        # No validated IP to pin to (allow_private_ips, or DNS-literal
+        # fallback): fall back to letting httpx resolve the hostname itself.
+        if pinned_ip is None:
+            with httpx.Client(timeout=self._timeout) as client:
+                return client.post(url, content=body, headers=headers)
+
+        # SSRF / DNS-rebinding hardening: connect to the *exact* IP that was
+        # validated against the blocklist, eliminating the TOCTOU window where
+        # a hostname could re-resolve to a blocked address (e.g. the cloud
+        # metadata endpoint 169.254.169.254) between validation and connect.
+        return self._post_pinned(url, body, headers, pinned_ip)
+
+    def _post_pinned(
+        self,
+        url: str,
+        body: bytes,
+        headers: dict[str, str],
+        pinned_ip: str,
+    ) -> httpx.Response:
+        parsed = urlparse(url)
+        hostname = parsed.hostname or ""
+        # Rebuild the URL with the validated IP as the connect target. Brackets
+        # are required for IPv6 literals in the authority component.
+        host_literal = f"[{pinned_ip}]" if ":" in pinned_ip else pinned_ip
+        netloc = f"{host_literal}:{parsed.port}" if parsed.port else host_literal
+        pinned_url = parsed._replace(netloc=netloc).geturl()
+
+        # Preserve virtual-host routing: the server must still see the original
+        # Host. urlparse keeps userinfo in netloc, but parsed.hostname strips
+        # it, so the Host header is free of credentials.
+        send_headers = dict(headers)
+        send_headers["Host"] = (
+            f"{hostname}:{parsed.port}" if parsed.port else hostname
+        )
+
+        # For TLS, route SNI + certificate verification through the original
+        # hostname (httpcore uses ``sni_hostname`` for ``server_hostname``),
+        # so the cert is still validated against the hostname, not the IP.
+        extensions = (
+            {"sni_hostname": hostname} if parsed.scheme == "https" else None
+        )
+
+        with httpx.Client(timeout=self._timeout) as client:
+            request = client.build_request(
+                "POST", pinned_url, content=body, headers=send_headers
+            )
+            if extensions is not None:
+                request.extensions = {**request.extensions, **extensions}
+            return client.send(request)
+
+    def _validate_target(self, url: str) -> str | None:
+        """Validate *url* against the SSRF policy.
+
+        Returns the single resolved IP address that the connection should be
+        pinned to (closing the DNS-rebinding TOCTOU window), or ``None`` when
+        pinning does not apply (``allow_private_ips`` opt-in, or DNS resolution
+        failed and was deferred to httpx).
+        """
         if not isinstance(url, str) or not url:
             raise WebhookSecurityError("Webhook URL is empty.")
         parsed = urlparse(url)
@@ -175,13 +233,25 @@ class HttpWebhookClient:
         if not parsed.hostname:
             raise WebhookSecurityError(f"URL '{url}' has no hostname.")
         if self._allow_private_ips:
-            return
-        for addr in _resolve_all(parsed.hostname):
+            return None
+        resolved = _resolve_all(parsed.hostname)
+        for addr in resolved:
             if _is_blocked_address(addr):
                 raise WebhookSecurityError(
                     f"Webhook target '{parsed.hostname}' resolves to blocked "
                     f"address '{addr}' (RFC1918/loopback/link-local/reserved)."
                 )
+        # Pin to the first validated address. _resolve_all returns the literal
+        # hostname (not an IP) when DNS failed; in that case there is nothing
+        # to pin and we defer connection to httpx.
+        first = resolved[0] if resolved else None
+        if first is None:
+            return None
+        try:
+            ipaddress.ip_address(first)
+        except ValueError:
+            return None
+        return first
 
     def _sign(self, body: bytes) -> str | None:
         if not self._signing_secret:

--- a/src/gispulse/core/bulk_runner.py
+++ b/src/gispulse/core/bulk_runner.py
@@ -1267,7 +1267,7 @@ def _extract_zip_archive(archive_path: Path, extract_dir: Path) -> list[Path]:
     with ZipFile(archive_path) as archive:
         for info in archive.infolist():
             dest = (extract_dir / info.filename).resolve()
-            if not str(dest).startswith(str(root)):
+            if not dest.is_relative_to(root):
                 raise ValueError(f"unsafe archive member path: {info.filename!r}")
             if info.is_dir():
                 dest.mkdir(parents=True, exist_ok=True)
@@ -1279,13 +1279,22 @@ def _extract_zip_archive(archive_path: Path, extract_dir: Path) -> list[Path]:
     return extracted
 
 
+def _assert_member_within(name: str, root: Path) -> None:
+    dest = (root / name).resolve()
+    if not dest.is_relative_to(root):
+        raise ValueError(f"unsafe archive member path: {name!r}")
+
+
 def _extract_7z_archive(archive_path: Path, extract_dir: Path) -> None:
+    root = extract_dir.resolve()
     try:
         import py7zr  # type: ignore[import-not-found]
     except ImportError:
         py7zr = None
     if py7zr is not None:
         with py7zr.SevenZipFile(archive_path, mode="r") as archive:
+            for name in archive.getnames():
+                _assert_member_within(name, root)
             archive.extractall(path=extract_dir)
         return
 
@@ -1294,13 +1303,31 @@ def _extract_7z_archive(archive_path: Path, extract_dir: Path) -> None:
         None,
     )
     if binary is None:
-        raise RuntimeError("7z DOWNLOAD archives require py7zr or a local 7zz/7z/7za binary")
-    subprocess.run(
-        [binary, "x", str(archive_path), f"-o{extract_dir}", "-y"],
-        check=True,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
+        raise RuntimeError(
+            "7z DOWNLOAD archives require py7zr or a local 7zz/7z/7za binary"
+        )
+    # Extract into a temporary staging directory, validate every produced
+    # member stays under extract_dir, then move it into place. This prevents a
+    # malicious archive member (e.g. ``../../x``) from escaping extract_dir.
+    extract_dir.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(dir=extract_dir) as staging:
+        staging_root = Path(staging).resolve()
+        subprocess.run(
+            [binary, "x", str(archive_path), f"-o{staging_root}", "-y"],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        for member in sorted(staging_root.rglob("*")):
+            rel = member.relative_to(staging_root)
+            dest = (root / rel).resolve()
+            if not dest.is_relative_to(root):
+                raise ValueError(f"unsafe archive member path: {str(rel)!r}")
+            if member.is_dir():
+                dest.mkdir(parents=True, exist_ok=True)
+                continue
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(member), str(dest))
 
 
 def _vector_members(extract_dir: Path, extracted: Iterable[Path]) -> list[Path]:

--- a/src/gispulse/persistence/io.py
+++ b/src/gispulse/persistence/io.py
@@ -65,6 +65,7 @@ KMZ_KML_MAX_BYTES = 50 * 1024 * 1024
 WRITABLE_FORMATS = {
     ".gpkg", ".geojson", ".json", ".shp", ".fgb",
     ".gml", ".parquet", ".sqlite",
+    ".csv", ".tsv", ".xlsx",
 }
 
 
@@ -528,6 +529,33 @@ def write_vector(
     # --- GeoParquet ---
     if ext == ".parquet":
         gdf.to_parquet(path, **kwargs)
+    elif ext in (".csv", ".tsv", ".xlsx"):
+        # --- Tabular formats: serialize geometry as WKT ---
+        # The geometry is written into a "geometry" column so the matching
+        # reader (_read_csv_geo / WKT auto-detection) can round-trip it.
+        import pandas as pd
+
+        df = pd.DataFrame(gdf.copy())
+        geom_name = gdf.geometry.name if gdf.geometry is not None else "geometry"
+        # Serialize geometries to WKT, mapping null/empty geometries to None.
+        wkt_series = gdf.geometry.apply(
+            lambda geom: geom.wkt if geom is not None and not geom.is_empty else None
+        )
+        if geom_name in df.columns:
+            df = df.drop(columns=[geom_name])
+        df["geometry"] = wkt_series.values
+
+        if ext == ".xlsx":
+            try:
+                df.to_excel(path, index=False, sheet_name="Sheet1", **kwargs)
+            except ImportError as exc:
+                raise ImportError(
+                    "Writing XLSX files requires openpyxl. Install gispulse with its "
+                    "declared dependencies, or install openpyxl>=3.1,<4.0."
+                ) from exc
+        else:
+            sep = "\t" if ext == ".tsv" else ","
+            df.to_csv(path, sep=sep, index=False, **kwargs)
     else:
         # --- Standard Fiona-based ---
         driver = VECTOR_DRIVERS[ext]

--- a/src/gispulse/persistence/raster_io.py
+++ b/src/gispulse/persistence/raster_io.py
@@ -170,9 +170,18 @@ def write_raster(
     transform: Any,
     nodata: Optional[float] = None,
     dtype: Optional[str] = None,
+    cog: Optional[bool] = None,
+    compress: str = "DEFLATE",
+    blocksize: int = 512,
     **kwargs: Any,
 ) -> None:
     """Write a numpy array as a raster file.
+
+    For GeoTIFF outputs (``.tif`` / ``.tiff``) the data is written as a
+    Cloud-Optimized GeoTIFF (COG) by default, using rasterio's native
+    ``COG`` driver. COGs are tiled, carry internal overviews and a
+    cloud-friendly layout, which makes them efficient to stream from object
+    storage while remaining valid GeoTIFFs for any GDAL reader.
 
     Args:
         data:      Array of shape [bands, height, width] or [height, width].
@@ -181,7 +190,12 @@ def write_raster(
         transform: Affine transform.
         nodata:    Nodata value.
         dtype:     Output dtype. Defaults to data.dtype.
-        **kwargs:  Extra rasterio profile options.
+        cog:       Write a Cloud-Optimized GeoTIFF. ``None`` (default) means
+                   auto: COG for ``.tif``/``.tiff``, plain driver otherwise.
+                   Pass ``False`` to force a plain ``GTiff`` for ``.tif``.
+        compress:  Compression for COG output (e.g. "DEFLATE", "LZW", "ZSTD").
+        blocksize: Internal tile/block size for COG output.
+        **kwargs:  Extra rasterio profile options (override the defaults).
     """
     import numpy as np
     import rasterio
@@ -201,19 +215,47 @@ def write_raster(
     if isinstance(transform, (list, tuple)):
         transform = Affine(*transform[:6])
 
-    profile = {
-        "driver": RASTER_DRIVERS.get(ext, "GTiff"),
-        "dtype": dtype or str(data.dtype),
-        "width": width,
-        "height": height,
-        "count": count,
-        "crs": crs,
-        "transform": transform,
-    }
+    # Decide whether to emit a Cloud-Optimized GeoTIFF. Auto-enable for
+    # GeoTIFF extensions; never for other formats (which lack a COG driver).
+    is_geotiff = ext in (".tif", ".tiff")
+    use_cog = is_geotiff if cog is None else (cog and is_geotiff)
+
+    if use_cog:
+        profile = {
+            "driver": "COG",
+            "dtype": dtype or str(data.dtype),
+            "width": width,
+            "height": height,
+            "count": count,
+            "crs": crs,
+            "transform": transform,
+            # COG driver creation options: tiled + internal overviews.
+            "compress": compress,
+            "blocksize": blocksize,
+            "overview_resampling": "nearest",
+        }
+    else:
+        profile = {
+            "driver": RASTER_DRIVERS.get(ext, "GTiff"),
+            "dtype": dtype or str(data.dtype),
+            "width": width,
+            "height": height,
+            "count": count,
+            "crs": crs,
+            "transform": transform,
+        }
     if nodata is not None:
         profile["nodata"] = nodata
 
     profile.update(kwargs)
+
+    # Validate the CRS up-front so an invalid value raises a clean Python
+    # exception. The COG driver may otherwise abort hard (rather than raising)
+    # on a malformed CRS during its internal translate step.
+    if profile.get("crs") is not None:
+        from rasterio.crs import CRS
+
+        profile["crs"] = CRS.from_user_input(profile["crs"])
 
     # Atomic write: write to temp file first, then rename
     import tempfile

--- a/src/gispulse/rules/operation_executor.py
+++ b/src/gispulse/rules/operation_executor.py
@@ -61,6 +61,19 @@ def _bind_geom(geom_wkt: str | None, srid: int) -> tuple[str | None, tuple]:
     return _GEOM_BIND, (geom_wkt, srid)
 
 
+def _quote_ident(name: str) -> str:
+    """Double-quote a (possibly schema-qualified) SQL identifier.
+
+    ``validate_layer_name`` is permissive (it accepts spaces, ``=``, parens,
+    ``UNION`` …) and is therefore only safe when the resulting identifier is
+    interpolated **between double quotes**. It forbids the ``"`` character, so
+    no escaping is required. Schema-qualified names (``schema.table``) are
+    split on ``.`` so each part is quoted independently:
+    ``"schema"."table"``.
+    """
+    return ".".join(f'"{part}"' for part in name.split("."))
+
+
 # ---------------------------------------------------------------------------
 # OperationExecutor
 # ---------------------------------------------------------------------------
@@ -197,9 +210,10 @@ class OperationExecutor:
         table = _validate_identifier(op.get("table", "") or "")
         if not table:
             return None
+        qtable = _quote_ident(table)
         geom, params = _bind_geom(geom_wkt, srid)
         rows = self._conn.execute(
-            f"SELECT id FROM {table} WHERE {predicate}({geom}, geom) LIMIT 1",
+            f"SELECT id FROM {qtable} WHERE {predicate}({geom}, geom) LIMIT 1",
             params,
         )
         return rows[0]["id"] if rows else None
@@ -209,11 +223,12 @@ class OperationExecutor:
         table = _validate_identifier(op.get("table", "") or "")
         if not table:
             return None
+        qtable = _quote_ident(table)
         geom, params = _bind_geom(geom_wkt, srid)
         point_expr = f"{point_wrapper}({geom})" if point_wrapper else geom
         rows = self._conn.execute(
             f"SELECT id, ST_Distance({point_expr}::geography, geom::geography) AS dist "
-            f"FROM {table} ORDER BY dist LIMIT 1",
+            f"FROM {qtable} ORDER BY dist LIMIT 1",
             params,
         )
         return rows[0]["id"] if rows else None
@@ -260,17 +275,20 @@ def _filter_phase(operations: list[dict], phase: str) -> list[dict]:
 def _validated_distant(op: dict) -> tuple[str, str, str, str]:
     """Validate distant_table / distant_field / table / distant_filter.
 
-    Returns a 4-tuple ``(distant_table, distant_field, table, where_clause)``.
+    Returns a 4-tuple ``(distant_table, distant_field, table, where_clause)``
+    where the three identifiers are already **double-quoted** (the validator
+    is permissive and only safe inside quotes). ``where_clause`` is an opaque
+    SQL predicate (``distant_filter``) and is intentionally left unquoted.
     Raises on identifier or expression validation failure.
     """
-    distant_table = _validate_identifier(op.get("distant_table", "") or "")
-    distant_field = _validate_identifier(op.get("distant_field", "") or "")
+    distant_table = _quote_ident(_validate_identifier(op.get("distant_table", "") or ""))
+    distant_field = _quote_ident(_validate_identifier(op.get("distant_field", "") or ""))
     distant_filter = op.get("distant_filter", "")
     if distant_filter:
         _validate_expression(distant_filter)
     table = op.get("table", "") or ""
     if table:
-        table = _validate_identifier(table)
+        table = _quote_ident(_validate_identifier(table))
     where = f"AND {distant_filter}" if distant_filter else ""
     return distant_table, distant_field, table, where
 
@@ -298,7 +316,7 @@ def _after_sum_st_contains(op, geom_wkt, srid):
     if geom is None:
         return None, ()
     dt, df, table, where = _validated_distant(op)
-    field = _validate_identifier(op.get("field", "value") or "value")
+    field = _quote_ident(_validate_identifier(op.get("field", "value") or "value"))
     return (
         f"UPDATE {dt} SET {df} = ("
         f"  SELECT COALESCE(SUM({table}.{field}), 0) FROM {table} "
@@ -326,7 +344,7 @@ def _after_sum_st_within(op, geom_wkt, srid):
     if geom is None:
         return None, ()
     dt, df, table, where = _validated_distant(op)
-    field = _validate_identifier(op.get("field", "value") or "value")
+    field = _quote_ident(_validate_identifier(op.get("field", "value") or "value"))
     return (
         f"UPDATE {dt} SET {df} = ("
         f"  SELECT COALESCE(SUM({table}.{field}), 0) FROM {table} "
@@ -354,7 +372,7 @@ def _after_sum_st_intersects(op, geom_wkt, srid):
     if geom is None:
         return None, ()
     dt, df, table, where = _validated_distant(op)
-    field = _validate_identifier(op.get("field", "value") or "value")
+    field = _quote_ident(_validate_identifier(op.get("field", "value") or "value"))
     return (
         f"UPDATE {dt} SET {df} = ("
         f"  SELECT COALESCE(SUM({table}.{field}), 0) FROM {table} "
@@ -369,7 +387,7 @@ def _after_string_agg_st_intersects(op, geom_wkt, srid):
     if geom is None:
         return None, ()
     dt, df, table, where = _validated_distant(op)
-    field = _validate_identifier(op.get("field", "name") or "name")
+    field = _quote_ident(_validate_identifier(op.get("field", "name") or "name"))
     return (
         f"UPDATE {dt} SET {df} = ("
         f"  SELECT STRING_AGG({table}.{field}::TEXT, ', ') FROM {table} "

--- a/src/gispulse/rules/trigger_evaluator.py
+++ b/src/gispulse/rules/trigger_evaluator.py
@@ -42,6 +42,19 @@ from gispulse.rules.predicates import PredicateEvaluator
 MAX_CASCADE_DEPTH = 3
 
 
+def _quote_ident(name: str) -> str:
+    """Double-quote a (possibly schema-qualified) SQL identifier.
+
+    ``validate_layer_name`` is permissive (it accepts spaces, ``=``, parens,
+    ``UNION`` …) and is therefore only safe when the resulting identifier is
+    interpolated **between double quotes**. It forbids the ``"`` character, so
+    no escaping is required. Schema-qualified names (``schema.table``) are
+    split on ``.`` so each part is quoted independently:
+    ``"schema"."table"``.
+    """
+    return ".".join(f'"{part}"' for part in name.split("."))
+
+
 class CascadeDepthExceeded(Exception):
     """Levée quand une cascade de triggers dépasse MAX_CASCADE_DEPTH niveaux."""
 
@@ -289,7 +302,7 @@ class TriggerEvaluator:
 
         table = tc.table or record.table_name
         try:
-            table = _validate_identifier(table)
+            table = _quote_ident(_validate_identifier(table))
             if tc.metric == "feature_count":
                 sql = f"SELECT COUNT(*) AS val FROM {table}"
             elif tc.metric == "total_area":
@@ -297,7 +310,7 @@ class TriggerEvaluator:
             elif tc.metric == "total_length":
                 sql = f"SELECT COALESCE(SUM(ST_Length(geom::geography)), 0) AS val FROM {table}"
             elif tc.metric in ("sum_value", "avg_value", "max_value", "min_value"):
-                field = _validate_identifier(tc.field or "value")
+                field = _quote_ident(_validate_identifier(tc.field or "value"))
                 agg = tc.metric.split("_")[0].upper()
                 sql = f"SELECT COALESCE({agg}({field}), 0) AS val FROM {table}"
             else:
@@ -362,7 +375,7 @@ class TriggerEvaluator:
             return True
 
         try:
-            table = _validate_identifier(table)
+            table = _quote_ident(_validate_identifier(table))
             _validate_business_expression(expression)
             sql = f"SELECT NOT ({expression}) AS violated FROM {table} WHERE id = %s"
             rows = self._postgis.execute(sql, (str(fid),))
@@ -391,7 +404,7 @@ class TriggerEvaluator:
 
         table = tc.table or record.table_name
         try:
-            table = _validate_identifier(table)
+            table = _quote_ident(_validate_identifier(table))
             geom_param = "ST_GeomFromText(%s, 4326)"
             params: list[Any] = [record.new_geom_wkt]
             if tc.topo_check == "no_overlap":
@@ -405,12 +418,12 @@ class TriggerEvaluator:
             elif tc.topo_check == "must_be_inside":
                 if not tc.ref_table:
                     return False
-                ref_table = _validate_identifier(tc.ref_table)
+                ref_table = _quote_ident(_validate_identifier(tc.ref_table))
                 sql = f"SELECT NOT EXISTS (SELECT 1 FROM {ref_table} WHERE ST_Contains(geom, {geom_param})) AS violated"
             elif tc.topo_check == "must_not_overlap_with":
                 if not tc.ref_table:
                     return False
-                ref_table = _validate_identifier(tc.ref_table)
+                ref_table = _quote_ident(_validate_identifier(tc.ref_table))
                 sql = f"SELECT EXISTS (SELECT 1 FROM {ref_table} WHERE ST_Overlaps(geom, {geom_param})) AS violated"
             else:
                 return False
@@ -437,7 +450,7 @@ class TriggerEvaluator:
             return True
 
         try:
-            ref_table = _validate_identifier(sc.ref_table)
+            ref_table = _quote_ident(_validate_identifier(sc.ref_table))
             geom_param = "ST_GeomFromText(%s, 4326)"
             params: list[Any] = [record.new_geom_wkt]
             if sc.spatial_type == "min_distance":

--- a/tests/test_read_only_middleware.py
+++ b/tests/test_read_only_middleware.py
@@ -36,7 +36,7 @@ def _make_app(admin_keys: set[str] | None = None) -> FastAPI:
     def rule_validate(rid: str):
         return {"valid": True}
 
-    @app.post("/filter/apply")
+    @app.post("/api/filter/apply")
     def filter_apply():
         return {"ok": True}
 
@@ -77,7 +77,7 @@ def test_compute_only_post_allowed():
     client = TestClient(_make_app())
     assert client.post("/capabilities/sql-preview", json={"sql": "SELECT 1"}).status_code == 200
     assert client.post("/rules/abc/validate", json={}).status_code == 200
-    assert client.post("/filter/apply", json={}).status_code == 200
+    assert client.post("/api/filter/apply", json={}).status_code == 200
 
 
 def test_upload_post_blocked_because_persistent():

--- a/tests/unit/test_marketplace_router.py
+++ b/tests/unit/test_marketplace_router.py
@@ -91,13 +91,51 @@ class TestSafeNameRegex:
 
 @pytest.fixture
 def client():
-    """Minimal test client with the marketplace router mounted."""
+    """Minimal test client with the marketplace router mounted.
+
+    No ``auth_repo`` is attached, so privileged install/uninstall endpoints
+    are fail-closed (HTTP 403) — see ``require_rbac_enabled``.
+    """
     from fastapi import FastAPI
     from fastapi.testclient import TestClient
 
     app = FastAPI()
     app.include_router(router)
     return TestClient(app)
+
+
+@pytest.fixture
+def admin_client():
+    """Test client with RBAC configured and an admin user resolvable by key.
+
+    Wires a stub ``AuthRepository`` on ``app.state`` so ``require_rbac_enabled``
+    passes and ``require_role('admin')`` resolves an admin user from the
+    ``X-API-Key`` header. Privileged endpoints are reached with
+    ``headers={"X-API-Key": "admin-key"}``.
+    """
+    from types import SimpleNamespace
+
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from gispulse.persistence.auth_models import User
+
+    admin_user = User(id="u-admin", email="admin@example.com", role="admin", is_active=True)
+    api_key_row = SimpleNamespace(
+        user_id="u-admin", scopes=["admin"], expires_at=None
+    )
+
+    auth_repo = MagicMock()
+    auth_repo.get_api_key_by_hash.return_value = api_key_row
+    auth_repo.get_user.return_value = admin_user
+
+    app = FastAPI()
+    app.state.auth_repo = auth_repo
+    app.include_router(router)
+    return TestClient(app)
+
+
+_ADMIN_HEADERS = {"X-API-Key": "admin-key"}
 
 
 class TestListPlugins:
@@ -300,7 +338,7 @@ class TestCatalog:
 
 
 class TestInstallPluginById:
-    def test_install_by_id(self, client, tmp_path):
+    def test_install_by_id(self, admin_client, tmp_path):
         registry_data = {
             "plugins": [{"id": "gispulse-cap-ftth", "package": "gispulse-cap-ftth", "name": "FTTH"}]
         }
@@ -310,12 +348,14 @@ class TestInstallPluginById:
 
         with patch("gispulse.adapters.http.routers.marketplace_router._REGISTRY_PATH", fake_path):
             with patch("subprocess.run", return_value=fake_result):
-                resp = client.post("/marketplace/plugins/gispulse-cap-ftth/install")
+                resp = admin_client.post(
+                    "/marketplace/plugins/gispulse-cap-ftth/install", headers=_ADMIN_HEADERS
+                )
         assert resp.status_code == 200
         assert resp.json()["ok"] is True
         assert resp.json()["package"] == "gispulse-cap-ftth"
 
-    def test_install_unknown_id(self, client, tmp_path):
+    def test_install_unknown_id(self, admin_client, tmp_path):
         registry_data = {"plugins": []}
         fake_path = tmp_path / "registry.json"
         fake_path.write_text(json.dumps(registry_data))
@@ -323,13 +363,22 @@ class TestInstallPluginById:
 
         with patch("gispulse.adapters.http.routers.marketplace_router._REGISTRY_PATH", fake_path):
             with patch("subprocess.run", return_value=fake_result):
-                resp = client.post("/marketplace/plugins/myplug/install")
+                resp = admin_client.post(
+                    "/marketplace/plugins/myplug/install", headers=_ADMIN_HEADERS
+                )
         assert resp.status_code == 200
         assert resp.json()["package"] == "gispulse-cap-myplug"
 
+    def test_install_by_id_fail_closed_without_rbac(self, client):
+        """Install is rejected (403) when RBAC is not configured."""
+        with patch("subprocess.run") as mock_run:
+            resp = client.post("/marketplace/plugins/gispulse-cap-ftth/install")
+        assert resp.status_code == 403
+        mock_run.assert_not_called()
+
 
 class TestUninstallPluginById:
-    def test_uninstall_by_id(self, client, tmp_path):
+    def test_uninstall_by_id(self, admin_client, tmp_path):
         registry_data = {
             "plugins": [{"id": "gispulse-cap-ftth", "package": "gispulse-cap-ftth", "name": "FTTH"}]
         }
@@ -339,55 +388,70 @@ class TestUninstallPluginById:
 
         with patch("gispulse.adapters.http.routers.marketplace_router._REGISTRY_PATH", fake_path):
             with patch("subprocess.run", return_value=fake_result):
-                resp = client.delete("/marketplace/plugins/gispulse-cap-ftth/uninstall")
+                resp = admin_client.delete(
+                    "/marketplace/plugins/gispulse-cap-ftth/uninstall", headers=_ADMIN_HEADERS
+                )
         assert resp.status_code == 200
         assert resp.json()["ok"] is True
 
 
 class TestInstallPlugin:
-    """Install requires admin role.
+    """Install requires admin role and a configured RBAC backend.
 
-    In our minimal test app the require_role dependency is active but no
-    auth repo is attached, so in legacy/dev mode the check is a no-op
-    (returns None). We test the happy path and the validation.
+    When no auth repo is attached (dev/legacy mode), ``require_role('admin')``
+    is a no-op, so ``require_rbac_enabled`` fails the request closed (403).
+    The happy-path tests use ``admin_client`` which wires a stub
+    AuthRepository resolving an admin user from the API key.
     """
 
-    def test_install_success(self, client):
+    def test_install_fail_closed_without_rbac(self, client):
+        """Without RBAC configured, install is rejected with 403 and pip never runs."""
+        with patch("subprocess.run") as mock_run:
+            resp = client.post("/marketplace/install", json={"name": "ftth"})
+        assert resp.status_code == 403
+        assert "RBAC" in resp.json()["detail"]
+        mock_run.assert_not_called()
+
+    def test_install_success(self, admin_client):
         fake_result = MagicMock(returncode=0, stderr="", stdout="ok")
         with patch("subprocess.run", return_value=fake_result):
-            resp = client.post(
+            resp = admin_client.post(
                 "/marketplace/install",
                 json={"name": "ftth"},
+                headers=_ADMIN_HEADERS,
             )
         assert resp.status_code == 200
         data = resp.json()
         assert data["ok"] is True
         assert data["package"] == "gispulse-cap-ftth"
 
-    def test_install_failure(self, client):
+    def test_install_failure(self, admin_client):
         fake_result = MagicMock(returncode=1, stderr="not found", stdout="")
         with patch("subprocess.run", return_value=fake_result):
-            resp = client.post(
+            resp = admin_client.post(
                 "/marketplace/install",
                 json={"name": "ftth"},
+                headers=_ADMIN_HEADERS,
             )
         assert resp.status_code == 200
         data = resp.json()
         assert data["ok"] is False
 
-    def test_install_invalid_name(self, client):
-        resp = client.post(
+    def test_install_invalid_name(self, admin_client):
+        resp = admin_client.post(
             "/marketplace/install",
             json={"name": "foo;rm -rf /"},
+            headers=_ADMIN_HEADERS,
         )
         assert resp.status_code == 400
 
-    def test_install_with_upgrade(self, client):
+    def test_install_with_upgrade(self, admin_client):
         fake_result = MagicMock(returncode=0, stderr="", stdout="ok")
         with patch("subprocess.run", return_value=fake_result) as mock_run:
-            resp = client.post(
+            resp = admin_client.post(
                 "/marketplace/install",
                 json={"name": "ftth", "upgrade": True},
+                headers=_ADMIN_HEADERS,
             )
         assert resp.status_code == 200
         # Verify --upgrade was passed
@@ -396,19 +460,28 @@ class TestInstallPlugin:
 
 
 class TestUninstallPlugin:
-    def test_uninstall_success(self, client):
+    def test_uninstall_success(self, admin_client):
         fake_result = MagicMock(returncode=0, stderr="", stdout="ok")
         with patch("subprocess.run", return_value=fake_result):
-            resp = client.post(
+            resp = admin_client.post(
                 "/marketplace/uninstall",
                 json={"name": "ftth"},
+                headers=_ADMIN_HEADERS,
             )
         assert resp.status_code == 200
         assert resp.json()["ok"] is True
 
-    def test_uninstall_invalid_name(self, client):
-        resp = client.post(
+    def test_uninstall_invalid_name(self, admin_client):
+        resp = admin_client.post(
             "/marketplace/uninstall",
             json={"name": "../../etc/passwd"},
+            headers=_ADMIN_HEADERS,
         )
         assert resp.status_code == 400
+
+    def test_uninstall_fail_closed_without_rbac(self, client):
+        """Without RBAC configured, uninstall is rejected with 403."""
+        with patch("subprocess.run") as mock_run:
+            resp = client.post("/marketplace/uninstall", json={"name": "ftth"})
+        assert resp.status_code == 403
+        mock_run.assert_not_called()

--- a/tests/unit/test_operation_executor.py
+++ b/tests/unit/test_operation_executor.py
@@ -303,8 +303,8 @@ class TestExecuteAfter:
         assert len(applied) == 1
         assert applied[0]["table"] == "zones"
         sql = conn.calls[0][0]
-        assert "UPDATE zones" in sql
-        assert "SET pois_count" in sql
+        assert 'UPDATE "zones"' in sql
+        assert 'SET "pois_count"' in sql
         assert "ST_Contains" in sql
 
     def test_sum_st_contains_uses_field_parameter(self):
@@ -320,7 +320,7 @@ class TestExecuteAfter:
         }]
         exec_.execute_after(ops, {}, geom_wkt="POINT(0 0)")
         sql = conn.calls[0][0]
-        assert "SUM(buildings.population)" in sql
+        assert 'SUM("buildings"."population")' in sql
 
     def test_string_agg_st_intersects(self):
         conn = FakeConn()

--- a/tests/unit/test_trigger_evaluator_handlers.py
+++ b/tests/unit/test_trigger_evaluator_handlers.py
@@ -164,7 +164,7 @@ class TestThresholdHandler:
             },
         )
         ev.evaluate(_make_record(), [trig])
-        assert "SUM(population)" in pg.calls[0][0]
+        assert 'SUM("population")' in pg.calls[0][0]
 
     def test_unsafe_table_silently_rejected(self):
         pg = FakePG(rows_queue=[])

--- a/tests/unit/test_webhook_client.py
+++ b/tests/unit/test_webhook_client.py
@@ -184,6 +184,80 @@ class TestSSRFPolicy:
 
 
 # ---------------------------------------------------------------------------
+# DNS rebinding (TOCTOU): connection is pinned to the validated IP
+# ---------------------------------------------------------------------------
+
+
+class TestDnsRebindingPinning:
+    """Without a DI client, the request must connect to the *validated* IP
+    while keeping the original Host header (and SNI for https), so a hostname
+    cannot re-resolve to a blocked address between validation and connect."""
+
+    def test_https_pins_ip_keeps_host_and_sni(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        # Validation resolves to this public IP exactly once.
+        monkeypatch.setattr(_module, "_resolve_all", lambda host: ["93.184.216.34"])
+
+        captured: list[httpx.Request] = []
+        _real_client = httpx.Client
+
+        class _CaptureClient:
+            def __init__(self, *a, **k):
+                self._inner = _real_client(
+                    transport=httpx.MockTransport(self._handler)
+                )
+
+            def _handler(self, request: httpx.Request) -> httpx.Response:
+                captured.append(request)
+                return httpx.Response(200)
+
+            def build_request(self, *a, **k):
+                return self._inner.build_request(*a, **k)
+
+            def send(self, request):
+                return self._inner.send(request)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                self._inner.close()
+
+        monkeypatch.setattr(_module.httpx, "Client", _CaptureClient)
+
+        c = HttpWebhookClient(allow_private_ips=False)
+        c.post("https://api.example.com/hook", {"x": 1})
+
+        assert len(captured) == 1
+        req = captured[0]
+        # Connection target is the validated IP, not the hostname.
+        assert req.url.host == "93.184.216.34"
+        # Host header preserves virtual-host routing on the original name.
+        assert req.headers["Host"] == "api.example.com"
+        # TLS verifies against the original hostname, not the IP.
+        assert req.extensions.get("sni_hostname") == "api.example.com"
+
+    def test_rebinding_to_metadata_ip_is_blocked_before_connect(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        # Hostname resolves to the cloud metadata endpoint at validation time.
+        monkeypatch.setattr(
+            _module, "_resolve_all", lambda host: ["169.254.169.254"]
+        )
+        # Any attempt to actually open a client would be a bug.
+        monkeypatch.setattr(
+            _module.httpx,
+            "Client",
+            lambda *a, **k: (_ for _ in ()).throw(AssertionError("connected!")),
+        )
+
+        c = HttpWebhookClient(allow_private_ips=False)
+        with pytest.raises(WebhookSecurityError, match="blocked"):
+            c.post("https://attacker.example/hook", {"x": 1})
+
+
+# ---------------------------------------------------------------------------
 # HMAC signing
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Implémente les correctifs de l'audit technique du **2026-06-09** (5 agents d'audit + 9 agents d'implémentation en parallèle, fichiers disjoints).

## Sécurité

| Lot | Sévérité | Correctif |
|---|---|---|
| **SQLi** | HIGH | `operation_executor.py` + `trigger_evaluator.py` quotent désormais tous les identifiants interpolés (`"schema"."table"`), corrigeant l'anti-pattern « validateur permissif + identifiant non quoté » exploitable via ESB→PostGIS. Expressions/prédicats (`ST_*`, `distant_filter`) restent volontairement non quotés. Calqué sur `change_log_watcher.py`. |
| **Auth HTTP** | HIGH | `filter`/`catalog` montés `**protected`, `ogc` `**read_protected`, `marketplace` `**protected` (étaient sans dépendance d'auth) ; `install`/`uninstall` **fail-closed 403** quand RBAC non configuré (le `require_role("admin")` était un no-op) ; `/metrics` passe à `hmac.compare_digest`. |
| read-only middleware | LOW | admin key en constant-time + regex allowlist corrigées vers les vrais préfixes `/api/filter/...` (ne matchaient jamais). |
| zip-slip | MEDIUM | validation des membres 7z (py7zr + subprocess) + ZIP via `is_relative_to` (l'ancien `startswith` laissait passer un sibling). |
| upload portail | MEDIUM | plafond streaming `max_upload_mb` (413), symétrique à `datasets_router`. |
| SQL portail | LOW | `DELETE`/`INSERT`/`UPDATE`/`MERGE` ajoutés à la blocklist + `/sql/export` en transaction read-only. |
| webhook SSRF | LOW | connexion pinnée sur l'IP validée (anti DNS-rebinding/TOCTOU). |

## Fonctionnalités

- **Écriture CSV/TSV/XLSX** (géométrie en WKT) — corrige aussi le **bug d'export CSV du portail** qui levait une 500 (`/datasets/export` annonçait `csv` mais `write_vector` le rejetait).
- **Sortie raster COG first-class** (`driver=COG` + overviews), rétro-compatible.

## Tests

544 tests ciblés verts (189 + 355 : injection SQL, io, raster, filter/ogc/catalog, marketplace, middleware, webhook, bulk, metrics, sql_safety), `ruff` clean sur les 11 fichiers source. Tests existants migrés au nouveau contrat, aucun fichier orphelin.

## Hors périmètre (PR séparées)

- Bumps deps : pyjwt→2.13, urllib3→2.7 (`uv lock`) ; JS react-router≥7.15 + shadcn en devDeps (portail).
- Chantiers produit : `publish()` multi-cibles, PMTiles, geocode BAN, lots raster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)