### PR TITLE
feat(persistence): PG-direct building blocks — ST_Subdivide materializer + batched DuckDB→PostGIS loader

### DIFF
--- a/src/gispulse/persistence/postgis_bulk.py
+++ b/src/gispulse/persistence/postgis_bulk.py
@@ -1,0 +1,553 @@
+"""
+PostGIS bulk operations for PG-direct spatial workflows.
+
+Pattern: PG-direct + ST_Subdivide
+======================================
+Spatial joins on large geometry layers (GPU zones, IRIS, OCSGE, …) cause
+Out-Of-Memory errors in DuckDB when run at the national scale.  The durable
+pattern is:
+
+1. **Subdivide** large geometries in PostGIS using ``ST_Subdivide``:
+   each original geometry is exploded into sub-polygons of at most
+   ``max_vertices`` vertices.  This bounds the cost of spatial index lookups:
+   *brut ≈ 12 min/commune vs. subdivisé ≈ 5 s*.
+
+2. **Batch-load** the scoped data from a DuckDB query result into the
+   subdivided PostGIS table using ``executemany`` in fixed-size batches,
+   flushed with a single ``commit`` (atomique: delete + all inserts share
+   one transaction).
+
+Trust boundaries
+----------------
+* ``delete_predicate`` and ``insert_predicate`` (SubdivideSpec) — **trusted
+  caller input**.  The caller is responsible for their safety, exactly like
+  ``pre_drop_sql`` in the lifecycle module.  They are interpolated as-is into
+  the generated SQL.
+* ``select_sql`` and ``insert_sql`` (batch_load_duckdb_to_postgis) — likewise
+  **trusted caller input**.
+* Identifier arguments (schema/table/column names) and SQL type strings are
+  **validated** by this module against strict whitelists before interpolation.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Sequence
+
+from gispulse.core.logging import get_logger
+
+log = get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Identifier + type validation helpers
+# ---------------------------------------------------------------------------
+
+_IDENT_RE = re.compile(r"^[a-z_][a-z0-9_]*$")
+# Strict type whitelist: lowercase letters and spaces (base type name), with
+# an optional parenthesised numeric precision/scale suffix — e.g. varchar(255)
+# or numeric(10,2).  Rejects multi-statement injections like
+# "text, injected text" or "text NOT NULL, x text" because commas are only
+# allowed inside the parentheses and only between digits.
+_TYPE_RE = re.compile(r"^[a-z][a-z ]*(\(\s*\d+(\s*,\s*\d+)?\s*\))?$")
+
+
+def _validate_ident(value: str, label: str) -> str:
+    """Validate a SQL identifier (lowercase only, no quoting needed).
+
+    Raises ValueError if *value* does not match ``^[a-z_][a-z0-9_]*$``.
+    """
+    if not _IDENT_RE.match(value):
+        raise ValueError(
+            f"Invalid SQL identifier for {label!r}: {value!r}. "
+            "Must match ^[a-z_][a-z0-9_]*$ (lowercase, no special chars)."
+        )
+    return value
+
+
+def _validate_type(value: str, column: str) -> str:
+    """Validate a SQL type string.
+
+    Accepts lowercase base type names (letters and spaces) with an optional
+    numeric precision/scale suffix: ``text``, ``bigint``, ``double precision``,
+    ``timestamptz``, ``varchar(255)``, ``numeric(10,2)``.
+
+    Rejects multi-statement injections such as ``text, injected text``,
+    ``text NOT NULL, x text``, or ``jsonb); DROP`` — commas are only permitted
+    between digits inside parentheses.
+
+    Note: the ``geom geometry(Geometry, {srid})`` column is built by the
+    generator itself and never passes through this validator.
+
+    Raises ValueError if the value does not match the whitelist.
+    """
+    if not _TYPE_RE.match(value):
+        raise ValueError(
+            f"Invalid SQL type for column {column!r}: {value!r}. "
+            "Expected lowercase type name with optional numeric precision, "
+            r"e.g. 'text', 'double precision', 'varchar(255)', 'numeric(10,2)'."
+        )
+    return value
+
+
+def _qualified(schema: str, table: str) -> str:
+    """Return ``schema.table`` after validating both identifiers."""
+    return f"{_validate_ident(schema, 'schema')}.{_validate_ident(table, 'table')}"
+
+
+# ---------------------------------------------------------------------------
+# SubdivideSpec
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SubdivideSpec:
+    """Declarative description of a ST_Subdivide materialisation.
+
+    Parameters
+    ----------
+    source_schema:
+        Schema of the source table (must exist in the same database).
+    source_table:
+        Name of the source table.
+    target_schema:
+        Schema where the subdivided table will be created.
+    target_table:
+        Name of the subdivided table to create / refresh.
+    geom_column:
+        Name of the geometry column on the source table.
+    max_vertices:
+        Maximum number of vertices per subdivided fragment (passed to
+        ``ST_Subdivide``).  Default: 256.
+    key_columns:
+        Tuple of column names that together form the natural key of a feature
+        (used as part of the PRIMARY KEY alongside ``fragment_id``).
+    data_columns:
+        Extra columns copied verbatim from the source row into the target.
+    column_types:
+        Mapping ``{column_name: sql_type}`` for every column in
+        ``key_columns`` and ``data_columns``.  A ``ValueError`` is raised at
+        SQL-build time if any column is missing from this mapping.
+    srid:
+        SRID for the ``geom`` column.  Default: 4326.
+    delete_predicate:
+        **Trusted caller input** — an optional SQL predicate applied to the
+        DELETE statement.  The target table is aliased ``frag`` in that
+        context, e.g. ``frag.dept = '63'``.  When ``None``, the DELETE
+        removes all rows from the target table (full-refresh semantics).
+    insert_predicate:
+        **Trusted caller input** — an optional SQL predicate added to the
+        WHERE clause of the ``dumped`` CTE inside the INSERT.  The source
+        table is aliased ``src`` in that context, e.g. ``src.dept = '63'``.
+        When ``None``, no extra filter is applied and all source rows are
+        processed.
+
+    Note: keeping ``delete_predicate`` and ``insert_predicate`` separate
+    avoids the alias mismatch that a single ``scope_predicate`` would cause
+    (the DELETE alias ``frag`` is different from the INSERT alias ``src``).
+    """
+
+    source_schema: str
+    source_table: str
+    target_schema: str
+    target_table: str
+    geom_column: str = "geom"
+    max_vertices: int = 256
+    key_columns: tuple[str, ...] = ()
+    data_columns: tuple[str, ...] = ()
+    column_types: Mapping[str, str] = field(default_factory=dict)
+    srid: int = 4326
+    delete_predicate: str | None = None
+    insert_predicate: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# build_subdivide_sql — pure function
+# ---------------------------------------------------------------------------
+
+
+def build_subdivide_sql(spec: SubdivideSpec) -> str:  # noqa: C901  (acceptable complexity)
+    """Return the full DDL+DML SQL block that materialises subdivided fragments.
+
+    This is a **pure function**: it performs no I/O and can be tested without
+    a live database connection.
+
+    The generated block (in order):
+
+    1. ``CREATE TABLE IF NOT EXISTS`` target with typed key+data columns,
+       ``fragment_id bigint``, and ``geom geometry(Geometry, {srid})``.
+       Primary key = ``(key_columns..., fragment_id)``.
+    2. ``DELETE`` — scoped by ``delete_predicate`` if provided (alias ``frag``);
+       otherwise a full-table delete (full-refresh semantics).
+    3. Plain ``INSERT`` (no ON CONFLICT) — uses the ST_Dump → dimension-aware
+       ST_Subdivide pipeline:
+       * ``CROSS JOIN LATERAL (SELECT (ST_Dump(src.geom)).geom) c`` explodes
+         multi-geometries.
+       * ``CROSS JOIN LATERAL (passthrough dim=0 UNION ALL ST_Subdivide dim>0)``
+         passes point geometries through unchanged and subdivides all surface
+         and line geometries (``ST_Dimension > 0``).
+       * ``row_number() OVER (PARTITION BY key_columns ORDER BY
+         ST_Area(ST_Envelope) DESC, ST_AsEWKB)`` produces stable
+         ``fragment_id`` values.
+    4. ``CREATE INDEX IF NOT EXISTS`` GIST on ``geom``.
+    5. ``CREATE INDEX IF NOT EXISTS`` btree on ``key_columns`` (if non-empty).
+
+    Parameters
+    ----------
+    spec:
+        Fully-populated :class:`SubdivideSpec`.
+
+    Raises
+    ------
+    ValueError
+        * Any identifier (schema/table/column) fails the ``^[a-z_][a-z0-9_]*$``
+          regex.
+        * A column in ``key_columns`` or ``data_columns`` is absent from
+          ``spec.column_types``.
+        * A SQL type string fails the type whitelist regex.
+    """
+    # --- validate identifiers -----------------------------------------------
+    src = _qualified(spec.source_schema, spec.source_table)
+    tgt = _qualified(spec.target_schema, spec.target_table)
+    geom_col = _validate_ident(spec.geom_column, "geom_column")
+
+    all_data_cols: list[str] = []
+    for col in list(spec.key_columns) + list(spec.data_columns):
+        _validate_ident(col, f"column:{col}")
+        all_data_cols.append(col)
+
+    # --- validate types ------------------------------------------------------
+    for col in list(spec.key_columns) + list(spec.data_columns):
+        if col not in spec.column_types:
+            raise ValueError(
+                f"Column {col!r} has no entry in column_types. "
+                "Every key_column and data_column must have an explicit SQL type."
+            )
+        _validate_type(spec.column_types[col], col)
+
+    max_vertices = int(spec.max_vertices)
+    srid = int(spec.srid)
+
+    # --- CREATE TABLE --------------------------------------------------------
+    col_defs: list[str] = []
+    for col in list(spec.key_columns) + list(spec.data_columns):
+        col_defs.append(f"    {col} {spec.column_types[col]} NOT NULL")
+    col_defs.append("    fragment_id bigint NOT NULL")
+    col_defs.append(f"    geom geometry(Geometry, {srid}) NOT NULL")
+
+    pk_cols = list(spec.key_columns) + ["fragment_id"]
+    pk_clause = ", ".join(pk_cols)
+    col_defs.append(f"    PRIMARY KEY ({pk_clause})")
+
+    create_table = (
+        f"CREATE TABLE IF NOT EXISTS {tgt} (\n"
+        + ",\n".join(col_defs)
+        + "\n);"
+    )
+
+    # --- DELETE (scope or full refresh) -------------------------------------
+    if spec.delete_predicate:
+        delete_sql = (
+            f"DELETE FROM {tgt} frag\nWHERE {spec.delete_predicate};"
+        )
+    else:
+        # Full-refresh: no delete_predicate → delete everything in the target.
+        # Documented as intentional full-refresh semantics (see module docstring).
+        delete_sql = f"DELETE FROM {tgt};"
+
+    # --- INSERT --------------------------------------------------------------
+    # Columns to select from the source in the dumped CTE (excluding geom):
+    src_key_data_cols = list(spec.key_columns) + list(spec.data_columns)
+
+    # dumped CTE — select key+data cols from src + ST_Dump + ST_Subdivide
+    if src_key_data_cols:
+        dumped_select_cols = ",\n        ".join(f"src.{c}" for c in src_key_data_cols)
+        dumped_select = f"        {dumped_select_cols},\n        d.geom"
+    else:
+        dumped_select = "        d.geom"
+
+    geom_not_null = (
+        f"WHERE src.{geom_col} IS NOT NULL\n      AND NOT ST_IsEmpty(d.geom)"
+    )
+    if spec.insert_predicate:
+        geom_not_null += f"\n      AND {spec.insert_predicate}"
+
+    dumped_cte = f"""\
+dumped AS (
+    SELECT
+{dumped_select}
+    FROM {src} src
+    CROSS JOIN LATERAL (
+        SELECT (ST_Dump(src.{geom_col})).geom
+    ) c
+    CROSS JOIN LATERAL (
+        SELECT c.geom
+        WHERE ST_Dimension(c.geom) = 0
+        UNION ALL
+        SELECT subdivided.geom
+        FROM ST_Subdivide(c.geom, {max_vertices}) AS subdivided(geom)
+        WHERE ST_Dimension(c.geom) > 0
+    ) d
+    {geom_not_null}
+)"""
+
+    # numbered CTE — row_number partitioned by key_columns
+    if spec.key_columns:
+        partition_cols = ", ".join(spec.key_columns)
+        numbered_select_cols = ", ".join(src_key_data_cols) + ",\n        " if src_key_data_cols else ""
+        numbered_cte = f"""\
+numbered AS (
+    SELECT
+        {numbered_select_cols}row_number() OVER (
+            PARTITION BY {partition_cols}
+            ORDER BY ST_Area(ST_Envelope(geom)) DESC, ST_AsEWKB(geom)
+        ) AS fragment_id,
+        geom
+    FROM dumped
+)"""
+    else:
+        # No key columns: partition is the whole table (degenerate case)
+        numbered_cte = """\
+numbered AS (
+    SELECT
+        row_number() OVER (
+            ORDER BY ST_Area(ST_Envelope(geom)) DESC, ST_AsEWKB(geom)
+        ) AS fragment_id,
+        geom
+    FROM dumped
+)"""
+
+    # INSERT target columns
+    insert_cols = src_key_data_cols + ["fragment_id", "geom"]
+    insert_col_list = ", ".join(insert_cols)
+
+    # Plain INSERT — no ON CONFLICT clause.
+    #
+    # Rationale: the DELETE above is supposed to clear exactly the scope that
+    # will be re-inserted.  If the DELETE predicate and the INSERT WHERE
+    # diverge, ON CONFLICT DO UPDATE would silently overwrite the overlapping
+    # fragments while leaving stale fragments alive (e.g. a feature that went
+    # from 10 to 7 fragments would keep 3 ghost fragments → wrong spatial
+    # joins, zero signal).  A PK violation is the honest signal of a
+    # scope mismatch — matches the behaviour of the reference implementation.
+    final_select = ", ".join(insert_cols)
+
+    insert_sql = f"""\
+INSERT INTO {tgt} (
+    {insert_col_list}
+)
+WITH {dumped_cte},
+{numbered_cte}
+SELECT
+    {final_select}
+FROM numbered;"""
+
+    # --- Indexes -------------------------------------------------------------
+    tgt_table = _validate_ident(spec.target_table, "target_table")
+    gist_index = (
+        f"CREATE INDEX IF NOT EXISTS {tgt_table}_geom_gist\n"
+        f"    ON {tgt} USING GIST (geom);"
+    )
+
+    indexes = [gist_index]
+    if spec.key_columns:
+        key_col_list = ", ".join(spec.key_columns)
+        key_index = (
+            f"CREATE INDEX IF NOT EXISTS {tgt_table}_key_idx\n"
+            f"    ON {tgt} ({key_col_list});"
+        )
+        indexes.append(key_index)
+
+    index_sql = "\n".join(indexes)
+
+    return "\n\n".join([create_table, delete_sql, insert_sql, index_sql])
+
+
+# ---------------------------------------------------------------------------
+# subdivide_table — executes (or dry-runs) the generated SQL
+# ---------------------------------------------------------------------------
+
+
+def subdivide_table(
+    conn: Any,
+    spec: SubdivideSpec,
+    *,
+    dry_run: bool = True,
+) -> dict[str, Any]:
+    """Materialise (or preview) a subdivided PostGIS table.
+
+    Parameters
+    ----------
+    conn:
+        A psycopg-compatible connection (``conn.cursor()`` / ``conn.commit()``
+        / ``conn.rollback()``).
+    spec:
+        Fully-populated :class:`SubdivideSpec`.
+    dry_run:
+        When ``True`` (the default), the SQL is generated and returned but
+        **never executed**.  Safe for inspection without touching the database.
+
+    Returns
+    -------
+    dict
+        * ``"sql"`` — the full SQL block (always present).
+        * ``"executed"`` — ``False`` on dry-run, ``True`` on success.
+        * ``"rows_inserted"`` — row count from the INSERT statement's
+          ``cursor.rowcount``, or ``-1`` if unavailable (only on success).
+    """
+    sql = build_subdivide_sql(spec)
+    if dry_run:
+        return {"sql": sql, "executed": False}
+
+    log.info(
+        "subdivide_table.start",
+        target=f"{spec.target_schema}.{spec.target_table}",
+        source=f"{spec.source_schema}.{spec.source_table}",
+        max_vertices=spec.max_vertices,
+        dry_run=False,
+    )
+
+    cur = conn.cursor()
+    rows_inserted = -1
+    try:
+        cur.execute(sql)
+        # rowcount after a multi-statement block is implementation-defined;
+        # document as -1 when unavailable.
+        try:
+            rows_inserted = cur.rowcount
+        except Exception:  # noqa: BLE001
+            rows_inserted = -1
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        cur.close()
+
+    log.info(
+        "subdivide_table.done",
+        target=f"{spec.target_schema}.{spec.target_table}",
+        rows_inserted=rows_inserted,
+    )
+    return {"sql": sql, "executed": True, "rows_inserted": rows_inserted}
+
+
+# ---------------------------------------------------------------------------
+# batch_load_duckdb_to_postgis
+# ---------------------------------------------------------------------------
+
+
+def batch_load_duckdb_to_postgis(
+    duck_conn: Any,
+    pg_conn: Any,
+    *,
+    select_sql: str,
+    insert_sql: str,
+    batch_size: int = 5_000,
+    delete_sql: str | None = None,
+    delete_params: Sequence[Any] | None = None,
+) -> dict[str, Any]:
+    """Stream rows from a DuckDB query into a PostGIS table in batches.
+
+    Reproduces the core of ``load_duckdb_scope_to_postgis`` from
+    gispulse-foncier as a parameterised primitive.
+
+    The entire operation (optional delete + all inserts) is wrapped in a
+    **single transaction**: only one ``commit`` is issued at the very end.
+    Any exception triggers ``rollback`` before propagating.
+
+    Trust boundary
+    --------------
+    ``select_sql``, ``insert_sql``, and ``delete_sql`` are **trusted caller
+    input** — the caller is responsible for their correctness and safety.
+
+    Parameters
+    ----------
+    duck_conn:
+        An open DuckDB connection (``duck_conn.execute(sql)`` returning a
+        cursor supporting ``fetchmany``).
+    pg_conn:
+        A psycopg-compatible connection.
+    select_sql:
+        DuckDB query whose result rows are streamed into PostGIS.  Must be
+        non-empty.
+    insert_sql:
+        Parameterised INSERT statement with ``%s`` placeholders (psycopg
+        style).  Must be non-empty.
+    batch_size:
+        Number of rows per ``executemany`` call.  Must be >= 1.
+    delete_sql:
+        Optional DELETE statement executed first (before any inserts) within
+        the same transaction.
+    delete_params:
+        Optional sequence of parameters bound to ``delete_sql``.
+
+    Returns
+    -------
+    dict
+        * ``"rows_loaded"`` — total number of rows inserted.
+        * ``"batches"`` — number of ``executemany`` calls issued.
+        * ``"executed"`` — always ``True``.
+
+    Raises
+    ------
+    ValueError
+        ``batch_size < 1`` or ``select_sql``/``insert_sql`` are empty.
+    """
+    if batch_size < 1:
+        raise ValueError(f"batch_size must be >= 1, got {batch_size!r}")
+    if not select_sql or not select_sql.strip():
+        raise ValueError("select_sql must not be empty")
+    if not insert_sql or not insert_sql.strip():
+        raise ValueError("insert_sql must not be empty")
+
+    log.info(
+        "batch_load_duckdb_to_postgis.start",
+        batch_size=batch_size,
+        has_delete=delete_sql is not None,
+    )
+
+    pg_cur = pg_conn.cursor()
+    rows_loaded = 0
+    batches = 0
+
+    try:
+        # --- optional scoped delete (same transaction) ----------------------
+        if delete_sql is not None:
+            if delete_params:
+                pg_cur.execute(delete_sql, delete_params)
+            else:
+                pg_cur.execute(delete_sql)
+
+        # --- stream DuckDB → PostGIS ----------------------------------------
+        duck_cur = duck_conn.execute(select_sql)
+        while True:
+            rows = duck_cur.fetchmany(batch_size)
+            if not rows:
+                break
+            pg_cur.executemany(insert_sql, rows)
+            rows_loaded += len(rows)
+            batches += 1
+
+            if batches % 50 == 0:
+                log.info(
+                    "batch_load_duckdb_to_postgis.progress",
+                    rows_loaded=rows_loaded,
+                    batches=batches,
+                )
+
+        # --- single commit covering delete + all inserts --------------------
+        pg_conn.commit()
+
+    except Exception:
+        pg_conn.rollback()
+        raise
+    finally:
+        pg_cur.close()
+
+    log.info(
+        "batch_load_duckdb_to_postgis.done",
+        rows_loaded=rows_loaded,
+        batches=batches,
+    )
+    return {"rows_loaded": rows_loaded, "batches": batches, "executed": True}

--- a/tests/persistence/test_postgis_bulk.py
+++ b/tests/persistence/test_postgis_bulk.py
@@ -1,0 +1,708 @@
+"""Tests for gispulse.persistence.postgis_bulk.
+
+Coverage
+--------
+* build_subdivide_sql — pure function, no DB required.
+* subdivide_table — dry_run (no execute), apply (execute+commit), rollback on error.
+* batch_load_duckdb_to_postgis — fake duck/pg fakes; ordering, counting, rollback.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from gispulse.persistence.postgis_bulk import (
+    SubdivideSpec,
+    batch_load_duckdb_to_postgis,
+    build_subdivide_sql,
+    subdivide_table,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — minimal SubdivideSpec fixtures
+# ---------------------------------------------------------------------------
+
+
+def _simple_spec(
+    *,
+    delete_predicate: str | None = None,
+    insert_predicate: str | None = None,
+) -> SubdivideSpec:
+    return SubdivideSpec(
+        source_schema="staging",
+        source_table="iris_raw",
+        target_schema="staging",
+        target_table="iris_subdivided",
+        geom_column="geom",
+        max_vertices=256,
+        key_columns=("code_iris", "dept"),
+        data_columns=("insee_com",),
+        column_types={
+            "code_iris": "text",
+            "dept": "text",
+            "insee_com": "text",
+        },
+        srid=4326,
+        delete_predicate=delete_predicate,
+        insert_predicate=insert_predicate,
+    )
+
+
+def _no_key_spec() -> SubdivideSpec:
+    """Spec with no key_columns (degenerate case)."""
+    return SubdivideSpec(
+        source_schema="public",
+        source_table="geom_raw",
+        target_schema="public",
+        target_table="geom_subdivided",
+        geom_column="shape",
+        max_vertices=128,
+        key_columns=(),
+        data_columns=(),
+        column_types={},
+        srid=4326,
+    )
+
+
+# ---------------------------------------------------------------------------
+# build_subdivide_sql — CREATE TABLE
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSubdivideSqlCreateTable:
+    def test_create_table_if_not_exists(self) -> None:
+        sql = build_subdivide_sql(_simple_spec())
+        assert "CREATE TABLE IF NOT EXISTS staging.iris_subdivided" in sql
+
+    def test_key_columns_in_create(self) -> None:
+        sql = build_subdivide_sql(_simple_spec())
+        assert "code_iris text NOT NULL" in sql
+        assert "dept text NOT NULL" in sql
+
+    def test_data_columns_in_create(self) -> None:
+        sql = build_subdivide_sql(_simple_spec())
+        assert "insee_com text NOT NULL" in sql
+
+    def test_fragment_id_in_create(self) -> None:
+        sql = build_subdivide_sql(_simple_spec())
+        assert "fragment_id bigint NOT NULL" in sql
+
+    def test_geom_column_with_srid(self) -> None:
+        sql = build_subdivide_sql(_simple_spec())
+        assert "geom geometry(Geometry, 4326) NOT NULL" in sql
+
+    def test_primary_key_includes_key_cols_and_fragment_id(self) -> None:
+        sql = build_subdivide_sql(_simple_spec())
+        assert "PRIMARY KEY (code_iris, dept, fragment_id)" in sql
+
+    def test_no_key_columns_pk_is_fragment_id_only(self) -> None:
+        sql = build_subdivide_sql(_no_key_spec())
+        assert "PRIMARY KEY (fragment_id)" in sql
+
+
+# ---------------------------------------------------------------------------
+# build_subdivide_sql — DELETE
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSubdivideSqlDelete:
+    def test_full_refresh_when_no_delete_predicate(self) -> None:
+        sql = build_subdivide_sql(_simple_spec(delete_predicate=None))
+        # Full-table delete — no alias, no WHERE clause
+        assert "DELETE FROM staging.iris_subdivided;" in sql
+
+    def test_scoped_delete_uses_predicate(self) -> None:
+        sql = build_subdivide_sql(
+            _simple_spec(delete_predicate="frag.dept = 'dept_63'")
+        )
+        assert "DELETE FROM staging.iris_subdivided frag" in sql
+        assert "frag.dept = 'dept_63'" in sql
+
+    def test_full_refresh_no_where_keyword(self) -> None:
+        sql = build_subdivide_sql(_simple_spec(delete_predicate=None))
+        # The full-table delete should not carry a WHERE clause
+        delete_line = [ln for ln in sql.splitlines() if "DELETE FROM staging" in ln]
+        assert len(delete_line) == 1
+        assert "WHERE" not in delete_line[0]
+
+
+# ---------------------------------------------------------------------------
+# build_subdivide_sql — INSERT / ST_Dump / ST_Subdivide
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSubdivideSqlInsert:
+    def test_insert_into_target(self) -> None:
+        sql = build_subdivide_sql(_simple_spec())
+        assert "INSERT INTO staging.iris_subdivided" in sql
+
+    def test_st_dump_present(self) -> None:
+        sql = build_subdivide_sql(_simple_spec())
+        assert "ST_Dump" in sql
+
+    def test_st_subdivide_with_max_vertices(self) -> None:
+        sql = build_subdivide_sql(_simple_spec())
+        assert "ST_Subdivide(c.geom, 256)" in sql
+
+    def test_dimension_zero_passthrough(self) -> None:
+        sql = build_subdivide_sql(_simple_spec())
+        assert "ST_Dimension(c.geom) = 0" in sql
+
+    def test_dimension_gt_zero_subdivide_branch(self) -> None:
+        sql = build_subdivide_sql(_simple_spec())
+        assert "ST_Dimension(c.geom) > 0" in sql
+
+    def test_union_all_between_passthrough_and_subdivide(self) -> None:
+        sql = build_subdivide_sql(_simple_spec())
+        assert "UNION ALL" in sql
+
+    def test_row_number_partitioned_by_key_columns(self) -> None:
+        sql = build_subdivide_sql(_simple_spec())
+        assert "row_number() OVER" in sql
+        assert "PARTITION BY code_iris, dept" in sql
+
+    def test_row_number_order_by_st_area_st_asewkb(self) -> None:
+        sql = build_subdivide_sql(_simple_spec())
+        assert "ST_Area(ST_Envelope(geom)) DESC" in sql
+        assert "ST_AsEWKB(geom)" in sql
+
+    def test_no_on_conflict(self) -> None:
+        # Plain INSERT — PK violation is the honest signal of a scope mismatch.
+        sql = build_subdivide_sql(_simple_spec())
+        assert "ON CONFLICT" not in sql
+
+    def test_geom_not_null_filter(self) -> None:
+        sql = build_subdivide_sql(_simple_spec())
+        assert "src.geom IS NOT NULL" in sql
+        assert "NOT ST_IsEmpty(d.geom)" in sql
+
+    def test_insert_predicate_in_dumped_where(self) -> None:
+        spec = _simple_spec(insert_predicate="src.dept = '63'")
+        sql = build_subdivide_sql(spec)
+        # predicate should appear in the WHERE of the dumped CTE
+        assert "src.dept = '63'" in sql
+
+    def test_predicates_go_to_correct_statement(self) -> None:
+        # Regression: a single scope_predicate with different aliases would
+        # break one of the two statements.  Verify each predicate lands only
+        # in its intended context.
+        spec = _simple_spec(
+            delete_predicate="frag.dept = '63'",
+            insert_predicate="src.dept = '63'",
+        )
+        sql = build_subdivide_sql(spec)
+
+        # Split on blank lines to isolate the DELETE block from the INSERT block.
+        blocks = sql.split("\n\n")
+        delete_block = next(b for b in blocks if b.strip().startswith("DELETE"))
+        insert_block = next(b for b in blocks if b.strip().startswith("INSERT"))
+
+        # delete_predicate must appear in DELETE, not in INSERT
+        assert "frag.dept = '63'" in delete_block
+        assert "frag.dept = '63'" not in insert_block
+
+        # insert_predicate must appear in INSERT, not in DELETE
+        assert "src.dept = '63'" in insert_block
+        assert "src.dept = '63'" not in delete_block
+
+    def test_no_key_columns_row_number_no_partition(self) -> None:
+        sql = build_subdivide_sql(_no_key_spec())
+        assert "row_number() OVER" in sql
+        # Without key columns, no PARTITION BY clause
+        assert "PARTITION BY" not in sql
+
+    def test_source_table_referenced_in_insert(self) -> None:
+        sql = build_subdivide_sql(_simple_spec())
+        assert "staging.iris_raw" in sql
+
+
+# ---------------------------------------------------------------------------
+# build_subdivide_sql — Indexes
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSubdivideSqlIndexes:
+    def test_gist_index_on_geom(self) -> None:
+        sql = build_subdivide_sql(_simple_spec())
+        assert "CREATE INDEX IF NOT EXISTS iris_subdivided_geom_gist" in sql
+        assert "USING GIST (geom)" in sql
+
+    def test_btree_index_on_key_columns(self) -> None:
+        sql = build_subdivide_sql(_simple_spec())
+        assert "CREATE INDEX IF NOT EXISTS iris_subdivided_key_idx" in sql
+        assert "code_iris, dept" in sql
+
+    def test_no_key_index_when_no_key_columns(self) -> None:
+        sql = build_subdivide_sql(_no_key_spec())
+        assert "_key_idx" not in sql
+
+
+# ---------------------------------------------------------------------------
+# build_subdivide_sql — Validation errors (fast-fail)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSubdivideSqlValidation:
+    def test_mixed_case_schema_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            build_subdivide_sql(
+                SubdivideSpec(
+                    source_schema="Staging",  # capital S
+                    source_table="iris_raw",
+                    target_schema="staging",
+                    target_table="iris_subdivided",
+                    column_types={},
+                )
+            )
+
+    def test_mixed_case_table_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            build_subdivide_sql(
+                SubdivideSpec(
+                    source_schema="staging",
+                    source_table="IrisRaw",  # camel case
+                    target_schema="staging",
+                    target_table="iris_subdivided",
+                    column_types={},
+                )
+            )
+
+    def test_identifier_with_special_chars_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            build_subdivide_sql(
+                SubdivideSpec(
+                    source_schema="staging; DROP TABLE users--",
+                    source_table="iris_raw",
+                    target_schema="staging",
+                    target_table="iris_subdivided",
+                    column_types={},
+                )
+            )
+
+    def test_column_with_dash_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            build_subdivide_sql(
+                SubdivideSpec(
+                    source_schema="staging",
+                    source_table="iris_raw",
+                    target_schema="staging",
+                    target_table="iris_subdivided",
+                    key_columns=("code-iris",),  # dash not allowed
+                    column_types={"code-iris": "text"},
+                )
+            )
+
+    def test_column_missing_from_column_types_raises(self) -> None:
+        with pytest.raises(ValueError, match="no entry in column_types"):
+            build_subdivide_sql(
+                SubdivideSpec(
+                    source_schema="staging",
+                    source_table="iris_raw",
+                    target_schema="staging",
+                    target_table="iris_subdivided",
+                    key_columns=("code_iris",),
+                    column_types={},  # missing code_iris
+                )
+            )
+
+    def test_type_comma_injection_raises(self) -> None:
+        # "text, injected text" was accepted by the old broad regex — must reject
+        with pytest.raises(ValueError, match="Invalid SQL type"):
+            build_subdivide_sql(
+                SubdivideSpec(
+                    source_schema="staging",
+                    source_table="iris_raw",
+                    target_schema="staging",
+                    target_table="iris_subdivided",
+                    key_columns=("code_iris",),
+                    column_types={"code_iris": "text, injected text"},
+                )
+            )
+
+    def test_type_not_null_injection_raises(self) -> None:
+        # "text NOT NULL, x text" must be rejected
+        with pytest.raises(ValueError, match="Invalid SQL type"):
+            build_subdivide_sql(
+                SubdivideSpec(
+                    source_schema="staging",
+                    source_table="iris_raw",
+                    target_schema="staging",
+                    target_table="iris_subdivided",
+                    key_columns=("col",),
+                    column_types={"col": "text NOT NULL, x text"},
+                )
+            )
+
+    def test_type_drop_injection_raises(self) -> None:
+        # "jsonb); DROP" must be rejected
+        with pytest.raises(ValueError, match="Invalid SQL type"):
+            build_subdivide_sql(
+                SubdivideSpec(
+                    source_schema="staging",
+                    source_table="iris_raw",
+                    target_schema="staging",
+                    target_table="iris_subdivided",
+                    key_columns=("col",),
+                    column_types={"col": "jsonb); DROP"},
+                )
+            )
+
+    def test_type_with_single_quote_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid SQL type"):
+            build_subdivide_sql(
+                SubdivideSpec(
+                    source_schema="staging",
+                    source_table="iris_raw",
+                    target_schema="staging",
+                    target_table="iris_subdivided",
+                    key_columns=("col",),
+                    column_types={"col": "text'"},
+                )
+            )
+
+    # --- accepted valid types ------------------------------------------------
+
+    def test_valid_types_accepted(self) -> None:
+        valid_types = ["text", "bigint", "double precision", "timestamptz",
+                       "varchar(255)", "numeric(10,2)"]
+        for t in valid_types:
+            # Should not raise
+            build_subdivide_sql(
+                SubdivideSpec(
+                    source_schema="staging",
+                    source_table="iris_raw",
+                    target_schema="staging",
+                    target_table="iris_subdivided",
+                    key_columns=("col",),
+                    column_types={"col": t},
+                )
+            )
+
+    def test_geom_column_with_space_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            build_subdivide_sql(
+                SubdivideSpec(
+                    source_schema="staging",
+                    source_table="iris_raw",
+                    target_schema="staging",
+                    target_table="iris_subdivided",
+                    geom_column="bad col",  # space not allowed
+                    column_types={},
+                )
+            )
+
+
+# ---------------------------------------------------------------------------
+# subdivide_table — dry_run / apply / rollback
+# ---------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[str] = []
+        self.rowcount: int = 42
+
+    def execute(self, sql: str) -> None:
+        self.executed.append(sql)
+
+    def close(self) -> None:
+        pass
+
+
+class _FakeConn:
+    def __init__(self, raise_on_execute: bool = False) -> None:
+        self._raise = raise_on_execute
+        self._cursor = _FakeCursor()
+        self.committed = False
+        self.rolled_back = False
+
+    def cursor(self) -> _FakeCursor:
+        if self._raise:
+            # Raise on the first execute inside cursor
+            orig_execute = self._cursor.execute
+
+            def _failing_execute(sql: str) -> None:
+                raise RuntimeError("DB error")
+
+            self._cursor.execute = _failing_execute  # type: ignore[method-assign]
+        return self._cursor
+
+    def commit(self) -> None:
+        self.committed = True
+
+    def rollback(self) -> None:
+        self.rolled_back = True
+
+
+class TestSubdivideTable:
+    def test_dry_run_returns_sql_not_executed(self) -> None:
+        conn = _FakeConn()
+        spec = _simple_spec()
+        result = subdivide_table(conn, spec, dry_run=True)
+        assert result["executed"] is False
+        assert "CREATE TABLE IF NOT EXISTS" in result["sql"]
+        # No execute should have happened
+        assert conn._cursor.executed == []
+        assert not conn.committed
+
+    def test_apply_executes_and_commits(self) -> None:
+        conn = _FakeConn()
+        spec = _simple_spec()
+        result = subdivide_table(conn, spec, dry_run=False)
+        assert result["executed"] is True
+        assert len(conn._cursor.executed) == 1  # single SQL block
+        assert conn.committed is True
+        assert conn.rolled_back is False
+
+    def test_apply_returns_rows_inserted(self) -> None:
+        conn = _FakeConn()
+        result = subdivide_table(conn, _simple_spec(), dry_run=False)
+        assert result["rows_inserted"] == 42
+
+    def test_exception_triggers_rollback_not_commit(self) -> None:
+        conn = _FakeConn(raise_on_execute=True)
+        with pytest.raises(RuntimeError, match="DB error"):
+            subdivide_table(conn, _simple_spec(), dry_run=False)
+        assert conn.rolled_back is True
+        assert conn.committed is False
+
+    def test_dry_run_is_default(self) -> None:
+        conn = _FakeConn()
+        result = subdivide_table(conn, _simple_spec())  # no dry_run kwarg
+        assert result["executed"] is False
+
+
+# ---------------------------------------------------------------------------
+# batch_load_duckdb_to_postgis
+# ---------------------------------------------------------------------------
+
+
+class _FakeDuckCursor:
+    """Fake DuckDB cursor yielding predetermined batches."""
+
+    def __init__(self, batches: list[list[Any]]) -> None:
+        self._batches = list(batches)
+        self._index = 0
+
+    def fetchmany(self, size: int) -> list[Any]:
+        if self._index >= len(self._batches):
+            return []
+        rows = self._batches[self._index]
+        self._index += 1
+        return rows
+
+
+class _FakeDuckConn:
+    def __init__(self, batches: list[list[Any]], raise_on_batch: int | None = None) -> None:
+        self._batches = batches
+        self._raise_on_batch = raise_on_batch
+
+    def execute(self, sql: str) -> _FakeDuckCursor:
+        if self._raise_on_batch is not None:
+            # Inject a cursor that will raise on the specified batch
+            return _RaisingDuckCursor(self._batches, self._raise_on_batch)
+        return _FakeDuckCursor(self._batches)
+
+
+class _RaisingDuckCursor(_FakeDuckCursor):
+    def __init__(self, batches: list[list[Any]], raise_on: int) -> None:
+        super().__init__(batches)
+        self._raise_on = raise_on
+
+    def fetchmany(self, size: int) -> list[Any]:
+        if self._index == self._raise_on:
+            raise RuntimeError("DuckDB fetch error")
+        return super().fetchmany(size)
+
+
+class _FakePgCursor:
+    def __init__(self) -> None:
+        self.executed_deletes: list[tuple[str, Any]] = []
+        self.inserted_rows: list[Any] = []
+        self.executemany_calls: int = 0
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed_deletes.append((sql, params))
+
+    def executemany(self, sql: str, rows: list[Any]) -> None:
+        self.inserted_rows.extend(rows)
+        self.executemany_calls += 1
+
+    def close(self) -> None:
+        pass
+
+
+class _FakePgConn:
+    def __init__(self) -> None:
+        self._cursor = _FakePgCursor()
+        self.committed = False
+        self.rolled_back = False
+
+    def cursor(self) -> _FakePgCursor:
+        return self._cursor
+
+    def commit(self) -> None:
+        self.committed = True
+
+    def rollback(self) -> None:
+        self.rolled_back = True
+
+
+class TestBatchLoadDuckdbToPostgis:
+    def _make(self, batches: list[list[Any]], **kwargs: Any) -> tuple[_FakeDuckConn, _FakePgConn, dict]:
+        duck = _FakeDuckConn(batches)
+        pg = _FakePgConn()
+        result = batch_load_duckdb_to_postgis(
+            duck, pg,
+            select_sql="SELECT * FROM x",
+            insert_sql="INSERT INTO y VALUES (%s, %s)",
+            **kwargs,
+        )
+        return duck, pg, result
+
+    # --- basic correctness --------------------------------------------------
+
+    def test_rows_and_batches_counted(self) -> None:
+        batches = [[("a", 1), ("b", 2)], [("c", 3)]]
+        _, _, result = self._make(batches)
+        assert result["rows_loaded"] == 3
+        assert result["batches"] == 2
+        assert result["executed"] is True
+
+    def test_single_commit_at_end(self) -> None:
+        _, pg, _ = self._make([[("a", 1)]])
+        assert pg.committed is True
+        assert pg.rolled_back is False
+
+    def test_empty_source_zero_rows(self) -> None:
+        _, _, result = self._make([])
+        assert result["rows_loaded"] == 0
+        assert result["batches"] == 0
+
+    def test_last_partial_batch_handled(self) -> None:
+        # batch_size=3 but last batch has only 1 row
+        batches = [[(i,) for i in range(3)], [(99,)]]
+        _, pg, result = self._make(batches, batch_size=3)
+        assert result["rows_loaded"] == 4
+        assert result["batches"] == 2
+        assert len(pg._cursor.inserted_rows) == 4
+
+    # --- delete before inserts ----------------------------------------------
+
+    def test_delete_executed_before_inserts(self) -> None:
+        duck = _FakeDuckConn([[("a", 1)]])
+        pg = _FakePgConn()
+        batch_load_duckdb_to_postgis(
+            duck, pg,
+            select_sql="SELECT * FROM x",
+            insert_sql="INSERT INTO y VALUES (%s, %s)",
+            delete_sql="DELETE FROM y WHERE dept = %s",
+            delete_params=("63",),
+        )
+        # Delete should have been recorded
+        assert len(pg._cursor.executed_deletes) == 1
+        del_sql, del_params = pg._cursor.executed_deletes[0]
+        assert "DELETE FROM y" in del_sql
+        assert del_params == ("63",)
+        # Insert should also have happened
+        assert len(pg._cursor.inserted_rows) == 1
+
+    def test_delete_then_insert_then_single_commit(self) -> None:
+        duck = _FakeDuckConn([[("x",)]])
+        pg = _FakePgConn()
+        batch_load_duckdb_to_postgis(
+            duck, pg,
+            select_sql="SELECT 1",
+            insert_sql="INSERT INTO t VALUES (%s)",
+            delete_sql="DELETE FROM t WHERE 1=1",
+        )
+        assert pg.committed is True
+        assert pg.rolled_back is False
+
+    def test_no_delete_when_delete_sql_is_none(self) -> None:
+        _, pg, _ = self._make([[("a",)]])
+        assert len(pg._cursor.executed_deletes) == 0
+
+    # --- rollback on error --------------------------------------------------
+
+    def test_exception_on_second_batch_triggers_rollback(self) -> None:
+        batches = [[("a",)], [("b",)], [("c",)]]
+        duck = _FakeDuckConn(batches, raise_on_batch=1)  # raise on batch index 1
+        pg = _FakePgConn()
+        with pytest.raises(RuntimeError, match="DuckDB fetch error"):
+            batch_load_duckdb_to_postgis(
+                duck, pg,
+                select_sql="SELECT 1",
+                insert_sql="INSERT INTO t VALUES (%s)",
+            )
+        assert pg.rolled_back is True
+        assert pg.committed is False
+
+    def test_no_commit_on_rollback(self) -> None:
+        duck = _FakeDuckConn([[("a",)]], raise_on_batch=0)
+        pg = _FakePgConn()
+        with pytest.raises(RuntimeError):
+            batch_load_duckdb_to_postgis(
+                duck, pg,
+                select_sql="SELECT 1",
+                insert_sql="INSERT INTO t VALUES (%s)",
+            )
+        assert not pg.committed
+
+    # --- validation ---------------------------------------------------------
+
+    def test_batch_size_zero_raises(self) -> None:
+        duck = _FakeDuckConn([])
+        pg = _FakePgConn()
+        with pytest.raises(ValueError, match="batch_size must be >= 1"):
+            batch_load_duckdb_to_postgis(
+                duck, pg,
+                select_sql="SELECT 1",
+                insert_sql="INSERT INTO t VALUES (%s)",
+                batch_size=0,
+            )
+
+    def test_batch_size_negative_raises(self) -> None:
+        duck = _FakeDuckConn([])
+        pg = _FakePgConn()
+        with pytest.raises(ValueError, match="batch_size must be >= 1"):
+            batch_load_duckdb_to_postgis(
+                duck, pg,
+                select_sql="SELECT 1",
+                insert_sql="INSERT INTO t VALUES (%s)",
+                batch_size=-5,
+            )
+
+    def test_empty_select_sql_raises(self) -> None:
+        duck = _FakeDuckConn([])
+        pg = _FakePgConn()
+        with pytest.raises(ValueError, match="select_sql must not be empty"):
+            batch_load_duckdb_to_postgis(
+                duck, pg,
+                select_sql="",
+                insert_sql="INSERT INTO t VALUES (%s)",
+            )
+
+    def test_empty_insert_sql_raises(self) -> None:
+        duck = _FakeDuckConn([])
+        pg = _FakePgConn()
+        with pytest.raises(ValueError, match="insert_sql must not be empty"):
+            batch_load_duckdb_to_postgis(
+                duck, pg,
+                select_sql="SELECT 1",
+                insert_sql="   ",
+            )
+
+    # --- multi-batch exact count --------------------------------------------
+
+    def test_multi_batch_exact_row_count(self) -> None:
+        # 5 batches × 3 rows + 1 partial = 16 rows
+        full_batches = [[(i, j) for j in range(3)] for i in range(5)]
+        partial_batch = [(99, 0)]
+        batches = full_batches + [partial_batch]
+        _, _, result = self._make(batches, batch_size=3)
+        assert result["rows_loaded"] == 16
+        assert result["batches"] == 6


### PR DESCRIPTION
## Problem

Heavy polygonal spatial joins OOM in DuckDB at national scale. The durable pattern (proven downstream) is to **subdivide the layers in PostGIS** — raw geometry joins ≈12 min/commune, subdivided ≈5 s — and batch-load scoped data DuckDB→PostGIS. Applications currently hand-write one near-identical subdivide SQL builder per source (the reference app has five).

## What

**New self-contained `persistence/postgis_bulk.py`** (no existing module touched):

**A. Subdivide materializer**
- `SubdivideSpec` + **`build_subdivide_sql()`** — one parameterised, *pure* SQL builder (testable without Postgres) for the fragments pattern: `CREATE TABLE IF NOT EXISTS` with `PRIMARY KEY (key_columns…, fragment_id)`, scoped or full-refresh `DELETE`, `INSERT` via `ST_Dump` → dimension-aware `ST_Subdivide` (points pass through; lines and surfaces subdivided), deterministic `row_number()` fragment ids, GIST + key btree indexes.
- **Deliberately a plain INSERT** — a primary-key violation is the honest signal of a DELETE/INSERT scope mismatch. `ON CONFLICT` would let stale fragments survive silently (a feature shrinking from 10 to 7 fragments keeps 3 stale ones) and corrupt downstream spatial joins.
- `delete_predicate` (alias `frag`) and `insert_predicate` (alias `src`) are **separate fields** — one shared predicate cannot serve two aliases. Both are documented trusted caller input; identifiers are lowercase-validated and column types pass a strict whitelist (lowercase letters + numeric-only parentheses: `numeric(10,2)` passes, `text, injected text` is rejected).
- `subdivide_table(conn, spec, dry_run=True)` — plan-only by default, execute+commit with rollback on failure otherwise.

**B. Batched loader**
- `batch_load_duckdb_to_postgis()` — streams a DuckDB cursor via `fetchmany` into psycopg `executemany` batches; optional scope `DELETE` first; the delete and all inserts are **one transaction with a single final commit** (rollback + re-raise on any batch failure).

Scope resolution (administrative code normalisation à la RunScope) stays application-side — core takes resolved predicates.

## Tests

57 tests: full SQL-shape assertions (CREATE/PK/DELETE variants/ST_Dump/ST_Subdivide/passthrough/row_number/indexes), cross-statement predicate routing (qualified `frag.`/`src.` predicates each land in their own statement only), injection rejection (3 type vectors + identifiers), dry-run zero-execute, atomicity (failure at 2nd batch → rollback, no commit), partial last batch. Ruff clean.

Independent of the open PR queue (#419–#431) — no shared files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)