### PR TITLE
feat(orchestration): run completion as a trigger source + scenario run wiring (#440 c, fixes #443)

### DIFF
--- a/src/gispulse/adapters/http/app.py
+++ b/src/gispulse/adapters/http/app.py
@@ -365,13 +365,43 @@ def create_app(
 
             hub_sink = EventHubSink(app.state.event_hub)
 
+            # RunCompletionTriggerSink (issue #440-c): évalue les triggers
+            # on_run_completed sur chaque run.completed/run.failed et
+            # enqueue les jobs déclenchés. Vit ici (adapters layer) pour la
+            # même raison qu'EventHubSink : orchestration ne doit pas
+            # dépendre de adapters/.
+            # Sans triggers déclarés, comportement strictement identique
+            # à l'injection d'hub_sink seul (no-op conditionnel).
+            from gispulse.orchestration.trigger_bridge import TriggerJobBridge
+            from gispulse.orchestration.run_trigger_sink import RunCompletionTriggerSink
+
+            trigger_bridge = TriggerJobBridge(
+                job_queue=app.state.job_queue,
+                dataset_repo=app.state.dataset_repo,
+            )
+            # Capture the running event loop now (inside the async lifespan)
+            # so RunCompletionTriggerSink can schedule coroutines from sync
+            # FastAPI handler threads via asyncio.run_coroutine_threadsafe.
+            import asyncio as _asyncio
+            _lifespan_loop = _asyncio.get_running_loop()
+            run_trigger_sink = RunCompletionTriggerSink(
+                trigger_repo=app.state.trigger_repo,
+                bridge=trigger_bridge,
+                inner=hub_sink,
+                loop=_lifespan_loop,
+            )
+            app.state.trigger_bridge = trigger_bridge
+            # Expose the composite sink on app.state so scenario/manifest routers
+            # can emit run.* events through the same pipeline (EventHub + triggers).
+            app.state.event_sink = run_trigger_sink
+
             worker = JobWorker(
                 queue=app.state.job_queue,
                 runner=app.state.job_runner,
                 dataset_repo=app.state.dataset_repo,
                 job_repo=app.state.job_repo,
                 run_repo=run_repo,
-                event_sink=hub_sink,
+                event_sink=run_trigger_sink,
                 results_dir=_results_path,
             )
             app.state.job_worker = worker

--- a/src/gispulse/adapters/http/routers/scenarios_router.py
+++ b/src/gispulse/adapters/http/routers/scenarios_router.py
@@ -28,6 +28,7 @@ from gispulse.adapters.http.dependencies import (
 )
 from gispulse.adapters.http.schemas import ScenarioCreate, ScenarioResponse
 from gispulse.core.models import Scenario
+from gispulse.orchestration.event_sink import NoOpSink
 from gispulse.persistence.engine import SpatialEngine
 from gispulse.persistence.repository import Repository
 
@@ -192,12 +193,48 @@ def run_scenario(
     If the scenario has a graph definition (nodes + edges), uses the
     GraphExecutor for DAG execution. Otherwise falls back to the
     sequential ScenarioRunner.
+
+    Emits ``run.started`` / ``run.completed`` / ``run.failed`` lifecycle events
+    via the app's event sink (EventHubSink + RunCompletionTriggerSink when
+    running in full mode) and persists a PipelineRun record.
     """
     import time
 
     scenario = repo.get(scenario_id)
     if scenario is None:
+        # Validation rejection — no PipelineRun is created.
+        # A PipelineRun exists ONLY once execution actually starts (below).
         raise HTTPException(status_code=404, detail=f"Scenario '{scenario_id}' not found.")
+
+    # --- PipelineRun plumbing (issue #440-c) ---
+    # INVARIANT: run creation is strictly after all validation guards.
+    # 404/422 rejections produce no PipelineRun; a run exists only once
+    # execution starts. This keeps run history clean and avoids phantom
+    # entries for invalid requests.
+    from datetime import datetime, timezone
+    from gispulse.core.run_models import PipelineRun
+    from gispulse.orchestration.event_sink import RecordingSink
+
+    run_repo = getattr(request.app.state, "run_repo", None)
+    outer_sink = getattr(request.app.state, "event_sink", None)
+    if outer_sink is None:
+        outer_sink = NoOpSink()
+
+    run = PipelineRun(
+        source="scenario",
+        spec_ref=str(scenario_id),
+        scope="",
+    )
+    if run_repo is not None:
+        run_repo.save(run)
+
+    run_sink = RecordingSink(run=run, run_repo=run_repo, inner=outer_sink)
+    run_sink.emit("run.started", {
+        "run_id": str(run.run_id),
+        "source": "scenario",
+        "spec_ref": str(scenario_id),
+        "started_at": run.started_at.isoformat(),
+    })
 
     start = time.monotonic()
     node_results: list[NodeExecResult] = []
@@ -205,14 +242,46 @@ def run_scenario(
     graph = scenario.graph
     has_graph = bool(graph and graph.get("nodes"))
 
-    if has_graph:
-        node_results = _run_graph(scenario, engine, rule_repo, dataset_repo)
-    else:
-        node_results = _run_sequential(scenario, engine, rule_repo, dataset_repo)
+    try:
+        if has_graph:
+            node_results = _run_graph(scenario, engine, rule_repo, dataset_repo)
+        else:
+            node_results = _run_sequential(scenario, engine, rule_repo, dataset_repo)
+    except Exception as exc:
+        from gispulse.core.models import JobStatus
+        run.status = JobStatus.FAILED
+        run.error = str(exc)
+        run.ended_at = datetime.now(timezone.utc)
+        if run_repo is not None:
+            run_repo.save(run)
+        run_sink.emit("run.failed", {
+            "run_id": str(run.run_id),
+            "source": "scenario",
+            "spec_ref": str(scenario_id),
+            "status": "failed",
+            "ended_at": run.ended_at.isoformat(),
+            "error": str(exc),
+        })
+        raise
 
     duration_ms = (time.monotonic() - start) * 1000
     failed = any(nr.status == "failed" for nr in node_results)
     status = "failed" if failed else "success"
+
+    from gispulse.core.models import JobStatus
+    run.status = JobStatus.FAILED if failed else JobStatus.COMPLETED
+    run.ended_at = datetime.now(timezone.utc)
+    if run_repo is not None:
+        run_repo.save(run)
+
+    terminal_event = "run.failed" if failed else "run.completed"
+    run_sink.emit(terminal_event, {
+        "run_id": str(run.run_id),
+        "source": "scenario",
+        "spec_ref": str(scenario_id),
+        "status": status,
+        "ended_at": run.ended_at.isoformat(),
+    })
 
     return ScenarioRunResult(
         scenario_id=scenario.id,
@@ -230,6 +299,7 @@ def _run_graph(
 ) -> list[NodeExecResult]:
     """Execute a scenario via the GraphExecutor."""
 
+    from gispulse.capabilities import get as _get_capability
     from gispulse.core.models import NodeDef, EdgeDef, NodeType
     from gispulse.orchestration.graph_executor import GraphExecutor
 
@@ -256,11 +326,7 @@ def _run_graph(
         for e in raw_edges
     ]
 
-    # NOTE: GraphExecutor(rule_repo=...) is a pre-existing API mismatch on
-    # upstream/integration/v2.4 (constructor expects capability_getter, not rule_repo).
-    # This is NOT introduced by this PR (issue #440 volets a+b) — filed as follow-up.
-    # Run events for scenarios are also out of scope until the mismatch is repaired.
-    executor = GraphExecutor(rule_repo=rule_repo)  # type: ignore[call-arg]
+    executor = GraphExecutor(capability_getter=_get_capability)
     results: list[NodeExecResult] = []
 
     # Execute node by node with individual timing
@@ -380,6 +446,7 @@ class RunNodeResult(BaseModel):
 
 @router.post("/{scenario_id}/run-node", response_model=RunNodeResult)
 def run_single_node(
+    request: Request,
     scenario_id: UUID,
     payload: RunNodeRequest,
     repo: Repository = Depends(get_scenario_repo),
@@ -397,10 +464,12 @@ def run_single_node(
 
     scenario = repo.get(scenario_id)
     if scenario is None:
+        # Validation rejection — no PipelineRun is created.
         raise HTTPException(status_code=404, detail=f"Scenario '{scenario_id}' not found.")
 
     graph = scenario.graph
     if not graph or not graph.get("nodes"):
+        # Validation rejection — no PipelineRun is created.
         raise HTTPException(status_code=422, detail="Scenario has no graph definition.")
 
     raw_nodes = graph.get("nodes", [])
@@ -411,6 +480,7 @@ def run_single_node(
     if target_raw is None:
         raise HTTPException(status_code=404, detail=f"Node '{payload.node_id}' not found in scenario graph.")
 
+    from gispulse.capabilities import get as _get_capability
     from gispulse.core.models import NodeDef, EdgeDef, NodeType
     from gispulse.orchestration.graph_executor import GraphExecutor
     import geopandas as gpd
@@ -458,8 +528,37 @@ def run_single_node(
         for e in sub_edges_raw
     ]
 
-    # NOTE: same pre-existing mismatch as _run_graph above — see comment there.
-    executor = GraphExecutor(rule_repo=rule_repo)  # type: ignore[call-arg]
+    # --- PipelineRun plumbing (issue #440-c) ---
+    # INVARIANT: run creation is strictly after all validation guards above
+    # (404 scenario not found, 422 no graph, 404 node not found).
+    # Validation rejections produce no PipelineRun; a run exists only once
+    # execution starts.
+    from datetime import datetime, timezone
+    from gispulse.core.run_models import PipelineRun
+    from gispulse.orchestration.event_sink import RecordingSink
+
+    run_repo = getattr(request.app.state, "run_repo", None)
+    outer_sink = getattr(request.app.state, "event_sink", None)
+    if outer_sink is None:
+        outer_sink = NoOpSink()
+
+    node_run = PipelineRun(
+        source="scenario",
+        spec_ref=f"{scenario_id}#{payload.node_id}",
+        scope="",
+    )
+    if run_repo is not None:
+        run_repo.save(node_run)
+
+    node_sink = RecordingSink(run=node_run, run_repo=run_repo, inner=outer_sink)
+    node_sink.emit("run.started", {
+        "run_id": str(node_run.run_id),
+        "source": "scenario",
+        "spec_ref": f"{scenario_id}#{payload.node_id}",
+        "started_at": node_run.started_at.isoformat(),
+    })
+
+    executor = GraphExecutor(capability_getter=_get_capability)
     inputs: dict[str, gpd.GeoDataFrame] = {}
     for n in nodes:
         if n.node_type == NodeType.DATASET and n.bind:
@@ -475,6 +574,20 @@ def run_single_node(
         results = executor.execute(nodes, edges, inputs=inputs)
         output = results.get(payload.node_id)
         duration_ms = round((time.monotonic() - t0) * 1000, 1)
+
+        from gispulse.core.models import JobStatus
+        node_run.status = JobStatus.COMPLETED
+        node_run.ended_at = datetime.now(timezone.utc)
+        if run_repo is not None:
+            run_repo.save(node_run)
+        node_sink.emit("run.completed", {
+            "run_id": str(node_run.run_id),
+            "source": "scenario",
+            "spec_ref": f"{scenario_id}#{payload.node_id}",
+            "status": "completed",
+            "ended_at": node_run.ended_at.isoformat(),
+        })
+
         return RunNodeResult(
             node_id=payload.node_id,
             scenario_id=scenario_id,
@@ -484,6 +597,22 @@ def run_single_node(
         )
     except Exception as exc:
         duration_ms = round((time.monotonic() - t0) * 1000, 1)
+
+        from gispulse.core.models import JobStatus
+        node_run.status = JobStatus.FAILED
+        node_run.error = str(exc)
+        node_run.ended_at = datetime.now(timezone.utc)
+        if run_repo is not None:
+            run_repo.save(node_run)
+        node_sink.emit("run.failed", {
+            "run_id": str(node_run.run_id),
+            "source": "scenario",
+            "spec_ref": f"{scenario_id}#{payload.node_id}",
+            "status": "failed",
+            "ended_at": node_run.ended_at.isoformat(),
+            "error": str(exc),
+        })
+
         return RunNodeResult(
             node_id=payload.node_id,
             scenario_id=scenario_id,

--- a/src/gispulse/core/conditions.py
+++ b/src/gispulse/core/conditions.py
@@ -79,11 +79,38 @@ class ScheduleConditions:
     timezone: str = "UTC"
 
 
+@dataclass
+class OnRunCompletedConditions:
+    """Conditions for an on_run_completed trigger (issue #440-c).
+
+    Fires when a ``run.completed`` or ``run.failed`` event is emitted and the
+    optional filters match.
+
+    Attributes:
+        status:   Which run terminal state triggers this: ``"completed"``
+                  (default), ``"failed"``, or ``"any"``.
+        source:   If set, only match runs whose ``PipelineRun.source`` equals
+                  this value (e.g. ``"job"`` or ``"scenario"``).
+        spec_ref: If set, only match runs whose ``PipelineRun.spec_ref``
+                  contains this string.
+        scope:    If set, only match runs whose ``PipelineRun.scope`` equals
+                  this value (e.g. a department code ``"63"``).
+        max_depth: Maximum trigger-chain depth for this trigger (default 5).
+                   A run enqueued *by* a trigger already carries depth+1.
+    """
+
+    status: str = "completed"   # "completed" | "failed" | "any"
+    source: str = ""            # "" = match all sources
+    spec_ref: str = ""          # "" = match all spec_refs (substring match)
+    scope: str = ""             # "" = match all scopes
+    max_depth: int = 5
+
+
 # Union type for all structured conditions
 TriggerConditions = (
     DMLConditions | ThresholdConditions | ValidationConditions |
     BusinessRuleConditions | TopologyConditions | SpatialConstraintConditions |
-    CompositeConditions | ScheduleConditions
+    CompositeConditions | ScheduleConditions | OnRunCompletedConditions
 )
 
 # Map TriggerType → conditions dataclass
@@ -96,6 +123,7 @@ _CONDITIONS_TYPE_MAP: dict[str, type] = {
     "spatial_constraint": SpatialConstraintConditions,
     "composite": CompositeConditions,
     "schedule": ScheduleConditions,
+    "on_run_completed": OnRunCompletedConditions,
 }
 
 

--- a/src/gispulse/core/enums.py
+++ b/src/gispulse/core/enums.py
@@ -91,6 +91,8 @@ class TriggerType(str, Enum):
     WEBHOOK_IN = "webhook_in"
     # --- External-source freshness (issue #186) ---
     SOURCE_CHANGED = "source_changed"
+    # --- Run-completion chaining (issue #440-c) ---
+    ON_RUN_COMPLETED = "on_run_completed"
 
 
 class ChangeOperation(str, Enum):

--- a/src/gispulse/core/models.py
+++ b/src/gispulse/core/models.py
@@ -55,6 +55,7 @@ from gispulse.core.conditions import (  # noqa: F401
     SpatialConstraintConditions,
     CompositeConditions,
     ScheduleConditions,
+    OnRunCompletedConditions,
     TriggerConditions,
     parse_conditions,
     _CONDITIONS_TYPE_MAP,

--- a/src/gispulse/core/run_models.py
+++ b/src/gispulse/core/run_models.py
@@ -62,3 +62,4 @@ class PipelineRun:
     ended_at: datetime | None = None
     error: str = ""
     steps: list[PipelineRunStep] = field(default_factory=list)
+    depth: int = 0

--- a/src/gispulse/orchestration/run_trigger_sink.py
+++ b/src/gispulse/orchestration/run_trigger_sink.py
@@ -1,0 +1,280 @@
+"""RunCompletionTriggerSink — branche les événements run.* vers TriggerJobBridge.
+
+Décore un RunEventSink existant (inner) et, sur chaque ``run.completed`` ou
+``run.failed``, évalue les triggers de type ``on_run_completed`` et enqueue les
+jobs résultants via TriggerJobBridge.
+
+Architecture (layering) :
+    orchestration/ ← pas d'import de adapters/http/*
+    Le branchement du sink dans le worker se fait dans adapters/http/app.py
+    (exactement comme EventHubSink).
+
+Garantie anti-boucle infinie :
+    Chaque job enqueué par ce sink reçoit ``triggered_by="run_trigger"`` et
+    ``trigger_depth = event_depth + 1``. L'évaluation lit ``depth`` depuis
+    les ``new_values`` du ChangeRecord synthétique, et
+    ``OnRunCompletedConditions.max_depth`` bloque le tir au-delà du seuil.
+
+Usage::
+
+    from gispulse.orchestration.run_trigger_sink import RunCompletionTriggerSink
+
+    sink = RunCompletionTriggerSink(
+        trigger_repo=trigger_repo,
+        bridge=bridge,
+        inner=hub_sink,
+    )
+    worker = JobWorker(..., event_sink=sink)
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from gispulse.core.logging import get_logger
+from gispulse.core.models import ChangeOperation, ChangeRecord, TriggerType
+from gispulse.orchestration.event_sink import NoOpSink, RunEventSink
+
+log = get_logger(__name__)
+
+
+def _log_enqueue_error(future: "asyncio.Future[Any]") -> None:  # type: ignore[name-defined]
+    """Done-callback for asyncio.ensure_future — logs P3 enqueue errors."""
+    try:
+        exc = future.exception()
+    except Exception:
+        exc = None
+    if exc is not None:
+        log.error(
+            "run_trigger_sink_enqueue_error",
+            error=str(exc),
+            detail="on_triggers_fired coroutine raised; original run event intact.",
+        )
+
+
+def _log_concurrent_future_error(future: "asyncio.futures.Future[Any]") -> None:  # type: ignore[name-defined]
+    """Done-callback for run_coroutine_threadsafe concurrent.futures.Future."""
+    try:
+        exc = future.exception()
+    except Exception:
+        exc = None
+    if exc is not None:
+        log.error(
+            "run_trigger_sink_enqueue_error",
+            error=str(exc),
+            detail="on_triggers_fired (threadsafe) raised; original run event intact.",
+        )
+
+
+# Terminal run event types that may fire on_run_completed triggers
+_RUN_TERMINAL_EVENTS = frozenset({"run.completed", "run.failed"})
+
+# Event-type → run status value forwarded in ChangeRecord.new_values
+_EVENT_TO_STATUS = {
+    "run.completed": "completed",
+    "run.failed": "failed",
+}
+
+
+class RunCompletionTriggerSink:
+    """Sink composite qui évalue les triggers on_run_completed sur chaque run terminal.
+
+    Args:
+        trigger_repo:  Repository<Trigger> — source des triggers actifs.
+        bridge:        TriggerJobBridge — traduit FiredTrigger en Job et enqueue.
+        inner:         Sink délégué (e.g. EventHubSink). Reçoit *tous* les événements
+                       indépendamment de l'évaluation des triggers.
+        loop:          Event loop asyncio pour l'enqueue depuis un contexte sync.
+                       Si None, ``asyncio.get_event_loop()`` est utilisé.
+    """
+
+    def __init__(
+        self,
+        trigger_repo: Any,
+        bridge: Any,
+        inner: RunEventSink | None = None,
+        loop: Any | None = None,
+    ) -> None:
+        self._trigger_repo = trigger_repo
+        self._bridge = bridge
+        self._inner = inner if inner is not None else NoOpSink()
+        self._loop = loop
+
+    def emit(self, event_type: str, data: dict) -> None:
+        """Émet l'événement vers l'inner sink puis évalue les triggers si terminal."""
+        # Toujours déléguer en premier — l'inner (EventHubSink) broadcast sur WS
+        self._inner.emit(event_type, data)
+
+        if event_type not in _RUN_TERMINAL_EVENTS:
+            return
+
+        # Évaluation des triggers on_run_completed
+        try:
+            self._evaluate_and_dispatch(event_type, data)
+        except Exception as exc:
+            log.error(
+                "run_trigger_sink_eval_error",
+                event_type=event_type,
+                error=str(exc),
+            )
+
+    def _evaluate_and_dispatch(self, event_type: str, data: dict) -> None:
+        """Évalue les triggers et enqueue les jobs déclenchés."""
+        from gispulse.rules.trigger_evaluator import TriggerEvaluator
+        from gispulse.core.models import Trigger
+
+        # Récupérer les triggers on_run_completed actifs
+        try:
+            all_triggers: list[Trigger] = self._trigger_repo.list_all()
+        except Exception as exc:
+            log.warning("run_trigger_sink_repo_error", error=str(exc))
+            return
+
+        run_triggers = [
+            t for t in all_triggers
+            if getattr(t, "enabled", True)
+            and (
+                (hasattr(t.trigger_type, "value") and t.trigger_type.value == TriggerType.ON_RUN_COMPLETED.value)
+                or str(t.trigger_type) == TriggerType.ON_RUN_COMPLETED.value
+                or t.trigger_type == TriggerType.ON_RUN_COMPLETED
+            )
+        ]
+
+        if not run_triggers:
+            return
+
+        # Construire un ChangeRecord synthétique portant le contexte du run
+        run_id = data.get("run_id", "")
+        status = _EVENT_TO_STATUS.get(event_type, "completed")
+        depth = int(data.get("depth", 0))
+
+        record = ChangeRecord(
+            table_name="run.events",
+            operation=ChangeOperation.INSERT,
+            new_values={
+                "run_id": run_id,
+                "status": status,
+                "source": data.get("source", ""),
+                "spec_ref": data.get("spec_ref", ""),
+                "scope": data.get("scope", ""),
+                "depth": depth,
+            },
+        )
+
+        evaluator = TriggerEvaluator()
+        try:
+            fired = evaluator.evaluate(record, run_triggers)
+        except Exception as exc:
+            log.warning("run_trigger_sink_evaluator_error", error=str(exc))
+            return
+
+        matched = [ft for ft in fired if ft.matched]
+        if not matched:
+            return
+
+        # Build a trigger lookup to recover action configs (rule_id / graph_id)
+        trigger_map = {t.id: t for t in run_triggers}
+
+        # Enrichir chaque FiredTrigger avec le contexte run pour le job
+        for ft in matched:
+            ft.result_summary.update({
+                "run_id": run_id,
+                "scope": data.get("scope", ""),
+                "status": status,
+                "trigger_depth": depth + 1,
+            })
+            # Reconstruct full action dicts from the trigger's ActionDef.config so
+            # TriggerJobBridge can extract rule_id / graph_id. The evaluator
+            # stores only action_type strings in actions_dispatched; we merge
+            # the config back here.
+            trigger = trigger_map.get(ft.trigger_id)
+            trigger_action_configs: dict[str, dict] = {}
+            if trigger is not None:
+                for adef in trigger.actions:
+                    atype = adef.action_type.value if hasattr(adef.action_type, "value") else str(adef.action_type)
+                    trigger_action_configs[atype] = dict(adef.config) if adef.config else {}
+
+            enriched_actions = []
+            for action in ft.actions_dispatched:
+                if isinstance(action, dict):
+                    a = dict(action)
+                else:
+                    # action may be an ActionType enum (str subclass) or a plain string
+                    # Normalise to the .value string so the lookup key is consistent
+                    aval = action.value if hasattr(action, "value") else str(action)
+                    a = {"action_type": aval}
+                    # Merge rule_id / graph_id from the original ActionDef.config
+                    a.update(trigger_action_configs.get(aval, {}))
+                a.setdefault("trigger_depth", depth + 1)
+                a.setdefault("scope", data.get("scope", ""))
+                enriched_actions.append(a)
+            ft.actions_dispatched = enriched_actions
+
+        # Enqueue — bridge.on_triggers_fired est async; on schedule sur l'event loop.
+        #
+        # Quatre cas :
+        #   A) emit() appelé DEPUIS le thread de la loop (worker asyncio) ET loop
+        #      fournie → asyncio.ensure_future (schedule dans la loop courante).
+        #   B) emit() appelé DEPUIS un thread sync (FastAPI handler thread) ET loop
+        #      fournie → asyncio.run_coroutine_threadsafe (thread-safe cross-thread).
+        #   C) Pas de loop fournie mais une loop en cours → ensure_future (même thread).
+        #   D) Aucune loop disponible → contexte synchrone pur (tests sans asyncio).
+        #
+        # Détermination A vs B : on tente get_running_loop() ; si ça retourne la
+        # même loop que self._loop on est sur le bon thread (cas A) ; si ça lève
+        # RuntimeError ou retourne une loop différente, on est dans un thread
+        # externe (cas B).
+        loop = self._loop
+
+        # Attempt to detect whether we're on the event loop thread.
+        try:
+            calling_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            calling_loop = None
+
+        if loop is not None and loop.is_running():
+            if calling_loop is loop:
+                # Case A: we ARE on the event loop thread — schedule directly.
+                future = asyncio.ensure_future(
+                    self._bridge.on_triggers_fired(matched),
+                    loop=loop,
+                )
+                future.add_done_callback(_log_enqueue_error)
+            else:
+                # Case B: called from a sync handler thread — use thread-safe variant.
+                future = asyncio.run_coroutine_threadsafe(
+                    self._bridge.on_triggers_fired(matched),
+                    loop,
+                )
+                future.add_done_callback(_log_concurrent_future_error)
+        elif calling_loop is not None and calling_loop.is_running():
+            # Case C: no explicit loop stored but one is currently running (rare).
+            future = asyncio.ensure_future(
+                self._bridge.on_triggers_fired(matched),
+                loop=calling_loop,
+            )
+            future.add_done_callback(_log_enqueue_error)
+        else:
+            # Case D: purely synchronous context (unit tests without asyncio).
+            if loop is None and calling_loop is None:
+                log.warning(
+                    "run_trigger_sink_triggers_discarded",
+                    reason="no_event_loop",
+                    matched_triggers=len(matched),
+                    detail=(
+                        "No event loop available. Triggers were matched but "
+                        "on_triggers_fired could not be scheduled. "
+                        "Ensure RunCompletionTriggerSink receives the lifespan "
+                        "loop via the 'loop' constructor argument."
+                    ),
+                )
+            jobs = self._bridge.on_triggers_fired_sync(matched)
+            log.info("run_trigger_sink_jobs_created_sync", count=len(jobs))
+            return
+
+        log.info(
+            "run_trigger_sink_dispatched",
+            event_type=event_type,
+            run_id=run_id,
+            matched_triggers=len(matched),
+        )

--- a/src/gispulse/orchestration/trigger_bridge.py
+++ b/src/gispulse/orchestration/trigger_bridge.py
@@ -115,12 +115,41 @@ class TriggerJobBridge:
 
     @staticmethod
     def _normalize_action(action: Any) -> tuple[str, dict]:
-        """Normalize an action to (action_type, action_dict)."""
+        """Normalize an action to (action_type_upper, action_dict).
+
+        Accepts:
+        - dict with ``action_type`` key (may be "RUN_JOB" or "run_job")
+        - str / ActionType enum (str subclass) — converted to UPPER for comparison
+        """
         if isinstance(action, dict):
-            return action.get("action_type", ""), action
-        if isinstance(action, str):
-            return action, {}
-        return str(getattr(action, "action_type", "")), {}
+            raw_type = action.get("action_type", "")
+            # Normalize: enum value "run_job" → "RUN_JOB"; already upper stays upper
+            if hasattr(raw_type, "value"):
+                raw_type = raw_type.value
+            return str(raw_type).upper(), action
+        # str / ActionType enum subclass
+        raw = getattr(action, "value", None) or str(action)
+        return str(raw).upper(), {}
+
+    @staticmethod
+    def _extract_run_context(ft: FiredTrigger, action: dict) -> dict:
+        """Extract run-chain context (depth, scope) from a FiredTrigger action.
+
+        These keys are injected by RunCompletionTriggerSink when an
+        on_run_completed trigger fires, so downstream jobs know their depth
+        in the trigger chain and can parameterize (e.g. inherit scope).
+        """
+        ctx: dict = {}
+        depth = action.get("trigger_depth")
+        if depth is not None:
+            ctx["trigger_depth"] = int(depth)
+        scope = action.get("scope") or ft.result_summary.get("scope")
+        if scope:
+            ctx["scope"] = str(scope)
+        run_id = ft.result_summary.get("run_id")
+        if run_id:
+            ctx["source_run_id"] = str(run_id)
+        return ctx
 
     def _create_job_from_trigger(
         self, ft: FiredTrigger, action: Any
@@ -131,14 +160,16 @@ class TriggerJobBridge:
             log.warning("trigger_run_job_no_rule_id", trigger_id=ft.trigger_id)
             return None
 
+        params = {
+            "rule_ids": [str(rule_id)],
+            "triggered_by": "trigger",
+            "trigger_id": str(ft.trigger_id),
+            "change_record_id": str(ft.change_record_id) if ft.change_record_id else None,
+        }
+        params.update(self._extract_run_context(ft, action if isinstance(action, dict) else {}))
         return Job(
             name=f"trigger_{ft.trigger_id}",
-            parameters={
-                "rule_ids": [str(rule_id)],
-                "triggered_by": "trigger",
-                "trigger_id": str(ft.trigger_id),
-                "change_record_id": str(ft.change_record_id) if ft.change_record_id else None,
-            },
+            parameters=params,
         )
 
     def _create_graph_job_from_trigger(
@@ -150,12 +181,14 @@ class TriggerJobBridge:
             log.warning("trigger_run_graph_no_graph_id", trigger_id=ft.trigger_id)
             return None
 
+        params = {
+            "graph_id": str(graph_id),
+            "triggered_by": "trigger",
+            "trigger_id": str(ft.trigger_id),
+            "change_record_id": str(ft.change_record_id) if ft.change_record_id else None,
+        }
+        params.update(self._extract_run_context(ft, action if isinstance(action, dict) else {}))
         return Job(
             name=f"trigger_graph_{ft.trigger_id}",
-            parameters={
-                "graph_id": str(graph_id),
-                "triggered_by": "trigger",
-                "trigger_id": str(ft.trigger_id),
-                "change_record_id": str(ft.change_record_id) if ft.change_record_id else None,
-            },
+            parameters=params,
         )

--- a/src/gispulse/orchestration/worker.py
+++ b/src/gispulse/orchestration/worker.py
@@ -166,10 +166,16 @@ class JobWorker:
         source = "schedule" if triggered_by == "scheduler" else "job"
 
         # Create PipelineRun record
+        # trigger_depth is injected by TriggerJobBridge when a job is created
+        # from an on_run_completed trigger. Propagating it to PipelineRun.depth
+        # is what makes the anti-loop depth guard effective: the next terminal
+        # event carries the incremented depth so max_depth comparisons work.
+        trigger_depth = int(job.parameters.get("trigger_depth", 0))
         run = PipelineRun(
             source=source,
             spec_ref=job.name,
             scope=str(job.parameters.get("scope", "")),
+            depth=trigger_depth,
         )
 
         # RecordingSink keeps PipelineRunStep entries in sync with the run entity
@@ -203,6 +209,10 @@ class JobWorker:
                 "status": "failed",
                 "ended_at": run.ended_at.isoformat(),
                 "error": "cancelled",
+                "depth": run.depth,
+                "source": run.source,
+                "spec_ref": run.spec_ref,
+                "scope": run.scope,
             })
             return
 
@@ -252,6 +262,10 @@ class JobWorker:
                     "status": "failed",
                     "ended_at": run.ended_at.isoformat(),
                     "error": "cancelled",
+                    "depth": run.depth,
+                    "source": run.source,
+                    "spec_ref": run.spec_ref,
+                    "scope": run.scope,
                 })
                 return
 
@@ -300,6 +314,10 @@ class JobWorker:
                 "job_id": job_id,
                 "status": "completed",
                 "ended_at": run.ended_at.isoformat(),
+                "depth": run.depth,
+                "source": run.source,
+                "spec_ref": run.spec_ref,
+                "scope": run.scope,
             })
             log.info("worker_job_completed", job_id=job_id)
 
