### PR TITLE
feat(bulk): opt-in skip-if-staged resume for BulkIngestRunner

### DIFF
--- a/src/gispulse/core/bulk_runner.py
+++ b/src/gispulse/core/bulk_runner.py
@@ -14,7 +14,7 @@ import json
 import shutil
 import subprocess
 import tempfile
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from datetime import date
 from pathlib import Path
 from typing import Any, Iterable, Iterator
@@ -31,6 +31,7 @@ from gispulse.core.bulk_ingest import (
 )
 from gispulse.core.config import settings
 from gispulse.core.fetchers import register_core_fetchers
+from gispulse.core.logging import get_logger
 from gispulse.core.plugin_model import (
     AccessProtocol,
     AccessSpec,
@@ -44,6 +45,8 @@ from gispulse.core.ssrf import guard_outbound_url
 from gispulse.persistence.storage import DatasetStorage, S3Storage
 
 __all__ = ["BulkIngestResult", "BulkIngestRunner"]
+
+log = get_logger(__name__)
 
 _VECTOR_SUFFIXES = (".gpkg", ".shp", ".geojson", ".json", ".fgb", ".gml")
 _SPATIAL_GZIP_ARCHIVE_FORMATS = {"geojson.gz", "json.gz"}
@@ -61,6 +64,7 @@ class BulkIngestResult:
     access: AccessSpec
     fetch_result: SourceResult
     manifest: dict[str, object]
+    skipped: bool = field(default=False)
 
 
 class BulkIngestRunner:
@@ -75,7 +79,30 @@ class BulkIngestRunner:
         key_prefix: str | None = None,
         write_table_raw: bool = False,
         temp_dir: str | Path | None = None,
+        skip_if_staged: bool = False,
     ) -> None:
+        """Initialise the runner.
+
+        Args:
+            skip_if_staged: When ``True``, check whether the stage object already
+                exists in S3 before fetching or uploading.  If it does, the entry
+                is returned as ``BulkIngestResult(skipped=True)`` without any
+                network or compute work.  Defaults to ``False`` (current behaviour
+                preserved).
+
+                **Failure semantics of the existence check**: depending on the
+                storage backend, a transient error during the check may surface
+                differently.  With the local or fake backends the exception
+                propagates and is caught by the runner, which logs
+                ``bulk_ingest.skip_check_failed`` and falls through to the
+                nominal path.  With the real S3 backend
+                (:class:`~gispulse.persistence.storage.S3Storage`), head-object
+                errors are caught internally and the method returns ``False``
+                instead, so the runner proceeds nominally without logging a
+                warning.  In both cases the skip optimisation is never a cause
+                of failure or of a false-positive skip — the safe direction is
+                always to run the full fetch/upload.
+        """
         if registry is None:
             registry = ProtocolRegistry()
             register_core_fetchers(registry)
@@ -85,6 +112,7 @@ class BulkIngestRunner:
         self._key_prefix = key_prefix
         self._write_table_raw = write_table_raw
         self._temp_dir = Path(temp_dir) if temp_dir is not None else None
+        self._skip_if_staged = skip_if_staged
 
     def run_registered(
         self,
@@ -95,6 +123,7 @@ class BulkIngestRunner:
         partition: object | None = None,
         revision: object | None = None,
         params: dict[str, Any] | None = None,
+        force: bool = False,
     ) -> BulkIngestResult:
         """Run an entry from the process-wide source registry."""
         from gispulse.core.sources import SOURCES
@@ -107,6 +136,7 @@ class BulkIngestRunner:
             partition=partition,
             revision=revision,
             params=params,
+            force=force,
         )
 
     def run_entry(
@@ -118,6 +148,7 @@ class BulkIngestRunner:
         partition: object | None = None,
         revision: object | None = None,
         params: dict[str, Any] | None = None,
+        force: bool = False,
     ) -> BulkIngestResult:
         """Materialize one declarative source entry to the N3 S3 layout."""
         entry = _entry_from_source(source, entry_id)
@@ -139,6 +170,7 @@ class BulkIngestRunner:
                 departement=scope_departement,
                 partition=partition,
                 revision=revision_token,
