### PR TITLE
fix(orchestration): scheduled pipelines actually execute their pipeline_config

### DIFF
--- a/src/gispulse/adapters/http/routers/schedules_router.py
+++ b/src/gispulse/adapters/http/routers/schedules_router.py
@@ -43,7 +43,16 @@ class ScheduleCreate(BaseModel):
     )
     pipeline_config: dict[str, Any] = Field(
         default_factory=dict,
-        description="Pipeline configuration (rules, input, output).",
+        description="Pipeline configuration (v2 format with steps).",
+    )
+    dataset_id: str | None = Field(
+        default=None,
+        description=(
+            "UUID of the Dataset to use as input for this pipeline. "
+            "Required when the pipeline_config steps need real geodata. "
+            "If omitted the scheduled job will fail with an explicit error "
+            "rather than silently running on an empty GeoDataFrame."
+        ),
     )
     enabled: bool = True
     created_by: str | None = None
@@ -55,6 +64,7 @@ class ScheduleUpdate(BaseModel):
     name: str | None = None
     cron_expression: str | None = None
     pipeline_config: dict[str, Any] | None = None
+    dataset_id: str | None = None
     enabled: bool | None = None
 
 
@@ -65,6 +75,7 @@ class ScheduleResponse(BaseModel):
     name: str
     cron_expression: str
     pipeline_config: dict[str, Any]
+    dataset_id: str | None = None
     enabled: bool
     last_run: datetime | None = None
     next_run: datetime | None = None
@@ -101,6 +112,7 @@ def _schedule_to_response(sp) -> ScheduleResponse:
         name=sp.name,
         cron_expression=sp.cron_expression,
         pipeline_config=sp.pipeline_config,
+        dataset_id=str(sp.dataset_id) if sp.dataset_id is not None else None,
         enabled=sp.enabled,
         last_run=sp.last_run,
         next_run=sp.next_run,
