### PR TITLE
fix(tests): resolve config_loader path from the imported module

### DIFF
--- a/tests/runtime/test_config_loader.py
+++ b/tests/runtime/test_config_loader.py
@@ -289,7 +289,9 @@ def test_validate_reports_webhook_without_url(
 
 def test_module_does_not_call_unsafe_yaml_load() -> None:
     """Static grep: ensure the module never reaches for ``yaml.load``."""
-    src = Path(__file__).resolve().parents[2] / "gispulse" / "runtime" / "config_loader.py"
+    import gispulse.runtime.config_loader as config_loader_module
+
+    src = Path(config_loader_module.__file__).resolve()
     text = src.read_text(encoding="utf-8")
     # Reject ``yaml.load(`` exactly. ``yaml.safe_load`` is fine.
     bad_patterns = ["yaml.load(", "yaml.unsafe_load(", "yaml.full_load("]


### PR DESCRIPTION
`test_module_does_not_call_unsafe_yaml_load` builds the source path as `parents[2] / "gispulse" / "runtime" / "config_loader.py"`, which skips the `src/` layout segment — so the static yaml.load grep fails with `FileNotFoundError` on a clean checkout (found while validating an unrelated branch). Deriving the path from the imported module's `__file__` is layout-independent and also covers editable installs.

One-line behaviour: the test now passes against the actual module the suite imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)