+                force=force,
             )
         if access.protocol is AccessProtocol.DOWNLOAD:
             return self._run_download_archive(
@@ -149,6 +181,7 @@ class BulkIngestRunner:
                 partition=partition,
                 revision=revision_token,
                 source_schema=_source_schema(source, entry.id),
+                force=force,
             )
         raise NotImplementedError(
             "N3 bulk runner currently supports TABLE_FILE and DOWNLOAD entries; "
@@ -212,6 +245,7 @@ class BulkIngestRunner:
         departement: object | None,
         partition: object | None,
         revision: str,
+        force: bool = False,
     ) -> BulkIngestResult:
         stage_filename = _stage_filename(entry)
         raw_filename = _raw_filename(entry, access)
@@ -236,6 +270,64 @@ class BulkIngestRunner:
             filename=raw_filename,
         )
         stage_uri = bulk_s3_uri(key=stage_key, bucket=self._bucket)
+
+        # --- skip-if-staged optimisation (opt-in via skip_if_staged=True) ---
+        if self._skip_if_staged and not force:
+            try:
+                storage_for_check = self._storage or _create_s3_storage(self._bucket)
+                already_staged = _await_storage(storage_for_check.exists(stage_key))
+            except Exception as exc:  # noqa: BLE001
+                log.warning(
+                    "bulk_ingest.skip_check_failed",
+                    source=source_name,
+                    entry=entry.id,
+                    stage_key=stage_key,
+                    error=str(exc),
+                )
+                already_staged = False
+            if already_staged:
+                log.info(
+                    "bulk_ingest.skipped",
+                    source=source_name,
+                    entry=entry.id,
+                    stage_key=stage_key,
+                )
+                resolved_access_skip = resolve_access_endpoint(access)
+                params_skip = dict(resolved_access_skip.params)
+                params_skip["s3_key"] = stage_key
+                params_skip["s3_bucket"] = self._bucket
+                stage_access_skip = replace(resolved_access_skip, params=params_skip)
+                result_skip = SourceResult(
+                    payload=entry.payload or Payload.TABLE,
+                    mode=FetchMode.MATERIALIZE,
+                    data=stage_uri,
+                    reference=stage_uri,
+                    metadata={"s3_uri": stage_uri},
+                )
+                manifest_skip = bulk_ingest_manifest_record(
+                    key_prefix=self._key_prefix,
+                    bucket=self._bucket,
+                    source=source_name,
+                    entry=entry.id,
+                    departement=departement,
+                    partition=partition,
+                    revision=revision,
+                    raw_filename=raw_filename,
+                    stage_filename=stage_filename,
+                    status="skipped",
+                )
+                manifest_skip["skipped"] = True
+                manifest_skip["reason"] = "stage_exists"
+                return BulkIngestResult(
+                    source=source_name,
+                    entry=entry.id,
+                    access=stage_access_skip,
+                    fetch_result=result_skip,
+                    manifest=manifest_skip,
+                    skipped=True,
+                )
+        # --- end skip-if-staged ---
+
         resolved_access = resolve_access_endpoint(access)
         guard_outbound_url(resolved_access.endpoint)
 
@@ -321,7 +413,22 @@ class BulkIngestRunner:
         partition: object | None,
         revision: str,
         source_schema: dict[str, Any] | None,
+        force: bool = False,
     ) -> BulkIngestResult:
+        """Download and stage an archive entry.
+
+        Skip behaviour (``skip_if_staged=True`` on the runner):
+
+        - **Spatial gzip** (``.geojson.gz`` / ``.json.gz``): the single stage key
+          is deterministic before any download, so the skip check is performed
+          upfront — if the stage object already exists the archive is never
+          fetched.
+        - **ZIP / 7z archives**: stage keys are derived from the names of the
+          vector members extracted from the archive, which are only known *after*
+          download.  These archives are always re-fetched; the skip optimisation
+          does not apply.  This is intentional — archives with content-determined
+          stage keys are always re-fetched.
+        """
         resolved_access = resolve_access_endpoint(access)
         guard_outbound_url(resolved_access.endpoint)
 
@@ -337,6 +444,73 @@ class BulkIngestRunner:
             filename=raw_filename,
         )
         storage = self._storage or _create_s3_storage(self._bucket)