@@ -123,6 +135,8 @@ async def create_schedule(
     """Create a new scheduled pipeline (Pro tier)."""
     _require_pro()
 
+    from uuid import UUID as _UUID
+
     from gispulse.orchestration.scheduler import ScheduledPipeline, validate_cron_expression
 
     # Validate cron expression early for a clear 422 error
@@ -131,10 +145,22 @@ async def create_schedule(
     except (ValueError, ImportError) as exc:
         raise HTTPException(status_code=422, detail=str(exc))
 
+    # Parse dataset_id string to UUID (Pydantic accepts str for flexibility)
+    parsed_dataset_id = None
+    if body.dataset_id is not None:
+        try:
+            parsed_dataset_id = _UUID(body.dataset_id)
+        except ValueError:
+            raise HTTPException(
+                status_code=422,
+                detail=f"dataset_id is not a valid UUID: {body.dataset_id!r}",
+            )
+
     sp = ScheduledPipeline(
         name=body.name,
         cron_expression=body.cron_expression,
         pipeline_config=body.pipeline_config,
+        dataset_id=parsed_dataset_id,
         enabled=body.enabled,
         created_by=body.created_by,
     )
@@ -184,12 +210,24 @@ async def update_schedule(
         except (ValueError, ImportError) as exc:
             raise HTTPException(status_code=422, detail=str(exc))
 
+    patch_dataset_id = None
+    if body.dataset_id is not None:
+        from uuid import UUID as _UUID2
+        try:
+            patch_dataset_id = _UUID2(body.dataset_id)
+        except ValueError:
+            raise HTTPException(
+                status_code=422,
+                detail=f"dataset_id is not a valid UUID: {body.dataset_id!r}",
+            )
+
     updated = await scheduler.update(
         schedule_id,
         cron_expression=body.cron_expression,
         enabled=body.enabled,
         pipeline_config=body.pipeline_config,
         name=body.name,
+        dataset_id=patch_dataset_id if body.dataset_id is not None else None,
     )
     if updated is None:
         raise HTTPException(status_code=404, detail=f"Schedule '{schedule_id}' not found")

--- a/src/gispulse/orchestration/runner.py
+++ b/src/gispulse/orchestration/runner.py
@@ -20,6 +20,9 @@ from gispulse.core.models import Job, JobStatus, Rule
 from gispulse.persistence.repository import Repository
 from gispulse.rules.engine import RuleEngine
 
+# Key injected by PipelineScheduler._enqueue_pipeline into job.parameters.
+_PIPELINE_CONFIG_KEY = "pipeline_config"
+
 log = get_logger(__name__)
 _metrics = MetricsCollector.get()
 
@@ -89,6 +92,20 @@ class JobRunner:
         attempt = 0
         last_exc: Exception | None = None
 
+        # Dispatch: pipeline_config (scheduler path) takes priority over rule_ids.
+        # If both are present, pipeline_config wins and a warning is emitted so the
+        # discrepancy is visible in logs. This is the safer choice: the scheduler
+        # never sets rule_ids, and a caller that sets both has an ambiguity that
+        # must not be silently resolved in the wrong direction.
+        use_pipeline_config = _PIPELINE_CONFIG_KEY in job.parameters
+        if use_pipeline_config and job.parameters.get("rule_ids"):
+            log.warning(
+                "job_pipeline_config_takes_priority",
+                job_id=str(job.id),
+                detail="Both pipeline_config and rule_ids are present; "
+                       "pipeline_config takes priority and rule_ids is ignored.",
+            )
+
         while attempt <= max_retries:
             attempt += 1
             job.status = JobStatus.RUNNING
@@ -97,31 +114,41 @@ class JobRunner:
 
             try:
                 with _metrics.timer("job_duration_seconds"):
-                    requested_ids = job.parameters.get("rule_ids", [])
-                    rules = self._resolve_rules(requested_ids)
-
-                    if requested_ids and not rules:
-                        raise ValueError(
-                            f"Job {job.id}: none of the {len(requested_ids)} "
-                            f"requested rule(s) could be resolved"
+                    if use_pipeline_config:
+                        result_gdf = self._execute_pipeline_config(
+                            job, gdf, timeout
                         )
+                        steps_count = len(
+                            job.parameters[_PIPELINE_CONFIG_KEY].get("steps", [])
+                        )
+                    else:
+                        requested_ids = job.parameters.get("rule_ids", [])
+                        rules = self._resolve_rules(requested_ids)
 
-                    result_gdf = self._execute_with_timeout(rules, gdf, timeout, layer_resolver=layer_resolver)
+                        if requested_ids and not rules:
+                            raise ValueError(
+                                f"Job {job.id}: none of the {len(requested_ids)} "
+                                f"requested rule(s) could be resolved"
+                            )
+
+                        result_gdf = self._execute_with_timeout(rules, gdf, timeout, layer_resolver=layer_resolver)
+                        steps_count = len(rules)
+                        if len(rules) < len(requested_ids):
+                            log.warning(
+                                "job_rules_missing",
+                                job_id=str(job.id),
+                                requested=len(requested_ids),
+                                resolved=len(rules),
+                            )
+
                 job.status = JobStatus.COMPLETED
                 job.completed_at = datetime.now(timezone.utc)
                 _metrics.inc("jobs_total")
-                if len(rules) < len(requested_ids):
-                    log.warning(
-                        "job_rules_missing",
-                        job_id=str(job.id),
-                        requested=len(requested_ids),
-                        resolved=len(rules),
-                    )
                 log.info(
                     "job_completed",
                     job_id=str(job.id),
                     job_name=job.name,
-                    rules_applied=len(rules),
+                    rules_applied=steps_count,
                     attempt=attempt,
                 )
                 return job, result_gdf
@@ -139,6 +166,7 @@ class JobRunner:
         # All retries exhausted
         job.status = JobStatus.FAILED
         job.completed_at = datetime.now(timezone.utc)
+        job.error_message = str(last_exc)
         _metrics.inc("jobs_total")
         _metrics.inc("jobs_failed")
         log.error(
@@ -150,17 +178,151 @@ class JobRunner:
         )
         raise last_exc  # type: ignore[misc]
 
+    def _execute_pipeline_config(
+        self,
+        job: Job,
+        gdf: gpd.GeoDataFrame,
+        timeout: int,
+    ) -> gpd.GeoDataFrame:
+        """Execute a job whose parameters contain a ``pipeline_config`` dict.
+
+        Validates the dict against SCHEMA_V2 (the canonical path used by
+        ``POST /pipelines/validate`` and ``load_pipeline``), parses it into a
+        :class:`~gispulse.core.pipeline.PipelineSpec`, then delegates to
+        :class:`~gispulse.orchestration.pipeline_executor.PipelineExecutor`.
+        The last step's output GeoDataFrame is returned.
+
+        Validation rules enforced here (in addition to the JSON Schema):
+        - Must be a dict (not a list/v1, not a string).
+        - ``version`` must be 2; v1 lists and v3 manifests are rejected with
+          a message naming the received version.
+        - At least one enabled step must be present; a spec that would run
+          zero steps is rejected (silent no-op is the bug we are fixing).
+        - Input GeoDataFrame must be non-empty when the spec has runnable steps
+          and no dataset_id was set on the job (guards against the scheduler
+          firing on an empty GDF because dataset_id was not wired).
+
+        Raises:
+            ValueError: Malformed config, wrong version, zero runnable steps,
+                        or empty input — caught by the caller's retry/FAILED path.
+
+        Note on timeout behaviour:
+            ``future.result(timeout)`` raises ``concurrent.futures.TimeoutError``
+            when the step computation exceeds ``timeout`` seconds. We then call
+            ``executor.shutdown(wait=False, cancel_futures=True)`` to avoid
+            blocking the calling thread indefinitely (the worker thread itself
+            may still linger — same known limitation as ``_execute_with_timeout``
+            on the rule_ids path; a proper fix requires a process-level interrupt
+            which is out of scope for this PR).
+        """
+        from gispulse.core.pipeline import _parse_v2
+        from gispulse.core.pipeline_schema import validate_pipeline_json
+        from gispulse.orchestration.pipeline_executor import PipelineExecutor
+
+        raw_config = job.parameters[_PIPELINE_CONFIG_KEY]
+
+        # --- Type guard ---------------------------------------------------
+        if not isinstance(raw_config, dict):
+            raise ValueError(
+                f"Job {job.id}: pipeline_config must be a v2 dict, "
+                f"got {type(raw_config).__name__}"
+            )
+
+        # --- Version guard (catch v3 manifests, v1 lists stored as dicts) --
+        received_version = raw_config.get("version")
+        if received_version != 2:
+            raise ValueError(
+                f"Job {job.id}: pipeline_config must be version 2, "
+                f"got version={received_version!r}. "
+                "Use a v2 pipeline spec ({{\"version\": 2, \"steps\": [...]}}). "
+                "v3 manifests and v1 rule lists are not accepted here."
+            )
+
+        # --- Canonical JSON Schema validation (same as load_pipeline) ------
+        errors = validate_pipeline_json(raw_config)
+        if errors:
+            summary = "; ".join(errors[:5])
+            if len(errors) > 5:
+                summary += f" … and {len(errors) - 5} more"
+            raise ValueError(
+                f"Job {job.id}: pipeline_config schema validation failed — {summary}"
+            )
+
+        # --- Parse ---------------------------------------------------------
+        try:
+            spec = _parse_v2(raw_config)
+        except Exception as exc:
+            raise ValueError(
+                f"Job {job.id}: pipeline_config could not be parsed — {exc}"
+            ) from exc
+
+        # --- Zero runnable steps guard ------------------------------------
+        runnable = spec.enabled_steps
+        if not runnable:
+            raise ValueError(
+                f"Job {job.id}: pipeline_config produced no runnable steps "
+                "(all steps are disabled or the steps list is empty). "
+                "At least one enabled capability step is required."
+            )
+
+        # --- Empty-input guard (P1b companion) ----------------------------
+        if gdf.empty and job.dataset_id is None:
+            raise ValueError(
+                f"Job {job.id}: scheduled pipeline has no input dataset — "
+                "set dataset_id on the ScheduledPipeline so the worker can "
+                "load real data before executing the pipeline."
+            )
+
+        # --- Execute with timeout -----------------------------------------
+        executor = PipelineExecutor()
+        pool = ThreadPoolExecutor(max_workers=1)
+        try:
+            future = pool.submit(executor.execute, spec, {"input": gdf})
+            results = future.result(timeout=timeout)
+        except FuturesTimeoutError:
+            # Avoid blocking the calling thread in pool.shutdown(wait=True).
+            # The worker thread may still linger (same limitation as
+            # _execute_with_timeout on the rule_ids path).
+            pool.shutdown(wait=False, cancel_futures=True)
+            raise
+        finally:
+            # Normal completion: shutdown is quick (worker already done).
+            # Timeout path already called shutdown above; calling it again
+            # with wait=False is a no-op on an already-shutdown pool.
+            pool.shutdown(wait=False)
+
+        # Return the last step's output (linear pipeline convention).
+        last_step_gdf = list(results.values())[-1]
+        return last_step_gdf
+
     def _execute_with_timeout(
         self, rules: list[Rule], gdf: gpd.GeoDataFrame, timeout: int,
         layer_resolver: Any | None = None,
     ) -> gpd.GeoDataFrame:
-        """Execute rule pipeline with a timeout (in seconds)."""
-        with ThreadPoolExecutor(max_workers=1) as pool:
+        """Execute rule pipeline with a timeout (in seconds).
+
+        Note on timeout behaviour:
+            When ``future.result(timeout)`` raises ``TimeoutError``, we call
+            ``pool.shutdown(wait=False, cancel_futures=True)`` to avoid
+            blocking the calling thread in ``ThreadPoolExecutor.__exit__``
+            (which calls ``shutdown(wait=True)`` and would hang until the
+            stuck worker thread finally returns). The worker thread itself
+            may still linger until the GIL releases — this is a known
+            limitation of CPython thread cancellation and is out of scope
+            for this PR.
+        """
+        pool = ThreadPoolExecutor(max_workers=1)
+        try:
             future = pool.submit(
                 self.rule_engine.apply_all, rules, gdf,
                 layer_resolver=layer_resolver,
             )
             return future.result(timeout=timeout)
+        except FuturesTimeoutError:
+            pool.shutdown(wait=False, cancel_futures=True)
+            raise
+        finally:
+            pool.shutdown(wait=False)
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/src/gispulse/orchestration/scheduler.py
+++ b/src/gispulse/orchestration/scheduler.py
@@ -40,7 +40,11 @@ class ScheduledPipeline:
         id:              Unique identifier.
         name:            Human-readable schedule name.
         cron_expression: Standard cron expression (e.g. ``"0 */6 * * *"``).
-        pipeline_config: Dict describing the pipeline (rules, input, output).
+        pipeline_config: Dict describing the pipeline (v2 format with steps).
+        dataset_id:      UUID of the Dataset the pipeline reads as input.
+                         Optional — if None, the scheduled job runs on an empty
+                         GeoDataFrame and the runner raises an explicit error
+                         rather than silently producing no output.
         enabled:         Whether this schedule is active.
         last_run:        Timestamp of the last execution (None if never run).
         next_run:        Computed next execution time.
@@ -51,6 +55,7 @@ class ScheduledPipeline:
     name: str = ""
     cron_expression: str = "0 * * * *"
     pipeline_config: dict[str, Any] = field(default_factory=dict)
+    dataset_id: UUID | None = None
     enabled: bool = True
     last_run: datetime | None = None
     next_run: datetime | None = None
@@ -219,6 +224,7 @@ class PipelineScheduler:
         enabled: bool | None = None,
         pipeline_config: dict[str, Any] | None = None,
         name: str | None = None,
+        dataset_id: UUID | None = None,
     ) -> ScheduledPipeline | None:
         """Update an existing schedule.
 
@@ -244,6 +250,9 @@ class PipelineScheduler:
 
         if name is not None:
             schedule.name = name
+
+        if dataset_id is not None:
+            schedule.dataset_id = dataset_id
 
         # Persist
         if self._schedule_repo is not None:
@@ -326,9 +335,17 @@ class PipelineScheduler:
                     )
 
     async def _enqueue_pipeline(self, schedule: ScheduledPipeline) -> str:
-        """Create a Job from the schedule's pipeline_config and enqueue it."""
+        """Create a Job from the schedule's pipeline_config and enqueue it.
+
+        ``dataset_id`` is forwarded from the schedule so the worker can load
+        the right GeoDataFrame before handing it to the runner.  Without it
+        ``JobWorker._load_dataset`` returns an empty GeoDataFrame and the
+        runner raises an explicit error (rather than silently executing on
+        zero features).
+        """
         job = Job(
             name=f"scheduled:{schedule.name}",
+            dataset_id=schedule.dataset_id,
             parameters={
                 "schedule_id": str(schedule.id),
                 "pipeline_config": schedule.pipeline_config,

--- a/src/gispulse/persistence/schedule_repository.py
+++ b/src/gispulse/persistence/schedule_repository.py
@@ -32,12 +32,20 @@ CREATE TABLE IF NOT EXISTS scheduled_pipelines (
     name TEXT NOT NULL DEFAULT '',
     cron_expression TEXT NOT NULL DEFAULT '0 * * * *',
     pipeline_config TEXT NOT NULL DEFAULT '{}',
+    dataset_id TEXT,
     enabled INTEGER NOT NULL DEFAULT 1,
     last_run TEXT,
     next_run TEXT,
     created_by TEXT
 )
 """
+
+# Idempotent migration: add dataset_id to existing tables that pre-date this
+# column.  SQLite does not support IF NOT EXISTS on ALTER TABLE ADD COLUMN, so
+# we swallow the "duplicate column" error instead.
+_MIGRATE_ADD_DATASET_ID = (
+    "ALTER TABLE scheduled_pipelines ADD COLUMN dataset_id TEXT"
+)
 
 
 class ScheduleRepository:
@@ -51,6 +59,12 @@ class ScheduleRepository:
         self._lock = threading.Lock()
         self._db_path.parent.mkdir(parents=True, exist_ok=True)
         self._execute(_CREATE_TABLE_SQL)
+        # Idempotent migration: add dataset_id on existing DBs.
+        try:
+            self._execute(_MIGRATE_ADD_DATASET_ID)
+        except Exception:
+            # Column already exists — safe to ignore.
+            pass
 
     # ------------------------------------------------------------------
     # Connection helpers
@@ -84,6 +98,7 @@ class ScheduleRepository:
             "name": sp.name,
             "cron_expression": sp.cron_expression,
             "pipeline_config": json.dumps(sp.pipeline_config, default=str),
+            "dataset_id": str(sp.dataset_id) if sp.dataset_id is not None else None,
             "enabled": int(sp.enabled),
             "last_run": sp.last_run.isoformat() if sp.last_run else None,
             "next_run": sp.next_run.isoformat() if sp.next_run else None,
@@ -93,11 +108,13 @@ class ScheduleRepository:
     @staticmethod
     def _from_row(row: sqlite3.Row) -> ScheduledPipeline:
         d = dict(row)
+        raw_dataset_id = d.get("dataset_id")
         return ScheduledPipeline(
             id=UUID(d["id"]),
             name=d.get("name", ""),
             cron_expression=d.get("cron_expression", "0 * * * *"),
             pipeline_config=json.loads(d.get("pipeline_config", "{}") or "{}"),
+            dataset_id=UUID(raw_dataset_id) if raw_dataset_id else None,
             enabled=bool(d.get("enabled", 1)),
             last_run=(
                 datetime.fromisoformat(d["last_run"]) if d.get("last_run") else None

--- a/tests/unit/test_orchestration.py
+++ b/tests/unit/test_orchestration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from uuid import uuid4
 
 import geopandas as gpd
@@ -12,6 +13,20 @@ from gispulse.core.models import Job, JobStatus, Rule
 from gispulse.orchestration.runner import JobRunner
 from gispulse.persistence.repository import InMemoryRepository
 from gispulse.rules.engine import RuleEngine
+
+# Minimal v2 pipeline_config dict as produced by the scheduler (_enqueue_pipeline)
+_SCHEDULER_PIPELINE_CONFIG = {
+    "version": 2,
+    "name": "scheduled_filter_pipeline",
+    "steps": [
+        {
+            "id": "step_filter",
+            "type": "capability",
+            "capability": "filter",
+            "params": {"expression": "value > 10"},
+        },
+    ],
+}
 
 
 # ---------------------------------------------------------------------------
@@ -139,3 +154,255 @@ class TestJobRunner:
         assert updated_job.status == JobStatus.COMPLETED
         assert len(result) == 2
         assert result.crs.to_epsg() == 3857
+
+
+# ---------------------------------------------------------------------------
+# Tests: pipeline_config path (scheduler-originated jobs)
+# ---------------------------------------------------------------------------
+
+
+class TestJobRunnerPipelineConfig:
+    """Jobs carrying pipeline_config (scheduler path) must execute the pipeline."""
+
+    def test_pipeline_config_steps_are_executed(self, setup_runner, point_gdf):
+        """Core regression: pipeline_config filter step reduces feature count."""
+        runner, _ = setup_runner
+        job = Job(
+            name="scheduled:nightly",
+            parameters={
+                "schedule_id": str(uuid4()),
+                "pipeline_config": _SCHEDULER_PIPELINE_CONFIG,
+                "triggered_by": "scheduler",
+            },
+        )
+        updated_job, result = runner.run(job, point_gdf)
+
+        assert updated_job.status == JobStatus.COMPLETED
+        # filter "value > 10" keeps rows with value=15 and value=25 (point_gdf has 3 rows: 5, 15, 25)
+        assert len(result) == 2, (
+            f"Expected 2 features after filter(value>10) but got {len(result)}. "
+            "pipeline_config steps were silently ignored."
+        )
+
+    def test_pipeline_config_invalid_fails_with_message(self, setup_runner, point_gdf):
+        """pipeline_config with unknown capability → job FAILED, explicit error message."""
+        runner, _ = setup_runner
+        bad_config = {
+            "version": 2,
+            "name": "bad_pipeline",
+            "steps": [
+                {
+                    "id": "bad_step",
+                    "type": "capability",
+                    "capability": "nonexistent_capability_xyz",
+                    "params": {},
+                },
+            ],
+        }
+        job = Job(
+            name="scheduled:bad",
+            parameters={
+                "pipeline_config": bad_config,
+                "triggered_by": "scheduler",
+            },
+        )
+        with pytest.raises(Exception):
+            runner.run(job, point_gdf)
+
+        assert job.status == JobStatus.FAILED
+        assert job.error_message  # must not be empty
+
+    def test_both_pipeline_config_and_rule_ids_pipeline_config_wins(
+        self, setup_runner, point_gdf
+    ):
+        """When both pipeline_config and rule_ids are present, pipeline_config takes priority."""
+        runner, repo = setup_runner
+        rule = Rule(
+            name="reproject_rule",
+            capability="reproject",
+            config={"target_crs": "EPSG:3857"},
+        )
+        repo.save(rule)
+
+        job = Job(
+            name="ambiguous_job",
+            parameters={
+                # rule_ids would reproject to EPSG:3857
+                "rule_ids": [str(rule.id)],
+                # pipeline_config filters — if it wins, crs stays 4326 and rows shrink
+                "pipeline_config": _SCHEDULER_PIPELINE_CONFIG,
+                "triggered_by": "scheduler",
+            },
+        )
+        updated_job, result = runner.run(job, point_gdf)
+
+        assert updated_job.status == JobStatus.COMPLETED
+        # pipeline_config (filter) wins: 2 rows, CRS unchanged (4326)
+        assert len(result) == 2
+        assert result.crs.to_epsg() == 4326
+
+    def test_rule_ids_path_unchanged(self, setup_runner, point_gdf):
+        """Existing rule_ids path is unaffected by the fix."""
+        runner, repo = setup_runner
+        rule = Rule(
+            name="filter_rule",
+            capability="filter",
+            config={"expression": "value > 10"},
+        )
+        repo.save(rule)
+        job = Job(
+            name="rule_ids_job",
+            parameters={"rule_ids": [str(rule.id)]},
+        )
+        updated_job, result = runner.run(job, point_gdf)
+        assert updated_job.status == JobStatus.COMPLETED
+        assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# Tests: P1a — validation guards in _execute_pipeline_config
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineConfigValidation:
+    """P1a: schema validation, version guard, zero-step guard, empty-input guard."""
+
+    def test_empty_dict_fails_with_message(self, setup_runner, point_gdf):
+        """{} has no version/steps → schema validation → FAILED with message."""
+        runner, _ = setup_runner
+        job = Job(
+            name="sched:empty",
+            parameters={"pipeline_config": {}, "triggered_by": "scheduler"},
+        )
+        with pytest.raises(ValueError, match="version"):
+            runner.run(job, point_gdf)
+        assert job.status == JobStatus.FAILED
+        assert job.error_message
+
+    def test_v3_manifest_rejected_naming_version(self, setup_runner, point_gdf):
+        """A v3 manifest dict → FAILED with message naming version 3."""
+        runner, _ = setup_runner
+        v3_config = {"version": 3, "name": "manifest", "sources": {}}
+        job = Job(
+            name="sched:v3",
+            parameters={"pipeline_config": v3_config, "triggered_by": "scheduler"},
+        )
+        with pytest.raises(ValueError, match="version=3"):
+            runner.run(job, point_gdf)
+        assert job.status == JobStatus.FAILED
+        assert "version=3" in (job.error_message or "")
+
+    def test_v2_all_steps_disabled_fails(self, setup_runner, point_gdf):
+        """v2 spec with all steps disabled → zero runnable steps → FAILED."""
+        runner, _ = setup_runner
+        config = {
+            "version": 2,
+            "name": "disabled_steps",
+            "steps": [
+                {
+                    "id": "step1",
+                    "type": "capability",
+                    "capability": "filter",
+                    "params": {"expression": "value > 0"},
+                    "enabled": False,
+                },
+            ],
+        }
+        job = Job(
+            name="sched:disabled",
+            parameters={"pipeline_config": config, "triggered_by": "scheduler"},
+        )
+        with pytest.raises(ValueError, match="no runnable steps"):
+            runner.run(job, point_gdf)
+        assert job.status == JobStatus.FAILED
+
+    def test_empty_input_gdf_without_dataset_id_fails(self, setup_runner):
+        """pipeline_config job with empty GDF and no dataset_id → FAILED explicit."""
+        runner, _ = setup_runner
+        empty_gdf = gpd.GeoDataFrame({"geometry": []}, crs="EPSG:4326")
+        job = Job(
+            name="sched:no-input",
+            dataset_id=None,
+            parameters={
+                "pipeline_config": _SCHEDULER_PIPELINE_CONFIG,
+                "triggered_by": "scheduler",
+            },
+        )
+        with pytest.raises(ValueError, match="no input dataset"):
+            runner.run(job, empty_gdf)
+        assert job.status == JobStatus.FAILED
+
+    def test_v2_valid_one_step_executes(self, setup_runner, point_gdf):
+        """Positive control: valid v2 1-step pipeline executes correctly."""
+        runner, _ = setup_runner
+        job = Job(
+            name="sched:valid",
+            parameters={
+                "pipeline_config": _SCHEDULER_PIPELINE_CONFIG,
+                "triggered_by": "scheduler",
+            },
+        )
+        updated_job, result = runner.run(job, point_gdf)
+        assert updated_job.status == JobStatus.COMPLETED
+        assert len(result) == 2  # filter value > 10
+
+
+# ---------------------------------------------------------------------------
+# Tests: P2 — timeout does not hang (pipeline_config path and rule_ids path)
+# ---------------------------------------------------------------------------
+
+
+class TestTimeoutNonBlocking:
+    """P2: timeout on both execution paths raises FAILED without blocking."""
+
+    def test_pipeline_config_timeout_raises_and_job_fails(self, setup_runner, point_gdf):
+        """timeout=0 on pipeline_config path → TimeoutError → job FAILED, no hang.
+
+        max_retries=0 prevents a retry from succeeding before the future is
+        submitted (trivial filter can beat a 0-second timeout on a fast host).
+        """
+        runner, _ = setup_runner
+        job = Job(
+            name="sched:timeout",
+            parameters={
+                "pipeline_config": _SCHEDULER_PIPELINE_CONFIG,
+                "triggered_by": "scheduler",
+                "timeout": 0,  # expires immediately
+                "max_retries": 0,
+            },
+        )
+        t0 = time.monotonic()
+        with pytest.raises(Exception):
+            runner.run(job, point_gdf)
+        elapsed = time.monotonic() - t0
+        assert job.status == JobStatus.FAILED
+        # Must return in well under 5 s (not block on pool.shutdown(wait=True))
+        assert elapsed < 4.0, f"Took {elapsed:.1f}s — likely blocking on pool shutdown"
+
+    def test_rule_ids_timeout_raises_and_job_fails(self, setup_runner, point_gdf):
+        """timeout=0 on rule_ids path → TimeoutError → job FAILED, no hang.
+
+        max_retries=0 prevents a retry from succeeding on a trivial fast-path
+        before the executor even touches the thread pool.
+        """
+        runner, repo = setup_runner
+        rule = Rule(
+            name="filter_rule",
+            capability="filter",
+            config={"expression": "value > 10"},
+        )
+        repo.save(rule)
+        job = Job(
+            name="rule:timeout",
+            parameters={
+                "rule_ids": [str(rule.id)],
+                "timeout": 0,
+                "max_retries": 0,
+            },
+        )
+        t0 = time.monotonic()
+        with pytest.raises(Exception):
+            runner.run(job, point_gdf)
+        elapsed = time.monotonic() - t0
+        assert job.status == JobStatus.FAILED
+        assert elapsed < 4.0, f"Took {elapsed:.1f}s — likely blocking on pool shutdown"

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -21,6 +21,20 @@ from gispulse.orchestration.scheduler import (
 )
 from gispulse.persistence.schedule_repository import ScheduleRepository
 
+# Valid v2 pipeline_config for tests that need a real config
+_VALID_PIPELINE_CONFIG = {
+    "version": 2,
+    "name": "test_pipeline",
+    "steps": [
+        {
+            "id": "filter",
+            "type": "capability",
+            "capability": "filter",
+            "params": {"expression": "value > 0"},
+        }
+    ],
+}
+
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -373,3 +387,90 @@ class TestPipelineScheduler:
             assert size == 0
         finally:
             await scheduler.stop()
+
+
+# ---------------------------------------------------------------------------
+# Test: P1b — dataset_id propagation from ScheduledPipeline → Job
+# ---------------------------------------------------------------------------
+
+
+class TestScheduledPipelineDatasetId:
+    """P1b: dataset_id is carried from the schedule through to the enqueued Job."""
+
+    @pytest.fixture(autouse=True)
+    def _set_pro_tier(self):
+        with patch.dict(os.environ, {
+            "GISPULSE_TIER": "pro",
+            "GISPULSE_LICENCE_SKIP_VERIFY": "true",
+            "GISPULSE_LICENSE_KEY": (
+                "eyJvcmciOiAidGVzdCIsICJ0aWVyIjogInBybyIsICJleHAiOiAiMjAzMC0wMS0wMVQwMDowMDowMFoifQ"
+                ".AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+            ),
+        }):
+            yield
+
+    @pytest.mark.asyncio
+    async def test_enqueue_propagates_dataset_id(self):
+        """schedule.dataset_id is forwarded to job.dataset_id when enqueued."""
+        queue = InMemoryJobQueue()
+        dataset_id = uuid4()
+        schedule = ScheduledPipeline(
+            name="with_dataset",
+            cron_expression="* * * * *",
+            pipeline_config=_VALID_PIPELINE_CONFIG,
+            dataset_id=dataset_id,
+        )
+        scheduler = PipelineScheduler(job_queue=queue)
+        await scheduler.add(schedule)
+
+        job_id = await scheduler.run_now(str(schedule.id))
+        assert job_id is not None
+
+        job = await queue.dequeue()
+        assert job is not None
+        assert job.dataset_id == dataset_id
+
+    @pytest.mark.asyncio
+    async def test_enqueue_without_dataset_id_job_has_none(self):
+        """schedule without dataset_id → job.dataset_id is None."""
+        queue = InMemoryJobQueue()
+        schedule = ScheduledPipeline(
+            name="no_dataset",
+            cron_expression="* * * * *",
+            pipeline_config=_VALID_PIPELINE_CONFIG,
+            dataset_id=None,
+        )
+        scheduler = PipelineScheduler(job_queue=queue)
+        await scheduler.add(schedule)
+
+        await scheduler.run_now(str(schedule.id))
+        job = await queue.dequeue()
+        assert job is not None
+        assert job.dataset_id is None
+
+    def test_schedule_repository_persists_dataset_id(self, schedule_repo):
+        """dataset_id round-trips through SQLite save/get."""
+        dataset_id = uuid4()
+        sp = ScheduledPipeline(
+            name="persisted_dataset",
+            cron_expression="0 * * * *",
+            pipeline_config=_VALID_PIPELINE_CONFIG,
+            dataset_id=dataset_id,
+        )
+        schedule_repo.save(sp)
+        retrieved = schedule_repo.get(sp.id)
+        assert retrieved is not None
+        assert retrieved.dataset_id == dataset_id
+
+    def test_schedule_repository_persists_null_dataset_id(self, schedule_repo):
+        """dataset_id=None round-trips correctly (no coercion to str 'None')."""
+        sp = ScheduledPipeline(
+            name="null_dataset",
+            cron_expression="0 * * * *",
+            pipeline_config=_VALID_PIPELINE_CONFIG,
+            dataset_id=None,
+        )
+        schedule_repo.save(sp)
+        retrieved = schedule_repo.get(sp.id)
+        assert retrieved is not None
+        assert retrieved.dataset_id is None

--- a/tests/unit/test_schedules_router.py
+++ b/tests/unit/test_schedules_router.py
@@ -29,6 +29,7 @@ class _FakeScheduledPipeline:
     name: str = ""
     cron_expression: str = ""
     pipeline_config: dict[str, Any] = field(default_factory=dict)
+    dataset_id: UUID | None = None
     enabled: bool = True
     last_run: datetime | None = None
     next_run: datetime | None = None
@@ -46,6 +47,7 @@ class _FakeScheduler:
             name=sp.name,
             cron_expression=sp.cron_expression,
             pipeline_config=sp.pipeline_config,
+            dataset_id=getattr(sp, "dataset_id", None),
             enabled=sp.enabled,
             created_by=getattr(sp, "created_by", None),
         )


### PR DESCRIPTION
Wave 1 of the orchestration chantier. Full description in commit 27a2d10: JobRunner dispatches pipeline_config through the canonical v2 validation (loud failures instead of silent COMPLETED), ScheduledPipeline gains an additive dataset_id wired end-to-end (scheduled jobs previously ran on an empty GeoDataFrame), and the execution timeout no longer hangs the executor shutdown. 164 orchestration tests passing (+11 new), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)