### PR TITLE
fix(cdc): v2.3.0 hardening — pg_notify DELETE/PK (#402), composite PK (#403), docs drift (#404)

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ gispulse/
 
 ## Capabilities
 
-**117 registered capabilities** across 18 categories. Full reference: [capabilities guide](https://imagodata.github.io/gispulse/guide/capabilities).
+**128 registered capabilities** across 18 categories. Full reference: [capabilities guide](https://imagodata.github.io/gispulse/guide/capabilities).
 
 ### Vector — geometry & analysis
 
@@ -536,7 +536,7 @@ GISPULSE_TELEMETRY=0           # Disable via env var (CI-friendly)
 | Module | Status | Notes |
 |---|---|---|
 | Core models | Done | Dataset, Layer, Rule, Job, Artifact, Scenario, Trigger |
-| Vector capabilities | Done | 117 capabilities across 18 categories (geometry, overlay, attributes, classification, clustering, topology, temporal, 3D pointcloud, network), registry + strategy pattern |
+| Vector capabilities | Done | 128 capabilities across 18 categories (geometry, overlay, attributes, classification, clustering, topology, temporal, 3D pointcloud, network), registry + strategy pattern |
 | Rules engine | Done | JSON rules, sequential execution, predicates |
 | DuckDB session | Done | <100ms startup, GPKG native |
 | Multi-format I/O | Done | 13+ read formats, pyogrio |
@@ -547,7 +547,7 @@ GISPULSE_TELEMETRY=0           # Disable via env var (CI-friendly)
 | Portal API | Done | FastAPI, 27 routers, 100+ endpoints |
 | Python SDK | Done | httpx + pydantic, 10 endpoint modules, async client, WebSocket/SSE |
 | QGIS plugin | Done | Dataset browser, jobs, OGC/PostGIS/MVT layer factories |
-| Tauri desktop app | Done | Tauri 2 + React 19 + MapLibre GL JS, splash screen, file import |
+| Tauri desktop app | Beta | Tauri 2 + React 19 + MapLibre GL JS, splash screen, file import — not yet packaged for distribution |
 | ArcGIS Pro add-in | Done | Dockpanes, 3 GP tools |
 | PostGIS + ESB | Done | PostGIS adapter, pg_notify triggers, circuit breaker, DLQ |
 | VPS deploy | Done | Caddy TLS, Prometheus, Grafana, pg-backup |

--- a/src/gispulse/adapters/esb/trigger_manager.py
+++ b/src/gispulse/adapters/esb/trigger_manager.py
@@ -47,17 +47,19 @@ BEGIN
             'trigger_id', '{trigger_id}',
             'table',      TG_TABLE_SCHEMA || '.' || TG_TABLE_NAME,
             'operation',  TG_OP,
-            'row_id',     COALESCE(NEW.id::text, OLD.id::text, ''),
+            'row_id',     {row_id_expr},
             'timestamp',  now()::text
         )::text
     );
-    RETURN NEW;
+    -- AFTER triggers ignore the return value, but DELETE leaves NEW NULL;
+    -- COALESCE keeps the statement valid for all three operations.
+    RETURN COALESCE(NEW, OLD);
 END;
 $$ LANGUAGE plpgsql;
 
 DROP TRIGGER IF EXISTS gispulse_trg_{suffix} ON "{schema}"."{table}";
 CREATE TRIGGER gispulse_trg_{suffix}
-    AFTER INSERT OR UPDATE ON "{schema}"."{table}"
+    AFTER INSERT OR UPDATE OR DELETE ON "{schema}"."{table}"
     FOR EACH ROW EXECUTE FUNCTION gispulse_notify_{suffix}();
 """
 
@@ -65,6 +67,34 @@ _DROP_TRIGGER_SQL = """
 DROP TRIGGER IF EXISTS gispulse_trg_{suffix} ON "{schema}"."{table}";
 DROP FUNCTION IF EXISTS gispulse_notify_{suffix}();
 """
+
+
+def _build_row_id_expr(pk: str | list[str]) -> str:
+    """Build the ``row_id`` SQL expression for the notify payload.
+
+    The primary key is configurable via the trigger's
+    ``conditions['pk']`` (default ``"id"``). For a composite key the
+    values are joined with ``concat_ws(',', ...)`` so the emitted
+    ``row_id`` carries every key column instead of just the first.
+
+    Every column name is validated with
+    :func:`gispulse.core.sql_safety.validate_identifier` before
+    interpolation — the DDL has no parameter binding.
+    """
+    cols = [pk] if isinstance(pk, str) else list(pk)
+    if not cols:
+        raise ValueError("trigger 'pk' must name at least one column")
+    for col in cols:
+        _safe_ident(col, "pk")
+    if len(cols) == 1:
+        c = cols[0]
+        return f'COALESCE(NEW."{c}"::text, OLD."{c}"::text, \'\')'
+    new_parts = ", ".join(f'NEW."{c}"::text' for c in cols)
+    old_parts = ", ".join(f'OLD."{c}"::text' for c in cols)
+    return (
+        f"COALESCE(concat_ws(',', {new_parts}), "
+        f"concat_ws(',', {old_parts}), '')"
+    )
 
 
 class TriggerManager:
@@ -106,6 +136,9 @@ class TriggerManager:
         The trigger model must have ``conditions`` with keys:
         - ``table``:  target table name
         - ``schema``: target schema (default "public")
+        - ``pk``:     primary-key column, or list of columns for a
+                      composite key (default "id"). Used to build the
+                      ``row_id`` carried in the notify payload.
 
         .. note::
             This method is part of the **Pro-only** ``esb_triggers`` feature.
@@ -127,6 +160,10 @@ class TriggerManager:
         _safe_ident(table, "table")
         _safe_ident(schema, "schema")
 
+        # Configurable primary key (default "id"); supports composite keys.
+        pk = trigger.conditions.get("pk", "id")
+        row_id_expr = _build_row_id_expr(pk)
+
         # Use trigger ID suffix to allow multiple triggers per table
         suffix = str(trigger.id).replace("-", "_")
         sql = _TRIGGER_FUNC_SQL.format(
@@ -134,6 +171,7 @@ class TriggerManager:
             table=table,
             schema=schema,
             trigger_id=str(trigger.id),
+            row_id_expr=row_id_expr,
         )
         self._engine.execute_sql(sql)
         self._installed[str(trigger.id)] = trigger

--- a/src/gispulse/persistence/change_log_watcher.py
+++ b/src/gispulse/persistence/change_log_watcher.py
@@ -102,6 +102,44 @@ class _ActionDispatcherProtocol(Protocol):
 
 
 # ---------------------------------------------------------------------------
+# Composite primary-key decoding (#403)
+# ---------------------------------------------------------------------------
+
+
+def _decode_composite_pk(fid: str) -> list[Any] | None:
+    """Decode a composite ``row_pk`` produced as a JSON array (#403).
+
+    The change-tracking triggers journal a multi-column primary key as
+    ``json_array(...)`` → e.g. ``[33, "075056"]``. A single-column PK is
+    journalled as the bare value, so anything that is not a JSON list of
+    length ≥ 2 is treated as a plain single key (returns ``None``).
+    """
+    s = fid.strip()
+    if not (s.startswith("[") and s.endswith("]")):
+        return None
+    try:
+        val = json.loads(s)
+    except (ValueError, TypeError):
+        return None
+    if isinstance(val, list) and len(val) > 1:
+        return val
+    return None
+
+
+def _table_pk_cols(conn: Any, safe_table: str) -> list[str]:
+    """Return *safe_table*'s primary-key columns, ordered by key position.
+
+    ``safe_table`` must already have passed identifier validation.
+    """
+    try:
+        rows = conn.execute(f'PRAGMA table_info("{safe_table}")').fetchall()
+    except Exception:
+        return []
+    pk = sorted(((r[5], r[1]) for r in rows if r[5]), key=lambda t: t[0])
+    return [str(name) for _, name in pk]
+
+
+# ---------------------------------------------------------------------------
 # Watcher
 # ---------------------------------------------------------------------------
 
@@ -837,9 +875,6 @@ class ChangeLogWatcher:
             )
             return None
 
-        # Default GPKG primary key is "fid". We fall back to a generic
-        # ``id``/``rowid`` lookup so non-GPKG layers still resolve.
-        pk_candidates = ("fid", "id", "rowid")
         get_conn = getattr(self._engine, "_get_conn", None)
         if get_conn is None:
             return None
@@ -849,7 +884,26 @@ class ChangeLogWatcher:
             return None
 
         try:
-            for pk in pk_candidates:
+            # #403: a composite primary key is journalled as a JSON array.
+            # Rebuild the multi-column lookup from the table's real PK
+            # column names instead of matching a single column.
+            composite = _decode_composite_pk(fid)
+            if composite is not None:
+                pk_names = _table_pk_cols(conn, safe_table)
+                if pk_names and len(pk_names) == len(composite):
+                    where = " AND ".join(f'"{c}" = ?' for c in pk_names)
+                    cur = conn.execute(
+                        f'SELECT * FROM "{safe_table}" WHERE {where} LIMIT 1',
+                        tuple(composite),
+                    )
+                    row = cur.fetchone()
+                    if row is not None:
+                        return {k: row[k] for k in row.keys()}
+                return None
+
+            # Default GPKG primary key is "fid". We fall back to a generic
+            # ``id``/``rowid`` lookup so non-GPKG layers still resolve.
+            for pk in ("fid", "id", "rowid"):
                 try:
                     cur = conn.execute(
                         f'SELECT * FROM "{safe_table}" WHERE "{pk}" = ? LIMIT 1',

--- a/src/gispulse/persistence/gpkg_schema.py
+++ b/src/gispulse/persistence/gpkg_schema.py
@@ -76,9 +76,28 @@ MODEL_TABLE_MAPPING = build_model_table_mapping(prefix="_gispulse_")
 # Change tracking trigger templates
 # ---------------------------------------------------------------------------
 
+def _row_pk_expr(ref: str, pk_cols: list[str]) -> str:
+    """Build the SQL expression that fills ``_gispulse_change_log.row_pk``.
+
+    Single-column PK → the bare ``ref."col"`` value (unchanged from the
+    pre-#403 behaviour, so existing single-PK change logs stay
+    byte-identical). Composite PK → a JSON array
+    ``json_array(ref."a", ref."b", ...)`` so the change log carries
+    *every* key column instead of silently dropping all but the first.
+    :func:`gispulse.persistence.change_log_watcher` decodes the array to
+    rebuild the full ``WHERE "a"=? AND "b"=?`` lookup.
+
+    Callers MUST validate every column name first (no DDL parameter binding).
+    """
+    if len(pk_cols) == 1:
+        return f'{ref}."{pk_cols[0]}"'
+    parts = ", ".join(f'{ref}."{c}"' for c in pk_cols)
+    return f"json_array({parts})"
+
+
 def _build_change_triggers(
     table_name: str,
-    pk_col: str = "fid",
+    pk_col: str | list[str] = "fid",
     *,
     columns: list[str] | None = None,
     geom_col: str | None = None,
@@ -108,7 +127,13 @@ def _build_change_triggers(
         ValueError: If any identifier is unsafe.
     """
     _validate_identifier(table_name)
-    _validate_identifier(pk_col)
+    pk_cols = [pk_col] if isinstance(pk_col, str) else list(pk_col)
+    if not pk_cols:
+        raise ValueError("pk_col must name at least one column")
+    for c in pk_cols:
+        _validate_identifier(c)
+    new_pk_expr = _row_pk_expr("NEW", pk_cols)
+    old_pk_expr = _row_pk_expr("OLD", pk_cols)
     cols = list(columns or [])
     for c in cols:
         _validate_identifier(c)
@@ -144,7 +169,7 @@ def _build_change_triggers(
         f"  INSERT INTO _gispulse_change_log"
         f"(table_name, operation, row_pk, new_values, geom_changed)\n"
         f"  VALUES ('{table_name}', 'INSERT', "
-        f'NEW."{pk_col}", {_json_obj("NEW")}, {gc_insert});\n'
+        f'{new_pk_expr}, {_json_obj("NEW")}, {gc_insert});\n'
         f"END"
     )
 
@@ -172,7 +197,7 @@ def _build_change_triggers(
         f"  INSERT INTO _gispulse_change_log"
         f"(table_name, operation, row_pk, new_values, old_values, geom_changed)\n"
         f"  VALUES ('{table_name}', 'UPDATE', "
-        f'NEW."{pk_col}", {_json_obj("NEW")}, {_json_obj("OLD")}, {gc_update});\n'
+        f'{new_pk_expr}, {_json_obj("NEW")}, {_json_obj("OLD")}, {gc_update});\n'
         f"END"
     )
 
@@ -183,7 +208,7 @@ def _build_change_triggers(
         f"  INSERT INTO _gispulse_change_log"
         f"(table_name, operation, row_pk, old_values, geom_changed)\n"
         f"  VALUES ('{table_name}', 'DELETE', "
-        f'OLD."{pk_col}", {_json_obj("OLD")}, {gc_delete});\n'
+        f'{old_pk_expr}, {_json_obj("OLD")}, {gc_delete});\n'
         f"END"
     )
 
@@ -191,7 +216,7 @@ def _build_change_triggers(
 
 
 def _inspect_layer(
-    conn: sqlite3.Connection, layer_name: str, pk_col: str
+    conn: sqlite3.Connection, layer_name: str, pk_col: str | list[str]
 ) -> tuple[list[str], str | None]:
     """Return (non-pk non-geom columns, geom_col_name) for a spatial layer.
 
@@ -221,11 +246,12 @@ def _inspect_layer(
         "GEOMETRY", "GEOMCOLLECTION", "GEOMETRYCOLLECTION",
     )
 
+    pk_set = {pk_col} if isinstance(pk_col, str) else set(pk_col)
     non_pk_cols: list[str] = []
     for cid, name, ctype, *_ in conn.execute(
         f'PRAGMA table_info("{layer_name}")'
     ).fetchall():
-        if name == pk_col:
+        if name in pk_set:
             continue
         if geom_col is None and ctype:
             if ctype.upper() in geometry_type_keywords:
@@ -423,8 +449,8 @@ def _migrate_v2_to_v3(conn: sqlite3.Connection) -> int:
         # with ``NEW."fid"`` and break tables whose PK is named
         # otherwise.
         try:
-            pk_col = _detect_pk_col(conn, layer)
-            install_change_tracking(conn, layer, pk_col=pk_col)
+            pk_cols = _detect_pk_cols(conn, layer)
+            install_change_tracking(conn, layer, pk_col=pk_cols)
         except ValueError as exc:
             # A pre-B-05 GPKG could conceivably hold a layer name that
             # is now rejected by ``validate_layer_name`` (control char,
@@ -519,7 +545,7 @@ def bootstrap_spatialite_project(conn: sqlite3.Connection) -> None:
 def install_change_tracking(
     conn: sqlite3.Connection,
     layer_name: str,
-    pk_col: str = "fid",
+    pk_col: str | list[str] = "fid",
     *,
     columns: list[str] | None = None,
     geom_col: str | None = None,
@@ -544,7 +570,9 @@ def install_change_tracking(
         layer_name: Spatial table to track. Any string except those
                     containing ``"``, ``'``, ``;``, ``\\`` or control
                     chars — see :func:`_validate_identifier`.
-        pk_col:     Primary key column (default ``fid`` per GPKG spec).
+        pk_col:     Primary key column (default ``fid`` per GPKG spec),
+                    or a list of columns for a composite key. A composite
+                    key is stored in ``row_pk`` as a ``json_array`` (#403).
         columns:    Optional explicit list of columns to capture in the
                     JSON payload. When ``None``, all non-pk non-geom
                     columns of the layer are inspected and included.
@@ -557,10 +585,14 @@ def install_change_tracking(
         ValueError: If any identifier is unsafe.
     """
     _validate_identifier(layer_name)
-    _validate_identifier(pk_col)
+    pk_cols = [pk_col] if isinstance(pk_col, str) else list(pk_col)
+    if not pk_cols:
+        raise ValueError("pk_col must name at least one column")
+    for _c in pk_cols:
+        _validate_identifier(_c)
 
     if columns is None or geom_col is None:
-        auto_cols, auto_geom = _inspect_layer(conn, layer_name, pk_col)
+        auto_cols, auto_geom = _inspect_layer(conn, layer_name, pk_cols)
         if columns is None:
             columns = auto_cols
         if geom_col is None:
@@ -618,25 +650,16 @@ def _ensure_origin_column(conn: sqlite3.Connection, layer_name: str) -> bool:
     return True
 
 
-def _detect_pk_col(conn: sqlite3.Connection, layer_name: str) -> str:
-    """Return the layer's primary key column name (defaults to ``"fid"``).
-
-    B-02 (#103): the v2→v3 migration re-installs change tracking on
-    every previously tracked layer. The legacy default of
-    ``pk_col="fid"`` would silently rewrite the trigger DDL with
-    ``NEW."fid"`` even on tables whose PK is named otherwise (``id``,
-    ``rowid``, ...) — breaking ``test_set_field_e2e`` and any caller
-    that originally passed an explicit ``pk_col=`` to
-    :func:`install_change_tracking`.
+def _detect_pk_cols(conn: sqlite3.Connection, layer_name: str) -> list[str]:
+    """Return the layer's primary-key columns, ordered by key position.
 
     SQLite's ``PRAGMA table_info`` reports the PK position in column 5
-    (``pk``) — non-zero means PK, with the position when composite. We
-    pick the *first* PK column; for single-column PKs that's always
-    correct. For multi-column PKs (rare in GPKG layers) the change-log
-    can only carry one ``row_pk`` value, so taking the first is the
-    conservative compromise.
+    (``pk``) — non-zero means PK, with the position when composite. A
+    composite key returns every column in declaration order; #403: the
+    change-log ``row_pk`` then carries all of them (via ``json_array``)
+    instead of silently keeping only the first.
 
-    Falls back to ``"fid"`` when PRAGMA returns no PK (legacy GPKG
+    Falls back to ``["fid"]`` when PRAGMA returns no PK (legacy GPKG
     layers without a declared primary key would have failed install
     too — keep the legacy default for graceful degradation).
     """
@@ -645,14 +668,26 @@ def _detect_pk_col(conn: sqlite3.Connection, layer_name: str) -> str:
             f'PRAGMA table_info("{layer_name}")'
         ).fetchall()
     except Exception:
-        return "fid"
+        return ["fid"]
     pk_cols = sorted(
         ((row[5], row[1]) for row in rows if row[5]),
         key=lambda t: t[0],
     )
     if pk_cols:
-        return str(pk_cols[0][1])
-    return "fid"
+        return [str(name) for _, name in pk_cols]
+    return ["fid"]
+
+
+def _detect_pk_col(conn: sqlite3.Connection, layer_name: str) -> str:
+    """Return the layer's first primary-key column (defaults to ``"fid"``).
+
+    Thin wrapper over :func:`_detect_pk_cols` kept for callers that only
+    need a single column name. B-02 (#103): the v2→v3 migration honours
+    the original PK column name rather than the legacy ``fid`` default,
+    which would otherwise rewrite the trigger DDL with ``NEW."fid"`` and
+    break tables whose PK is named otherwise (``id``, ``rowid``, ...).
+    """
+    return _detect_pk_cols(conn, layer_name)[0]
 
 
 def _list_gispulse_triggers(

--- a/tests/unit/test_change_log_watcher_shadow_zones.py
+++ b/tests/unit/test_change_log_watcher_shadow_zones.py
@@ -620,3 +620,62 @@ class TestSingleEngineConstraint:
         #       copy — current behaviour suggests this is NOT the case),
         #   (c) Live-sync only works for the project GPKG, not uploads
         #       (current de-facto behaviour — needs documentation).
+
+
+# ---------------------------------------------------------------------------
+# #403 — composite primary-key reload
+# ---------------------------------------------------------------------------
+
+
+class TestCompositePkReload:
+    """The CDC change log journals a composite PK as a JSON array; the
+    watcher must rebuild the full multi-column lookup to reload the row."""
+
+    def _make_conn(self, tmp_path: Path) -> sqlite3.Connection:
+        conn = sqlite3.connect(tmp_path / "ods.gpkg")
+        conn.row_factory = sqlite3.Row
+        bootstrap_gpkg_project(conn)
+        conn.execute(
+            'CREATE TABLE "ods" '
+            "(dept INTEGER, commune TEXT, val INTEGER, "
+            "PRIMARY KEY (dept, commune))"
+        )
+        conn.execute(
+            'INSERT INTO "ods" (dept, commune, val) VALUES (33, \'075056\', 7)'
+        )
+        conn.commit()
+        return conn
+
+    def test_decode_composite_pk(self) -> None:
+        from gispulse.persistence.change_log_watcher import _decode_composite_pk
+
+        assert _decode_composite_pk('[33, "075056"]') == [33, "075056"]
+        assert _decode_composite_pk("42") is None  # single PK → bare value
+        assert _decode_composite_pk("[5]") is None  # 1-element ≠ composite
+        assert _decode_composite_pk("not-json [") is None
+
+    def test_load_row_values_composite(self, tmp_path: Path) -> None:
+        conn = self._make_conn(tmp_path)
+
+        class _Eng:
+            backend_name = "gpkg"
+
+            def __init__(self, c: sqlite3.Connection) -> None:
+                self._c = c
+
+            def _get_conn(self) -> sqlite3.Connection:
+                return self._c
+
+            def get_pending_changes(self, limit: int = 100) -> list[dict]:
+                return []
+
+            def mark_changes_processed(self, up_to_id: int) -> int:
+                return 0
+
+        watcher = ChangeLogWatcher(_Eng(conn), _RecordingHub(), dataset_id="d1")
+        row = watcher._load_row_values("ods", '[33, "075056"]')
+        assert row is not None
+        assert row["val"] == 7
+        assert row["dept"] == 33
+        assert row["commune"] == "075056"
+        conn.close()

--- a/tests/unit/test_gpkg_schema.py
+++ b/tests/unit/test_gpkg_schema.py
@@ -88,6 +88,21 @@ class TestBuildChangeTriggers:
         triggers = _build_change_triggers("x")
         assert all('."fid"' in t for t in triggers)
 
+    def test_composite_pk_uses_json_array(self):
+        # #403: a composite key must journal every column via json_array,
+        # not silently keep only the first.
+        triggers = _build_change_triggers("ods", pk_col=["dept", "commune"])
+        assert any(
+            'json_array(NEW."dept", NEW."commune")' in t for t in triggers
+        )
+        assert any(
+            'json_array(OLD."dept", OLD."commune")' in t for t in triggers
+        )
+
+    def test_empty_pk_list_rejected(self):
+        with pytest.raises(ValueError):
+            _build_change_triggers("x", pk_col=[])
+
 
 # ---------------------------------------------------------------------------
 # _ensure_gpkg_extensions_table
@@ -313,6 +328,31 @@ class TestInstallChangeTracking:
             "SELECT row_pk FROM _gispulse_change_log WHERE table_name='t'"
         ).fetchone()
         assert row["row_pk"] == "42"
+
+    def test_install_composite_pk_roundtrip(self, conn):
+        # #403: a composite PK is journalled as a JSON array carrying
+        # every key column, and _detect_pk_cols discovers both columns.
+        import json as _json
+
+        from gispulse.persistence.gpkg_schema import _detect_pk_cols
+
+        bootstrap_gpkg_project(conn)
+        conn.execute(
+            'CREATE TABLE "ods" '
+            '(dept INTEGER, commune TEXT, val INTEGER, '
+            "PRIMARY KEY (dept, commune))"
+        )
+        conn.commit()
+        assert _detect_pk_cols(conn, "ods") == ["dept", "commune"]
+        install_change_tracking(conn, "ods", pk_col=["dept", "commune"])
+        conn.execute(
+            'INSERT INTO "ods" (dept, commune, val) VALUES (33, \'075056\', 7)'
+        )
+        conn.commit()
+        row = conn.execute(
+            "SELECT row_pk FROM _gispulse_change_log WHERE table_name='ods'"
+        ).fetchone()
+        assert _json.loads(row["row_pk"]) == [33, "075056"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_spatial_engine.py
+++ b/tests/unit/test_spatial_engine.py
@@ -331,3 +331,53 @@ class TestTriggerManager:
         ]
         count = mgr.install_all(triggers)
         assert count == 1  # only t1 is DML + enabled
+
+    def _install_and_capture_sql(self, conditions: dict) -> str:
+        from gispulse.adapters.esb.trigger_manager import TriggerManager
+
+        mock_engine = MagicMock()
+        mgr = TriggerManager(engine=mock_engine)
+        trigger = Trigger(
+            name="t",
+            trigger_type=TriggerType.DML,
+            conditions=conditions,
+        )
+        mgr.install(trigger)
+        assert mock_engine.execute_sql.call_count == 1
+        return mock_engine.execute_sql.call_args[0][0]
+
+    def test_install_covers_delete_and_default_pk(self):
+        # #402: the trigger must fire on DELETE too, default PK is "id",
+        # and the function must survive a NULL NEW row (DELETE).
+        sql = self._install_and_capture_sql({"table": "parcelles", "schema": "public"})
+        assert "AFTER INSERT OR UPDATE OR DELETE" in sql
+        assert 'COALESCE(NEW."id"::text, OLD."id"::text, \'\')' in sql
+        assert "RETURN COALESCE(NEW, OLD)" in sql
+
+    def test_install_custom_pk(self):
+        # #402: PK column is configurable via conditions['pk'].
+        sql = self._install_and_capture_sql(
+            {"table": "lots", "schema": "public", "pk": "gid"}
+        )
+        assert 'COALESCE(NEW."gid"::text, OLD."gid"::text, \'\')' in sql
+        assert '"id"' not in sql.split("json_build_object")[1].split("timestamp")[0]
+
+    def test_install_composite_pk(self):
+        # #403/#402: composite key joins every column instead of the first.
+        sql = self._install_and_capture_sql(
+            {"table": "ods", "schema": "public", "pk": ["dept", "commune"]}
+        )
+        assert (
+            "concat_ws(',', NEW.\"dept\"::text, NEW.\"commune\"::text)" in sql
+        )
+        assert (
+            "concat_ws(',', OLD.\"dept\"::text, OLD.\"commune\"::text)" in sql
+        )
+
+    def test_install_rejects_unsafe_pk(self):
+        import pytest
+
+        with pytest.raises(ValueError):
+            self._install_and_capture_sql(
+                {"table": "t", "schema": "public", "pk": "id; DROP TABLE t"}
+            )


### PR DESCRIPTION
Complète le milestone **v2.3.0 Hardening** après #418, sur la branche d'intégration `integration/v2.4` (dev parallèle, hors production). Voir le plan `docs/roadmap-v2.3-v2.6-plan.md`.

## Contenu

### #402 — Trigger PostGIS pg_notify
- Couvre **DELETE** (le trigger ne firait que sur INSERT/UPDATE).
- Colonne **PK configurable** via `conditions['pk']` (était `id` codée en dur), supporte les clés composites (`concat_ws`).
- `RETURN COALESCE(NEW, OLD)` — la fonction reste valide quand `NEW` est NULL sur DELETE.

### #403 — CDC clés primaires composites
- Les triggers de change-tracking GPKG journalisent désormais une PK composite en **`json_array`** (toutes les colonnes), au lieu de ne garder que la première.
- Le watcher **décode le tableau** pour reconstruire la recherche `WHERE "a"=? AND "b"=?` lors du reload de ligne.
- **Rétro-compat totale** : une PK simple reste byte-identique (`NEW."col"`).

### #404 — Drift documentaire
- README : compteur de capabilities **117 → 128** (aligné sur la matrice de couverture, vérifiée `--check` en sync).
- Statut de l'app desktop **Tauri "Done" → "Beta"** (pas encore packagée pour distribution).

## Tests
133 tests ciblés verts, ruff clean :
- `TriggerManager` : DELETE + PK défaut/custom/composite + rejet PK unsafe.
- `gpkg_schema` : DDL composite (`json_array`) + round-trip insert→change_log.
- `change_log_watcher` : décodeur composite + reload multi-colonnes.
- Régression CDC complète (199 tests) : aucune régression sur PK simple.

Reste pour clore v2.3.0 : #400 (bumps deps, PR séparée cross-repo) et #401 (CI SHA-pin).