+
+        # --- skip-if-staged: spatial gzip only (deterministic stage key) ---
+        if self._skip_if_staged and not force and _is_spatial_gzip_download(entry, resolved_access):
+            stage_filename_skip = _stage_filename(entry)
+            stage_key_skip = bulk_s3_key(
+                key_prefix=self._key_prefix,
+                kind=BULK_STAGE_PREFIX,
+                source=source_name,
+                entry=entry.id,
+                departement=departement,
+                partition=partition,
+                revision=revision,
+                filename=stage_filename_skip,
+            )
+            stage_uri_skip = bulk_s3_uri(key=stage_key_skip, bucket=self._bucket)
+            try:
+                already_staged = _await_storage(storage.exists(stage_key_skip))
+            except Exception as exc:  # noqa: BLE001
+                log.warning(
+                    "bulk_ingest.skip_check_failed",
+                    source=source_name,
+                    entry=entry.id,
+                    stage_key=stage_key_skip,
+                    error=str(exc),
+                )
+                already_staged = False
+            if already_staged:
+                log.info(
+                    "bulk_ingest.skipped",
+                    source=source_name,
+                    entry=entry.id,
+                    stage_key=stage_key_skip,
+                )
+                result_skip = SourceResult(
+                    payload=entry.payload or Payload.VECTOR,
+                    mode=FetchMode.MATERIALIZE,
+                    data=stage_uri_skip,
+                    reference=stage_uri_skip,
+                    metadata={
+                        "raw_s3_uri": bulk_s3_uri(key=raw_key, bucket=self._bucket),
+                        "stage_s3_uris": [stage_uri_skip],
+                    },
+                )
+                manifest_skip = bulk_ingest_manifest_record(
+                    key_prefix=self._key_prefix,
+                    bucket=self._bucket,
+                    source=source_name,
+                    entry=entry.id,
+                    departement=departement,
+                    partition=partition,
+                    revision=revision,
+                    raw_filename=raw_filename,
+                    stage_filename=stage_filename_skip,
+                    status="skipped",
+                )
+                manifest_skip["stage_s3_uris"] = [stage_uri_skip]
+                manifest_skip["skipped"] = True
+                manifest_skip["reason"] = "stage_exists"
+                return BulkIngestResult(
+                    source=source_name,
+                    entry=entry.id,
+                    access=resolved_access,
+                    fetch_result=result_skip,
+                    manifest=manifest_skip,
+                    skipped=True,
+                )
+        # --- end skip-if-staged ---
 
         copy_sqls: list[str] = []
         stage_uris: list[str] = []

--- a/tests/unit/test_bulk_runner.py
+++ b/tests/unit/test_bulk_runner.py
@@ -74,8 +74,16 @@ class _StaticSource(DeclarativeSource):
 
 
 class _FakeStorage:
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        existing_keys: set[str] | None = None,
+        exists_raises: Exception | None = None,
+    ) -> None:
         self.uploads: list[tuple[str, bytes, str]] = []
