### PR TITLE
feat(core): source readiness probe engine with extensible probe kinds

### DIFF
--- a/src/gispulse/core/readiness.py
+++ b/src/gispulse/core/readiness.py
@@ -1,0 +1,699 @@
+"""Generic readiness probe engine for staged data sources.
+
+Checks that data artefacts are present before a costly build (fast-fail at the
+boundary). Supports three guard modes: ``strict`` (block on any missing source),
+``warn`` (continue but emit warnings), and ``off`` (no-op, always ok).
+
+Probe kinds are **extensible**: the application registers its own kinds via
+:func:`register_probe_kind`; the core ships three generic kinds out of the box:
+``parquet_template``, ``stage_status``, and ``static``.
+
+Extension example::
+
+    from gispulse.core.readiness import (
+        ProbeContext,
+        ProbeResult,
+        ReadinessSpec,
+        register_probe_kind,
+    )
+
+    def _probe_my_kind(
+        spec: ReadinessSpec,
+        scope: str,
+        context: ProbeContext,
+    ) -> ProbeResult:
+        path = f"/data/{spec.name}-{scope}.parquet"
+        if Path(path).exists():
+            return ProbeResult(ready=True, status="present", message=path)
+        return ProbeResult(ready=False, status="missing", message=f"not found: {path}")
+
+    register_probe_kind("my_kind", _probe_my_kind)
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Literal, Mapping, Sequence
+
+import structlog
+
+log = structlog.get_logger(__name__)
+
+GuardMode = Literal["strict", "warn", "off"]
+
+# ---------------------------------------------------------------------------
+# Probe-kind registry
+# ---------------------------------------------------------------------------
+
+_PROBE_REGISTRY: dict[str, Callable[["ReadinessSpec", str, "ProbeContext"], "ProbeResult"]] = {}
+
+
+def register_probe_kind(
+    name: str,
+    fn: Callable[["ReadinessSpec", str, "ProbeContext"], "ProbeResult"],
+    *,
+    replace: bool = False,
+) -> None:
+    """Register a probe kind handler.
+
+    Args:
+        name: Unique identifier for the kind (e.g. ``"parquet_template"``).
+        fn: Callable ``(spec, scope, context) -> ProbeResult``.
+        replace: When ``False`` (default) a second registration for the same
+            name raises :exc:`ValueError`. Set to ``True`` to override.
+
+    Raises:
+        ValueError: If *name* is already registered and *replace* is ``False``.
+    """
+    if name in _PROBE_REGISTRY and not replace:
+        raise ValueError(
+            f"probe kind {name!r} is already registered; "
+            "pass replace=True to override"
+        )
+    _PROBE_REGISTRY[name] = fn
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ProbeSpec:
+    """Machine-readable description of how source presence is checked.
+
+    *metadata* is an open mapping for probe-kind-specific parameters.  The
+    built-in kinds consume keys documented below; application kinds may add
+    whatever they need.
+
+    Built-in keys consumed by ``parquet_template``:
+        - ``env_names`` (list[str]): env-var names tried in order.
+        - ``default_template`` (str | None): fallback path template.
+
+    Built-in keys consumed by ``stage_status``:
+        - ``required_entries`` (list[str] | None): entry names that must be
+          present and green in *context.stage_statuses*.
+
+    Built-in keys consumed by ``static``:
+        - ``ready`` (bool): fixed readiness value.
+        - ``status`` (str): fixed status string.
+        - ``message`` (str): fixed message.
+    """
+
+    kind: str
+    description: str = ""
+    env_names: tuple[str, ...] = ()
+    default_template: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ReadinessSpec:
+    """Generic description of a source to probe.
+
+    Unlike the applicative ``SourceSpec``, this carries no product-level
+    wiring or plugin metadata — those belong to the application layer.
+    *metadata* is an open slot for anything the application needs.
+    """
+
+    name: str
+    probe: ProbeSpec
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ProbeResult:
+    """Outcome of a single probe execution.
+
+    Renamed ``ingested`` → ``ready`` to avoid foncier-specific vocabulary.
+    """
+
+    ready: bool
+    status: str
+    version: str | None = None
+    observed_at: str | None = None
+    message: str = ""
+    details: Mapping[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ProbeContext:
+    """Runtime context passed to every probe call.
+
+    Attributes:
+        env: Optional environment mapping; falls back to :data:`os.environ`.
+        templates: Explicit template overrides keyed by env-var name.
+        stage_statuses: Staging manifest entries (any mapping structure —
+            the ``stage_status`` kind reads them with duck-typing, matching
+            the reference implementation).
+        probe_overrides: Hard-wired probe results keyed by
+            ``(spec.name, scope)``; bypasses the probe entirely.
+    """
+
+    env: Mapping[str, str] | None = None
+    templates: Mapping[str, str] | None = None
+    stage_statuses: Mapping[str, Any] | None = None
+    probe_overrides: Mapping[tuple[str, str], ProbeResult] | None = None
+
+    @property
+    def environ(self) -> Mapping[str, str]:
+        """Resolved environment: explicit *env* or :data:`os.environ`."""
+        return self.env if self.env is not None else os.environ
+
+
+# ---------------------------------------------------------------------------
+# ReadinessReport  (generalised SourceGuardResult)
+# ---------------------------------------------------------------------------
+
+
+def _coerce_json(value: object) -> object:
+    """Recursively coerce non-JSON-serialisable values to strings.
+
+    Handles ``Path``, any non-primitive scalar, and nested dicts/lists.
+    Keeps ``None``, ``bool``, ``int``, ``float``, ``str`` as-is.
+    """
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, dict):
+        return {str(k): _coerce_json(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_coerce_json(item) for item in value]
+    return str(value)
+
+
+@dataclass(frozen=True)
+class _ResultRow:
+    """Internal row: one (source, scope) probe result."""
+
+    source: str
+    scope: str
+    ready: bool
+    status: str
+    version: str | None
+    observed_at: str | None
+    message: str
+    details: dict[str, object] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, object]:
+        d = asdict(self)
+        # Coerce details values so the dict is always JSON-safe
+        d["details"] = _coerce_json(d.get("details", {}))
+        return d
+
+
+@dataclass(frozen=True)
+class ReadinessReport:
+    """Aggregated report for a set of sources × scopes.
+
+    Conceptually equivalent to ``SourceGuardResult``; generalised to avoid
+    foncier-specific fields (``profile``, ``granularity``, ``partial_sources``,
+    ``blocked``).
+
+    Attributes:
+        ok: ``True`` when no error is present (mode off → always True).
+        mode: The guard mode that produced this report.
+        errors: Error messages (strict mode: missing required sources).
+        warnings: Warning messages (warn mode: missing optional sources).
+        results: Individual ``(source, scope)`` probe rows.
+    """
+
+    ok: bool
+    mode: GuardMode
+    errors: list[str]
+    warnings: list[str]
+    results: list[_ResultRow]
+
+    def to_manifest(self) -> dict[str, object]:
+        """Return a JSON-serialisable manifest dict.
+
+        Shape mirrors ``SourceGuardResult.to_manifest()`` conceptually:
+        ``status`` summarises the outcome (``"off"``, ``"failed"``,
+        ``"warn"``, ``"ok"``).
+        """
+        if self.mode == "off":
+            status = "off"
+        elif not self.ok:
+            status = "failed"
+        elif self.warnings:
+            status = "warn"
+        else:
+            status = "ok"
+        return {
+            "status": status,
+            "mode": self.mode,
+            "ok": self.ok,
+            "errors": list(self.errors),
+            "warnings": list(self.warnings),
+            "sources": [row.to_dict() for row in self.results],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Core probe dispatch
+# ---------------------------------------------------------------------------
+
+
+def probe_source(
+    spec: ReadinessSpec,
+    scope: str,
+    context: ProbeContext,
+) -> ProbeResult:
+    """Probe a single source for a given scope.
+
+    Resolution order:
+
+    1. If ``context.probe_overrides`` contains ``(spec.name, scope)``, return it
+       directly (no I/O).
+    2. Dispatch to the registered handler for ``spec.probe.kind``.
+    3. If the kind is unknown, return a ``probe_error`` result (never raises — a
+       bad kind must not abort a guard in ``warn`` mode).
+    """
+    override = (context.probe_overrides or {}).get((spec.name, scope))
+    if override is not None:
+        return override
+
+    handler = _PROBE_REGISTRY.get(spec.probe.kind)
+    if handler is None:
+        return ProbeResult(
+            ready=False,
+            status="probe_error",
+            message=f"unknown probe kind {spec.probe.kind!r}",
+        )
+    try:
+        return handler(spec, scope, context)
+    except Exception as exc:  # noqa: BLE001 — probe errors must never crash guard
+        log.warning(
+            "probe_kind_raised",
+            kind=spec.probe.kind,
+            source=spec.name,
+            scope=scope,
+            error=str(exc),
+        )
+        return ProbeResult(ready=False, status="probe_error", message=str(exc))
+
+
+# ---------------------------------------------------------------------------
+# resolve_status
+# ---------------------------------------------------------------------------
+
+
+def resolve_status(
+    specs: Sequence[ReadinessSpec],
+    scopes: Sequence[str],
+    context: ProbeContext | None = None,
+    mode: GuardMode = "strict",
+) -> ReadinessReport:
+    """Check readiness for all *specs* across all *scopes*.
+
+    Args:
+        specs: Ordered sequence of :class:`ReadinessSpec` to probe.
+        scopes: Scope identifiers (e.g. department codes, region IDs, or any
+            opaque string meaningful to the probe kind).
+        context: Runtime context. Defaults to an empty :class:`ProbeContext`.
+        mode: Guard mode — ``"strict"``, ``"warn"``, or ``"off"``.
+
+    Returns:
+        A :class:`ReadinessReport` aggregating all results.
+
+    When *mode* is ``"off"`` no probing is performed and the report is always
+    ``ok=True`` with empty errors/warnings (mirrors the reference).
+    """
+    if mode not in {"strict", "warn", "off"}:
+        raise ValueError(f"mode must be one of strict, warn, off; got {mode!r}")
+
+    if mode == "off":
+        return ReadinessReport(
+            ok=True,
+            mode="off",
+            errors=[],
+            warnings=[],
+            results=[],
+        )
+
+    ctx = context or ProbeContext()
+    rows: list[_ResultRow] = []
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    for spec in specs:
+        for scope in scopes:
+            result = probe_source(spec, scope, ctx)
+            rows.append(
+                _ResultRow(
+                    source=spec.name,
+                    scope=scope,
+                    ready=result.ready,
+                    status=result.status,
+                    version=result.version,
+                    observed_at=result.observed_at,
+                    message=result.message,
+                    details=dict(result.details),
+                )
+            )
+            if result.ready:
+                continue
+
+            missing_msg = (
+                f"missing expected source {spec.name!r} for scope={scope!r}: "
+                f"{result.message or result.status}"
+            )
+            if mode == "strict":
+                errors.append(missing_msg)
+            elif mode == "warn":
+                warnings.append(missing_msg)
+
+    ok = len(errors) == 0
+    return ReadinessReport(
+        ok=ok,
+        mode=mode,
+        errors=errors,
+        warnings=warnings,
+        results=rows,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Built-in probe kinds
+# ---------------------------------------------------------------------------
+
+# --- helpers shared by built-in kinds ---
+
+_PLACEHOLDER_TOKEN = "/gispulse-missing/"
+
+
+def _is_placeholder(path: str) -> bool:
+    return _PLACEHOLDER_TOKEN in path.replace("\\", "/")
+
+
+def _is_glob_template(template: str) -> bool:
+    """Return True when the template string (before scope substitution) contains glob chars."""
+    return any(ch in template for ch in "*?[")
+
+
+def _local_matches(path: str) -> list[Path]:
+    """Resolve a local path or glob pattern; returns empty list for s3://."""
+    if path.startswith("s3://"):
+        return []
+    if any(ch in path for ch in "*?["):
+        return [Path(m) for m in glob.glob(path)]
+    candidate = Path(path)
+    return [candidate] if candidate.exists() else []
+
+
+def _latest_mtime_iso(paths: list[Path]) -> str | None:
+    mtimes = [p.stat().st_mtime for p in paths if p.exists()]
+    if not mtimes:
+        return None
+    return (
+        datetime.fromtimestamp(max(mtimes), tz=timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+    )
+
+
+def _local_matches_exact(path: str) -> list[Path]:
+    """Strict existence check — never glob, even if path contains glob chars."""
+    if path.startswith("s3://"):
+        return []
+    candidate = Path(path)
+    return [candidate] if candidate.exists() else []
+
+
+def _probe_paths(
+    paths: tuple[str, ...],
+    *,
+    version: str | None,
+    source_name: str,
+    is_glob_template: bool = False,
+) -> ProbeResult:
+    """Check that each path exists (or matches if glob template).
+
+    Args:
+        paths: Resolved path strings (after scope substitution).
+        version: Embedded version token extracted from the template, if any.
+        source_name: Source name for error messages.
+        is_glob_template: When ``True``, the *template* contained glob chars and
+            the paths are resolved via :func:`glob.glob`.  When ``False``, each
+            path is checked with strict :meth:`~pathlib.Path.exists` — glob
+            characters introduced by the scope value are not expanded.
+    """
+    missing: list[str] = []
+    matched: list[Path] = []
+    for path in paths:
+        if _is_placeholder(path):
+            missing.append(path)
+            continue
+        hits = _local_matches(path) if is_glob_template else _local_matches_exact(path)
+        if hits:
+            matched.extend(hits)
+        else:
+            missing.append(path)
+
+    if missing:
+        return ProbeResult(
+            ready=False,
+            status="missing",
+            version=version,
+            message=f"missing {source_name} artifact(s): {', '.join(missing)}",
+            details={"paths": paths},
+        )
+    observed_at = _latest_mtime_iso(matched)
+    return ProbeResult(
+        ready=True,
+        status="present",
+        version=version,
+        observed_at=observed_at,
+        message=f"{len(matched)} artifact(s) found",
+        details={"paths": [str(p) for p in matched]},
+    )
+
+
+def _resolve_template(
+    spec: ReadinessSpec,
+    context: ProbeContext,
+) -> str | None:
+    """Resolve the template string for a *parquet_template* kind probe.
+
+    Priority (mirrors reference ``_template_value``):
+    1. ``context.templates[env_name]`` for each env_name in order.
+    2. ``context.environ[env_name]`` for each env_name in order.
+    3. ``spec.probe.default_template`` (if any env_name is listed).
+
+    Returns the first non-empty value found, or ``None``.
+    """
+    templates_map = context.templates or {}
+    for env_name in spec.probe.env_names:
+        val = templates_map.get(env_name)
+        if val:
+            return str(val)
+    for env_name in spec.probe.env_names:
+        val = context.environ.get(env_name)
+        if val:
+            return str(val)
+    if spec.probe.env_names and spec.probe.default_template:
+        return spec.probe.default_template
+    return None
+
+
+def _format_scope_template(template: str, scope: str) -> str:
+    """Expand scope into template placeholders.
+
+    Supports ``{scope}`` (generic) and ``{dept}`` / ``{departement}`` (compat
+    with foncier reference templates).
+
+    When the *template* itself contains glob characters (``*``, ``?``, ``[``),
+    the scope value is passed through :func:`glob.escape` so that a scope like
+    ``"*"`` or ``"[0-9]"`` cannot accidentally match arbitrary files.  The glob
+    characters that belong to the *template* are preserved and evaluated
+    normally by the filesystem.
+    """
+    # Determine glob-ness on the raw template, before any substitution.
+    scope_value = glob.escape(scope) if _is_glob_template(template) else scope
+    value = os.path.expanduser(template)
+    value = value.replace("{scope}", scope_value)
+    value = value.replace("{dept}", scope_value)
+    value = value.replace("{departement}", scope_value)
+    return value
+
+
+def _template_version(template: str) -> str | None:
+    """Extract an embedded version token from the template string."""
+    for token in ("millesime=", "revision=", "version="):
+        if token not in template:
+            continue
+        tail = template.split(token, 1)[1]
+        return tail.split("/", 1)[0].split("}", 1)[0] or None
+    return None
+
+
+# --- parquet_template ---
+
+_GREEN_STAGE_STATUSES = {"success", "skipped"}
+
+
+def _probe_parquet_template(
+    spec: ReadinessSpec,
+    scope: str,
+    context: ProbeContext,
+) -> ProbeResult:
+    """Check that a parquet file derived from a template exists on disk."""
+    template = _resolve_template(spec, context)
+    if not template:
+        env_desc = ", ".join(spec.probe.env_names) if spec.probe.env_names else "(none)"
+        return ProbeResult(
+            ready=False,
+            status="missing",
+            message=f"none of {env_desc} is set and no default_template configured",
+        )
+    is_glob = _is_glob_template(template)
+    path = _format_scope_template(template, scope)
+    return _probe_paths(
+        (path,),
+        version=_template_version(template),
+        source_name=spec.name,
+        is_glob_template=is_glob,
+    )
+
+
+register_probe_kind("parquet_template", _probe_parquet_template)
+
+
+# --- stage_status ---
+
+
+def _probe_stage_status(
+    spec: ReadinessSpec,
+    scope: str,
+    context: ProbeContext,
+) -> ProbeResult:
+    """Check stage-manifest entries for the given source/scope pair.
+
+    Mirrors the reference ``_probe_stage_statuses`` without the cadastre-specific
+    logic. Reads duck-typed objects or plain dicts.
+
+    Probe metadata keys (set via ``ProbeSpec.metadata``):
+        ``required_entries`` (list[str]): Entry names that must all be present
+        and green in the stage manifest.
+    """
+    stage_statuses = context.stage_statuses or {}
+    if not stage_statuses:
+        return ProbeResult(
+            ready=False,
+            status="missing",
+            message="no stage_statuses in context",
+        )
+
+    # Match entries by (source, scope/departement) using duck-typing
+    def _get(obj: Any, *attrs: str, default: Any = None) -> Any:
+        for attr in attrs:
+            try:
+                val = getattr(obj, attr, _SENTINEL)
+                if val is not _SENTINEL:
+                    return val
+            except Exception:  # noqa: BLE001
+                pass
+            if isinstance(obj, dict):
+                try:
+                    return obj[attr]
+                except KeyError:
+                    pass
+        return default
+
+    _SENTINEL = object()
+
+    matching = [
+        status
+        for status in stage_statuses.values()
+        for item in [_get(status, "item", default=status)]
+        if _get(item, "source") == spec.name
+        and _get(item, "departement", "scope") == scope
+    ]
+
+    if not matching:
+        return ProbeResult(
+            ready=False,
+            status="missing",
+            message=f"no stage entries found for source={spec.name!r} scope={scope!r}",
+        )
+
+    required_entries: list[str] = list(spec.probe.metadata.get("required_entries", []))
+    if required_entries:
+        seen_entries = set()
+        for status in matching:
+            item = _get(status, "item", default=status)
+            entry = _get(item, "entry")
+            if entry is not None:
+                seen_entries.add(str(entry))
+        missing_entries = sorted(set(required_entries) - seen_entries)
+        if missing_entries:
+            return ProbeResult(
+                ready=False,
+                status="missing",
+                message=f"stage manifest missing entries: {', '.join(missing_entries)}",
+            )
+
+    failed = [
+        status
+        for status in matching
+        if _get(status, "status") not in _GREEN_STAGE_STATUSES
+    ]
+
+    first_item = _get(matching[0], "item", default=matching[0])
+    version = (
+        str(
+            _get(first_item, "source_revision_token")
+            or _get(first_item, "revision")
+            or ""
+        )
+        or None
+    )
+
+    if failed:
+        return ProbeResult(
+            ready=False,
+            status="missing",
+            version=version,
+            message="stage manifest contains failed source item(s)",
+        )
+
+    return ProbeResult(
+        ready=True,
+        status="present",
+        version=version,
+        message="stage manifest green",
+    )
+
+
+register_probe_kind("stage_status", _probe_stage_status)
+
+
+# --- static ---
+
+
+def _probe_static(
+    spec: ReadinessSpec,
+    scope: str,  # noqa: ARG001 — ignored, result is fixed
+    context: ProbeContext,  # noqa: ARG001 — ignored, result is fixed
+) -> ProbeResult:
+    """Return a fixed result specified in ``spec.probe.metadata``.
+
+    Useful for tests and for sources that are always available.
+
+    Probe metadata keys (set via ``ProbeSpec.metadata``):
+        ``ready`` (bool, default ``True``): readiness value.
+        ``status`` (str, default ``"static"``): status string.
+        ``message`` (str, default ``""``): message.
+    """
+    meta = spec.probe.metadata
+    return ProbeResult(
+        ready=bool(meta.get("ready", True)),
+        status=str(meta.get("status", "static")),
+        message=str(meta.get("message", "")),
+    )
+
+
+register_probe_kind("static", _probe_static)

--- a/src/gispulse/core/readiness.py
+++ b/src/gispulse/core/readiness.py
@@ -86,13 +86,14 @@ def register_probe_kind(
 class ProbeSpec:
     """Machine-readable description of how source presence is checked.
 
-    *metadata* is an open mapping for probe-kind-specific parameters.  The
-    built-in kinds consume keys documented below; application kinds may add
-    whatever they need.
+    Template resolution inputs are first-class *fields*, not metadata keys:
+    ``env_names`` (env-var names tried in order) and ``default_template``
+    (fallback path template) — ``parquet_template`` reads the fields directly
+    and ignores same-named metadata keys.
 
-    Built-in keys consumed by ``parquet_template``:
-        - ``env_names`` (list[str]): env-var names tried in order.
-        - ``default_template`` (str | None): fallback path template.
+    *metadata* is an open mapping for the remaining probe-kind-specific
+    parameters.  The built-in kinds consume the keys documented below;
+    application kinds may add whatever they need.
 
     Built-in keys consumed by ``stage_status``:
         - ``required_entries`` (list[str] | None): entry names that must be

--- a/tests/unit/test_readiness.py
+++ b/tests/unit/test_readiness.py
@@ -1,0 +1,635 @@
+"""Tests for gispulse.core.readiness.
+
+All fixtures are pure (tmp_path for parquet templates, plain dicts for context).
+No external I/O besides file system via tmp_path.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from gispulse.core.readiness import (
+    GuardMode,
+    ProbeContext,
+    ProbeResult,
+    ProbeSpec,
+    ReadinessReport,
+    ReadinessSpec,
+    _PROBE_REGISTRY,
+    probe_source,
+    register_probe_kind,
+    resolve_status,
+)
+
+
+# ---------------------------------------------------------------------------
+# Registry isolation: snapshot before each test, restore after
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolate_probe_registry() -> Any:
+    """Prevent test-registered kinds from leaking into subsequent tests."""
+    snapshot = dict(_PROBE_REGISTRY)
+    yield
+    _PROBE_REGISTRY.clear()
+    _PROBE_REGISTRY.update(snapshot)
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+def _spec(name: str, kind: str, **probe_kwargs: Any) -> ReadinessSpec:
+    return ReadinessSpec(name=name, probe=ProbeSpec(kind=kind, **probe_kwargs))
+
+
+def _static_spec(name: str, *, ready: bool = True) -> ReadinessSpec:
+    return _spec(
+        name,
+        "static",
+        metadata={"ready": ready, "status": "present" if ready else "missing"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_register_and_dispatch(self) -> None:
+        def _my_probe(spec: ReadinessSpec, scope: str, ctx: ProbeContext) -> ProbeResult:
+            return ProbeResult(ready=True, status="ok_test")
+
+        register_probe_kind("_test_custom_kind_a", _my_probe, replace=True)
+        spec = _spec("src", "_test_custom_kind_a")
+        result = probe_source(spec, "42", ProbeContext())
+        assert result.ready is True
+        assert result.status == "ok_test"
+
+    def test_double_registration_raises(self) -> None:
+        def _fn(s: Any, sc: Any, c: Any) -> ProbeResult:
+            return ProbeResult(ready=True, status="x")
+
+        register_probe_kind("_test_double_reg", _fn, replace=True)
+        with pytest.raises(ValueError, match="already registered"):
+            register_probe_kind("_test_double_reg", _fn, replace=False)
+
+    def test_replace_true_overwrites(self) -> None:
+        def _v1(s: Any, sc: Any, c: Any) -> ProbeResult:
+            return ProbeResult(ready=False, status="v1")
+
+        def _v2(s: Any, sc: Any, c: Any) -> ProbeResult:
+            return ProbeResult(ready=True, status="v2")
+
+        register_probe_kind("_test_replace_kind", _v1, replace=True)
+        register_probe_kind("_test_replace_kind", _v2, replace=True)
+        spec = _spec("x", "_test_replace_kind")
+        result = probe_source(spec, "s", ProbeContext())
+        assert result.status == "v2"
+
+    def test_unknown_kind_returns_probe_error_not_exception(self) -> None:
+        """An unregistered kind must yield probe_error, not raise."""
+        spec = _spec("src", "kind_that_does_not_exist_42")
+        result = probe_source(spec, "01", ProbeContext())
+        assert result.ready is False
+        assert result.status == "probe_error"
+        assert "unknown probe kind" in result.message
+
+
+# ---------------------------------------------------------------------------
+# parquet_template
+# ---------------------------------------------------------------------------
+
+
+class TestParquetTemplate:
+    def test_present_via_explicit_template(self, tmp_path: Path) -> None:
+        parquet = tmp_path / "iris-63.parquet"
+        parquet.touch()
+        spec = _spec(
+            "iris",
+            "parquet_template",
+            env_names=("IRIS_PARQUET_TEMPLATE",),
+        )
+        ctx = ProbeContext(templates={"IRIS_PARQUET_TEMPLATE": str(tmp_path / "iris-{scope}.parquet")})
+        result = probe_source(spec, "63", ctx)
+        assert result.ready is True
+        assert result.status == "present"
+
+    def test_missing_file_returns_not_ready(self, tmp_path: Path) -> None:
+        spec = _spec(
+            "iris",
+            "parquet_template",
+            env_names=("IRIS_PARQUET_TEMPLATE",),
+        )
+        ctx = ProbeContext(templates={"IRIS_PARQUET_TEMPLATE": str(tmp_path / "iris-{scope}.parquet")})
+        result = probe_source(spec, "99", ctx)
+        assert result.ready is False
+        assert result.status == "missing"
+
+    def test_fallback_env_var(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        parquet = tmp_path / "dpe-75.parquet"
+        parquet.touch()
+        monkeypatch.setenv("DPE_PARQUET_TEMPLATE", str(tmp_path / "dpe-{scope}.parquet"))
+        spec = _spec(
+            "dpe",
+            "parquet_template",
+            env_names=("DPE_PARQUET_TEMPLATE",),
+        )
+        result = probe_source(spec, "75", ProbeContext())
+        assert result.ready is True
+
+    def test_default_template_used_when_no_env_no_override(self, tmp_path: Path) -> None:
+        parquet = tmp_path / "gpu-13.parquet"
+        parquet.touch()
+        spec = _spec(
+            "gpu",
+            "parquet_template",
+            env_names=("GPU_PARQUET_TEMPLATE",),
+            default_template=str(tmp_path / "gpu-{scope}.parquet"),
+        )
+        # No templates and no env var set → must fall through to default_template
+        result = probe_source(spec, "13", ProbeContext(env={}))
+        assert result.ready is True
+
+    def test_priority_templates_over_env(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """context.templates must win over env var."""
+        env_dir = tmp_path / "env"
+        env_dir.mkdir()
+        tpl_dir = tmp_path / "tpl"
+        tpl_dir.mkdir()
+        (tpl_dir / "x-42.parquet").touch()
+        # env var points at a directory that does NOT have the file
+        monkeypatch.setenv("X_PARQUET_TEMPLATE", str(env_dir / "x-{scope}.parquet"))
+        spec = _spec(
+            "x",
+            "parquet_template",
+            env_names=("X_PARQUET_TEMPLATE",),
+        )
+        ctx = ProbeContext(templates={"X_PARQUET_TEMPLATE": str(tpl_dir / "x-{scope}.parquet")})
+        result = probe_source(spec, "42", ctx)
+        assert result.ready is True
+
+    def test_no_env_no_default_returns_missing(self) -> None:
+        spec = _spec(
+            "orphan",
+            "parquet_template",
+            env_names=("ORPHAN_TEMPLATE",),
+        )
+        result = probe_source(spec, "01", ProbeContext(env={}))
+        assert result.ready is False
+        assert "ORPHAN_TEMPLATE" in result.message
+
+    def test_scope_substitution_dept_alias(self, tmp_path: Path) -> None:
+        """{dept} placeholder must be substituted like {scope}."""
+        parquet = tmp_path / "dvf-33.parquet"
+        parquet.touch()
+        spec = _spec(
+            "dvf",
+            "parquet_template",
+            env_names=("DVF_PARQUET_TEMPLATE",),
+        )
+        ctx = ProbeContext(templates={"DVF_PARQUET_TEMPLATE": str(tmp_path / "dvf-{dept}.parquet")})
+        result = probe_source(spec, "33", ctx)
+        assert result.ready is True
+
+    def test_scope_substitution_departement_alias(self, tmp_path: Path) -> None:
+        """{departement} placeholder must also work (full-word alias)."""
+        parquet = tmp_path / "iris-44.parquet"
+        parquet.touch()
+        spec = _spec(
+            "iris",
+            "parquet_template",
+            env_names=("IRIS_PARQUET_TEMPLATE",),
+        )
+        ctx = ProbeContext(
+            templates={"IRIS_PARQUET_TEMPLATE": str(tmp_path / "iris-{departement}.parquet")}
+        )
+        result = probe_source(spec, "44", ctx)
+        assert result.ready is True
+
+    def test_glob_pattern_present(self, tmp_path: Path) -> None:
+        (tmp_path / "sup-63-foo.parquet").touch()
+        spec = _spec(
+            "sup",
+            "parquet_template",
+            env_names=("SUP_PARQUET_TEMPLATE",),
+        )
+        ctx = ProbeContext(templates={"SUP_PARQUET_TEMPLATE": str(tmp_path / "sup-{scope}-*.parquet")})
+        result = probe_source(spec, "63", ctx)
+        assert result.ready is True
+
+    def test_observed_at_populated(self, tmp_path: Path) -> None:
+        (tmp_path / "src-01.parquet").touch()
+        spec = _spec(
+            "src",
+            "parquet_template",
+            env_names=("SRC_TEMPLATE",),
+        )
+        ctx = ProbeContext(templates={"SRC_TEMPLATE": str(tmp_path / "src-{scope}.parquet")})
+        result = probe_source(spec, "01", ctx)
+        assert result.observed_at is not None
+
+    def test_wildcard_scope_on_exact_template_is_not_ready(self, tmp_path: Path) -> None:
+        """scope='*' must not glob-match arbitrary files when template has no glob chars."""
+        # Create a file that a naive glob of '*' would match
+        (tmp_path / "iris-anything.parquet").touch()
+        spec = _spec(
+            "iris",
+            "parquet_template",
+            env_names=("IRIS_PARQUET_TEMPLATE",),
+        )
+        # Template is exact (no glob chars) — scope '*' is a literal filename component
+        ctx = ProbeContext(
+            templates={"IRIS_PARQUET_TEMPLATE": str(tmp_path / "iris-{scope}.parquet")}
+        )
+        result = probe_source(spec, "*", ctx)
+        # Path "iris-*.parquet" doesn't exist as a literal file → not ready
+        assert result.ready is False
+
+    def test_bracket_scope_on_glob_template_is_escaped(self, tmp_path: Path) -> None:
+        """scope='[0-9]' in a glob template must match literally, not as a character class."""
+        # Create a file that the escaped literal would need to match
+        (tmp_path / "sup-[0-9]-foo.parquet").touch()
+        spec = _spec(
+            "sup",
+            "parquet_template",
+            env_names=("SUP_PARQUET_TEMPLATE",),
+        )
+        # Template has glob '*' → scope will be glob.escape'd
+        ctx = ProbeContext(
+            templates={"SUP_PARQUET_TEMPLATE": str(tmp_path / "sup-{scope}-*.parquet")}
+        )
+        # A file named "sup-[0-9]-foo.parquet" exists; glob.escape("[0-9]") = "[[]0-9]"
+        # so the expanded pattern is "sup-[[]0-9]-*.parquet" which matches the literal name
+        result = probe_source(spec, "[0-9]", ctx)
+        assert result.ready is True
+
+
+# ---------------------------------------------------------------------------
+# stage_status
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeItem:
+    source: str
+    departement: str
+    entry: str = ""
+    source_revision_token: str = ""
+
+
+@dataclass
+class _FakeStatus:
+    item: _FakeItem
+    status: str
+
+
+class TestStageStatus:
+    def _make_ctx(self, *statuses: _FakeStatus) -> ProbeContext:
+        return ProbeContext(stage_statuses={str(i): s for i, s in enumerate(statuses)})
+
+    def test_green_entry_returns_ready(self) -> None:
+        ctx = self._make_ctx(_FakeStatus(_FakeItem("dvf", "63"), "success"))
+        spec = _spec("dvf", "stage_status")
+        result = probe_source(spec, "63", ctx)
+        assert result.ready is True
+        assert result.status == "present"
+
+    def test_failed_entry_returns_not_ready(self) -> None:
+        ctx = self._make_ctx(_FakeStatus(_FakeItem("dvf", "63"), "error"))
+        spec = _spec("dvf", "stage_status")
+        result = probe_source(spec, "63", ctx)
+        assert result.ready is False
+
+    def test_missing_source_in_stage(self) -> None:
+        ctx = self._make_ctx(_FakeStatus(_FakeItem("cadastre", "63"), "success"))
+        spec = _spec("dvf", "stage_status")
+        result = probe_source(spec, "63", ctx)
+        assert result.ready is False
+        assert "no stage entries" in result.message
+
+    def test_missing_required_entries(self) -> None:
+        ctx = self._make_ctx(
+            _FakeStatus(_FakeItem("cadastre", "63", entry="parcelles_bulk"), "success")
+        )
+        # required_entries lives in ProbeSpec.metadata (probe parameters belong to the probe)
+        spec = ReadinessSpec(
+            name="cadastre",
+            probe=ProbeSpec(
+                kind="stage_status",
+                metadata={"required_entries": ["parcelles_bulk", "sections_bulk", "communes_bulk"]},
+            ),
+        )
+        result = probe_source(spec, "63", ctx)
+        assert result.ready is False
+        assert "sections_bulk" in result.message or "communes_bulk" in result.message
+
+    def test_all_required_entries_present(self) -> None:
+        ctx = self._make_ctx(
+            _FakeStatus(_FakeItem("cadastre", "63", entry="parcelles_bulk"), "success"),
+            _FakeStatus(_FakeItem("cadastre", "63", entry="sections_bulk"), "success"),
+            _FakeStatus(_FakeItem("cadastre", "63", entry="communes_bulk"), "skipped"),
+        )
+        spec = ReadinessSpec(
+            name="cadastre",
+            probe=ProbeSpec(
+                kind="stage_status",
+                metadata={"required_entries": ["parcelles_bulk", "sections_bulk", "communes_bulk"]},
+            ),
+        )
+        result = probe_source(spec, "63", ctx)
+        assert result.ready is True
+
+    def test_empty_stage_statuses(self) -> None:
+        ctx = ProbeContext(stage_statuses={})
+        spec = _spec("dvf", "stage_status")
+        result = probe_source(spec, "63", ctx)
+        assert result.ready is False
+
+    def test_no_stage_statuses_in_context(self) -> None:
+        spec = _spec("dvf", "stage_status")
+        result = probe_source(spec, "63", ProbeContext())
+        assert result.ready is False
+
+    def test_skipped_counts_as_green(self) -> None:
+        ctx = self._make_ctx(_FakeStatus(_FakeItem("rnb", "75"), "skipped"))
+        spec = _spec("rnb", "stage_status")
+        result = probe_source(spec, "75", ctx)
+        assert result.ready is True
+
+    def test_version_extracted_from_source_revision_token(self) -> None:
+        item = _FakeItem("dvf", "13", source_revision_token="2024-Q3")
+        ctx = self._make_ctx(_FakeStatus(item, "success"))
+        spec = _spec("dvf", "stage_status")
+        result = probe_source(spec, "13", ctx)
+        assert result.version == "2024-Q3"
+
+
+# ---------------------------------------------------------------------------
+# static
+# ---------------------------------------------------------------------------
+
+
+class TestStatic:
+    def test_default_ready(self) -> None:
+        spec = ReadinessSpec(
+            name="always_ready",
+            probe=ProbeSpec(kind="static"),
+        )
+        result = probe_source(spec, "any", ProbeContext())
+        assert result.ready is True
+        assert result.status == "static"
+
+    def test_explicitly_not_ready(self) -> None:
+        spec = ReadinessSpec(
+            name="never_ready",
+            probe=ProbeSpec(
+                kind="static",
+                metadata={"ready": False, "status": "disabled", "message": "turned off"},
+            ),
+        )
+        result = probe_source(spec, "any", ProbeContext())
+        assert result.ready is False
+        assert result.status == "disabled"
+        assert result.message == "turned off"
+
+
+# ---------------------------------------------------------------------------
+# Overrides
+# ---------------------------------------------------------------------------
+
+
+class TestOverrides:
+    def test_override_bypasses_probe(self) -> None:
+        override = ProbeResult(ready=True, status="override_ok", message="manual")
+        ctx = ProbeContext(probe_overrides={("src", "63"): override})
+        spec = _spec("src", "parquet_template", env_names=("MISSING_VAR",))
+        result = probe_source(spec, "63", ctx)
+        assert result is override
+
+    def test_override_key_is_name_scope(self) -> None:
+        override = ProbeResult(ready=False, status="forced_missing")
+        ctx = ProbeContext(probe_overrides={("mydb", "test-scope"): override})
+        spec = _spec("mydb", "static", metadata={"ready": True})
+        result = probe_source(spec, "test-scope", ctx)
+        assert result is override
+
+    def test_override_does_not_affect_other_scope(self) -> None:
+        override = ProbeResult(ready=False, status="forced")
+        ctx = ProbeContext(probe_overrides={("src", "63"): override})
+        spec = _spec("src", "static", metadata={"ready": True, "status": "present"})
+        result = probe_source(spec, "75", ctx)  # different scope
+        assert result.ready is True
+
+
+# ---------------------------------------------------------------------------
+# resolve_status — strict mode
+# ---------------------------------------------------------------------------
+
+
+class TestResolveStatusStrict:
+    def test_all_ready_strict_ok(self, tmp_path: Path) -> None:
+        (tmp_path / "a-01.parquet").touch()
+        spec = _spec("a", "parquet_template", env_names=("A_TPL",))
+        ctx = ProbeContext(templates={"A_TPL": str(tmp_path / "a-{scope}.parquet")})
+        report = resolve_status([spec], ["01"], ctx, mode="strict")
+        assert report.ok is True
+        assert report.errors == []
+
+    def test_missing_source_strict_error(self, tmp_path: Path) -> None:
+        spec = _spec("b", "parquet_template", env_names=("B_TPL",))
+        ctx = ProbeContext(templates={"B_TPL": str(tmp_path / "b-{scope}.parquet")})
+        report = resolve_status([spec], ["01"], ctx, mode="strict")
+        assert report.ok is False
+        assert len(report.errors) == 1
+        assert "b" in report.errors[0]
+
+    def test_multi_scope_all_errors_collected(self, tmp_path: Path) -> None:
+        spec = _spec("c", "parquet_template", env_names=("C_TPL",))
+        ctx = ProbeContext(templates={"C_TPL": str(tmp_path / "c-{scope}.parquet")})
+        report = resolve_status([spec], ["01", "63", "75"], ctx, mode="strict")
+        assert not report.ok
+        assert len(report.errors) == 3
+
+    def test_results_row_per_source_per_scope(self, tmp_path: Path) -> None:
+        s1 = _static_spec("s1")
+        s2 = _static_spec("s2")
+        report = resolve_status([s1, s2], ["01", "63"], mode="strict")
+        assert len(report.results) == 4
+        sources = {r.source for r in report.results}
+        scopes = {r.scope for r in report.results}
+        assert sources == {"s1", "s2"}
+        assert scopes == {"01", "63"}
+
+
+# ---------------------------------------------------------------------------
+# resolve_status — warn mode
+# ---------------------------------------------------------------------------
+
+
+class TestResolveStatusWarn:
+    def test_missing_in_warn_is_warning_not_error(self, tmp_path: Path) -> None:
+        spec = _spec("d", "parquet_template", env_names=("D_TPL",))
+        ctx = ProbeContext(templates={"D_TPL": str(tmp_path / "d-{scope}.parquet")})
+        report = resolve_status([spec], ["01"], ctx, mode="warn")
+        assert report.ok is True
+        assert len(report.warnings) == 1
+        assert report.errors == []
+
+    def test_partially_present_warn(self, tmp_path: Path) -> None:
+        (tmp_path / "e-01.parquet").touch()
+        spec = _spec("e", "parquet_template", env_names=("E_TPL",))
+        ctx = ProbeContext(templates={"E_TPL": str(tmp_path / "e-{scope}.parquet")})
+        report = resolve_status([spec], ["01", "63"], ctx, mode="warn")
+        assert report.ok is True
+        assert len(report.warnings) == 1  # only 63 is missing
+        assert len(report.results) == 2
+
+
+# ---------------------------------------------------------------------------
+# resolve_status — off mode
+# ---------------------------------------------------------------------------
+
+
+class TestResolveStatusOff:
+    def test_off_is_always_ok(self) -> None:
+        spec = ReadinessSpec(
+            name="broken",
+            probe=ProbeSpec(kind="static", metadata={"ready": False}),
+        )
+        report = resolve_status([spec], ["01", "63"], mode="off")
+        assert report.ok is True
+        assert report.errors == []
+        assert report.warnings == []
+        assert report.results == []  # no probing done
+
+    def test_off_mode_string_in_manifest(self) -> None:
+        report = resolve_status([], [], mode="off")
+        manifest = report.to_manifest()
+        assert manifest["status"] == "off"
+
+    def test_invalid_mode_raises(self) -> None:
+        with pytest.raises(ValueError, match="mode must be one of"):
+            resolve_status([], [], mode="invalid")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# to_manifest / JSON serialisability
+# ---------------------------------------------------------------------------
+
+
+class TestToManifest:
+    def _report_for(self, mode: GuardMode, ready: bool, tmp_path: Path) -> ReadinessReport:
+        spec = ReadinessSpec(
+            name="src",
+            probe=ProbeSpec(kind="static", metadata={"ready": ready, "status": "present" if ready else "missing"}),
+        )
+        return resolve_status([spec], ["01"], mode=mode)
+
+    def test_manifest_ok(self, tmp_path: Path) -> None:
+        report = self._report_for("strict", True, tmp_path)
+        m = report.to_manifest()
+        assert m["status"] == "ok"
+        assert m["ok"] is True
+
+    def test_manifest_failed(self, tmp_path: Path) -> None:
+        report = self._report_for("strict", False, tmp_path)
+        m = report.to_manifest()
+        assert m["status"] == "failed"
+        assert m["ok"] is False
+
+    def test_manifest_warn(self, tmp_path: Path) -> None:
+        report = self._report_for("warn", False, tmp_path)
+        m = report.to_manifest()
+        assert m["status"] == "warn"
+        assert m["ok"] is True
+
+    def test_manifest_off(self) -> None:
+        report = resolve_status([], [], mode="off")
+        assert report.to_manifest()["status"] == "off"
+
+    def test_manifest_json_serialisable(self, tmp_path: Path) -> None:
+        """json.dumps must not raise on any manifest."""
+        (tmp_path / "q-63.parquet").touch()
+        spec = _spec("q", "parquet_template", env_names=("Q_TPL",))
+        ctx = ProbeContext(templates={"Q_TPL": str(tmp_path / "q-{scope}.parquet")})
+        report = resolve_status([spec], ["63", "75"], ctx, mode="warn")
+        raw = json.dumps(report.to_manifest())
+        parsed = json.loads(raw)
+        assert parsed["mode"] == "warn"
+        # 63 present, 75 missing → one warning
+        assert len(parsed["warnings"]) == 1
+
+    def test_manifest_sources_contain_all_results(self, tmp_path: Path) -> None:
+        s1 = _static_spec("s1")
+        s2 = _static_spec("s2", ready=False)
+        report = resolve_status([s1, s2], ["01"], mode="warn")
+        m = report.to_manifest()
+        sources = {row["source"] for row in m["sources"]}
+        assert sources == {"s1", "s2"}
+
+    def test_manifest_details_path_objects_coerced(self, tmp_path: Path) -> None:
+        """details containing Path objects must be coerced to str in to_manifest()."""
+        artifact = tmp_path / "p-01.parquet"
+        artifact.touch()
+
+        # Register a probe kind that intentionally returns a Path in details
+        def _probe_with_path_detail(
+            spec: ReadinessSpec, scope: str, ctx: ProbeContext
+        ) -> ProbeResult:
+            return ProbeResult(
+                ready=False,
+                status="missing",
+                message="test probe",
+                details={"path": artifact, "nested": {"also": artifact}},
+            )
+
+        register_probe_kind("_test_path_detail", _probe_with_path_detail)
+        spec = _spec("p", "_test_path_detail")
+        report = resolve_status([spec], ["01"], mode="strict")
+        manifest = report.to_manifest()
+        # Must not raise
+        raw = json.dumps(manifest)
+        parsed = json.loads(raw)
+        # The Path must have been stringified
+        found_paths = [
+            row["details"]["path"]
+            for row in parsed["sources"]
+            if "path" in row.get("details", {})
+        ]
+        assert found_paths, "details.path not present in manifest sources"
+        assert found_paths[0] == str(artifact)
+        assert parsed["sources"][0]["details"]["nested"]["also"] == str(artifact)
+
+
+# ---------------------------------------------------------------------------
+# Multi-scopes edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestMultiScope:
+    def test_empty_specs_gives_empty_report(self) -> None:
+        report = resolve_status([], ["01", "63"], mode="strict")
+        assert report.ok is True
+        assert report.results == []
+
+    def test_empty_scopes_gives_empty_report(self) -> None:
+        spec = _static_spec("src")
+        report = resolve_status([spec], [], mode="strict")
+        assert report.ok is True
+        assert report.results == []
+
+    def test_five_scopes_four_sources(self, tmp_path: Path) -> None:
+        specs = [_static_spec(f"src{i}") for i in range(4)]
+        scopes = [f"0{i}" for i in range(5)]
+        report = resolve_status(specs, scopes, mode="strict")
+        assert len(report.results) == 20
+        assert report.ok is True


### PR DESCRIPTION
## Problem

Before an expensive build, pipelines need to verify that staged data is present for every source over the requested scopes — and fail fast at the boundary instead of hours into the run. Each downstream app currently re-implements this (probe functions, guard modes, manifest output).

## What

**New self-contained `core/readiness.py`** (no existing module touched):

- `ReadinessSpec` / `ProbeSpec` / `ProbeResult` / `ProbeContext` (frozen dataclasses). Probe parameters live in `ProbeSpec.metadata`; `ReadinessSpec.metadata` is for source-level metadata.
- **`register_probe_kind(name, fn)`** — the architectural point: a module-level registry so applications add their own probe kinds (e.g. domain-specific layouts) without touching core. Double registration without `replace=True` raises. An *unknown* kind resolves to a `probe_error` result rather than raising — a warn-mode guard never dies on a misconfigured spec.
- Built-in kinds: **`parquet_template`** (resolution priority `context.templates` > env > `default_template`; supports `{scope}` plus `{dept}`/`{departement}` aliases for existing templates; **glob-ness is a property of the template, never of the scope** — scope values are glob-escaped, so a `"*"` scope cannot turn an exact existence check into a wildcard match), **`stage_status`** (lookup against caller-provided stage statuses with `required_entries`), **`static`**.
- `resolve_status(specs, scopes, mode strict|warn|off)` → `ReadinessReport`: strict puts non-ready sources in `errors` (ok=False), warn collects warnings (ok=True), off skips probing entirely. `to_manifest()` is JSON-serialisable end-to-end (non-JSON detail values like `Path` coerced recursively).

## Tests

49 tests: registry behaviour (duplicate, replace, unknown kind, per-test isolation via an autouse snapshot fixture), template resolution priority and formatting, glob-escape edge cases (wildcard scope on exact template → not ready; `[0-9]` scope on a glob template matched literally), overrides, all three guard modes, multi-scope, manifest serialisation proof with nested `Path` values. Ruff clean.

Wiring (CLI/doctor integration) is deliberately a follow-up — this PR ships the engine.

Independent of the open PR queue (#419–#430) — no shared files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)