### PR TITLE
feat(http): run and validate manifest v3 pipelines over HTTP (#440 wave 3)

### DIFF
--- a/src/gispulse/adapters/http/app.py
+++ b/src/gispulse/adapters/http/app.py
@@ -50,6 +50,7 @@ from gispulse.adapters.http.routers.templates_router import router as templates_
 from gispulse.adapters.http.routers.triggers_router import router as triggers_router
 from gispulse.adapters.http.routers.watchers_router import router as watchers_router
 from gispulse.adapters.http.routers.relations_router import router as relations_router
+from gispulse.adapters.http.routers.manifests_router import router as manifests_router
 from gispulse.adapters.http.routers.marketplace_router import router as marketplace_router
 from gispulse.adapters.http.routers.pipelines_router import router as pipelines_router
 from gispulse.adapters.http.routers.ws_router import router as ws_router
@@ -886,6 +887,7 @@ def create_app(
         app.include_router(filter_router)
         app.include_router(schedules_router)
         app.include_router(pipelines_router)
+        app.include_router(manifests_router)
         app.include_router(system_router)
         app.include_router(watchers_router)
         try:
@@ -927,6 +929,7 @@ def create_app(
         app.include_router(filter_router, **protected)
         app.include_router(schedules_router, **write_protected)
         app.include_router(pipelines_router, **write_protected)
+        app.include_router(manifests_router, **write_protected)
         app.include_router(system_router, **protected)
         app.include_router(watchers_router, **read_protected)
 

--- a/src/gispulse/adapters/http/routers/manifests_router.py
+++ b/src/gispulse/adapters/http/routers/manifests_router.py
@@ -1,0 +1,278 @@
+"""
+Manifests router for the GISPulse HTTP API — vague 3 orchestration.
+
+Endpoints:
+    POST /manifests/run      -- submit a v3 manifest for async execution (202)
+    POST /manifests/validate -- validate a v3 manifest without executing (200)
+
+Architecture:
+    Execution goes through the same job/worker pipeline as POST /jobs.
+    The manifest dict is stored in job.parameters["manifest"] so the
+    existing worker + JobRunner._execute_manifest picks it up.
+    PipelineRun.spec_ref = manifest name, .scope = optional body param.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+
+from gispulse.adapters.http.dependencies import (
+    get_dataset_repo,
+    get_job_queue,
+    get_job_repo,
+    get_results_dir,
+)
+from gispulse.adapters.http.rate_limit import limiter
+from gispulse.core.logging import get_logger
+from gispulse.core.models import Job
+from gispulse.orchestration.job_queue import JobQueue
+from gispulse.persistence.repository import Repository
+
+log = get_logger(__name__)
+
+router = APIRouter(prefix="/manifests", tags=["manifests"])
+
+
+# ---------------------------------------------------------------------------
+# Request / response schemas
+# ---------------------------------------------------------------------------
+
+
+class ManifestRunRequest(BaseModel):
+    """Request body for POST /manifests/run."""
+
+    manifest: dict[str, Any] = Field(
+        ...,
+        description="A v3 manifest dict ({version: 3, sources: {...}, models: {...}}).",
+    )
+    dataset_id: UUID | None = Field(
+        None,
+        description="Optional dataset UUID to load as the primary source for this run.",
+    )
+    scope: str | None = Field(
+        None,
+        description="Optional scope tag (e.g. department code '63'). "
+        "Stored on PipelineRun.scope and used by monitoring platforms to filter runs.",
+    )
+
+
+class ManifestRunResponse(BaseModel):
+    """Response for POST /manifests/run — 202 Accepted."""
+
+    job_id: UUID = Field(..., description="UUID of the enqueued job.")
+    status: str = Field("pending", description="Initial job status.")
+    manifest_name: str = Field("", description="Name field from the submitted manifest.")
+
+
+class ManifestValidateRequest(BaseModel):
+    """Request body for POST /manifests/validate."""
+
+    manifest: dict[str, Any] = Field(
+        ...,
+        description="A v3 manifest dict to validate without executing.",
+    )
+
+
+class ManifestValidateResponse(BaseModel):
+    """Validation result for POST /manifests/validate."""
+
+    valid: bool = Field(..., description="True when the manifest passes all checks.")
+    errors: list[str] = Field(
+        default_factory=list,
+        description="Validation errors (empty when valid=True).",
+    )
+    compiled_steps_count: int = Field(
+        0,
+        description="Number of steps the compiled PipelineSpec would contain "
+        "(only meaningful when valid=True).",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _validate_manifest_dict(raw: dict[str, Any]) -> tuple[bool, list[str], int]:
+    """Full validation pipeline for a raw manifest dict.
+
+    Returns (valid, errors, compiled_steps_count).
+    Errors are human-readable strings, not exceptions — caller decides
+    whether to 422 (router) or propagate (runner).
+    """
+    from gispulse.core.pipeline_schema import validate_pipeline_json
+    from gispulse.core.manifest_v3 import (
+        ManifestV3,
+        _parse_sources,
+        _parse_staging,
+        _parse_models,
+        _parse_v3_triggers,
+        validate_manifest,
+        compile_to_pipeline,
+        ManifestValidationError,
+    )
+
+    # 1. Type + version guard
+    if not isinstance(raw, dict):
+        return False, [f"manifest must be a dict, got {type(raw).__name__}"], 0
+    received_version = raw.get("version")
+    if received_version != 3:
+        return False, [
+            f"manifest must be version 3, got version={received_version!r}. "
+            'Use a v3 manifest ({"version": 3, "sources": {...}, "models": {...}}).'
+        ], 0
+
+    # 2. JSON Schema (SCHEMA_V3)
+    schema_errors = validate_pipeline_json(raw)
+    if schema_errors:
+        return False, schema_errors, 0
+
+    # 3. Parse + graph checks (refs, cycles)
+    try:
+        manifest = ManifestV3(
+            name=raw.get("name", ""),
+            description=raw.get("description", ""),
+            sources=_parse_sources(raw.get("sources", {})),
+            staging=_parse_staging(raw.get("staging")),
+            models=_parse_models(raw.get("models", {})),
+            triggers=_parse_v3_triggers(raw.get("triggers", [])),
+            security=dict(raw.get("security") or {}),
+            runtime=dict(raw.get("runtime") or {}),
+        )
+    except Exception as exc:
+        return False, [f"manifest parse error: {exc}"], 0
+
+    try:
+        validate_manifest(manifest)
+    except ManifestValidationError as exc:
+        return False, exc.errors, 0
+
+    # 4. Compile + capability existence check
+    # Mirrors the check in POST /pipelines/validate (pipelines_router.py:187-207)
+    # so unknown capabilities are caught at the manifest layer too.
+    try:
+        compiled = compile_to_pipeline(manifest)
+        steps_count = len(compiled.steps)
+    except Exception as exc:
+        return False, [f"compile error: {exc}"], 0
+
+    try:
+        from gispulse.capabilities import list_all as _list_caps
+        known_caps = {c["name"] for c in _list_caps()}
+        cap_errors = [
+            f"unknown capability '{step.capability}' in step '{step.id}'. "
+            f"Available: {sorted(known_caps)}."
+            for step in compiled.steps
+            if step.type == "capability" and step.capability
+            and step.capability not in known_caps
+        ]
+        if cap_errors:
+            return False, cap_errors, steps_count
+    except ImportError:
+        # capabilities module unavailable (stripped build); skip the check.
+        pass
+
+    return True, [], steps_count
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post("/run", response_model=ManifestRunResponse, status_code=202)
+@limiter.limit("10/minute")
+async def run_manifest_job(
+    request: Request,
+    payload: ManifestRunRequest,
+    background_tasks: BackgroundTasks,
+    job_repo: Repository = Depends(get_job_repo),
+    dataset_repo: Repository = Depends(get_dataset_repo),
+    job_queue: JobQueue = Depends(get_job_queue),
+    results_dir: Path = Depends(get_results_dir),
+) -> ManifestRunResponse:
+    """Submit a v3 manifest for asynchronous execution.
+
+    Returns immediately with HTTP 202 and the job in ``pending`` status.
+    Use ``GET /jobs/{job_id}`` to poll for completion, or
+    ``GET /jobs/{job_id}/events`` for SSE streaming.
+    Use ``GET /runs`` to find the associated PipelineRun (spec_ref = manifest name).
+
+    The manifest is validated upfront before enqueueing — an invalid manifest
+    (bad version, unresolved refs, cycle) returns 422 immediately without
+    creating a job.
+    """
+    # --- Upfront validation (422 before any enqueue) ----------------------
+    valid, errors, _ = _validate_manifest_dict(payload.manifest)
+    if not valid:
+        raise HTTPException(
+            status_code=422,
+            detail={"valid": False, "errors": errors},
+        )
+
+    manifest_name = payload.manifest.get("name", "") or "manifest"
+
+    # --- Build job parameters ---------------------------------------------
+    parameters: dict[str, Any] = {"manifest": payload.manifest}
+    if payload.scope:
+        parameters["scope"] = payload.scope
+
+    job = Job(
+        name=manifest_name,
+        dataset_id=payload.dataset_id,
+        parameters=parameters,
+    )
+    job_repo.save(job)
+
+    # --- Enqueue ----------------------------------------------------------
+    if job_queue is not None:
+        await job_queue.enqueue(job)
+    else:
+        # Fallback: BackgroundTasks (no worker running)
+        from gispulse.adapters.http.routers.jobs_router import _run_job_background
+
+        runner = request.app.state.job_runner
+        background_tasks.add_task(
+            _run_job_background,
+            job,
+            job_repo,
+            dataset_repo,
+            runner,
+            results_dir,
+        )
+
+    log.info(
+        "manifest_job_enqueued",
+        job_id=str(job.id),
+        manifest_name=manifest_name,
+        scope=payload.scope or "",
+    )
+
+    return ManifestRunResponse(
+        job_id=job.id,
+        status="pending",
+        manifest_name=manifest_name,
+    )
+
+
+@router.post("/validate", response_model=ManifestValidateResponse)
+def validate_manifest_endpoint(
+    payload: ManifestValidateRequest,
+) -> ManifestValidateResponse:
+    """Validate a v3 manifest without executing.
+
+    Checks version, JSON Schema (SCHEMA_V3), unresolved source/model
+    references, and inter-model cycles. Returns the number of compiled
+    steps when the manifest is valid.
+    """
+    valid, errors, compiled_steps_count = _validate_manifest_dict(payload.manifest)
+    return ManifestValidateResponse(
+        valid=valid,
+        errors=errors,
+        compiled_steps_count=compiled_steps_count,
+    )

--- a/src/gispulse/adapters/http/schemas.py
+++ b/src/gispulse/adapters/http/schemas.py
@@ -249,6 +249,29 @@ class JobCreate(BaseModel):
         description="Execution parameters (e.g. rule_ids to apply).",
     )
 
+    @field_validator("parameters")
+    @classmethod
+    def _reject_reserved_keys(cls, v: dict[str, Any]) -> dict[str, Any]:
+        """Reject orchestration-internal keys that must go through dedicated endpoints.
+
+        These keys are injected by the scheduler, trigger bridge, or
+        ``POST /manifests/run`` — they are not valid external job parameters.
+        Accepting them via ``POST /jobs`` would bypass auth/validation on those
+        dedicated routes.
+        """
+        _RESERVED: dict[str, str] = {
+            "manifest": "POST /manifests/run",
+            "pipeline_config": "POST /pipelines/<id>/run (or the scheduler)",
+            "trigger_depth": "internal trigger bridge (not settable externally)",
+        }
+        for key, hint in _RESERVED.items():
+            if key in v:
+                raise ValueError(
+                    f"'{key}' is a reserved orchestration parameter and cannot "
+                    f"be set via POST /jobs. Use {hint} instead."
+                )
+        return v
+
 
 class JobResponse(BaseModel):
     """Serialised Job returned by the API."""

--- a/src/gispulse/orchestration/runner.py
+++ b/src/gispulse/orchestration/runner.py
@@ -20,9 +20,12 @@ from gispulse.core.models import Job, JobStatus, Rule
 from gispulse.orchestration.event_sink import RunEventSink
 from gispulse.persistence.repository import Repository
 from gispulse.rules.engine import RuleEngine
+from gispulse.runtime.manifest_runner import run_manifest
 
 # Key injected by PipelineScheduler._enqueue_pipeline into job.parameters.
 _PIPELINE_CONFIG_KEY = "pipeline_config"
+# Key injected by POST /manifests/run into job.parameters.
+_MANIFEST_KEY = "manifest"
 
 log = get_logger(__name__)
 _metrics = MetricsCollector.get()
@@ -96,13 +99,26 @@ class JobRunner:
         attempt = 0
         last_exc: Exception | None = None
 
-        # Dispatch: pipeline_config (scheduler path) takes priority over rule_ids.
-        # If both are present, pipeline_config wins and a warning is emitted so the
-        # discrepancy is visible in logs. This is the safer choice: the scheduler
-        # never sets rule_ids, and a caller that sets both has an ambiguity that
-        # must not be silently resolved in the wrong direction.
+        # Dispatch priority: manifest > pipeline_config > rule_ids.
+        # If multiple keys are present, the highest-priority one wins and a
+        # warning is emitted so the discrepancy is visible in logs.
+        use_manifest = _MANIFEST_KEY in job.parameters
         use_pipeline_config = _PIPELINE_CONFIG_KEY in job.parameters
-        if use_pipeline_config and job.parameters.get("rule_ids"):
+        if use_manifest and use_pipeline_config:
+            log.warning(
+                "job_manifest_takes_priority",
+                job_id=str(job.id),
+                detail="Both manifest and pipeline_config are present; "
+                       "manifest takes priority.",
+            )
+        if use_manifest and job.parameters.get("rule_ids"):
+            log.warning(
+                "job_manifest_takes_priority_over_rule_ids",
+                job_id=str(job.id),
+                detail="Both manifest and rule_ids are present; "
+                       "manifest takes priority.",
+            )
+        if use_pipeline_config and not use_manifest and job.parameters.get("rule_ids"):
             log.warning(
                 "job_pipeline_config_takes_priority",
                 job_id=str(job.id),
@@ -118,7 +134,16 @@ class JobRunner:
 
             try:
                 with _metrics.timer("job_duration_seconds"):
-                    if use_pipeline_config:
+                    if use_manifest:
+                        result_gdf = self._execute_manifest(
+                            job, gdf, timeout,
+                            event_sink=event_sink,
+                            run_id=run_id,
+                        )
+                        steps_count = len(
+                            job.parameters[_MANIFEST_KEY].get("models", {})
+                        )
+                    elif use_pipeline_config:
                         result_gdf = self._execute_pipeline_config(
                             job, gdf, timeout,
                             event_sink=event_sink,
@@ -308,6 +333,154 @@ class JobRunner:
         # Return the last step's output (linear pipeline convention).
         last_step_gdf = list(results.values())[-1]
         return last_step_gdf
+
+    def _execute_manifest(
+        self,
+        job: Job,
+        gdf: gpd.GeoDataFrame,
+        timeout: int,
+        *,
+        event_sink: RunEventSink | None = None,
+        run_id: str | None = None,
+    ) -> gpd.GeoDataFrame:
+        """Execute a job whose parameters contain a ``manifest`` dict (v3 ManifestV3).
+
+        Validates the manifest dict through validate_pipeline_json (JSON Schema
+        SCHEMA_V3) then through validate_manifest (refs/cycles), parses it into
+        a ManifestV3 in-memory object, and delegates to run_manifest.
+
+        The source_loader routes each declared source to the job's loaded GDF.
+        For the common case (single dataset → single source), this is correct.
+        Multi-source manifests where sources point to different files require
+        explicit dataset_id wiring per source — a follow-up concern.
+
+        Raises:
+            ValueError: Invalid manifest (schema errors, unresolved refs, cycles,
+                        incremental mode). Caught by the caller's retry/FAILED path
+                        and stored as job.error_message.
+        """
+        from gispulse.core.manifest_v3 import (
+            ManifestV3,
+            _parse_sources,
+            _parse_staging,
+            _parse_models,
+            _parse_v3_triggers,
+            validate_manifest,
+        )
+        from gispulse.core.pipeline_schema import validate_pipeline_json
+
+        raw = job.parameters[_MANIFEST_KEY]
+
+        # --- Type guard ---------------------------------------------------
+        if not isinstance(raw, dict):
+            raise ValueError(
+                f"Job {job.id}: manifest must be a dict, "
+                f"got {type(raw).__name__}"
+            )
+
+        # --- Version guard ------------------------------------------------
+        received_version = raw.get("version")
+        if received_version != 3:
+            raise ValueError(
+                f"Job {job.id}: manifest must be version 3, "
+                f"got version={received_version!r}. "
+                'Use a v3 manifest ({"version": 3, "sources": {...}, "models": {...}}).'
+            )
+
+        # --- JSON Schema validation (SCHEMA_V3) ---------------------------
+        errors = validate_pipeline_json(raw)
+        if errors:
+            summary = "; ".join(errors[:5])
+            if len(errors) > 5:
+                summary += f" … and {len(errors) - 5} more"
+            raise ValueError(
+                f"Job {job.id}: manifest schema validation failed — {summary}"
+            )
+
+        # --- Parse into ManifestV3 ----------------------------------------
+        try:
+            manifest = ManifestV3(
+                name=raw.get("name", job.name),
+                description=raw.get("description", ""),
+                sources=_parse_sources(raw.get("sources", {})),
+                staging=_parse_staging(raw.get("staging")),
+                models=_parse_models(raw.get("models", {})),
+                triggers=_parse_v3_triggers(raw.get("triggers", [])),
+                security=dict(raw.get("security") or {}),
+                runtime=dict(raw.get("runtime") or {}),
+            )
+        except Exception as exc:
+            raise ValueError(
+                f"Job {job.id}: manifest could not be parsed — {exc}"
+            ) from exc
+
+        # --- Load-time graph check ----------------------------------------
+        # validate_manifest raises ManifestValidationError (subclass of ValueError)
+        # on unresolved refs / cycles — propagated directly to the FAILED path.
+        validate_manifest(manifest)
+
+        # --- Incremental guard — explicit FAILED before touching the GDF --
+        # run_manifest would raise NotImplementedError deep in the stack;
+        # we surface it as a clear ValueError with explicit "not implemented"
+        # so job.error_message is actionable.
+        for model_name, model in manifest.models.items():
+            if model.materialize == "incremental":
+                raise ValueError(
+                    f"Job {job.id}: model '{model_name}' uses materialize=incremental "
+                    "which is not implemented. Use materialize=view or materialize=table."
+                )
+
+        # --- Source loader: canonical URI-based loader with job-GDF fallback ---
+        # Priority: if the source URI is a real path or a remote URI that the
+        # persistence.loader.load() can resolve, use it directly.
+        # Fallback (memory:// scheme or any load failure): return the job's GDF
+        # loaded by the worker (useful for in-memory tests and pipeline_config
+        # datasets that arrive via dataset_id).
+        #
+        # This means manifests with real file/S3/WFS sources work WITHOUT a
+        # dataset_id — the source loader fetches each declared source URI.
+        # The empty-input guard (pipeline_config path) does NOT apply here.
+        def source_loader(src):
+            from gispulse.persistence.loader import load as _load_source
+
+            uri = src.uri if src.uri else ""
+            # memory:// URIs and blank URIs are test-only in-memory sources;
+            # fall back to the job GDF (loaded from dataset_id by the worker,
+            # or empty when no dataset_id is set).
+            if not uri or uri.startswith("memory://"):
+                return gdf
+            try:
+                return _load_source(uri, layer=src.layer or None)
+            except (FileNotFoundError, ValueError) as exc:
+                raise ValueError(
+                    f"Job {job.id}: cannot load source '{uri}' "
+                    f"(layer={src.layer!r}) — {exc}"
+                ) from exc
+
+        # --- Execute with timeout -----------------------------------------
+        pool = ThreadPoolExecutor(max_workers=1)
+        try:
+            future = pool.submit(
+                run_manifest,
+                manifest,
+                source_loader=source_loader,
+                event_sink=event_sink,
+                run_id=run_id,
+            )
+            result = future.result(timeout=timeout)
+        except FuturesTimeoutError:
+            pool.shutdown(wait=False, cancel_futures=True)
+            raise
+        finally:
+            pool.shutdown(wait=False)
+
+        # Return the last materialized model's GeoDataFrame as the job result.
+        if result.materialized and result.execution_order:
+            last_model = result.execution_order[-1]
+            return result.materialized[last_model].result
+        if result.materialized:
+            return list(result.materialized.values())[-1].result
+        return gdf
 
     def _execute_with_timeout(
         self, rules: list[Rule], gdf: gpd.GeoDataFrame, timeout: int,

--- a/src/gispulse/runtime/manifest_runner.py
+++ b/src/gispulse/runtime/manifest_runner.py
@@ -50,6 +50,7 @@ from gispulse.core.manifest_v3 import (
 )
 from gispulse.core.pipeline import PipelineSpec, StepSpec
 from gispulse.core.logging import get_logger
+from gispulse.orchestration.event_sink import NoOpSink, RunEventSink
 from gispulse.orchestration.pipeline_executor import PipelineExecutor
 
 log = get_logger(__name__)
@@ -233,6 +234,8 @@ def run_manifest(
     engine: Any | None = None,
     source_loader: SourceLoader | None = None,
     materializer: Materializer | None = None,
+    event_sink: RunEventSink | None = None,
+    run_id: str | None = None,
 ) -> ManifestRunResult:
     """Execute a v3 manifest end-to-end.
 
@@ -301,9 +304,7 @@ def run_manifest(
             "source nor a previously materialized model"
         )
 
-    # NOTE: event_sink not propagated here — manifest runs are not yet surfaced as
-    # PipelineRun entities. Pass event_sink= when wiring manifest execution through
-    # the job layer (volet c, issue #440).
+    _sink = event_sink if event_sink is not None else NoOpSink()
     executor = PipelineExecutor(execution_context=None)
     assertion_warnings: list = []
 
@@ -321,7 +322,7 @@ def run_manifest(
             if isinstance(alias, str) and alias not in inputs:
                 inputs[alias] = _resolve(alias)
 
-        results = executor.execute(sub_spec, inputs)
+        results = executor.execute(sub_spec, inputs, None, event_sink=_sink, run_id=run_id)
 
         # The model's output is the last step's result — fall back to
         # any single produced output, then to the primary, so a

--- a/tests/unit/test_manifest_runner.py
+++ b/tests/unit/test_manifest_runner.py
@@ -249,3 +249,38 @@ def test_run_manifest_with_clause_routes_ref_layer():
     # Inner-joined with the filtered set (vals >= 20) → 2 rows kept.
     assert len(joined) == 2
     assert sorted(joined["id"].tolist()) == [2, 3]
+
+
+def test_run_manifest_propagates_event_sink():
+    """event_sink and run_id are forwarded to PipelineExecutor — events are emitted."""
+    from gispulse.runtime.manifest_runner import run_manifest
+    from gispulse.core.manifest_v3 import ManifestV3, ModelSpec, SourceSpec
+
+    emitted = []
+
+    class _Sink:
+        def emit(self, event_type, data):
+            emitted.append((event_type, data))
+
+    src = _make_layer([1, 2], [10, 20])
+    manifest = ManifestV3(
+        sources={"s": SourceSpec(name="s", uri="memory://s")},
+        models={
+            "m": ModelSpec(
+                name="m",
+                select="s",
+                transform=[{"filter": {"expression": "val >= 10"}}],
+            )
+        },
+    )
+    result = run_manifest(
+        manifest,
+        source_loader=_source_loader_for({"s": src}),
+        event_sink=_Sink(),
+        run_id="test-run-123",
+    )
+    assert result.execution_order == ["m"]
+    # PipelineExecutor emits run.step.started and run.step.completed for each step
+    event_types = [e[0] for e in emitted]
+    assert "run.step.started" in event_types
+    assert "run.step.completed" in event_types

--- a/tests/unit/test_manifests_router.py
+++ b/tests/unit/test_manifests_router.py
@@ -1,0 +1,537 @@
+"""Tests for manifest v3 HTTP execution — vague 3 orchestration (issue #440).
+
+Covers:
+- JobRunner._execute_manifest dispatch path
+- POST /manifests/run (202, 422 upfront validation)
+- POST /manifests/validate (200)
+- End-to-end worker integration with PipelineRun persistence
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+from uuid import UUID
+
+import geopandas as gpd
+import pytest
+from shapely.geometry import Point
+
+from gispulse.core.models import Job, JobStatus
+from gispulse.orchestration.runner import JobRunner
+from gispulse.persistence.repository import InMemoryRepository
+from gispulse.rules.engine import RuleEngine
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_gdf():
+    return gpd.GeoDataFrame(
+        {"id": [1, 2], "val": [10, 20]},
+        geometry=[Point(0, 0), Point(1, 1)],
+        crs="EPSG:4326",
+    )
+
+
+def _minimal_manifest_dict(name: str = "test_manifest") -> dict:
+    """A valid inline v3 manifest with 1 source + 1 model (filter identity)."""
+    return {
+        "version": 3,
+        "name": name,
+        "sources": {"s": {"uri": "memory://s"}},
+        "models": {
+            "m": {
+                "select": "s",
+                "transform": [{"filter": {"expression": "val >= 0"}}],
+            }
+        },
+    }
+
+
+@pytest.fixture
+def runner():
+    repo = InMemoryRepository()
+    engine = RuleEngine(repository=repo)
+    return JobRunner(repository=repo, rule_engine=engine)
+
+
+# ---------------------------------------------------------------------------
+# JobRunner._execute_manifest path
+# ---------------------------------------------------------------------------
+
+
+def test_runner_manifest_dispatch_completes(runner):
+    """job.parameters['manifest'] → _execute_manifest → COMPLETED."""
+    from gispulse.runtime.manifest_runner import ManifestRunResult
+
+    gdf = _make_gdf()
+    job = Job(name="test_manifest", parameters={"manifest": _minimal_manifest_dict()})
+
+    def _fake_run_manifest(manifest, *, source_loader=None, materializer=None, event_sink=None, run_id=None):
+        return ManifestRunResult(materialized={}, execution_order=[])
+
+    with patch("gispulse.orchestration.runner.run_manifest", side_effect=_fake_run_manifest):
+        updated_job, result_gdf = runner.run(job, gdf)
+
+    assert updated_job.status == JobStatus.COMPLETED
+    assert isinstance(result_gdf, gpd.GeoDataFrame)
+
+
+def test_runner_manifest_takes_priority_over_pipeline_config(runner):
+    """manifest wins when both manifest + pipeline_config present; manifest is executed."""
+    from gispulse.runtime.manifest_runner import ManifestRunResult
+
+    gdf = _make_gdf()
+    job = Job(
+        name="conflict_job",
+        parameters={
+            "manifest": _minimal_manifest_dict(),
+            "pipeline_config": {
+                "version": 2,
+                "steps": [{"id": "s1", "type": "capability", "capability": "filter", "params": {}}],
+            },
+        },
+    )
+
+    executed = []
+
+    def _fake_run_manifest(manifest, *, source_loader=None, materializer=None, event_sink=None, run_id=None):
+        executed.append("manifest")
+        return ManifestRunResult(materialized={}, execution_order=[])
+
+    with patch("gispulse.orchestration.runner.run_manifest", side_effect=_fake_run_manifest):
+        updated_job, _ = runner.run(job, gdf)
+
+    assert executed == ["manifest"]
+    assert updated_job.status == JobStatus.COMPLETED
+
+
+def test_runner_manifest_invalid_raises_failed(runner):
+    """Invalid manifest dict (unresolved select) → job FAILED with descriptive error."""
+    gdf = _make_gdf()
+    bad_manifest = {
+        "version": 3,
+        "sources": {"s": {"uri": "memory://s"}},
+        "models": {"m": {"select": "ghost"}},  # ghost not declared
+    }
+    job = Job(name="bad_manifest", parameters={"manifest": bad_manifest})
+
+    with pytest.raises(Exception):
+        runner.run(job, gdf)
+
+    assert job.status == JobStatus.FAILED
+    assert job.error_message is not None
+
+
+def test_runner_manifest_incremental_fails_explicitly(runner):
+    """materialize: incremental → FAILED with 'incremental' in error message."""
+    gdf = _make_gdf()
+    manifest = {
+        "version": 3,
+        "name": "inc_test",
+        "sources": {"s": {"uri": "memory://s"}},
+        "models": {
+            "m": {
+                "select": "s",
+                "transform": [{"filter": {"expression": "val >= 0"}}],
+                "materialize": "incremental",
+            }
+        },
+    }
+    job = Job(name="inc_manifest", parameters={"manifest": manifest})
+
+    with pytest.raises(Exception):
+        runner.run(job, gdf)
+
+    assert job.status == JobStatus.FAILED
+    assert job.error_message is not None
+    assert "incremental" in job.error_message.lower() or "not implemented" in job.error_message.lower()
+
+
+# ---------------------------------------------------------------------------
+# P1 — canonical source loader (uri → read_vector, no dataset_id needed)
+# ---------------------------------------------------------------------------
+
+
+def test_runner_manifest_loads_sources_from_uri(runner, tmp_path):
+    """Sources with real file URIs must be loaded via loader.load(), not the job GDF.
+
+    The manifest declares 2 sources pointing to distinct GPKG files.
+    No dataset_id is set on the job (worker would return empty GDF).
+    After execution, the materialized model must contain the correct row
+    from the first source (val=42), NOT the rows from the fallback GDF
+    (val=10, val=20 from _make_gdf).
+    """
+    import geopandas as gpd
+    from shapely.geometry import Point
+
+    # Write 2 distinct source files
+    src1 = gpd.GeoDataFrame(
+        {"id": [99], "val": [42]}, geometry=[Point(2, 2)], crs="EPSG:4326"
+    )
+    src2 = gpd.GeoDataFrame(
+        {"id": [88], "val": [7]}, geometry=[Point(3, 3)], crs="EPSG:4326"
+    )
+    path1 = str(tmp_path / "src1.gpkg")
+    path2 = str(tmp_path / "src2.gpkg")
+    src1.to_file(path1, driver="GPKG")
+    src2.to_file(path2, driver="GPKG")
+
+    manifest = {
+        "version": 3,
+        "name": "file_source_manifest",
+        "sources": {
+            "a": {"uri": path1},
+            "b": {"uri": path2},
+        },
+        "models": {
+            "out": {
+                "select": "a",
+                "transform": [{"filter": {"expression": "val >= 0"}}],
+            }
+        },
+    }
+    # Empty fallback GDF — if the loader falls back to this, id/val would be wrong
+    empty_gdf = gpd.GeoDataFrame(
+        {"id": [1, 2], "val": [10, 20]},
+        geometry=[Point(0, 0), Point(1, 1)],
+        crs="EPSG:4326",
+    )
+    job = Job(
+        name="file_source_job",
+        parameters={"manifest": manifest},
+        # dataset_id intentionally absent
+    )
+    updated_job, result_gdf = runner.run(job, empty_gdf)
+
+    assert updated_job.status == JobStatus.COMPLETED
+    assert not result_gdf.empty, "result must not be empty"
+    assert list(result_gdf["id"]) == [99], (
+        f"Expected id=[99] from src1, got {list(result_gdf['id'])} — "
+        "source_loader likely fell back to the job's GDF instead of reading the file"
+    )
+    assert list(result_gdf["val"]) == [42]
+
+
+# ---------------------------------------------------------------------------
+# P2b — POST /jobs must reject reserved orchestration keys in parameters
+# ---------------------------------------------------------------------------
+
+
+def _make_jobs_app():
+    """Minimal FastAPI app with jobs_router mounted, no auth."""
+    from gispulse.adapters.http.routers.jobs_router import router as jobs_router
+    from gispulse.orchestration.job_queue import InMemoryJobQueue
+
+    app = FastAPI()
+    app.state.job_repo = InMemoryRepository()
+    app.state.dataset_repo = InMemoryRepository()
+    app.state.job_runner = MagicMock()
+    app.state.results_dir = Path("/tmp/test_results_jobs")
+    app.state.job_queue = InMemoryJobQueue()
+    app.include_router(jobs_router)
+    return app
+
+
+@pytest.mark.parametrize("reserved_key,hint", [
+    ("manifest", "POST /manifests/run"),
+    ("pipeline_config", "POST /pipelines"),
+    ("trigger_depth", None),
+])
+def test_post_jobs_rejects_reserved_parameter_keys(reserved_key, hint):
+    """POST /jobs with reserved orchestration keys → 422 with helpful message."""
+    from fastapi.testclient import TestClient
+
+    app = _make_jobs_app()
+    client = TestClient(app, raise_server_exceptions=False)
+
+    resp = client.post("/jobs", json={
+        "name": "bad_job",
+        "parameters": {reserved_key: {"version": 3}},
+    })
+    assert resp.status_code == 422, (
+        f"Expected 422 for reserved key '{reserved_key}', got {resp.status_code}: {resp.text}"
+    )
+    body = resp.json()
+    # Error should mention the reserved key
+    body_text = str(body).lower()
+    assert reserved_key.replace("_", " ") in body_text or reserved_key in body_text, (
+        f"Expected '{reserved_key}' in error body, got: {body}"
+    )
+    if hint:
+        assert hint.lower() in body_text or hint.split("/")[1] in body_text, (
+            f"Expected hint '{hint}' in error body, got: {body}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# P2a — canonical validation: unknown capability rejected at both endpoints
+# ---------------------------------------------------------------------------
+
+
+def test_validate_endpoint_rejects_unknown_capability():
+    """POST /manifests/validate rejects a manifest whose compiled steps reference
+    an unknown capability — same as /pipelines/validate.
+    """
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from gispulse.orchestration.job_queue import InMemoryJobQueue
+
+    app = FastAPI()
+    app.state.job_repo = InMemoryRepository()
+    app.state.dataset_repo = InMemoryRepository()
+    app.state.job_runner = MagicMock()
+    app.state.results_dir = Path("/tmp/test_results_p2a")
+    app.state.job_queue = InMemoryJobQueue()
+    from gispulse.adapters.http.routers.manifests_router import router as manifests_router
+    app.include_router(manifests_router)
+
+    bad_manifest = {
+        "version": 3,
+        "sources": {"s": {"uri": "memory://s"}},
+        "models": {
+            "m": {
+                "select": "s",
+                "transform": [{"__nonexistent_capability__": {}}],
+            }
+        },
+    }
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.post("/manifests/validate", json={"manifest": bad_manifest})
+    # Either the transform parse fails with an error (unknown capability key),
+    # or validation finds the capability unknown — either way valid=False.
+    # The endpoint returns 200 with valid=False, not a 4xx.
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["valid"] is False, f"Expected valid=False for unknown capability, got: {body}"
+
+
+def test_run_endpoint_rejects_unknown_capability():
+    """POST /manifests/run returns 422 for a manifest whose compiled steps reference
+    an unknown capability — same gate as /validate.
+    """
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from gispulse.orchestration.job_queue import InMemoryJobQueue
+
+    app = FastAPI()
+    app.state.job_repo = InMemoryRepository()
+    app.state.dataset_repo = InMemoryRepository()
+    app.state.job_runner = MagicMock()
+    app.state.results_dir = Path("/tmp/test_results_p2a_run")
+    app.state.job_queue = InMemoryJobQueue()
+    from gispulse.adapters.http.routers.manifests_router import router as manifests_router
+    app.include_router(manifests_router)
+
+    bad_manifest = {
+        "version": 3,
+        "sources": {"s": {"uri": "memory://s"}},
+        "models": {
+            "m": {
+                "select": "s",
+                "transform": [{"__nonexistent_capability__": {}}],
+            }
+        },
+    }
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.post("/manifests/run", json={"manifest": bad_manifest})
+    assert resp.status_code == 422, f"Expected 422 for unknown capability, got {resp.status_code}: {resp.text}"
+
+
+# ---------------------------------------------------------------------------
+# HTTP router tests
+# ---------------------------------------------------------------------------
+
+
+from fastapi.testclient import TestClient
+from fastapi import FastAPI
+from gispulse.orchestration.job_queue import InMemoryJobQueue
+
+
+def _make_test_app(tmp_path_for_results=None):
+    """Minimal FastAPI app with manifests_router mounted, no auth."""
+    from gispulse.adapters.http.routers.manifests_router import router as manifests_router
+
+    app = FastAPI()
+    app.state.job_repo = InMemoryRepository()
+    app.state.dataset_repo = InMemoryRepository()
+    app.state.job_runner = MagicMock()
+    app.state.results_dir = Path(tmp_path_for_results or "/tmp/test_results_manifests")
+    app.state.job_queue = InMemoryJobQueue()
+    app.include_router(manifests_router)
+    return app
+
+
+@pytest.fixture
+def client(tmp_path):
+    app = _make_test_app(tmp_path / "results")
+    (tmp_path / "results").mkdir(parents=True, exist_ok=True)
+    return TestClient(app)
+
+
+def test_post_manifests_run_returns_202(client):
+    """POST /manifests/run with valid manifest → 202 + job_id."""
+    body = {
+        "manifest": _minimal_manifest_dict(),
+    }
+    resp = client.post("/manifests/run", json=body)
+    assert resp.status_code == 202, resp.text
+    data = resp.json()
+    assert "job_id" in data
+    assert data["status"] == "pending"
+
+
+def test_post_manifests_run_with_scope(client):
+    """POST /manifests/run with scope param propagates scope to job parameters."""
+    body = {
+        "manifest": _minimal_manifest_dict("scoped_run"),
+        "scope": "63",
+    }
+    resp = client.post("/manifests/run", json=body)
+    assert resp.status_code == 202, resp.text
+    data = resp.json()
+    job_repo = client.app.state.job_repo
+    job = job_repo.get(UUID(data["job_id"]))
+    assert job is not None
+    assert job.parameters.get("scope") == "63"
+
+
+def test_post_manifests_run_invalid_manifest_returns_422(client):
+    """POST /manifests/run with invalid manifest (bad version) → 422."""
+    body = {
+        "manifest": {"version": 2, "steps": []},
+    }
+    resp = client.post("/manifests/run", json=body)
+    assert resp.status_code == 422, resp.text
+
+
+def test_post_manifests_run_unresolved_ref_returns_422(client):
+    """POST /manifests/run with manifest that has unresolved select → 422."""
+    body = {
+        "manifest": {
+            "version": 3,
+            "sources": {"s": {"uri": "memory://s"}},
+            "models": {"m": {"select": "ghost_source"}},
+        }
+    }
+    resp = client.post("/manifests/run", json=body)
+    assert resp.status_code == 422, resp.text
+
+
+def test_post_manifests_validate_valid(client):
+    """POST /manifests/validate with valid manifest → 200 {valid: true}."""
+    body = {"manifest": _minimal_manifest_dict()}
+    resp = client.post("/manifests/validate", json=body)
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["valid"] is True
+    assert isinstance(data["errors"], list)
+    assert data["compiled_steps_count"] >= 1
+
+
+def test_post_manifests_validate_invalid(client):
+    """POST /manifests/validate with invalid manifest → 200 {valid: false, errors: [...]}."""
+    body = {
+        "manifest": {
+            "version": 3,
+            "sources": {"s": {"uri": "memory://s"}},
+            "models": {"m": {"select": "nonexistent"}},
+        }
+    }
+    resp = client.post("/manifests/validate", json=body)
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["valid"] is False
+    assert len(data["errors"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# End-to-end worker integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_manifest_job_worker_end_to_end(tmp_path):
+    """POST /manifests/run → job enqueued → worker processes → PipelineRun persisted."""
+    from gispulse.orchestration.job_queue import InMemoryJobQueue
+    from gispulse.orchestration.runner import JobRunner
+    from gispulse.orchestration.worker import JobWorker
+    from gispulse.persistence.repository import InMemoryRepository
+    from gispulse.persistence.run_repository import RunRepository
+    from gispulse.rules.engine import RuleEngine
+
+    queue = InMemoryJobQueue()
+    job_repo = InMemoryRepository()
+    dataset_repo = InMemoryRepository()
+    runner = JobRunner(
+        repository=InMemoryRepository(),
+        rule_engine=RuleEngine(repository=InMemoryRepository()),
+    )
+    results_dir = tmp_path / "results"
+    results_dir.mkdir()
+    run_repo = RunRepository(db_path=tmp_path / "runs.db")
+
+    emitted_events = []
+
+    class _Sink:
+        def emit(self, event_type, data):
+            emitted_events.append(event_type)
+
+    worker = JobWorker(
+        queue=queue,
+        runner=runner,
+        dataset_repo=dataset_repo,
+        job_repo=job_repo,
+        run_repo=run_repo,
+        event_sink=_Sink(),
+        results_dir=results_dir,
+        poll_interval=0.05,
+    )
+
+    # Write a real GeoDataFrame to disk so the worker can load it as the
+    # dataset. This lets _execute_manifest's source_loader receive a proper
+    # GDF (with CRS+geometry), which the PipelineExecutor requires even for
+    # transform-free models (the CRS auto-injection path reads gdf.crs).
+    from gispulse.core.models import Dataset
+
+    gdf_data = _make_gdf()
+    gpkg_path = tmp_path / "input.gpkg"
+    gdf_data.to_file(str(gpkg_path), driver="GPKG", layer="default")
+    dataset = Dataset(name="e2e_dataset", source_path=str(gpkg_path))
+    dataset_repo.save(dataset)
+
+    manifest = _minimal_manifest_dict("e2e_manifest")
+    job = Job(
+        name="e2e_manifest",
+        dataset_id=dataset.id,
+        parameters={"manifest": manifest, "scope": "test_scope"},
+    )
+    job_repo.save(job)
+    await queue.enqueue(job)
+
+    # Drive the worker until job reaches terminal state
+    task = asyncio.create_task(worker.start())
+    for _ in range(80):
+        await asyncio.sleep(0.1)
+        refreshed = job_repo.get(job.id)
+        if refreshed and refreshed.status in (JobStatus.COMPLETED, JobStatus.FAILED):
+            break
+    worker.stop()
+    await asyncio.wait_for(task, timeout=10.0)
+
+    refreshed = job_repo.get(job.id)
+    assert refreshed is not None
+    assert refreshed.status == JobStatus.COMPLETED, f"job failed: {refreshed.error_message}"
+
+    runs = run_repo.list_all()
+    assert len(runs) >= 1
+    run = runs[0]
+    assert run.spec_ref == "e2e_manifest"
+    assert run.scope == "test_scope"
+    assert run.status == JobStatus.COMPLETED
+
+    assert "run.started" in emitted_events
+    assert "run.completed" in emitted_events


### PR DESCRIPTION
Wave 3 of the orchestration track (#440): the command surface. `POST /manifests/run` → 202 {job_id} rides the same job path as everything else — queue, worker, retries, PipelineRun, lifecycle events, cancellation and completion triggers come for free. `POST /manifests/validate` shares one canonical validation (incl. compiled-capability existence, parity with /pipelines/validate). Manifest sources load through the canonical universal loader keyed by SourceSpec uri/layer — self-loading manifests need no dataset_id. `run_manifest` now propagates event_sink/run_id (closing the gap noted in #442). `POST /jobs` rejects reserved orchestration keys (422 pointing at the right door), closing the auth-boundary bypass.

26 manifest tests, 123 across the touched suites, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)