@@ -339,6 +357,10 @@ class JobWorker:
                 "status": "failed",
                 "ended_at": run.ended_at.isoformat(),
                 "error": error_msg,
+                "depth": run.depth,
+                "source": run.source,
+                "spec_ref": run.spec_ref,
+                "scope": run.scope,
             })
             log.error("worker_job_failed", job_id=job_id, error=error_msg)
         finally:

--- a/src/gispulse/persistence/run_repository.py
+++ b/src/gispulse/persistence/run_repository.py
@@ -32,9 +32,15 @@ CREATE TABLE IF NOT EXISTS pipeline_runs (
     started_at TEXT NOT NULL,
     ended_at TEXT,
     error TEXT NOT NULL DEFAULT '',
-    steps TEXT NOT NULL DEFAULT '[]'
+    steps TEXT NOT NULL DEFAULT '[]',
+    depth INTEGER NOT NULL DEFAULT 0
 )
 """
+
+# Idempotent migration for existing DBs created before depth was added.
+_MIGRATE_ADD_DEPTH_SQL = (
+    "ALTER TABLE pipeline_runs ADD COLUMN depth INTEGER NOT NULL DEFAULT 0"
+)
 
 
 class RunRepository:
@@ -48,6 +54,12 @@ class RunRepository:
         self._lock = threading.Lock()
         self._db_path.parent.mkdir(parents=True, exist_ok=True)
         self._execute(_CREATE_TABLE_SQL)
+        # Idempotent migration: add depth column if it was created by an older schema.
+        try:
+            self._execute(_MIGRATE_ADD_DEPTH_SQL)
+        except Exception:
+            # Column already exists — OperationalError "duplicate column name".
+            pass
 
     # ------------------------------------------------------------------
     # Connection helpers
@@ -119,6 +131,7 @@ class RunRepository:
             "ended_at": run.ended_at.isoformat() if run.ended_at else None,
             "error": run.error,
             "steps": RunRepository._steps_to_json(run.steps),
+            "depth": run.depth,
         }
 
     @classmethod
@@ -135,6 +148,7 @@ class RunRepository:
         run.ended_at = datetime.fromisoformat(d["ended_at"]) if d.get("ended_at") else None
         run.error = d.get("error", "")
         run.steps = cls._steps_from_json(d.get("steps", "[]"))
+        run.depth = int(d.get("depth", 0))
         return run
 
     # ------------------------------------------------------------------
@@ -214,6 +228,10 @@ class RunRepository:
                     "status": "failed",
                     "ended_at": run.ended_at.isoformat(),
                     "error": "orphaned by worker restart",
+                    "depth": run.depth,
+                    "source": run.source,
+                    "spec_ref": run.spec_ref,
+                    "scope": run.scope,
                 })
             recovered += 1
             log.info("run_orphan_recovered", run_id=str(run.run_id))

--- a/src/gispulse/rules/trigger_evaluator.py
+++ b/src/gispulse/rules/trigger_evaluator.py
@@ -28,6 +28,7 @@ from gispulse.core.models import (
     CompositeConditions,
     DMLConditions,
     FiredTrigger,
+    OnRunCompletedConditions,
     SpatialConstraintConditions,
     ThresholdConditions,
     TopologyConditions,
@@ -523,6 +524,58 @@ class TriggerEvaluator:
         """Generic handler for schedule, api, esb_event, webhook_in — always matches."""
         return True
 
+    def _eval_on_run_completed(
+        self, record: ChangeRecord, trigger: Trigger, typed_cond: Any = None
+    ) -> bool:
+        """ON_RUN_COMPLETED: fires when a run.completed/run.failed event arrives.
+
+        The ChangeRecord is synthetic, built by RunCompletionTriggerSink with::
+
+            table_name  = "run.events"
+            operation   = ChangeOperation.INSERT  (synthetic, ignored by this handler)
+            new_values  = {
+                "run_id":   str,
+                "status":   "completed" | "failed",
+                "source":   str,          # PipelineRun.source
+                "spec_ref": str,          # PipelineRun.spec_ref
+                "scope":    str,          # PipelineRun.scope
+                "depth":    int,          # trigger chain depth (0 = first-order)
+            }
+        """
+        if isinstance(typed_cond, OnRunCompletedConditions):
+            cond = typed_cond
+        else:
+            raw = trigger.conditions or {}
+            cond = OnRunCompletedConditions(
+                status=raw.get("status", "completed"),
+                source=raw.get("source", ""),
+                spec_ref=raw.get("spec_ref", ""),
+                scope=raw.get("scope", ""),
+                max_depth=int(raw.get("max_depth", 5)),
+            )
+
+        values = record.new_values or {}
+        event_status = values.get("status", "")
+        event_depth = int(values.get("depth", 0))
+
+        # Depth guard: reject if we are already at or beyond the max
+        if event_depth >= cond.max_depth:
+            return False
+
+        # Status filter: "any" matches both completed and failed
+        if cond.status != "any" and event_status != cond.status:
+            return False
+
+        # Optional filters (empty string = match all)
+        if cond.source and values.get("source", "") != cond.source:
+            return False
+        if cond.spec_ref and cond.spec_ref not in values.get("spec_ref", ""):
+            return False
+        if cond.scope and values.get("scope", "") != cond.scope:
+            return False
+
+        return True
+
     def _eval_source_changed(
         self, record: ChangeRecord, trigger: Trigger, typed_cond: Any = None
     ) -> bool:
@@ -569,6 +622,7 @@ class TriggerEvaluator:
         "esb_event": _eval_generic,
         "webhook_in": _eval_generic,
         "source_changed": _eval_source_changed,
+        "on_run_completed": _eval_on_run_completed,
     }
 
 

--- a/tests/unit/test_run_completion_triggers.py
+++ b/tests/unit/test_run_completion_triggers.py
@@ -1,0 +1,1051 @@
+"""Tests for on_run_completed trigger source (issue #440-c).
+
+Couvre :
+- Déclaration on_run_completed + run completed → job enqueué avec contexte
+- Filtre status (failed ne matche pas completed et vice-versa)
+- Filtre source / spec_ref / scope
+- Profondeur max (anti-boucle infinie)
+- Aucun trigger → comportement strictement identique (no-op)
+- RecordingSink + RunCompletionTriggerSink integration
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from gispulse.core.conditions import OnRunCompletedConditions
+from gispulse.core.enums import TriggerType
+from gispulse.core.models import (
+    ChangeOperation,
+    ChangeRecord,
+    FiredTrigger,
+    Trigger,
+)
+from gispulse.orchestration.run_trigger_sink import RunCompletionTriggerSink
+from gispulse.orchestration.trigger_bridge import TriggerJobBridge
+from gispulse.persistence.repository import InMemoryRepository
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_trigger(
+    status: str = "completed",
+    source: str = "",
+    spec_ref: str = "",
+    scope: str = "",
+    max_depth: int = 5,
+    rule_id: str = "r1",
+    enabled: bool = True,
+) -> Trigger:
+    """Build an on_run_completed Trigger with a RUN_JOB action.
+
+    ``actions_dispatched`` in FiredTrigger is built from ``trigger.actions``
+    via ``[a.action_type for a in trigger.actions]`` in TriggerEvaluator, so
+    the rule_id is injected separately into the action dict by
+    RunCompletionTriggerSink when enriching the FiredTrigger.
+    For tests that go through TriggerJobBridge directly, we inject rule_id
+    into the action dict in the FiredTrigger itself.
+    """
+    from gispulse.core.models import ActionDef, ActionType
+
+    return Trigger(
+        id=uuid4(),
+        name="test_run_trigger",
+        trigger_type=TriggerType.ON_RUN_COMPLETED,
+        enabled=enabled,
+        conditions={
+            "status": status,
+            "source": source,
+            "spec_ref": spec_ref,
+            "scope": scope,
+            "max_depth": max_depth,
+        },
+        # action_type only; rule_id goes in config for dispatch downstream
+        actions=[
+            ActionDef(
+                action_type=ActionType.RUN_JOB,
+                config={"rule_id": rule_id},
+            )
+        ],
+    )
+
+
+class SpySink:
+    """Records every emitted event for assertion."""
+
+    def __init__(self):
+        self.events: list[tuple[str, dict]] = []
+
+    def emit(self, event_type: str, data: dict) -> None:
+        self.events.append((event_type, data))
+
+    def types(self) -> list[str]:
+        return [t for t, _ in self.events]
+
+
+class FakeQueue:
+    """Minimal async job queue for tests."""
+
+    def __init__(self) -> None:
+        self.enqueued: list[Any] = []
+
+    async def enqueue(self, job: Any) -> None:
+        self.enqueued.append(job)
+
+
+# ---------------------------------------------------------------------------
+# OnRunCompletedConditions unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestOnRunCompletedConditions:
+    def test_default_status_is_completed(self) -> None:
+        cond = OnRunCompletedConditions()
+        assert cond.status == "completed"
+
+    def test_max_depth_default_is_5(self) -> None:
+        cond = OnRunCompletedConditions()
+        assert cond.max_depth == 5
+
+    def test_parse_conditions_registers_on_run_completed(self) -> None:
+        from gispulse.core.models import parse_conditions
+
+        cond = parse_conditions("on_run_completed", {"status": "failed", "max_depth": 3})
+        assert isinstance(cond, OnRunCompletedConditions)
+        assert cond.status == "failed"
+        assert cond.max_depth == 3
+
+    def test_trigger_type_enum_has_on_run_completed(self) -> None:
+        assert TriggerType.ON_RUN_COMPLETED.value == "on_run_completed"
+
+
+# ---------------------------------------------------------------------------
+# TriggerEvaluator — _eval_on_run_completed
+# ---------------------------------------------------------------------------
+
+
+class TestTriggerEvaluatorOnRunCompleted:
+    """TriggerEvaluator correctly evaluates on_run_completed triggers."""
+
+    def _make_record(
+        self,
+        status: str = "completed",
+        source: str = "job",
+        spec_ref: str = "my_job",
+        scope: str = "63",
+        depth: int = 0,
+    ) -> ChangeRecord:
+        return ChangeRecord(
+            table_name="run.events",
+            operation=ChangeOperation.INSERT,
+            new_values={
+                "run_id": str(uuid4()),
+                "status": status,
+                "source": source,
+                "spec_ref": spec_ref,
+                "scope": scope,
+                "depth": depth,
+            },
+        )
+
+    def test_completed_matches_completed_trigger(self) -> None:
+        from gispulse.rules.trigger_evaluator import TriggerEvaluator
+
+        trigger = _make_trigger(status="completed")
+        record = self._make_record(status="completed")
+        evaluator = TriggerEvaluator()
+        results = evaluator.evaluate(record, [trigger])
+        assert len(results) == 1
+        assert results[0].matched is True
+
+    def test_failed_does_not_match_completed_trigger(self) -> None:
+        from gispulse.rules.trigger_evaluator import TriggerEvaluator
+
+        trigger = _make_trigger(status="completed")
+        record = self._make_record(status="failed")
+        evaluator = TriggerEvaluator()
+        results = evaluator.evaluate(record, [trigger])
+        assert results[0].matched is False
+
+    def test_completed_does_not_match_failed_trigger(self) -> None:
+        from gispulse.rules.trigger_evaluator import TriggerEvaluator
+
+        trigger = _make_trigger(status="failed")
+        record = self._make_record(status="completed")
+        evaluator = TriggerEvaluator()
+        results = evaluator.evaluate(record, [trigger])
+        assert results[0].matched is False
+
+    def test_any_matches_both_completed_and_failed(self) -> None:
+        from gispulse.rules.trigger_evaluator import TriggerEvaluator
+
+        trigger = _make_trigger(status="any")
+        evaluator = TriggerEvaluator()
+
+        rec_c = self._make_record(status="completed")
+        rec_f = self._make_record(status="failed")
+        assert evaluator.evaluate(rec_c, [trigger])[0].matched is True
+        assert evaluator.evaluate(rec_f, [trigger])[0].matched is True
+
+    def test_source_filter(self) -> None:
+        from gispulse.rules.trigger_evaluator import TriggerEvaluator
+
+        trigger = _make_trigger(source="job")
+        evaluator = TriggerEvaluator()
+
+        rec_job = self._make_record(source="job")
+        rec_sched = self._make_record(source="schedule")
+        assert evaluator.evaluate(rec_job, [trigger])[0].matched is True
+        assert evaluator.evaluate(rec_sched, [trigger])[0].matched is False
+
+    def test_spec_ref_filter_substring(self) -> None:
+        from gispulse.rules.trigger_evaluator import TriggerEvaluator
+
+        trigger = _make_trigger(spec_ref="ingest")
+        evaluator = TriggerEvaluator()
+
+        rec_match = self._make_record(spec_ref="ingest_dept_63")
+        rec_no = self._make_record(spec_ref="build_dept_63")
+        assert evaluator.evaluate(rec_match, [trigger])[0].matched is True
+        assert evaluator.evaluate(rec_no, [trigger])[0].matched is False
+
+    def test_scope_filter(self) -> None:
+        from gispulse.rules.trigger_evaluator import TriggerEvaluator
+
+        trigger = _make_trigger(scope="63")
+        evaluator = TriggerEvaluator()
+
+        rec_match = self._make_record(scope="63")
+        rec_no = self._make_record(scope="75")
+        assert evaluator.evaluate(rec_match, [trigger])[0].matched is True
+        assert evaluator.evaluate(rec_no, [trigger])[0].matched is False
+
+    def test_depth_at_max_does_not_match(self) -> None:
+        """depth == max_depth → no match (anti-loop guard)."""
+        from gispulse.rules.trigger_evaluator import TriggerEvaluator
+
+        trigger = _make_trigger(max_depth=3)
+        evaluator = TriggerEvaluator()
+        record = self._make_record(depth=3)
+        assert evaluator.evaluate(record, [trigger])[0].matched is False
+
+    def test_depth_below_max_matches(self) -> None:
+        from gispulse.rules.trigger_evaluator import TriggerEvaluator
+
+        trigger = _make_trigger(max_depth=5)
+        evaluator = TriggerEvaluator()
+        record = self._make_record(depth=4)
+        assert evaluator.evaluate(record, [trigger])[0].matched is True
+
+    def test_disabled_trigger_never_matches(self) -> None:
+        from gispulse.rules.trigger_evaluator import TriggerEvaluator
+
+        trigger = _make_trigger(enabled=False)
+        evaluator = TriggerEvaluator()
+        record = self._make_record(status="completed")
+        results = evaluator.evaluate(record, [trigger])
+        # disabled triggers are skipped entirely (no FiredTrigger created)
+        matched = [ft for ft in results if ft.matched]
+        assert len(matched) == 0
+
+    def test_no_triggers_returns_empty(self) -> None:
+        from gispulse.rules.trigger_evaluator import TriggerEvaluator
+
+        evaluator = TriggerEvaluator()
+        record = self._make_record()
+        results = evaluator.evaluate(record, [])
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# TriggerJobBridge — run context propagation
+# ---------------------------------------------------------------------------
+
+
+class TestTriggerJobBridgeRunContext:
+    """Bridge propagates trigger_depth and scope from FiredTrigger to Job."""
+
+    def test_run_job_carries_trigger_depth_and_scope(self) -> None:
+        queue = FakeQueue()
+        bridge = TriggerJobBridge(job_queue=queue)
+
+        ft = FiredTrigger(
+            trigger_id=uuid4(),
+            matched=True,
+            actions_dispatched=[{
+                "action_type": "RUN_JOB",
+                "rule_id": "r1",
+                "trigger_depth": 2,
+                "scope": "63",
+            }],
+            result_summary={"run_id": "run-123", "scope": "63"},
+        )
+        jobs = bridge.on_triggers_fired_sync([ft])
+        assert len(jobs) == 1
+        assert jobs[0].parameters["trigger_depth"] == 2
+        assert jobs[0].parameters["scope"] == "63"
+        assert jobs[0].parameters["source_run_id"] == "run-123"
+
+    def test_run_graph_carries_trigger_depth_and_scope(self) -> None:
+        queue = FakeQueue()
+        bridge = TriggerJobBridge(job_queue=queue)
+
+        ft = FiredTrigger(
+            trigger_id=uuid4(),
+            matched=True,
+            actions_dispatched=[{
+                "action_type": "RUN_GRAPH",
+                "graph_id": "g1",
+                "trigger_depth": 1,
+                "scope": "75",
+            }],
+            result_summary={"run_id": "run-456", "scope": "75"},
+        )
+        jobs = bridge.on_triggers_fired_sync([ft])
+        assert len(jobs) == 1
+        assert jobs[0].parameters["trigger_depth"] == 1
+        assert jobs[0].parameters["scope"] == "75"
+
+    def test_no_context_keys_omit_optional_fields(self) -> None:
+        """Old-style actions without depth/scope don't break."""
+        queue = FakeQueue()
+        bridge = TriggerJobBridge(job_queue=queue)
+
+        ft = FiredTrigger(
+            trigger_id=uuid4(),
+            matched=True,
+            actions_dispatched=[{"action_type": "RUN_JOB", "rule_id": "r2"}],
+        )
+        jobs = bridge.on_triggers_fired_sync([ft])
+        assert len(jobs) == 1
+        assert "trigger_depth" not in jobs[0].parameters
+        assert "scope" not in jobs[0].parameters
+
+
+# ---------------------------------------------------------------------------
+# RunCompletionTriggerSink — unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunCompletionTriggerSink:
+    """Sink routes run terminal events to TriggerJobBridge."""
+
+    def _make_sink(self, triggers: list[Trigger] | None = None, inner=None):
+        """Build a RunCompletionTriggerSink wired to a FakeQueue."""
+        trigger_repo: InMemoryRepository = InMemoryRepository()
+        if triggers:
+            for t in triggers:
+                trigger_repo.save(t)
+
+        queue = FakeQueue()
+        bridge = TriggerJobBridge(job_queue=queue)
+
+        sink = RunCompletionTriggerSink(
+            trigger_repo=trigger_repo,
+            bridge=bridge,
+            inner=inner or SpySink(),
+        )
+        return sink, bridge, queue
+
+    def test_non_terminal_event_not_evaluated(self) -> None:
+        """run.step.started does not evaluate on_run_completed triggers."""
+        trigger = _make_trigger()
+        sink, bridge, queue = self._make_sink(triggers=[trigger])
+        sink.emit("run.step.started", {"run_id": "r1", "step_id": "s1"})
+        assert queue.enqueued == []
+
+    def test_inner_sink_always_receives_event(self) -> None:
+        """Inner sink (EventHubSink) receives all events, even non-terminal."""
+        inner = SpySink()
+        sink, _, _ = self._make_sink(inner=inner)
+        sink.emit("run.started", {"run_id": "r1"})
+        sink.emit("run.completed", {"run_id": "r1", "status": "completed"})
+        assert "run.started" in inner.types()
+        assert "run.completed" in inner.types()
+
+    def test_no_triggers_is_noop(self) -> None:
+        """Without any on_run_completed triggers, behaviour is identical to inner-only."""
+        inner = SpySink()
+        sink, _, queue = self._make_sink(triggers=[], inner=inner)
+        sink.emit("run.completed", {"run_id": "r1", "status": "completed"})
+        # inner still receives the event
+        assert "run.completed" in inner.types()
+        # but no job enqueued
+        assert queue.enqueued == []
+
+    def test_completed_event_enqueues_job_sync(self) -> None:
+        """run.completed matching an on_run_completed trigger creates job (sync path).
+
+        In sync path (no running event loop), on_triggers_fired_sync is used.
+        Jobs are created but NOT enqueued to the async queue (by design — the
+        bridge's sync path returns Job objects; callers must handle them).
+        We verify that the evaluator matched and produced jobs via bridge.
+        """
+        trigger = _make_trigger(status="completed", rule_id="r42")
+        trigger_repo: InMemoryRepository = InMemoryRepository()
+        trigger_repo.save(trigger)
+        queue = FakeQueue()
+        bridge = TriggerJobBridge(job_queue=queue)
+
+        # Patch on_triggers_fired_sync to capture calls
+        created_jobs: list = []
+        original_sync = bridge.on_triggers_fired_sync
+
+        def _capture_sync(fired):
+            jobs = original_sync(fired)
+            created_jobs.extend(jobs)
+            return jobs
+
+        bridge.on_triggers_fired_sync = _capture_sync
+
+        sink = RunCompletionTriggerSink(
+            trigger_repo=trigger_repo,
+            bridge=bridge,
+            inner=SpySink(),
+        )
+
+        sink.emit("run.completed", {
+            "run_id": "run-1",
+            "status": "completed",
+            "source": "job",
+            "spec_ref": "my_job",
+            "scope": "63",
+            "depth": 0,
+        })
+
+        # At least one job should have been produced
+        assert len(created_jobs) >= 1
+        assert created_jobs[0].parameters.get("rule_ids") == ["r42"]
+        assert created_jobs[0].parameters.get("trigger_depth") == 1
+        assert created_jobs[0].parameters.get("scope") == "63"
+
+    def test_failed_event_does_not_match_completed_trigger_sync(self) -> None:
+        """run.failed with a trigger that requires completed → no job."""
+        trigger = _make_trigger(status="completed")
+        inner = SpySink()
+        sink, bridge, queue = self._make_sink(triggers=[trigger], inner=inner)
+
+        sink.emit("run.failed", {
+            "run_id": "run-2",
+            "status": "failed",
+            "source": "job",
+            "spec_ref": "x",
+            "scope": "",
+            "depth": 0,
+        })
+        # inner received the event
+        assert "run.failed" in inner.types()
+
+    def test_depth_guard_in_sink(self) -> None:
+        """Depth ≥ max_depth → no job enqueued, no exception."""
+        trigger = _make_trigger(status="completed", max_depth=2)
+        inner = SpySink()
+        sink, bridge, queue = self._make_sink(triggers=[trigger], inner=inner)
+
+        # depth=2 == max_depth=2 → blocked
+        sink.emit("run.completed", {
+            "run_id": "run-deep",
+            "status": "completed",
+            "source": "job",
+            "spec_ref": "x",
+            "scope": "",
+            "depth": 2,
+        })
+        # inner still received it
+        assert "run.completed" in inner.types()
+        # no job queued
+        assert queue.enqueued == []
+
+    @pytest.mark.asyncio
+    async def test_completed_event_async_enqueues_job(self) -> None:
+        """run.completed with a running loop → job enqueued via asyncio."""
+        trigger = _make_trigger(status="completed", rule_id="r99")
+        trigger_repo: InMemoryRepository = InMemoryRepository()
+        trigger_repo.save(trigger)
+
+        queue = FakeQueue()
+        bridge = TriggerJobBridge(job_queue=queue)
+
+        # Capture the running loop before building the sink
+        loop = asyncio.get_running_loop()
+        sink = RunCompletionTriggerSink(
+            trigger_repo=trigger_repo,
+            bridge=bridge,
+            inner=SpySink(),
+            loop=loop,
+        )
+
+        sink.emit("run.completed", {
+            "run_id": "run-async",
+            "status": "completed",
+            "source": "job",
+            "spec_ref": "x",
+            "scope": "63",
+            "depth": 0,
+        })
+
+        # Give the scheduled coroutine a chance to run
+        await asyncio.sleep(0.1)
+
+        assert len(queue.enqueued) == 1
+        job = queue.enqueued[0]
+        assert "r99" in job.parameters.get("rule_ids", [])
+        assert job.parameters["trigger_depth"] == 1
+        assert job.parameters["scope"] == "63"
+
+    @pytest.mark.asyncio
+    async def test_max_depth_blocks_async_enqueue(self) -> None:
+        """Depth at max_depth → no coroutine scheduled, queue stays empty."""
+        trigger = _make_trigger(status="completed", max_depth=3)
+        trigger_repo: InMemoryRepository = InMemoryRepository()
+        trigger_repo.save(trigger)
+
+        queue = FakeQueue()
+        bridge = TriggerJobBridge(job_queue=queue)
+        loop = asyncio.get_running_loop()
+        sink = RunCompletionTriggerSink(
+            trigger_repo=trigger_repo,
+            bridge=bridge,
+            inner=SpySink(),
+            loop=loop,
+        )
+
+        sink.emit("run.completed", {
+            "run_id": "deep-run",
+            "status": "completed",
+            "source": "job",
+            "spec_ref": "x",
+            "scope": "",
+            "depth": 3,   # == max_depth
+        })
+        await asyncio.sleep(0.1)
+        assert queue.enqueued == []
+
+
+# ---------------------------------------------------------------------------
+# Scenarios router — GraphExecutor construction (anti-#443)
+# ---------------------------------------------------------------------------
+
+
+class TestScenariosRouterGraphExecutorConstruction:
+    """GraphExecutor is constructed with capability_getter, not rule_repo (#443)."""
+
+    def test_run_scenario_with_graph_constructs_executor_correctly(self) -> None:
+        """Calling POST /scenarios/{id}/run on a scenario with a graph should not
+        raise TypeError from the wrong constructor argument."""
+        import os
+        os.environ["GISPULSE_STORAGE"] = "memory"
+
+        from fastapi.testclient import TestClient
+        from gispulse.adapters.http.app import create_app
+        from gispulse.adapters.http.rate_limit import limiter
+        from unittest.mock import MagicMock
+
+        limiter.enabled = False
+        app = create_app()
+        app.state.spatial_engine = MagicMock()
+
+        client = TestClient(app)
+
+        # Create a scenario with a minimal graph (one DATASET node, no edges)
+        create_resp = client.post("/scenarios", json={
+            "name": "graph_scenario",
+            "dataset_id": None,
+            "jobs": [],
+            "rules": [],
+            "metadata": {
+                "graph": {
+                    "nodes": [
+                        {"id": "n1", "node_type": "dataset", "capability": None, "params": {}, "bind": None}
+                    ],
+                    "edges": [],
+                }
+            },
+        })
+        assert create_resp.status_code == 201
+        scenario_id = create_resp.json()["id"]
+
+        # Execute the scenario — this previously raised TypeError: unexpected keyword 'rule_repo'
+        run_resp = client.post(f"/scenarios/{scenario_id}/run")
+        assert run_resp.status_code == 200
+        body = run_resp.json()
+        assert body["status"] in ("success", "failed")  # execution may fail; ctor must not
+
+    def test_run_node_constructs_executor_correctly(self) -> None:
+        """POST /scenarios/{id}/run-node must not raise from wrong constructor arg."""
+        import os
+        os.environ["GISPULSE_STORAGE"] = "memory"
+
+        from fastapi.testclient import TestClient
+        from gispulse.adapters.http.app import create_app
+        from gispulse.adapters.http.rate_limit import limiter
+        from unittest.mock import MagicMock
+
+        limiter.enabled = False
+        app = create_app()
+        app.state.spatial_engine = MagicMock()
+
+        client = TestClient(app)
+
+        create_resp = client.post("/scenarios", json={
+            "name": "node_run_scenario",
+            "dataset_id": None,
+            "jobs": [],
+            "rules": [],
+            "metadata": {
+                "graph": {
+                    "nodes": [
+                        {"id": "cap1", "node_type": "capability", "capability": "buffer", "params": {"distance": 1.0}, "bind": None}
+                    ],
+                    "edges": [],
+                }
+            },
+        })
+        assert create_resp.status_code == 201
+        scenario_id = create_resp.json()["id"]
+
+        run_resp = client.post(
+            f"/scenarios/{scenario_id}/run-node",
+            json={"node_id": "cap1", "override_params": {}},
+        )
+        # May fail (no input GDF) but must not raise TypeError from ctor
+        assert run_resp.status_code in (200, 422, 500)
+        if run_resp.status_code == 200:
+            body = run_resp.json()
+            # Must not be a Python TypeError about rule_repo
+            if body.get("error"):
+                assert "rule_repo" not in str(body.get("error", ""))
+
+
+# ---------------------------------------------------------------------------
+# Scenarios router — PipelineRun persistence
+# ---------------------------------------------------------------------------
+
+
+class TestScenariosRunPipelineRun:
+    """POST /scenarios/{id}/run persists a PipelineRun and emits run events."""
+
+    def _client_with_run_repo(self, tmp_path):
+        """Create a TestClient with a real RunRepository attached to app.state."""
+        import os
+        os.environ["GISPULSE_STORAGE"] = "memory"
+
+        from fastapi.testclient import TestClient
+        from gispulse.adapters.http.app import create_app
+        from gispulse.adapters.http.rate_limit import limiter
+        from gispulse.persistence.run_repository import RunRepository
+        from unittest.mock import MagicMock
+
+        limiter.enabled = False
+        app = create_app()
+        app.state.spatial_engine = MagicMock()
+        # Inject a real run_repo + spy sink
+        run_repo = RunRepository(db_path=tmp_path / "runs.db")
+        app.state.run_repo = run_repo
+        spy = SpySink()
+        app.state.event_sink = spy
+        return TestClient(app), run_repo, spy
+
+    def test_run_scenario_persists_pipeline_run(self, tmp_path) -> None:
+        client, run_repo, spy = self._client_with_run_repo(tmp_path)
+
+        create_resp = client.post("/scenarios", json={
+            "name": "emit_scenario",
+            "dataset_id": None,
+            "jobs": [],
+            "rules": [],
+            "metadata": {},
+        })
+        assert create_resp.status_code == 201
+        scenario_id = create_resp.json()["id"]
+
+        run_resp = client.post(f"/scenarios/{scenario_id}/run")
+        assert run_resp.status_code == 200
+
+        runs = run_repo.list_all()
+        assert len(runs) >= 1
+        run = runs[-1]
+        assert run.source == "scenario"
+        assert str(scenario_id) in run.spec_ref
+
+    def test_run_scenario_emits_run_events(self, tmp_path) -> None:
+        client, run_repo, spy = self._client_with_run_repo(tmp_path)
+
+        create_resp = client.post("/scenarios", json={
+            "name": "events_scenario",
+            "dataset_id": None,
+            "jobs": [],
+            "rules": [],
+            "metadata": {},
+        })
+        scenario_id = create_resp.json()["id"]
+        client.post(f"/scenarios/{scenario_id}/run")
+
+        # run.started must precede run.completed/run.failed
+        assert "run.started" in spy.types()
+        terminal = [t for t in spy.types() if t in ("run.completed", "run.failed")]
+        assert len(terminal) >= 1
+        idx_started = spy.types().index("run.started")
+        idx_terminal = spy.types().index(terminal[0])
+        assert idx_started < idx_terminal
+
+
+# ---------------------------------------------------------------------------
+# P1a — full cycle anti-loop test
+# ---------------------------------------------------------------------------
+
+
+class TestAntiLoopCycleGuard:
+    """Self-triggering scenario: max_depth=2 → exactly 2 re-triggers then blocked.
+
+    Simulates the full chain without a real worker:
+      emit(run.completed, depth=0)
+        → trigger evaluates, creates job depth=1 → emit(run.completed, depth=1)
+          → trigger evaluates, creates job depth=2 → emit(run.completed, depth=2)
+            → depth=2 == max_depth=2 → blocked (no job created)
+    """
+
+    def test_self_trigger_stops_at_max_depth(self) -> None:
+        """depth propagates correctly through the chain; max_depth=2 blocks at depth=2."""
+        from gispulse.rules.trigger_evaluator import TriggerEvaluator
+
+        trigger = _make_trigger(status="completed", max_depth=2)
+        evaluator = TriggerEvaluator()
+
+        def _make_run_completed_record(depth: int) -> "ChangeRecord":
+            return ChangeRecord(
+                table_name="run.events",
+                operation=ChangeOperation.INSERT,
+                new_values={
+                    "run_id": str(uuid4()),
+                    "status": "completed",
+                    "source": "job",
+                    "spec_ref": "self_trigger_job",
+                    "scope": "",
+                    "depth": depth,
+                },
+            )
+
+        # depth=0 → matches (depth < max_depth=2)
+        result_d0 = evaluator.evaluate(_make_run_completed_record(0), [trigger])
+        assert result_d0[0].matched is True, "depth=0 must match when max_depth=2"
+
+        # depth=1 → matches (depth < max_depth=2)
+        result_d1 = evaluator.evaluate(_make_run_completed_record(1), [trigger])
+        assert result_d1[0].matched is True, "depth=1 must match when max_depth=2"
+
+        # depth=2 == max_depth → BLOCKED
+        result_d2 = evaluator.evaluate(_make_run_completed_record(2), [trigger])
+        assert result_d2[0].matched is False, "depth=2 == max_depth=2 must be blocked"
+
+        # depth=3 > max_depth → also blocked
+        result_d3 = evaluator.evaluate(_make_run_completed_record(3), [trigger])
+        assert result_d3[0].matched is False, "depth=3 > max_depth=2 must be blocked"
+
+    def test_sink_depth_propagation_chain(self) -> None:
+        """RunCompletionTriggerSink increments depth in FiredTrigger.result_summary."""
+        trigger = _make_trigger(status="completed", max_depth=3, rule_id="chain_rule")
+        trigger_repo: InMemoryRepository = InMemoryRepository()
+        trigger_repo.save(trigger)
+
+        queue = FakeQueue()
+        bridge = TriggerJobBridge(job_queue=queue)
+
+        # Capture what the sync bridge creates to inspect trigger_depth
+        created_jobs: list = []
+        original_sync = bridge.on_triggers_fired_sync
+
+        def _capture_sync(fired):
+            jobs = original_sync(fired)
+            created_jobs.extend(jobs)
+            return jobs
+
+        bridge.on_triggers_fired_sync = _capture_sync
+
+        sink = RunCompletionTriggerSink(
+            trigger_repo=trigger_repo,
+            bridge=bridge,
+            inner=SpySink(),
+        )
+
+        # Simulate depth=0 run completing
+        sink.emit("run.completed", {
+            "run_id": "run-chain-0",
+            "status": "completed",
+            "source": "job",
+            "spec_ref": "x",
+            "scope": "63",
+            "depth": 0,
+        })
+        assert len(created_jobs) == 1
+        assert created_jobs[0].parameters["trigger_depth"] == 1
+
+        # Simulate the triggered job at depth=1 completing
+        sink.emit("run.completed", {
+            "run_id": "run-chain-1",
+            "status": "completed",
+            "source": "job",
+            "spec_ref": "x",
+            "scope": "63",
+            "depth": 1,
+        })
+        assert len(created_jobs) == 2
+        assert created_jobs[1].parameters["trigger_depth"] == 2
+
+        # Simulate depth=2 completing (still < max_depth=3 → matches)
+        sink.emit("run.completed", {
+            "run_id": "run-chain-2",
+            "status": "completed",
+            "source": "job",
+            "spec_ref": "x",
+            "scope": "63",
+            "depth": 2,
+        })
+        assert len(created_jobs) == 3
+        assert created_jobs[2].parameters["trigger_depth"] == 3
+
+        # Simulate depth=3 completing (== max_depth=3 → BLOCKED)
+        sink.emit("run.completed", {
+            "run_id": "run-chain-3",
+            "status": "completed",
+            "source": "job",
+            "spec_ref": "x",
+            "scope": "63",
+            "depth": 3,
+        })
+        # No new job — depth guard blocks it
+        assert len(created_jobs) == 3, "depth=3 == max_depth=3 must be blocked; no 4th job"
+
+
+# ---------------------------------------------------------------------------
+# P1b — thread dispatch: emit from sync thread enqueues via loop
+# ---------------------------------------------------------------------------
+
+
+class TestThreadDispatch:
+    """emit() from a sync (non-event-loop) thread uses run_coroutine_threadsafe."""
+
+    @pytest.mark.asyncio
+    async def test_emit_from_thread_enqueues_job(self) -> None:
+        """Simulates the FastAPI sync handler context: emit called from a thread pool
+        worker while the event loop is running on the main thread."""
+        import threading
+
+        trigger = _make_trigger(status="completed", rule_id="thread_rule")
+        trigger_repo: InMemoryRepository = InMemoryRepository()
+        trigger_repo.save(trigger)
+
+        queue = FakeQueue()
+        bridge = TriggerJobBridge(job_queue=queue)
+        loop = asyncio.get_running_loop()
+
+        sink = RunCompletionTriggerSink(
+            trigger_repo=trigger_repo,
+            bridge=bridge,
+            inner=SpySink(),
+            loop=loop,
+        )
+
+        emit_done = threading.Event()
+
+        def _thread_emit():
+            # This simulates a sync FastAPI handler thread: no running loop here.
+            sink.emit("run.completed", {
+                "run_id": "thread-run-1",
+                "status": "completed",
+                "source": "job",
+                "spec_ref": "x",
+                "scope": "42",
+                "depth": 0,
+            })
+            emit_done.set()
+
+        thread = threading.Thread(target=_thread_emit)
+        thread.start()
+
+        # Wait for the thread to finish its emit call
+        await asyncio.get_event_loop().run_in_executor(None, emit_done.wait)
+        thread.join()
+
+        # Give the scheduled coroutine time to run
+        await asyncio.sleep(0.2)
+
+        assert len(queue.enqueued) == 1
+        job = queue.enqueued[0]
+        assert "thread_rule" in job.parameters.get("rule_ids", [])
+        assert job.parameters.get("trigger_depth") == 1
+        assert job.parameters.get("scope") == "42"
+
+
+# ---------------------------------------------------------------------------
+# P2 — 404 before run creation produces no PipelineRun
+# ---------------------------------------------------------------------------
+
+
+class TestScenarios404NoRun:
+    """Validation rejections (404/422) must not create a PipelineRun entry."""
+
+    def _client_with_run_repo(self, tmp_path):
+        import os
+        os.environ["GISPULSE_STORAGE"] = "memory"
+
+        from fastapi.testclient import TestClient
+        from gispulse.adapters.http.app import create_app
+        from gispulse.adapters.http.rate_limit import limiter
+        from gispulse.persistence.run_repository import RunRepository
+        from unittest.mock import MagicMock
+
+        limiter.enabled = False
+        app = create_app()
+        app.state.spatial_engine = MagicMock()
+        run_repo = RunRepository(db_path=tmp_path / "runs.db")
+        app.state.run_repo = run_repo
+        spy = SpySink()
+        app.state.event_sink = spy
+        return TestClient(app), run_repo, spy
+
+    def test_run_unknown_scenario_creates_no_run(self, tmp_path) -> None:
+        """POST /scenarios/{unknown_id}/run → 404 → no PipelineRun persisted."""
+        from uuid import uuid4 as _uuid4
+        client, run_repo, _ = self._client_with_run_repo(tmp_path)
+        unknown_id = str(_uuid4())
+        resp = client.post(f"/scenarios/{unknown_id}/run")
+        assert resp.status_code == 404
+        assert run_repo.count() == 0
+
+    def test_run_node_unknown_scenario_creates_no_run(self, tmp_path) -> None:
+        """POST /scenarios/{unknown_id}/run-node → 404 → no PipelineRun persisted."""
+        from uuid import uuid4 as _uuid4
+        client, run_repo, _ = self._client_with_run_repo(tmp_path)
+        unknown_id = str(_uuid4())
+        resp = client.post(
+            f"/scenarios/{unknown_id}/run-node",
+            json={"node_id": "n1", "override_params": {}},
+        )
+        assert resp.status_code == 404
+        assert run_repo.count() == 0
+
+    def test_run_node_no_graph_creates_no_run(self, tmp_path) -> None:
+        """POST /scenarios/{id}/run-node on scenario without graph → 422 → no PipelineRun."""
+        client, run_repo, _ = self._client_with_run_repo(tmp_path)
+
+        # Create scenario WITHOUT a graph
+        create_resp = client.post("/scenarios", json={
+            "name": "no_graph_scenario",
+            "dataset_id": None,
+            "jobs": [],
+            "rules": [],
+            "metadata": {},
+        })
+        assert create_resp.status_code == 201
+        scenario_id = create_resp.json()["id"]
+
+        resp = client.post(
+            f"/scenarios/{scenario_id}/run-node",
+            json={"node_id": "n1", "override_params": {}},
+        )
+        assert resp.status_code == 422
+        assert run_repo.count() == 0
+
+    def test_execution_error_emits_run_failed(self, tmp_path) -> None:
+        """If execution raises, a PipelineRun exists and run.failed is emitted."""
+        client, run_repo, spy = self._client_with_run_repo(tmp_path)
+
+        # Create a scenario with a graph node that will fail (unknown capability)
+        create_resp = client.post("/scenarios", json={
+            "name": "fail_scenario",
+            "dataset_id": None,
+            "jobs": [],
+            "rules": [],
+            "metadata": {
+                "graph": {
+                    "nodes": [
+                        {
+                            "id": "fail_node",
+                            "node_type": "capability",
+                            "capability": "__nonexistent_capability__",
+                            "params": {},
+                            "bind": None,
+                        }
+                    ],
+                    "edges": [],
+                }
+            },
+        })
+        assert create_resp.status_code == 201
+        scenario_id = create_resp.json()["id"]
+
+        run_resp = client.post(f"/scenarios/{scenario_id}/run")
+        # Execution may return 200 with failed status or 500 — either way run is persisted
+        assert run_resp.status_code in (200, 500)
+
+        # A PipelineRun must exist (execution started)
+        assert run_repo.count() >= 1
+        # run.started was emitted
+        assert "run.started" in spy.types()
+
+
+# ---------------------------------------------------------------------------
+# P3 — enqueue exceptions are observed and logged (not swallowed silently)
+# ---------------------------------------------------------------------------
+
+
+class TestEnqueueErrorObserved:
+    """P3: if on_triggers_fired raises, the error is logged and the original event
+    is unaffected (no exception propagates back to the caller)."""
+
+    @pytest.mark.asyncio
+    async def test_queue_raises_logs_error_and_original_event_intact(self, capsys) -> None:
+        """When the bridge's async enqueue raises, the done-callback logs the error.
+
+        The gispulse logger uses structlog (not stdlib), so we capture stdout
+        (structlog default output) rather than caplog. The original run.completed
+        event must still reach the inner sink untouched.
+        """
+        trigger = _make_trigger(status="completed", rule_id="err_rule")
+        trigger_repo: InMemoryRepository = InMemoryRepository()
+        trigger_repo.save(trigger)
+
+        # Bridge that raises on on_triggers_fired
+        class ErrorBridge:
+            async def on_triggers_fired(self, fired):
+                raise RuntimeError("redis_down")
+
+            def on_triggers_fired_sync(self, fired):
+                raise RuntimeError("redis_down")
+
+        inner = SpySink()
+        loop = asyncio.get_running_loop()
+        sink = RunCompletionTriggerSink(
+            trigger_repo=trigger_repo,
+            bridge=ErrorBridge(),
+            inner=inner,
+            loop=loop,
+        )
+
+        sink.emit("run.completed", {
+            "run_id": "err-run-1",
+            "status": "completed",
+            "source": "job",
+            "spec_ref": "x",
+            "scope": "",
+            "depth": 0,
+        })
+
+        # Give the future's done-callback a chance to fire
+        await asyncio.sleep(0.2)
+
+        # Original run.completed event was still delivered to inner sink
+        assert "run.completed" in inner.types()
+
+        # An error was logged (done-callback fired) — structlog writes to stdout
+        captured = capsys.readouterr()
+        assert "enqueue_error" in captured.out or "redis_down" in captured.out, (
+            f"Expected enqueue_error or redis_down in stdout. Got:\n{captured.out}"
+        )


### PR DESCRIPTION
Completes #440 (part c) and **fixes #443**. Targeted at integration/v2.4.

- **`TriggerType.ON_RUN_COMPLETED`** — declared as an ordinary Trigger ({status, source, spec_ref, scope, max_depth}), evaluated by the existing `TriggerEvaluator`, dispatched through the existing `TriggerJobBridge`: event-driven chaining between runs (« ingest scope X completed → enqueue build X ») with no parallel trigger system.
- **`RunCompletionTriggerSink`** (orchestration/, no adapters import) decorates any RunEventSink. Dispatch covers every calling context (loop thread, external sync thread via `run_coroutine_threadsafe` with the lifespan-bound loop, ad-hoc loop) and **never discards silently**; enqueue failures are observed via done-callbacks and never affect the original run event.
- **Loop containment proven end to end**: `PipelineRun.depth` (idempotent migration), seeded from the triggering job, embedded in every terminal event, blocked at `max_depth` — tested with a self-triggering chain (3 re-triggers then a logged block).
- **Scenarios wired**: `run_scenario`/`run_single_node` produce PipelineRuns (source=scenario) through the same RecordingSink plumbing; validation rejections deliberately produce no run. Fixes the pre-existing `GraphExecutor(rule_repo=...)` construction (#443) with a test that builds the real executor.

134 tests across the touched suites, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)