+        self.exists_calls: list[str] = []
+        self._existing_keys: set[str] = existing_keys or set()
+        self._exists_raises = exists_raises
 
     async def upload(
         self,
@@ -89,6 +97,12 @@ class _FakeStorage:
             payload = data.read()
         self.uploads.append((key, payload, content_type))
         return key
+
+    async def exists(self, key: str) -> bool:
+        self.exists_calls.append(key)
+        if self._exists_raises is not None:
+            raise self._exists_raises
+        return key in self._existing_keys
 
 
 def _zip_bytes(files: dict[str, bytes]) -> bytes:
@@ -723,3 +737,402 @@ def test_download_spatial_json_gz_uploads_raw_and_streams_geojson_to_stage(
         result.manifest["stage_s3_uri"]
     ]
     assert result.fetch_result.metadata["stage_rows"] == 2
+
+
+# ---------------------------------------------------------------------------
+# skip-if-staged feature
+# ---------------------------------------------------------------------------
+
+
+def _make_table_source(
+    registry: ProtocolRegistry,
+    *,
+    entry_id: str = "sis-bulk",
+    name: str = "georisques",
+) -> "_StaticSource":
+    return _StaticSource(
+        SourceEntryRef(
+            id=entry_id,
+            name="SIS bulk",
+            access=AccessSpec(
+                protocol=AccessProtocol.TABLE_FILE,
+                endpoint="https://host.example.org/sis.csv",
+                params={"table_format": "csv"},
+            ),
+            payload=Payload.TABLE,
+            metadata={"base_key": "sis", "data_format": "csv"},
+        ),
+        registry=registry,
+        name=name,
+    )
+
+
+def _make_json_gz_source(name: str = "cadastre") -> "_StaticSource":
+    return _StaticSource(
+        SourceEntryRef(
+            id="parcelles_bulk",
+            name="Parcelles bulk",
+            access=AccessSpec(
+                protocol=AccessProtocol.DOWNLOAD,
+                endpoint=(
+                    "https://cadastre.data.gouv.fr/data/etalab-cadastre/latest/"
+                    "geojson/departements/63/cadastre-63-parcelles.json.gz"
+                ),
+                params={"departement": "63"},
+                format="application/geo+json+gzip",
+            ),
+            payload=Payload.VECTOR,
+            metadata={"base_key": "parcelles", "archive_format": "json.gz"},
+        ),
+        name=name,
+    )
+
+
+# (a) Default (skip_if_staged=False) — no exists call, behaviour unchanged.
+def test_skip_if_staged_default_does_not_call_exists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gispulse.core.bulk_runner import BulkIngestRunner
+
+    _patch_duckdb(monkeypatch)
+    fetcher = _FakeTableFetcher()
+    registry = ProtocolRegistry()
+    registry.register(fetcher)
+    storage = _FakeStorage()
+    source = _make_table_source(registry)
+
+    result = BulkIngestRunner(
+        registry=registry,
+        storage=storage,
+        bucket="gispulse",
+        # skip_if_staged NOT set — default False
+    ).run_entry(source, "sis-bulk", revision="rev1")
+
+    assert not result.skipped
+    assert storage.exists_calls == []  # exists must not be consulted
+    assert len(fetcher.calls) == 1  # nominal path executed
+
+
+# (b) skip_if_staged=True + object present → skipped=True, no fetch/upload.
+def test_skip_if_staged_present_skips_fetch_and_upload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gispulse.core.bulk_runner import BulkIngestRunner
+
+    executed = _patch_duckdb(monkeypatch)
+    fetcher = _FakeTableFetcher()
+    registry = ProtocolRegistry()
+    registry.register(fetcher)
+    stage_key = "stage/georisques/sis-bulk/millesime=rev1/national/sis.parquet"
+    storage = _FakeStorage(existing_keys={stage_key})
+    source = _make_table_source(registry)
+
+    result = BulkIngestRunner(
+        registry=registry,
+        storage=storage,
+        bucket="gispulse",
+        skip_if_staged=True,
+    ).run_entry(source, "sis-bulk", revision="rev1")
+
+    assert result.skipped is True
+    assert result.manifest["skipped"] is True
+    assert result.manifest["reason"] == "stage_exists"
+    assert result.manifest["status"] == "skipped"
+    assert result.fetch_result.reference == f"s3://gispulse/{stage_key}"
+    assert fetcher.calls == []  # no fetch
+    assert storage.uploads == []  # no upload
+    assert executed == []  # no DuckDB
+    assert storage.exists_calls == [stage_key]
+
+
+# (c) skip_if_staged=True + object absent → nominal path executed.
+def test_skip_if_staged_absent_runs_nominal_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gispulse.core.bulk_runner import BulkIngestRunner
+
+    executed = _patch_duckdb(monkeypatch)
+    fetcher = _FakeTableFetcher()
+    registry = ProtocolRegistry()
+    registry.register(fetcher)
+    storage = _FakeStorage(existing_keys=set())  # nothing staged
+    source = _make_table_source(registry)
+
+    result = BulkIngestRunner(
+        registry=registry,
+        storage=storage,
+        bucket="gispulse",
+        skip_if_staged=True,
+    ).run_entry(source, "sis-bulk", revision="rev1")
+
+    assert result.skipped is False
+    assert len(fetcher.calls) == 1
+    assert len(executed) == 1  # DuckDB COPY ran
+
+
+# (d) force=True bypasses skip even when stage exists.
+def test_skip_if_staged_force_overrides_skip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gispulse.core.bulk_runner import BulkIngestRunner
+
+    executed = _patch_duckdb(monkeypatch)
+    fetcher = _FakeTableFetcher()
+    registry = ProtocolRegistry()
+    registry.register(fetcher)
+    stage_key = "stage/georisques/sis-bulk/millesime=rev1/national/sis.parquet"
+    storage = _FakeStorage(existing_keys={stage_key})
+    source = _make_table_source(registry)
+
+    result = BulkIngestRunner(
+        registry=registry,
+        storage=storage,
+        bucket="gispulse",
+        skip_if_staged=True,
+    ).run_entry(source, "sis-bulk", revision="rev1", force=True)
+
+    assert result.skipped is False
+    assert len(fetcher.calls) == 1
+    assert len(executed) == 1
+    assert storage.exists_calls == []  # exists not consulted when force=True
+
+
+# (e) exists raises → warning logged, nominal path executed.
+def test_skip_if_staged_exists_raises_falls_back_to_nominal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gispulse.core.bulk_runner import BulkIngestRunner
+
+    executed = _patch_duckdb(monkeypatch)
+    fetcher = _FakeTableFetcher()
+    registry = ProtocolRegistry()
+    registry.register(fetcher)
+    storage = _FakeStorage(exists_raises=OSError("network error"))
+    source = _make_table_source(registry)
+
+    # Should not raise — warning is swallowed, nominal path runs.
+    result = BulkIngestRunner(
+        registry=registry,
+        storage=storage,
+        bucket="gispulse",
+        skip_if_staged=True,
+    ).run_entry(source, "sis-bulk", revision="rev1")
+
+    assert result.skipped is False
+    assert len(fetcher.calls) == 1  # nominal ran
+    assert len(executed) == 1
+
+
+# (f) Spatial gzip archive: skip works when stage exists.
+def test_skip_if_staged_json_gz_present_skips_download(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pytest.FixtureDef,
+) -> None:
+    from gispulse.core.bulk_runner import BulkIngestRunner
+
+    requested = _patch_http_stream(monkeypatch, b"would-not-be-read")
+    stage_key = (
+        "stage/cadastre/parcelles_bulk/millesime=smoke/departement=63/parcelles.parquet"
+    )
+    storage = _FakeStorage(existing_keys={stage_key})
+    source = _make_json_gz_source()
+
+    result = BulkIngestRunner(
+        storage=storage,
+        bucket="gispulse",
+        skip_if_staged=True,
+    ).run_entry(source, "parcelles_bulk", departement="63", revision="smoke")
+
+    assert result.skipped is True
+    assert result.manifest["skipped"] is True
+    assert result.manifest["reason"] == "stage_exists"
+    assert result.fetch_result.reference == f"s3://gispulse/{stage_key}"
+    assert requested == []  # no HTTP download
+    assert storage.uploads == []  # no upload
+    assert storage.exists_calls == [stage_key]
+
+
+# (f-2) ZIP archive: no skip even when stage key would match (content-determined keys).
+def test_skip_if_staged_zip_archive_never_skips(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gispulse.core.bulk_runner import BulkIngestRunner
+
+    payload = _zip_bytes({"tri/tri_2020.shp": b"fake-shp"})
+    _patch_http_stream(monkeypatch, payload)
+    _patch_duckdb(monkeypatch)
+    # Pre-populate *any* key to prove skip is not attempted for ZIP archives.
+    storage = _FakeStorage(existing_keys={"stage/georisques/tri-bulk/millesime=2020/departement=69/tri_2020.parquet"})
+    source = _StaticSource(
+        SourceEntryRef(
+            id="tri-bulk",
+            name="TRI bulk",
+            access=AccessSpec(
+                protocol=AccessProtocol.DOWNLOAD,
+                endpoint="https://host.example.org/tri_2020_sig_di_{departement}.zip",
+                params={"departement": "69"},
+                format="application/zip",
+            ),
+            payload=Payload.VECTOR,
+            metadata={
+                "base_key": "tri_2020",
+                "archive_format": "zip",
+                "data_format": "shapefile",
+            },
+        ),
+        name="georisques",
+    )
+
+    result = BulkIngestRunner(
+        storage=storage,
+        bucket="gispulse",
+        skip_if_staged=True,
+    ).run_entry(source, "tri-bulk", departement="69", revision="2020")
+
+    # ZIP archive must always be processed — exists never called.
+    assert result.skipped is False
+    assert storage.exists_calls == []
+    assert len(storage.uploads) >= 1  # raw upload happened
+
+
+# (P2a) _create_s3_storage raises when self._storage is None → warning + nominal.
+def test_skip_if_staged_create_storage_raises_falls_back_to_nominal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gispulse.core import bulk_runner
+    from gispulse.core.bulk_runner import BulkIngestRunner
+
+    executed = _patch_duckdb(monkeypatch)
+    fetcher = _FakeTableFetcher()
+    registry = ProtocolRegistry()
+    registry.register(fetcher)
+
+    # _create_s3_storage raises — simulates missing S3 config.
+    monkeypatch.setattr(
+        bulk_runner,
+        "_create_s3_storage",
+        lambda bucket: (_ for _ in ()).throw(RuntimeError("no S3 endpoint")),
+    )
+
+    source = _make_table_source(registry)
+
+    # No storage= passed → runner would call _create_s3_storage for the check.
+    # It must catch the exception, warn, and proceed with the nominal path.
+    # But the nominal path also needs storage for write_table_raw — since
+    # write_table_raw=False (default), the nominal path only uses DuckDB COPY
+    # and does NOT call _create_s3_storage again.  So we expect success.
+    result = BulkIngestRunner(
+        registry=registry,
+        # storage=None intentionally — forces _create_s3_storage in skip check
+        bucket="gispulse",
+        skip_if_staged=True,
+    ).run_entry(source, "sis-bulk", revision="rev1")
+
+    assert result.skipped is False
+    assert len(fetcher.calls) == 1  # nominal ran
+    assert len(executed) == 1
+
+
+# (P3a) skip with partition= — stage key checked includes partition segment.
+def test_skip_if_staged_partition_key_includes_partition(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gispulse.core.bulk_runner import BulkIngestRunner
+
+    _patch_duckdb(monkeypatch)
+    fetcher = _FakeTableFetcher()
+    registry = ProtocolRegistry()
+    registry.register(fetcher)
+    # Key with partition segment as produced by bulk_s3_key.
+    stage_key = (
+        "stage/georisques/sis-bulk/millesime=rev1/"
+        "departement=63/partition=DU_200046977/sis.parquet"
+    )
+    storage = _FakeStorage(existing_keys={stage_key})
+    source = _StaticSource(
+        SourceEntryRef(
+            id="sis-bulk",
+            name="SIS bulk",
+            access=AccessSpec(
+                protocol=AccessProtocol.TABLE_FILE,
+                endpoint="https://host.example.org/sis.csv",
+                params={"table_format": "csv"},
+            ),
+            payload=Payload.TABLE,
+            metadata={"base_key": "sis", "data_format": "csv"},
+        ),
+        registry=registry,
+        name="georisques",
+    )
+
+    result = BulkIngestRunner(
+        registry=registry,
+        storage=storage,
+        bucket="gispulse",
+        skip_if_staged=True,
+    ).run_entry(
+        source,
+        "sis-bulk",
+        departement="63",
+        partition="DU_200046977",
+        revision="rev1",
+    )
+
+    assert result.skipped is True
+    # The key consulted must carry the partition segment.
+    assert storage.exists_calls == [stage_key]
+    assert fetcher.calls == []
+
+
+# (P3b) skipped result carries the same manifest fields as nominal for consumers
+# (e.g. scripts reading manifest["stage_s3_uri"]).
+def test_skip_if_staged_result_manifest_compatible_with_nominal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gispulse.core.bulk_runner import BulkIngestRunner
+
+    executed = _patch_duckdb(monkeypatch)
+    fetcher = _FakeTableFetcher()
+    registry = ProtocolRegistry()
+    registry.register(fetcher)
+
+    stage_key = "stage/georisques/sis-bulk/millesime=rev1/national/sis.parquet"
+    raw_key = "raw/georisques/sis-bulk/millesime=rev1/national/sis.csv"
+    storage_skip = _FakeStorage(existing_keys={stage_key})
+    storage_nominal = _FakeStorage(existing_keys=set())
+    source_skip = _make_table_source(registry)
+    source_nominal = _make_table_source(registry)
+
+    skipped_result = BulkIngestRunner(
+        registry=registry,
+        storage=storage_skip,
+        bucket="gispulse",
+        skip_if_staged=True,
+    ).run_entry(source_skip, "sis-bulk", revision="rev1")
+
+    # Re-register fetcher for the nominal run (calls list reused).
+    nominal_result = BulkIngestRunner(
+        registry=registry,
+        storage=storage_nominal,
+        bucket="gispulse",
+        skip_if_staged=True,
+    ).run_entry(source_nominal, "sis-bulk", revision="rev1")
+
+    # Both manifests must expose the same essential keys for downstream callers.
+    for key in ("stage_s3_uri", "raw_s3_uri", "source", "entry", "revision", "status"):
+        assert key in skipped_result.manifest, f"skipped manifest missing {key!r}"
+        assert key in nominal_result.manifest, f"nominal manifest missing {key!r}"
+
+    # Values must be consistent (same URIs).
+    assert skipped_result.manifest["stage_s3_uri"] == f"s3://gispulse/{stage_key}"
+    assert skipped_result.manifest["raw_s3_uri"] == f"s3://gispulse/{raw_key}"
+    assert skipped_result.manifest["status"] == "skipped"
+    assert nominal_result.manifest["status"] == "success"
+
+    # fetch_result.reference points to stage URI in both cases.
+    assert skipped_result.fetch_result.reference == skipped_result.manifest["stage_s3_uri"]
+    assert nominal_result.fetch_result.reference == nominal_result.manifest["stage_s3_uri"]
+
+    # Skipped result has no DuckDB/fetch side effects.
+    assert fetcher.calls  # nominal fetched
+    assert executed  # nominal ran DuckDB


### PR DESCRIPTION
## Problem

Interrupted national bulk runs re-download and re-stage every entry from scratch — hours of redundant fetch/upload when most stage objects already exist in S3 for the same revision.

## What

- **`BulkIngestRunner(skip_if_staged=True)`** — opt-in: when the stage object already exists for the same revision token, the fetch/upload is short-circuited. Default `False` keeps current behaviour byte-for-byte (no `exists()` call, no extra storage instantiation — covered by a dedicated test).
- **`force=True`** on `run_entry`/`run_registered` bypasses the skip for one call.
- **The check runs where the stage keys are computed** (they are not all known before dispatch): `_run_table_file`, and the spatial-gzip branch of `_run_download_archive` whose stage key is deterministic before download. ZIP/7z archives have member-determined stage keys and are **always re-fetched** — documented rather than guessed.
- **The skip is an optimisation, never a failure cause**: in `_run_table_file` storage creation and the `exists()` call are both inside the guard; in the spatial-gzip branch the check reuses the nominal-path storage (required for the raw upload regardless, so its failure is not a skip-introduced failure mode). Any check error logs `bulk_ingest.skip_check_failed` and falls through to the nominal path. (With the real S3 backend a failed check may also surface as a silent `False` — pre-existing `S3Storage.exists` semantics, left untouched; both shapes degrade safely to the nominal path, documented on the parameter.)
- **Skipped results stay consumable downstream**: `BulkIngestResult` gains `skipped: bool = False` (frozen dataclass, backward-compatible) and the skipped manifest carries the same fields as the nominal path (`stage_s3_uri`, `raw_s3_uri`, `revision`, …) — proven by a nominal-vs-skipped compatibility test.

## Tests

10 new tests (19 total in the runner suite, 46 with neighbours): default-off behaviour, skip hit (zero HTTP/upload/DuckDB asserted on fakes), miss, force override, storage-creation failure fallback, exists-failure fallback, partition-qualified key check, gzip skip, ZIP never skipped, downstream manifest compatibility. Ruff clean.

Independent of the open PR queue (#419–#432) — no shared files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
