### PR TITLE
feat(maps): saved-map CRUD API — layers + styles + view + filters (#405)

### DIFF
--- a/src/gispulse/adapters/http/app.py
+++ b/src/gispulse/adapters/http/app.py
@@ -42,6 +42,7 @@ from gispulse.adapters.http.routers.portal_router import router as portal_router
 from gispulse.adapters.http.routers.projects_router import router as projects_router
 from gispulse.adapters.http.routers.rules_router import router as rules_router
 from gispulse.adapters.http.routers.runs_router import router as runs_router
+from gispulse.adapters.http.routers.saved_maps_router import router as saved_maps_router
 from gispulse.adapters.http.routers.scenarios_router import router as scenarios_router
 from gispulse.adapters.http.routers.sessions_router import router as sessions_router
 from gispulse.adapters.http.routers.schedules_router import router as schedules_router
@@ -56,7 +57,7 @@ from gispulse.adapters.http.routers.ws_router import router as ws_router
 from gispulse.adapters.http.schemas import CapabilityInfo, HealthResponse
 from gispulse.capabilities import registry
 from gispulse.core.logging import get_logger
-from gispulse.core.models import Dataset, Job, Project, Rule, Scenario, TableRelation, Trigger
+from gispulse.core.models import Dataset, Job, Project, Rule, SavedMap, Scenario, TableRelation, Trigger
 from gispulse.core.observability import MetricsCollector
 from gispulse.orchestration.runner import JobRunner
 from gispulse.persistence.engine_factory import create_spatial_engine
@@ -114,6 +115,7 @@ def _setup_repos(app: FastAPI, storage_mode: str, db_path: Path) -> None:
         app.state.scenario_repo = SQLiteRepository(Scenario, db_path=db_path)
         app.state.trigger_repo = SQLiteRepository(Trigger, db_path=db_path)
         app.state.project_repo = SQLiteRepository(Project, db_path=db_path)
+        app.state.saved_map_repo = SQLiteRepository(SavedMap, db_path=db_path)
         app.state.relation_repo = SQLiteRepository(TableRelation, db_path=db_path)
     else:
         app.state.rule_repo = InMemoryRepository()
@@ -122,6 +124,7 @@ def _setup_repos(app: FastAPI, storage_mode: str, db_path: Path) -> None:
         app.state.scenario_repo = InMemoryRepository()
         app.state.trigger_repo = InMemoryRepository()
         app.state.project_repo = InMemoryRepository()
+        app.state.saved_map_repo = InMemoryRepository()
         app.state.relation_repo = InMemoryRepository()
 
     # RBAC auth repository (opt-in via GISPULSE_RBAC=true)
@@ -849,6 +852,7 @@ def create_app(
         app.include_router(jobs_router)
         app.include_router(runs_router)
         app.include_router(scenarios_router)
+        app.include_router(saved_maps_router)
         app.include_router(capabilities_router)
         app.include_router(templates_router)
         app.include_router(marketplace_router)
@@ -889,6 +893,7 @@ def create_app(
         app.include_router(datasets_router, **protected)
         app.include_router(projects_router, **protected)
         app.include_router(scenarios_router, **protected)
+        app.include_router(saved_maps_router, **protected)
         app.include_router(triggers_router, **write_protected)
         app.include_router(relations_router, **write_protected)
         app.include_router(sessions_router, **protected)

--- a/src/gispulse/adapters/http/dependencies.py
+++ b/src/gispulse/adapters/http/dependencies.py
@@ -84,6 +84,11 @@ def get_trigger_repo(request: Request) -> Repository:
     return request.app.state.trigger_repo  # type: ignore[return-value]
 
 
+def get_saved_map_repo(request: Request) -> Repository:
+    """Return the shared SavedMap repository from app state (#405)."""
+    return request.app.state.saved_map_repo  # type: ignore[return-value]
+
+
 def get_relation_repo(request: Request) -> Repository:
     """Return the shared TableRelation repository from app state."""
     return request.app.state.relation_repo  # type: ignore[return-value]

--- a/src/gispulse/adapters/http/routers/saved_maps_router.py
+++ b/src/gispulse/adapters/http/routers/saved_maps_router.py
@@ -1,0 +1,185 @@
+"""REST router for saved web maps (#405).
+
+A *saved map* is a reusable composition of layers + per-layer styles +
+viewport + filters that the web editor can store and reload. It is the
+persistence socle of the web-mapping editor EPIC (#409); publication as a
+public permalink (#406), MVT tiles (#407) and view stats (#408) build on
+top of this entity.
+
+Endpoints::
+
+    POST   /maps              — create a saved map
+    GET    /maps              — list saved maps (paginated)
+    GET    /maps/{id}         — get one saved map
+    PUT    /maps/{id}         — replace a saved map's composition
+    DELETE /maps/{id}         — delete a saved map
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+
+from gispulse.adapters.http.dependencies import get_saved_map_repo
+from gispulse.adapters.http.rate_limit import limiter
+from gispulse.core.models import SavedMap
+from gispulse.persistence.repository import Repository
+
+router = APIRouter(prefix="/maps", tags=["maps"])
+
+
+# ------------------------------------------------------------------
+# Schemas
+# ------------------------------------------------------------------
+
+
+class SavedMapCreate(BaseModel):
+    """Request body to create or replace a saved map.
+
+    ``layers`` is an ordered list of layer descriptors; ``styles`` /
+    ``filters`` are keyed by layer id; ``view`` holds the viewport. The
+    inner shapes are intentionally free-form (passthrough JSON) so the
+    editor can evolve them without a backend change.
+    """
+
+    name: str
+    description: str = ""
+    project_id: UUID | None = None
+    layers: list[dict[str, Any]] = Field(default_factory=list)
+    styles: dict[str, Any] = Field(default_factory=dict)
+    view: dict[str, Any] = Field(default_factory=dict)
+    filters: dict[str, Any] = Field(default_factory=dict)
+    basemap: str = ""
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class SavedMapResponse(BaseModel):
+    id: str
+    name: str
+    description: str
+    project_id: str | None
+    layers: list[dict[str, Any]]
+    styles: dict[str, Any]
+    view: dict[str, Any]
+    filters: dict[str, Any]
+    basemap: str
+    metadata: dict[str, Any]
+    created_at: str
+    updated_at: str
+
+
+class PaginatedSavedMaps(BaseModel):
+    items: list[SavedMapResponse]
+    total: int
+    limit: int
+    offset: int
+
+
+def _to_response(m: SavedMap) -> SavedMapResponse:
+    return SavedMapResponse(
+        id=str(m.id),
+        name=m.name,
+        description=m.description,
+        project_id=str(m.project_id) if m.project_id is not None else None,
+        layers=m.layers,
+        styles=m.styles,
+        view=m.view,
+        filters=m.filters,
+        basemap=m.basemap,
+        metadata=m.metadata,
+        created_at=m.created_at.isoformat(),
+        updated_at=m.updated_at.isoformat(),
+    )
+
+
+# ------------------------------------------------------------------
+# Endpoints
+# ------------------------------------------------------------------
+
+
+@router.post("", response_model=SavedMapResponse, status_code=201)
+@limiter.limit("30/minute")
+def create_map(
+    request: Request,
+    body: SavedMapCreate,
+    repo: Repository = Depends(get_saved_map_repo),
+) -> SavedMapResponse:
+    saved = SavedMap(
+        name=body.name,
+        description=body.description,
+        project_id=body.project_id,
+        layers=body.layers,
+        styles=body.styles,
+        view=body.view,
+        filters=body.filters,
+        basemap=body.basemap,
+        metadata=body.metadata,
+    )
+    repo.save(saved)
+    return _to_response(saved)
+
+
+@router.get("", response_model=PaginatedSavedMaps)
+def list_maps(
+    limit: int = 50,
+    offset: int = 0,
+    project_id: UUID | None = None,
+    repo: Repository = Depends(get_saved_map_repo),
+) -> PaginatedSavedMaps:
+    maps = repo.list_all()
+    if project_id is not None:
+        maps = [m for m in maps if str(m.project_id) == str(project_id)]
+    items = [_to_response(m) for m in maps]
+    return PaginatedSavedMaps(
+        items=items[offset: offset + limit],
+        total=len(items),
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.get("/{map_id}", response_model=SavedMapResponse)
+def get_map(
+    map_id: UUID,
+    repo: Repository = Depends(get_saved_map_repo),
+) -> SavedMapResponse:
+    saved = repo.get(map_id)
+    if saved is None:
+        raise HTTPException(status_code=404, detail="Saved map not found")
+    return _to_response(saved)
+
+
+@router.put("/{map_id}", response_model=SavedMapResponse)
+def update_map(
+    map_id: UUID,
+    body: SavedMapCreate,
+    repo: Repository = Depends(get_saved_map_repo),
+) -> SavedMapResponse:
+    saved = repo.get(map_id)
+    if saved is None:
+        raise HTTPException(status_code=404, detail="Saved map not found")
+    saved.name = body.name
+    saved.description = body.description
+    saved.project_id = body.project_id
+    saved.layers = body.layers
+    saved.styles = body.styles
+    saved.view = body.view
+    saved.filters = body.filters
+    saved.basemap = body.basemap
+    saved.metadata = body.metadata
+    saved.updated_at = datetime.now(timezone.utc)
+    repo.save(saved)
+    return _to_response(saved)
+
+
+@router.delete("/{map_id}", status_code=204)
+def delete_map(
+    map_id: UUID,
+    repo: Repository = Depends(get_saved_map_repo),
+) -> None:
+    if not repo.delete(map_id):
+        raise HTTPException(status_code=404, detail="Saved map not found")

--- a/src/gispulse/core/models.py
+++ b/src/gispulse/core/models.py
@@ -344,3 +344,43 @@ class Project:
     metadata: dict[str, Any] = field(default_factory=dict)
     created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     updated_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+# ---------------------------------------------------------------------------
+# Saved web map (#405 — editor composition: layers + styles + view + filters)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SavedMap:
+    """A saved web map composition.
+
+    Captures everything needed to reload a map in the web editor (and, in
+    a later step, to publish it as a public permalink — #406):
+
+    * ``layers``  — ordered list of layer descriptors, each a dict such as
+      ``{"dataset_id": "...", "layer": "...", "visible": true,
+      "opacity": 1.0}``. A list of dicts (not bare UUIDs) because a map
+      layer carries display state beyond its identity.
+    * ``styles``  — per-layer style-def dicts keyed by layer id. The shape
+      is the one consumed by
+      :func:`gispulse.persistence.style_converter.style_def_to_qml`
+      (``renderer`` key + symbol/classes), so a saved map's styles can be
+      exported to QML/SLD unchanged.
+    * ``view``    — viewport: ``{"center": [lng, lat], "zoom": ...,
+      "bearing": ..., "pitch": ..., "bbox": [...]}``.
+    * ``filters`` — per-layer filter expressions keyed by layer id.
+    """
+
+    id: UUID = field(default_factory=uuid4)
+    name: str = ""
+    description: str = ""
+    project_id: UUID | None = None
+    layers: list[dict[str, Any]] = field(default_factory=list)
+    styles: dict[str, Any] = field(default_factory=dict)
+    view: dict[str, Any] = field(default_factory=dict)
+    filters: dict[str, Any] = field(default_factory=dict)
+    basemap: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))

--- a/src/gispulse/persistence/gpkg_repository.py
+++ b/src/gispulse/persistence/gpkg_repository.py
@@ -21,6 +21,7 @@ from gispulse.core.models import (
     Project,
     RefLayerDef,
     Rule,
+    SavedMap,
     Scenario,
     TableRelation,
     Trigger,
@@ -41,6 +42,7 @@ T = TypeVar(
     Trigger,
     Scenario,
     Project,
+    SavedMap,
     TableRelation,
     RefLayerDef,
 )
@@ -53,6 +55,7 @@ _MODEL_TABLE: dict[type, str] = {
     Layer: "_gispulse_layers",
     Scenario: "_gispulse_scenarios",
     Project: "_gispulse_projects",
+    SavedMap: "_gispulse_saved_maps",
     Trigger: "_gispulse_triggers",
     TableRelation: "_gispulse_table_relations",
     RefLayerDef: "_gispulse_ref_layers",

--- a/src/gispulse/persistence/schema.py
+++ b/src/gispulse/persistence/schema.py
@@ -133,6 +133,20 @@ _TABLE_DEFS: dict[str, list[tuple[str, str]]] = {
         ("created_at", "TEXT"),
         ("updated_at", "TEXT"),
     ],
+    "saved_maps": [
+        ("id", "TEXT PRIMARY KEY"),
+        ("name", "TEXT NOT NULL"),
+        ("description", "TEXT DEFAULT ''"),
+        ("project_id", "TEXT"),
+        ("layers", "TEXT DEFAULT '[]'"),
+        ("styles", "TEXT DEFAULT '{}'"),
+        ("view", "TEXT DEFAULT '{}'"),
+        ("filters", "TEXT DEFAULT '{}'"),
+        ("basemap", "TEXT DEFAULT ''"),
+        ("metadata", "TEXT DEFAULT '{}'"),
+        ("created_at", "TEXT"),
+        ("updated_at", "TEXT"),
+    ],
     "ref_layers": [
         ("id", "TEXT PRIMARY KEY"),
         ("name", "TEXT NOT NULL"),
@@ -185,6 +199,8 @@ JSON_COLUMNS = frozenset({
     "predicates", "actions", "jobs", "rules", "graph",
     "datasets", "triggers", "ogc_source",
     "spatial_config", "computed_fields",
+    # saved_maps (#405)
+    "layers", "styles", "view", "filters",
 })
 
 # Columns that store datetimes (serialised as ISO text)
@@ -197,7 +213,7 @@ DATETIME_COLUMNS = frozenset({
 UUID_COLUMNS = frozenset({
     "id", "dataset_id", "job_id", "rule_id",
     "source_layer_id", "target_layer_id", "trigger_id",
-    "scope_target_id",
+    "scope_target_id", "project_id",
 })
 
 # Columns that store booleans (serialised as INTEGER 0/1)
@@ -268,4 +284,6 @@ def build_model_table_mapping(prefix: str = "_gispulse_") -> dict[str, str]:
 #                                  WHEN clause that suppresses re-fires when
 #                                  an action_dispatcher write-back tagged the
 #                                  row with ``trigger:<id>`` (origin-tagging M1).
-SCHEMA_VERSION = 3
+# v3 → v4 (2026-06-10, #405): added the ``saved_maps`` entity table (web-map
+#                             compositions: layers + styles + view + filters).
+SCHEMA_VERSION = 4

--- a/src/gispulse/persistence/sqlite_repository.py
+++ b/src/gispulse/persistence/sqlite_repository.py
@@ -27,6 +27,7 @@ from gispulse.core.models import (
     Project,
     RefLayerDef,
     Rule,
+    SavedMap,
     Scenario,
     TableRelation,
     Trigger,
@@ -50,6 +51,7 @@ T = TypeVar(
     Trigger,
     Scenario,
     Project,
+    SavedMap,
     TableRelation,
     RefLayerDef,
 )
@@ -118,6 +120,7 @@ _MODEL_TABLE: dict[type, str] = {
     Dataset: "datasets",
     Scenario: "scenarios",
     Project: "projects",
+    SavedMap: "saved_maps",
     Trigger: "triggers",
     TableRelation: "table_relations",
     RefLayerDef: "ref_layers",

--- a/tests/unit/test_saved_maps_router.py
+++ b/tests/unit/test_saved_maps_router.py
@@ -1,0 +1,198 @@
+"""Tests for the /maps/* endpoints — saved web maps CRUD (#405)."""
+
+from __future__ import annotations
+
+import os
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from gispulse.adapters.http.app import create_app
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch):
+    """Force in-memory storage and disable rate limiting."""
+    monkeypatch.setenv("GISPULSE_STORAGE", "memory")
+    from gispulse.adapters.http.rate_limit import limiter
+
+    limiter.enabled = False
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    os.environ["GISPULSE_STORAGE"] = "memory"
+    app = create_app()
+    from unittest.mock import MagicMock
+
+    app.state.spatial_engine = MagicMock()
+    return TestClient(app)
+
+
+def _payload(name: str = "Ma carte", **overrides) -> dict:
+    payload = {
+        "name": name,
+        "description": "carte de test",
+        "layers": [
+            {"dataset_id": "abc", "layer": "parcelles", "visible": True, "opacity": 0.8},
+        ],
+        "styles": {"parcelles": {"renderer": "single", "color": "#ff0000"}},
+        "view": {"center": [2.35, 48.85], "zoom": 12},
+        "filters": {"parcelles": "surface > 100"},
+        "basemap": "osm",
+        "metadata": {},
+    }
+    payload.update(overrides)
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# POST /maps
+# ---------------------------------------------------------------------------
+
+
+class TestCreateMap:
+    def test_create_returns_201_with_full_composition(self, client: TestClient) -> None:
+        resp = client.post("/maps", json=_payload())
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["name"] == "Ma carte"
+        assert "id" in body
+        assert body["layers"][0]["opacity"] == 0.8
+        assert body["styles"]["parcelles"]["renderer"] == "single"
+        assert body["view"]["zoom"] == 12
+        assert body["filters"]["parcelles"] == "surface > 100"
+        assert body["basemap"] == "osm"
+        assert body["created_at"] and body["updated_at"]
+
+    def test_create_with_project_id(self, client: TestClient) -> None:
+        pid = str(uuid4())
+        resp = client.post("/maps", json=_payload(project_id=pid))
+        assert resp.status_code == 201
+        assert resp.json()["project_id"] == pid
+
+    def test_create_defaults_empty_composition(self, client: TestClient) -> None:
+        resp = client.post("/maps", json={"name": "vide"})
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["layers"] == []
+        assert body["styles"] == {}
+        assert body["project_id"] is None
+
+    def test_create_422_on_missing_name(self, client: TestClient) -> None:
+        resp = client.post("/maps", json={"view": {}})
+        assert resp.status_code == 422
+        assert resp.json()["error"]["code"] == "VALIDATION_ERROR"
+
+    def test_create_422_on_invalid_project_id(self, client: TestClient) -> None:
+        resp = client.post("/maps", json=_payload(project_id="not-a-uuid"))
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /maps
+# ---------------------------------------------------------------------------
+
+
+class TestListMaps:
+    def test_list_empty(self, client: TestClient) -> None:
+        resp = client.get("/maps")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["items"] == []
+        assert body["total"] == 0
+
+    def test_list_after_create(self, client: TestClient) -> None:
+        client.post("/maps", json=_payload(name="a"))
+        client.post("/maps", json=_payload(name="b"))
+        body = client.get("/maps").json()
+        assert body["total"] == 2
+        assert {m["name"] for m in body["items"]} == {"a", "b"}
+
+    def test_list_pagination(self, client: TestClient) -> None:
+        for i in range(5):
+            client.post("/maps", json=_payload(name=f"m{i}"))
+        body = client.get("/maps?limit=2&offset=1").json()
+        assert body["total"] == 5
+        assert len(body["items"]) == 2
+        assert body["limit"] == 2
+        assert body["offset"] == 1
+
+    def test_list_filter_by_project(self, client: TestClient) -> None:
+        pid = str(uuid4())
+        client.post("/maps", json=_payload(name="in", project_id=pid))
+        client.post("/maps", json=_payload(name="out", project_id=str(uuid4())))
+        body = client.get(f"/maps?project_id={pid}").json()
+        assert body["total"] == 1
+        assert body["items"][0]["name"] == "in"
+
+
+# ---------------------------------------------------------------------------
+# GET /maps/{id}
+# ---------------------------------------------------------------------------
+
+
+class TestGetMap:
+    def test_get_existing(self, client: TestClient) -> None:
+        created = client.post("/maps", json=_payload()).json()
+        resp = client.get(f"/maps/{created['id']}")
+        assert resp.status_code == 200
+        assert resp.json()["id"] == created["id"]
+
+    def test_get_404(self, client: TestClient) -> None:
+        resp = client.get(f"/maps/{uuid4()}")
+        assert resp.status_code == 404
+        assert resp.json()["error"]["code"] == "NOT_FOUND"
+
+    def test_get_422_invalid_uuid(self, client: TestClient) -> None:
+        resp = client.get("/maps/not-a-uuid")
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# PUT /maps/{id}
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateMap:
+    def test_update_replaces_composition(self, client: TestClient) -> None:
+        created = client.post("/maps", json=_payload()).json()
+        new = _payload(
+            name="Renommée",
+            view={"center": [0, 0], "zoom": 3},
+            layers=[],
+        )
+        resp = client.put(f"/maps/{created['id']}", json=new)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["name"] == "Renommée"
+        assert body["view"]["zoom"] == 3
+        assert body["layers"] == []
+        assert body["id"] == created["id"]
+
+    def test_update_404(self, client: TestClient) -> None:
+        resp = client.put(f"/maps/{uuid4()}", json=_payload())
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# DELETE /maps/{id}
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteMap:
+    def test_delete_204(self, client: TestClient) -> None:
+        created = client.post("/maps", json=_payload()).json()
+        resp = client.delete(f"/maps/{created['id']}")
+        assert resp.status_code == 204
+        assert client.get(f"/maps/{created['id']}").status_code == 404
+
+    def test_delete_404(self, client: TestClient) -> None:
+        resp = client.delete(f"/maps/{uuid4()}")
+        assert resp.status_code == 404


### PR DESCRIPTION
Premier brique de l'**EPIC #409 (éditeur web mapping)**, sur `integration/v2.4`. Entité `SavedMap` + CRUD REST = le socle sur lequel s'appuieront la publication (#406), les tuiles MVT (#407) et les stats de vues (#408).

## Modèle
`SavedMap` (dataclass, `core/models.py`) = composition rechargeable d'une carte :
- `layers` : liste ordonnée de descripteurs de couche (`{dataset_id, layer, visible, opacity, ...}`)
- `styles` : style-def par couche (forme compatible `style_converter.style_def_to_qml` → export QML/SLD ultérieur sans conversion)
- `view` : viewport (`center`, `zoom`, `bearing`, `pitch`, `bbox`)
- `filters` : expressions de filtre par couche
- `basemap`, `project_id?`, `metadata`, `created_at`/`updated_at`

## Persistence
- Table `saved_maps` ajoutée à `_TABLE_DEFS` (colonnes JSON `layers/styles/view/filters`, UUID `project_id`), **SCHEMA_VERSION 3 → 4**.
- Câblée dans les repositories génériques **SQLite + GPKG** (pas de DAO par entité — le sérialiseur réflexif gère). La table GPKG `_gispulse_saved_maps` est créée au bootstrap automatiquement.

## API (`/maps`)
`POST` (201) · `GET` liste paginée + filtre `?project_id=` · `GET /{id}` · `PUT /{id}` (remplace la composition, bump `updated_at`) · `DELETE /{id}` (204). 404/422 via les error handlers centraux. Montée `**protected` (comme projects/scenarios) en mode full + portal.

## Tests
- 16 tests router : round-trip composition complète, filtre projet, pagination, chemins 404/422.
- Round-trips repository SQLite **et** GPKG (smoke).
- Régression : **698 HTTP/app** + **622 persistence** verts, ruff clean.

Suite EPIC #409 : #406 (publication token + read-only), #407 (MVT), #408 (stats vues) + frontend portal #133-#138.