### PR TITLE
feat(persistence): the universal loader handles non-geo tabular sources

### DIFF
--- a/src/gispulse/orchestration/runner.py
+++ b/src/gispulse/orchestration/runner.py
@@ -20,7 +20,9 @@ from gispulse.core.models import Job, JobStatus, Rule
 from gispulse.orchestration.event_sink import RunEventSink
 from gispulse.persistence.repository import Repository
 from gispulse.rules.engine import RuleEngine
-from gispulse.runtime.manifest_runner import run_manifest
+# run_manifest is imported locally inside _execute_manifest to avoid a
+# circular import: manifest_runner → orchestration.event_sink →
+# orchestration.__init__ → runner → manifest_runner.
 
 # Key injected by PipelineScheduler._enqueue_pipeline into job.parameters.
 _PIPELINE_CONFIG_KEY = "pipeline_config"
@@ -450,7 +452,7 @@ class JobRunner:
             if not uri or uri.startswith("memory://"):
                 return gdf
             try:
-                return _load_source(uri, layer=src.layer or None)
+                return _load_source(uri, layer=src.layer or None, geometry=None)
             except (FileNotFoundError, ValueError) as exc:
                 raise ValueError(
                     f"Job {job.id}: cannot load source '{uri}' "
@@ -458,6 +460,8 @@ class JobRunner:
                 ) from exc
 
         # --- Execute with timeout -----------------------------------------
+        from gispulse.runtime.manifest_runner import run_manifest  # local to avoid circular import
+
         pool = ThreadPoolExecutor(max_workers=1)
         try:
             future = pool.submit(

--- a/src/gispulse/persistence/duckdb_engine.py
+++ b/src/gispulse/persistence/duckdb_engine.py
@@ -17,6 +17,7 @@ from urllib.parse import urlparse
 
 import duckdb
 import geopandas as gpd
+import pandas as pd
 from shapely import wkb
 
 from gispulse.core.config import settings
@@ -376,8 +377,26 @@ class DuckDBSession(SpatialEngine):
     def sql_to_gdf(self, sql: str) -> gpd.GeoDataFrame:
         return self.sql(sql)
 
-    def register(self, name: str, gdf: gpd.GeoDataFrame) -> None:
-        self.register_gdf(name, gdf)
+    def register(self, name: str, gdf: "gpd.GeoDataFrame | pd.DataFrame") -> None:
+        """Register a GeoDataFrame or plain DataFrame as a named DuckDB table.
+
+        Dispatches to :meth:`register_gdf` for geometry-carrying inputs and
+        to :meth:`register_df` for plain DataFrames so that tabular (non-geo)
+        manifests with ``materialize: table`` work without ``AttributeError``.
+        """
+        if isinstance(gdf, gpd.GeoDataFrame):
+            self.register_gdf(name, gdf)
+        else:
+            self.register_df(name, gdf)
+
+    def register_df(self, name: str, df: pd.DataFrame) -> None:
+        """Register a plain pandas DataFrame as a named table in DuckDB.
+
+        Unlike :meth:`register_gdf`, no WKB serialisation is performed —
+        DuckDB can read a pandas DataFrame directly via its Arrow bridge.
+        """
+        self.conn.register(name, df)
+        log.debug("df_registered", table=name, rows=len(df))
 
     @property
     def backend_name(self) -> str:

--- a/src/gispulse/persistence/loader.py
+++ b/src/gispulse/persistence/loader.py
@@ -17,10 +17,12 @@ wired behind one verb:
   (:class:`LazyDataset`) that materialises to a GeoDataFrame on demand,
   so a project only ever reads the rows a bbox selects.
 
-Whatever the source, :func:`load` returns a plain
+By default, :func:`load` returns a plain
 :class:`geopandas.GeoDataFrame` (or a :class:`LazyDataset` when
 ``lazy=True``), so **every capability runs on the result unchanged** —
 ``gispulse.apply(verb, gispulse.load(src), ...)`` just works.
+Pass ``geometry=None`` (AUTO) or ``geometry=False`` to allow plain
+:class:`pandas.DataFrame` results for tabular (non-geo) sources.
 
 This module owns no transport code of its own: it resolves a source to a
 :class:`~gispulse.core.plugin_model.AccessSpec` and delegates to the
@@ -38,6 +40,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 import geopandas as gpd
+import pandas as pd
 
 from gispulse.core.logging import get_logger
 from gispulse.core.plugin_model import (
@@ -269,13 +272,17 @@ def _result_to_gdf(
     *,
     bbox: BBox | None,
     layer: str | None,
-) -> gpd.GeoDataFrame:
+    geometry: bool | None = True,
+) -> "gpd.GeoDataFrame | pd.DataFrame":
     """Normalise a heterogeneous :class:`SourceResult` into a GeoDataFrame.
 
     ``SourceResult.data`` is intentionally untyped — depending on the
     fetcher it is already a GeoDataFrame (OGC Features), a materialised
     file path (GeoParquet/S3, HTTP download), or ``None`` in
     :attr:`FetchMode.REFERENCE` mode with a DuckDB scan in ``metadata``.
+
+    *geometry* is forwarded to :func:`_read_path_with_geometry` when data
+    is a file path — enabling AUTO / tabular-direct for TABLE_FILE fetchers.
     """
     from gispulse.core.fetchers import DUCKDB_SCAN_KEY
 
@@ -287,7 +294,9 @@ def _result_to_gdf(
     elif result.mode is FetchMode.REFERENCE or (data is None and scan):
         if not scan:
             if result.reference:
-                gdf = _read_path(result.reference, bbox=bbox, layer=layer)
+                gdf = _read_path_with_geometry(
+                    result.reference, bbox=bbox, layer=layer, geometry=geometry
+                )
             else:  # pragma: no cover - defensive
                 raise ValueError(
                     "referenced SourceResult carries neither a DuckDB scan "
@@ -296,14 +305,16 @@ def _result_to_gdf(
         else:
             gdf = _scan_to_gdf(scan, crs=result.crs, bbox=bbox)
     elif isinstance(data, (str, Path)):
-        gdf = _read_path(str(data), bbox=bbox, layer=layer)
+        gdf = _read_path_with_geometry(
+            str(data), bbox=bbox, layer=layer, geometry=geometry
+        )
     else:  # pragma: no cover - defensive
         raise TypeError(
             f"cannot turn SourceResult.data of type {type(data).__name__} "
             "into a GeoDataFrame"
         )
 
-    if result.crs and gdf.crs is None:
+    if isinstance(gdf, gpd.GeoDataFrame) and result.crs and gdf.crs is None:
         gdf = gdf.set_crs(result.crs)
     return gdf
 
@@ -311,7 +322,7 @@ def _result_to_gdf(
 def _read_path(
     path: str, *, bbox: BBox | None, layer: str | None
 ) -> gpd.GeoDataFrame:
-    """Read a local/materialised file through the unified file reader."""
+    """Read a local/materialised file through the unified file reader (strict-geo)."""
     from gispulse.persistence.io import read_vector
 
     kwargs: dict[str, Any] = {}
@@ -320,6 +331,112 @@ def _read_path(
     if layer is not None:
         kwargs["layer"] = layer
     return read_vector(path, **kwargs)
+
+
+def _read_path_with_geometry(
+    path: str,
+    *,
+    bbox: BBox | None,
+    layer: str | None,
+    geometry: bool | None,
+) -> "gpd.GeoDataFrame | pd.DataFrame":
+    """Read a local/materialised file respecting the *geometry* mode.
+
+    Delegates to the same logic used in :func:`load` for the local-file branch
+    so that :func:`_result_to_gdf` (TABLE_FILE / DOWNLOAD SourceResults with
+    a path as ``data``) benefits from AUTO / tabular-direct semantics.
+    """
+    from gispulse.persistence.io import read_vector
+
+    ext = Path(path).suffix.lower()
+    opts: dict[str, Any] = {}
+    if bbox is not None:
+        opts["bbox"] = bbox
+    if layer is not None:
+        opts["layer"] = layer
+
+    if geometry is False:
+        if ext == ".parquet":
+            return _read_tabular_parquet(path)
+        if ext in (".csv", ".tsv"):
+            return _read_tabular_csv(path)
+        return pd.DataFrame(read_vector(path, **opts))
+
+    if geometry is True:
+        return read_vector(path, **opts)
+
+    # geometry=None (AUTO)
+    if ext == ".parquet":
+        if not _parquet_has_geo_metadata(path):
+            log.debug("loader_tabular_fallback_parquet", path=path)
+            return _read_tabular_parquet(path)
+        return read_vector(path, **opts)
+
+    _CSV_ONLY_KEYS = {"sep", "encoding", "nrows", "dtype", "usecols"}
+    csv_extra = {k: v for k, v in opts.items() if k in _CSV_ONLY_KEYS}
+    vec_opts = {k: v for k, v in opts.items() if k not in _CSV_ONLY_KEYS}
+    try:
+        return read_vector(path, **vec_opts)
+    except Exception as exc:
+        if ext in (".csv", ".tsv") and _is_missing_geo_csv_error(exc):
+            log.debug("loader_tabular_fallback_csv", path=path, reason=str(exc)[:120])
+            return _read_tabular_csv(path, **csv_extra)
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Tabular (non-geo) fallback helpers
+# ---------------------------------------------------------------------------
+
+#: Sentinel fragment in _read_csv_geo's error when no geometry column is found.
+_NO_GEO_COLUMNS_FRAGMENT = "cannot detect geometry columns"
+
+
+def _parquet_has_geo_metadata(path: str) -> bool:
+    """Return True when the Parquet file carries GeoParquet ``geo`` metadata.
+
+    Uses :func:`pyarrow.parquet.read_metadata` — O(1), reads only the footer.
+    Raises :class:`pyarrow.lib.ArrowInvalid` / :class:`OSError` on genuine
+    corruption, which the caller lets propagate unchanged.
+    """
+    import pyarrow.parquet as pq
+
+    file_meta = pq.read_metadata(path)
+    raw_meta: dict[bytes, bytes] = file_meta.metadata or {}
+    return b"geo" in raw_meta
+
+
+def _is_missing_geo_csv_error(exc: Exception) -> bool:
+    """True only for _read_csv_geo's 'Cannot detect geometry columns' ValueError."""
+    return (
+        isinstance(exc, ValueError)
+        and _NO_GEO_COLUMNS_FRAGMENT in str(exc).lower()
+    )
+
+
+def _read_tabular_parquet(path: str, *, rows: int | None = None) -> pd.DataFrame:
+    """Read a plain (non-geo) parquet file into a pd.DataFrame."""
+    df = pd.read_parquet(path)
+    if rows:
+        df = df.head(rows)
+    return df
+
+
+def _read_tabular_csv(path: str, *, rows: int | None = None, **kwargs: Any) -> pd.DataFrame:
+    """Read a CSV/TSV into a pd.DataFrame using the encoding cascade.
+
+    A caller-supplied ``sep`` kwarg takes precedence over the extension-based
+    default, preventing ``TypeError: multiple values for keyword argument 'sep'``
+    when the caller passes e.g. ``load(path, geometry=False, sep=";")``.
+    """
+    from gispulse.core.io.csv_encoding import read_csv_with_encoding_fallback
+
+    # Pop caller-supplied sep before building the default so we never
+    # pass sep twice to read_csv_with_encoding_fallback.
+    default_sep = "\t" if path.endswith(".tsv") else ","
+    sep = kwargs.pop("sep", default_sep)
+    nrows = rows if rows else None
+    return read_csv_with_encoding_fallback(path, sep=sep, nrows=nrows, **kwargs)
 
 
 def _scan_to_gdf(
@@ -413,9 +530,10 @@ def load(
     layer: str | None = None,
     lazy: bool = False,
     crs: str | None = None,
+    geometry: bool | None = True,
     registry: ProtocolRegistry | None = None,
     **read_opts: Any,
-) -> "gpd.GeoDataFrame | LazyDataset":
+) -> "gpd.GeoDataFrame | pd.DataFrame | LazyDataset":
     """Load any supported source into a GeoDataFrame (or a lazy handle).
 
     Args:
@@ -430,24 +548,44 @@ def load(
             handle instead of being materialised. Ignored (with a debug
             log) for local files, which are read eagerly.
         crs: Force this CRS on the result when the source declares none.
+        geometry: Controls geometry handling for file sources:
+
+            * ``True`` (**default**, strict geo) — raises if the source
+              has no geometry.  Preserves the historical behaviour of
+              :func:`~gispulse.persistence.io.read_vector` so existing
+              callers never silently receive a different type.
+            * ``None`` (AUTO) — attempts the geo read path; if the file
+              carries no geometry metadata (non-geo Parquet
+              ``ValueError: Missing geo metadata``; CSV without lat/lon /
+              WKT columns), falls back to a plain
+              :class:`pandas.DataFrame`.  Genuine corruption errors are
+              **not** swallowed.  Use this in source_loaders that must
+              handle mixed geo/tabular sources (e.g. manifest runners).
+            * ``False`` — tabular-direct: bypasses the geo read path and
+              returns a :class:`pandas.DataFrame` via ``pd.read_parquet``
+              or the CSV encoding cascade.  Ignores *bbox* and *layer*.
+
         registry: Protocol registry to dispatch through. Defaults to the
             process-wide :data:`PROTOCOLS`.
         **read_opts: Extra options forwarded to
             :func:`~gispulse.persistence.io.read_vector` for file sources.
 
     Returns:
-        A :class:`geopandas.GeoDataFrame`, or a :class:`LazyDataset` when
-        ``lazy=True`` and the source is remote.
+        A :class:`geopandas.GeoDataFrame`, a plain :class:`pandas.DataFrame`
+        (when the source has no geometry and ``geometry`` is ``None`` or
+        ``False``), or a :class:`LazyDataset` when ``lazy=True`` and the
+        source is remote.
 
     Raises:
         FileNotFoundError: If a local file source does not exist.
-        ValueError: On an unresolvable source or an unreadable result.
+        ValueError: On an unresolvable source, an unreadable result, or
+            when ``geometry=True`` and the source carries no geometry.
     """
     if isinstance(source, SourceResult):
-        gdf = _result_to_gdf(source, bbox=bbox, layer=layer)
-        if crs and gdf.crs is None:
-            gdf = gdf.set_crs(crs)
-        return gdf
+        result_df = _result_to_gdf(source, bbox=bbox, layer=layer, geometry=geometry)
+        if isinstance(result_df, gpd.GeoDataFrame) and crs and result_df.crs is None:
+            result_df = result_df.set_crs(crs)
+        return result_df
 
     resolved = resolve_source(source)
 
@@ -464,8 +602,45 @@ def load(
     if isinstance(resolved, Path):
         if lazy:
             log.debug("loader_lazy_ignored_for_file", path=str(resolved))
-        from gispulse.persistence.io import read_vector
 
+        ext = resolved.suffix.lower()
+
+        # geometry=False: tabulaire direct, bypasse read_vector
+        if geometry is False:
+            if ext == ".parquet":
+                return _read_tabular_parquet(str(resolved))
+            if ext in (".csv", ".tsv"):
+                # Passe les read_opts à la cascade CSV (ex. sep, nrows)
+                csv_opts = {k: v for k, v in read_opts.items()
+                            if k not in ("bbox", "layer", "crs")}
+                return _read_tabular_csv(str(resolved), **csv_opts)
+            # Pour les autres formats, on lit via read_vector et on retourne le DataFrame
+            from gispulse.persistence.io import read_vector
+            opts: dict[str, Any] = {}
+            if bbox is not None:
+                opts["bbox"] = bbox
+            if layer is not None:
+                opts["layer"] = layer
+            if crs is not None:
+                opts["crs"] = crs
+            opts.update(read_opts)
+            return pd.DataFrame(read_vector(str(resolved), **opts))
+
+        # geometry=True: strict, comportement historique
+        if geometry is True:
+            from gispulse.persistence.io import read_vector
+            opts = dict(read_opts)
+            if bbox is not None:
+                opts["bbox"] = bbox
+            if layer is not None:
+                opts["layer"] = layer
+            if crs is not None:
+                opts["crs"] = crs
+            return read_vector(str(resolved), **opts)
+
+        # geometry=None (AUTO): essaie géo, retombe sur tabulaire pour les
+        # erreurs spécifiques à l'absence de métadonnées géo.
+        from gispulse.persistence.io import read_vector
         opts = dict(read_opts)
         if bbox is not None:
             opts["bbox"] = bbox
@@ -473,7 +648,36 @@ def load(
             opts["layer"] = layer
         if crs is not None:
             opts["crs"] = crs
-        return read_vector(str(resolved), **opts)
+
+        # --- Parquet AUTO: structural check via pyarrow footer (O(1)).
+        # ArrowInvalid / OSError from read_metadata on a corrupt file propagate
+        # unchanged — they are NOT swallowed by the tabular fallback.
+        if ext == ".parquet":
+            has_geo = _parquet_has_geo_metadata(str(resolved))
+            if not has_geo:
+                log.debug("loader_tabular_fallback_parquet", path=str(resolved))
+                return _read_tabular_parquet(str(resolved))
+            return read_vector(str(resolved), **opts)
+
+        # --- CSV AUTO: attempt geo read, catch only the 'no geo columns' error.
+        # Strip CSV-specific opts (sep, encoding, …) from the opts passed to
+        # read_vector: read_vector→_read_csv_geo builds its own sep from the
+        # file extension and would raise TypeError on a duplicate kwarg.
+        _CSV_ONLY_KEYS = {"sep", "encoding", "nrows", "dtype", "usecols"}
+        csv_extra = {k: v for k, v in opts.items() if k in _CSV_ONLY_KEYS}
+        vec_opts = {k: v for k, v in opts.items() if k not in _CSV_ONLY_KEYS}
+        try:
+            return read_vector(str(resolved), **vec_opts)
+        except Exception as exc:
+            if ext in (".csv", ".tsv") and _is_missing_geo_csv_error(exc):
+                log.debug(
+                    "loader_tabular_fallback_csv",
+                    path=str(resolved),
+                    reason=str(exc)[:120],
+                )
+                return _read_tabular_csv(str(resolved), **csv_extra)
+            # Toute autre erreur (corruption, format inconnu, etc.) se propage.
+            raise
 
     # --- Remote / protocol source -----------------------------------------
     target = registry if registry is not None else PROTOCOLS
@@ -494,20 +698,24 @@ def load(
                 "loader_lazy_unsupported_falling_back",
                 protocol=resolved.protocol.value,
             )
-            gdf = _result_to_gdf(result, bbox=bbox, layer=layer)
-            if crs and gdf.crs is None:
-                gdf = gdf.set_crs(crs)
-            return gdf
+            result_df = _result_to_gdf(result, bbox=bbox, layer=layer, geometry=geometry)
+            if isinstance(result_df, gpd.GeoDataFrame) and crs and result_df.crs is None:
+                result_df = result_df.set_crs(crs)
+            return result_df
         return LazyDataset(
             scan_sql=scan,
             crs=crs or result.crs,
             metadata=dict(result.metadata),
         )
 
-    gdf = _result_to_gdf(result, bbox=bbox, layer=layer)
-    if crs and gdf.crs is None:
-        gdf = gdf.set_crs(crs)
-    return gdf
+    result_df = _result_to_gdf(result, bbox=bbox, layer=layer, geometry=geometry)
+    if isinstance(result_df, gpd.GeoDataFrame) and crs and result_df.crs is None:
+        result_df = result_df.set_crs(crs)
+    return result_df
 
 
 __all__ = ["BBox", "LazyDataset", "load", "resolve_source"]
+
+# Re-export pandas.DataFrame so callers can do ``from gispulse.persistence.loader import pd``
+# without a separate import when working with tabular results.
+# (Intentionally not in __all__; callers should import pandas directly.)

--- a/src/gispulse/runtime/manifest_runner.py
+++ b/src/gispulse/runtime/manifest_runner.py
@@ -36,6 +36,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any
 
 import geopandas as gpd
+import pandas as pd
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from gispulse.core.assertions import AssertionFailure
@@ -83,12 +84,18 @@ class RefreshMode(str, Enum):
 
 @dataclass
 class MaterializedModel:
-    """A model after materialization."""
+    """A model after materialization.
+
+    ``result`` is a :class:`geopandas.GeoDataFrame` for geo sources and a
+    plain :class:`pandas.DataFrame` for tabular (non-geo) sources.
+    Downstream steps that require geometry must guard against the plain
+    DataFrame case or ensure their source carries geometry.
+    """
 
     name: str
     mode: MaterializationMode
     refresh: RefreshMode
-    result: gpd.GeoDataFrame
+    result: "gpd.GeoDataFrame | pd.DataFrame"
     #: Engine table name when ``mode == TABLE`` — ``None`` otherwise.
     table_ref: str | None = None
 
@@ -121,7 +128,7 @@ class Materializer:
     def materialize(
         self,
         name: str,
-        gdf: gpd.GeoDataFrame,
+        gdf: "gpd.GeoDataFrame | pd.DataFrame",
         mode: MaterializationMode,
         refresh: RefreshMode = RefreshMode.MANUAL,
     ) -> MaterializedModel:
@@ -163,7 +170,8 @@ class Materializer:
 # ---------------------------------------------------------------------------
 
 #: Signature of a source-loader. Defaults to ``engine.load_layer(uri, layer)``.
-SourceLoader = Callable[[SourceSpec], gpd.GeoDataFrame]
+#: May return a plain :class:`pandas.DataFrame` for tabular (non-geo) sources.
+SourceLoader = Callable[["SourceSpec"], "gpd.GeoDataFrame | pd.DataFrame"]
 
 
 @dataclass
@@ -289,9 +297,9 @@ def run_manifest(
         order=order,
     )
 
-    source_cache: dict[str, gpd.GeoDataFrame] = {}
+    source_cache: "dict[str, gpd.GeoDataFrame | pd.DataFrame]" = {}
 
-    def _resolve(ref: str) -> gpd.GeoDataFrame:
+    def _resolve(ref: str) -> "gpd.GeoDataFrame | pd.DataFrame":
         if ref in manifest.sources:
             if ref not in source_cache:
                 source_cache[ref] = source_loader(manifest.sources[ref])
@@ -313,16 +321,42 @@ def run_manifest(
         primary = _resolve(model.select)
         sub_spec = _build_sub_pipeline(model, manifest.sources, model_names)
 
-        # Inputs: primary GDF first (PipelineExecutor's linear path keys
+        # Inputs: primary first (PipelineExecutor's linear path keys
         # off the first value); any `with: <ref>` resolves into a named
         # entry that the existing ``ref_layer`` plumbing picks up.
-        inputs: dict[str, gpd.GeoDataFrame] = {model.select: primary}
+        # When the primary is a plain pd.DataFrame (tabular/non-geo source)
+        # and the model has no transform steps, we short-circuit the executor
+        # to avoid handing a non-GeoDataFrame to geometry-aware capabilities.
+        inputs: "dict[str, gpd.GeoDataFrame | pd.DataFrame]" = {model.select: primary}
         for step in sub_spec.steps:
             alias = step.params.get("ref_layer")
             if isinstance(alias, str) and alias not in inputs:
                 inputs[alias] = _resolve(alias)
 
-        results = executor.execute(sub_spec, inputs, None, event_sink=_sink, run_id=run_id)
+        # Tabular guard: a plain pd.DataFrame source cannot be passed to
+        # geometry-aware capability steps. We distinguish two sub-cases:
+        #
+        # 1. Source is tabular AND the model has declared transform steps
+        #    → FAIL EXPLICITLY with a message naming the model, so the author
+        #    can fix their manifest rather than receiving silently wrong data.
+        # 2. Source is tabular AND no transform steps (passthrough)
+        #    → short-circuit: skip PipelineExecutor and use primary as terminal.
+        if not isinstance(primary, gpd.GeoDataFrame) and isinstance(primary, pd.DataFrame):
+            real_transforms = [t for t in (model.transform or []) if isinstance(t, dict)]
+            if real_transforms:
+                n = len(real_transforms)
+                raise ValueError(
+                    f"run_manifest: model '{model_name}' declares {n} transform "
+                    f"step(s) but its source '{model.select}' is tabular "
+                    f"(no geometry). Capability steps require a GeoDataFrame. "
+                    f"Either use a geo source or remove the transform steps."
+                )
+            # Passthrough — no transforms, materialise primary directly.
+            results: "dict[str, gpd.GeoDataFrame | pd.DataFrame]" = {}
+        else:
+            # For geo sources, all inputs must be GeoDataFrames — cast check
+            # delegated to capabilities at call time (existing behaviour).
+            results = executor.execute(sub_spec, inputs, None, event_sink=_sink, run_id=run_id)  # type: ignore[arg-type]
 
         # The model's output is the last step's result — fall back to
         # any single produced output, then to the primary, so a

--- a/tests/unit/test_loader_tabular.py
+++ b/tests/unit/test_loader_tabular.py
@@ -1,0 +1,536 @@
+"""Tests TDD — loader universel tabulaire non-géo (feat/loader-tabular).
+
+Cas couverts :
+- parquet géo → GeoDataFrame inchangé (régression)
+- parquet non-géo AUTO → pd.DataFrame avec les bonnes données
+- parquet non-géo geometry=True → ValueError claire
+- parquet non-géo geometry=False → pd.DataFrame
+- CSV non-géo (cp1252 !) avec cascade d'encodage → pd.DataFrame
+- CSV avec lat/lon → reste GeoDataFrame en AUTO
+- parquet corrompu (tronqué) → propagation de l'erreur, pas DataFrame vide
+- manifest e2e source non-géo → le run ne lève pas
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import geopandas as gpd
+import pandas as pd
+import pytest
+from shapely.geometry import Point
+
+from gispulse.persistence.loader import load
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def points_gdf() -> gpd.GeoDataFrame:
+    return gpd.GeoDataFrame(
+        {"code_insee": ["75056", "69123"], "valeur": [1.0, 2.0]},
+        geometry=[Point(2.35, 48.85), Point(4.83, 45.76)],
+        crs="EPSG:4326",
+    )
+
+
+@pytest.fixture
+def tabular_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {"code_insee": ["75056", "69123", "13055"], "dvf_transactions": [100, 200, 150]}
+    )
+
+
+@pytest.fixture
+def geo_parquet(tmp_path: Path, points_gdf: gpd.GeoDataFrame) -> Path:
+    p = tmp_path / "geo.parquet"
+    points_gdf.to_parquet(p)
+    return p
+
+
+@pytest.fixture
+def tabular_parquet(tmp_path: Path, tabular_df: pd.DataFrame) -> Path:
+    p = tmp_path / "tabular.parquet"
+    tabular_df.to_parquet(p, index=False)
+    return p
+
+
+@pytest.fixture
+def csv_latlon(tmp_path: Path) -> Path:
+    """CSV UTF-8 avec colonnes lat/lon."""
+    p = tmp_path / "pts.csv"
+    p.write_text("code_insee,lat,lon\n75056,48.85,2.35\n69123,45.76,4.83\n", encoding="utf-8")
+    return p
+
+
+@pytest.fixture
+def csv_no_geo(tmp_path: Path) -> Path:
+    """CSV UTF-8 sans aucune colonne géométrique."""
+    p = tmp_path / "nogeo.csv"
+    p.write_text("code_insee,valeur\n75056,100\n69123,200\n13055,150\n", encoding="utf-8")
+    return p
+
+
+@pytest.fixture
+def csv_cp1252_no_geo(tmp_path: Path) -> Path:
+    """CSV encodé cp1252 sans colonne géo — simule les exports gouvernementaux FR."""
+    p = tmp_path / "nogeo_cp1252.csv"
+    # 'café' et 'résumé' encodés en cp1252
+    content = "code_insee,libelle\n75056,caf\xe9\n69123,r\xe9sum\xe9\n"
+    p.write_bytes(content.encode("cp1252"))
+    return p
+
+
+@pytest.fixture
+def corrupted_parquet(tmp_path: Path) -> Path:
+    """Fichier .parquet tronqué/corrompu."""
+    p = tmp_path / "corrupt.parquet"
+    # Magic bytes parquet mais contenu invalide
+    p.write_bytes(b"PAR1" + b"\x00" * 20 + b"PAR1")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Régression géo : comportement actuel inchangé
+# ---------------------------------------------------------------------------
+
+
+def test_load_geo_parquet_returns_geodataframe(geo_parquet: Path) -> None:
+    result = load(str(geo_parquet))
+    assert isinstance(result, gpd.GeoDataFrame)
+    assert len(result) == 2
+    assert result.crs is not None
+
+
+def test_load_geo_parquet_geometry_true_returns_geodataframe(geo_parquet: Path) -> None:
+    result = load(str(geo_parquet), geometry=True)
+    assert isinstance(result, gpd.GeoDataFrame)
+    assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# AUTO (geometry=None) sur parquet non-géo
+# ---------------------------------------------------------------------------
+
+
+def test_load_tabular_parquet_auto_returns_dataframe(tabular_parquet: Path) -> None:
+    result = load(str(tabular_parquet), geometry=None)
+    assert isinstance(result, pd.DataFrame)
+    assert not isinstance(result, gpd.GeoDataFrame)
+    assert list(result.columns) == ["code_insee", "dvf_transactions"]
+    assert len(result) == 3
+
+
+def test_load_tabular_parquet_auto_preserves_values(tabular_parquet: Path, tabular_df: pd.DataFrame) -> None:
+    result = load(str(tabular_parquet), geometry=None)
+    assert list(result["code_insee"]) == list(tabular_df["code_insee"])
+    assert list(result["dvf_transactions"]) == list(tabular_df["dvf_transactions"])
+
+
+# ---------------------------------------------------------------------------
+# geometry=True strict — erreur explicite sur parquet non-géo
+# ---------------------------------------------------------------------------
+
+
+def test_load_tabular_parquet_geometry_true_raises(tabular_parquet: Path) -> None:
+    with pytest.raises((ValueError, Exception)) as exc_info:
+        load(str(tabular_parquet), geometry=True)
+    # Le message doit mentionner l'absence de géométrie, pas une corruption
+    msg = str(exc_info.value).lower()
+    assert any(kw in msg for kw in ("geo", "geometry", "spatial", "metadata")), (
+        f"Expected geometry-related error, got: {exc_info.value}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# geometry=False tabulaire direct
+# ---------------------------------------------------------------------------
+
+
+def test_load_tabular_parquet_geometry_false_returns_dataframe(tabular_parquet: Path) -> None:
+    result = load(str(tabular_parquet), geometry=False)
+    assert isinstance(result, pd.DataFrame)
+    assert not isinstance(result, gpd.GeoDataFrame)
+    assert len(result) == 3
+
+
+def test_load_geo_parquet_geometry_false_returns_plain_dataframe(geo_parquet: Path) -> None:
+    """geometry=False force le retour pd.DataFrame même pour un GeoParquet."""
+    result = load(str(geo_parquet), geometry=False)
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# CSV non-géo — cascade d'encodage
+# ---------------------------------------------------------------------------
+
+
+def test_load_csv_no_geo_auto_returns_dataframe(csv_no_geo: Path) -> None:
+    result = load(str(csv_no_geo), geometry=None)
+    assert isinstance(result, pd.DataFrame)
+    assert not isinstance(result, gpd.GeoDataFrame)
+    assert len(result) == 3
+    assert "code_insee" in result.columns
+    assert "valeur" in result.columns
+
+
+def test_load_csv_cp1252_no_geo_cascade(csv_cp1252_no_geo: Path) -> None:
+    """cp1252 : la cascade d'encodage doit produire un DataFrame sans UnicodeDecodeError."""
+    result = load(str(csv_cp1252_no_geo), geometry=None)
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) == 2
+    # cp1252 → 'é' doit être correctement décodé
+    assert result["libelle"].iloc[0] == "café"
+    assert result["libelle"].iloc[1] == "résumé"
+
+
+def test_load_csv_no_geo_geometry_false(csv_no_geo: Path) -> None:
+    result = load(str(csv_no_geo), geometry=False)
+    assert isinstance(result, pd.DataFrame)
+    assert not isinstance(result, gpd.GeoDataFrame)
+    assert len(result) == 3
+
+
+# ---------------------------------------------------------------------------
+# CSV avec lat/lon — reste GeoDataFrame en AUTO
+# ---------------------------------------------------------------------------
+
+
+def test_load_csv_latlon_auto_returns_geodataframe(csv_latlon: Path) -> None:
+    result = load(str(csv_latlon))
+    assert isinstance(result, gpd.GeoDataFrame)
+    assert len(result) == 2
+    assert result.crs is not None
+
+
+def test_load_csv_latlon_geometry_false_returns_dataframe(csv_latlon: Path) -> None:
+    """geometry=False sur un CSV avec lat/lon : retour pd.DataFrame sans géométrie."""
+    result = load(str(csv_latlon), geometry=False)
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# Parquet corrompu — erreur propagée, pas DataFrame vide
+# ---------------------------------------------------------------------------
+
+
+def test_load_corrupted_parquet_raises_not_returns_empty(corrupted_parquet: Path) -> None:
+    """Un fichier parquet corrompu doit lever, pas retourner silencieusement un DataFrame vide."""
+    with pytest.raises(Exception) as exc_info:
+        load(str(corrupted_parquet))
+    # On attend une vraie erreur de lecture, pas juste un DataFrame vide
+    assert exc_info.value is not None
+    # Ne doit PAS être une ValueError vague "no geo metadata" non plus —
+    # l'erreur doit refléter la corruption (ArrowInvalid, OSError, etc.)
+    # On vérifie juste qu'on lève bien quelque chose.
+    err_type_name = type(exc_info.value).__name__
+    assert err_type_name not in ("AssertionError",), f"Unexpected: {err_type_name}"
+
+
+# ---------------------------------------------------------------------------
+# Manifest e2e — source non-géo
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_e2e_tabular_source(tmp_path: Path, tabular_df: pd.DataFrame) -> None:
+    """run_manifest avec une source parquet non-géo ne doit pas lever."""
+    from gispulse.core.manifest_v3 import (
+        ManifestV3,
+        ModelSpec,
+        SourceSpec,
+        validate_manifest,
+    )
+    from gispulse.runtime.manifest_runner import run_manifest
+
+    # Écriture du parquet tabulaire
+    parquet_path = tmp_path / "dvf.parquet"
+    tabular_df.to_parquet(parquet_path, index=False)
+
+    manifest = ManifestV3(
+        name="test_tabular",
+        sources={
+            "dvf": SourceSpec(name="dvf", uri=str(parquet_path)),
+        },
+        models={
+            "dvf_clean": ModelSpec(
+                name="dvf_clean",
+                select="dvf",
+                transform=[],
+                materialize="view",
+            ),
+        },
+    )
+    validate_manifest(manifest)
+
+    loaded: dict = {}
+
+    def source_loader(src):
+        loaded[src.name] = True
+        return load(src.uri, geometry=None)
+
+    result = run_manifest(manifest, source_loader=source_loader)
+    # Le manifest doit s'exécuter sans lever
+    assert "dvf_clean" in result.materialized
+    assert "dvf" in loaded
+    # Le résultat est un DataFrame (pas forcément géo)
+    assert isinstance(result.materialized["dvf_clean"].result, pd.DataFrame)
+    assert len(result.materialized["dvf_clean"].result) == 3
+
+
+# ---------------------------------------------------------------------------
+# P1a — transforms tabulaires avec steps non vides → échec explicite
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_tabular_source_with_transform_steps_raises(
+    tmp_path: Path, tabular_df: pd.DataFrame
+) -> None:
+    """Source tabulaire + transform non vide → ValueError avec message actionnable."""
+    from gispulse.core.manifest_v3 import ManifestV3, ModelSpec, SourceSpec, validate_manifest
+    from gispulse.runtime.manifest_runner import run_manifest
+
+    parquet_path = tmp_path / "dvf.parquet"
+    tabular_df.to_parquet(parquet_path, index=False)
+
+    manifest = ManifestV3(
+        name="test_tabular_with_steps",
+        sources={"dvf": SourceSpec(name="dvf", uri=str(parquet_path))},
+        models={
+            "dvf_filtered": ModelSpec(
+                name="dvf_filtered",
+                select="dvf",
+                transform=[{"filter": {"expression": "dvf_transactions > 1"}}],
+                materialize="view",
+            ),
+        },
+    )
+    validate_manifest(manifest)
+
+    def source_loader(src):
+        return load(src.uri, geometry=None)
+
+    with pytest.raises(ValueError) as exc_info:
+        run_manifest(manifest, source_loader=source_loader)
+
+    msg = str(exc_info.value).lower()
+    # Le message doit être actionnable : nommer le modèle, mentionner tabulaire/transform
+    assert "dvf_filtered" in msg
+    assert any(kw in msg for kw in ("tabular", "transform", "geometry", "geodataframe"))
+
+
+def test_manifest_tabular_source_no_steps_does_not_raise(
+    tmp_path: Path, tabular_df: pd.DataFrame
+) -> None:
+    """Source tabulaire sans transform → pas de levée (régression P1a)."""
+    from gispulse.core.manifest_v3 import ManifestV3, ModelSpec, SourceSpec, validate_manifest
+    from gispulse.runtime.manifest_runner import run_manifest
+
+    parquet_path = tmp_path / "dvf.parquet"
+    tabular_df.to_parquet(parquet_path, index=False)
+
+    manifest = ManifestV3(
+        name="test_tabular_passthrough",
+        sources={"dvf": SourceSpec(name="dvf", uri=str(parquet_path))},
+        models={
+            "dvf_clean": ModelSpec(
+                name="dvf_clean",
+                select="dvf",
+                transform=[],
+                materialize="view",
+            ),
+        },
+    )
+    validate_manifest(manifest)
+
+    result = run_manifest(
+        manifest,
+        source_loader=lambda src: load(src.uri, geometry=None),
+    )
+    assert "dvf_clean" in result.materialized
+    assert len(result.materialized["dvf_clean"].result) == 3
+
+
+# ---------------------------------------------------------------------------
+# P1b — materialize: table avec source tabulaire → DuckDB register direct
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_tabular_materialize_table_registers_in_duckdb(
+    tmp_path: Path, tabular_df: pd.DataFrame
+) -> None:
+    """Source tabulaire + materialize=table → DataFrame enregistré dans DuckDB, interrogeable."""
+    from gispulse.core.manifest_v3 import ManifestV3, ModelSpec, SourceSpec, validate_manifest
+    from gispulse.runtime.manifest_runner import Materializer, run_manifest
+
+    parquet_path = tmp_path / "dvf.parquet"
+    tabular_df.to_parquet(parquet_path, index=False)
+
+    manifest = ManifestV3(
+        name="test_tabular_table",
+        sources={"dvf": SourceSpec(name="dvf", uri=str(parquet_path))},
+        models={
+            "dvf_mart": ModelSpec(
+                name="dvf_mart",
+                select="dvf",
+                transform=[],
+                materialize="table",
+            ),
+        },
+    )
+    validate_manifest(manifest)
+
+    # Moteur stub minimaliste : implémente register(name, df)
+    registered: dict = {}
+
+    class _StubEngine:
+        def register(self, name: str, df: pd.DataFrame) -> None:
+            registered[name] = df
+
+    engine = _StubEngine()
+    mat = Materializer(engine=engine)
+
+    result = run_manifest(
+        manifest,
+        source_loader=lambda src: load(src.uri, geometry=None),
+        materializer=mat,
+    )
+
+    assert "dvf_mart" in result.materialized
+    # TABLE mode : table_ref renseigné
+    assert result.materialized["dvf_mart"].table_ref is not None
+    table_ref = result.materialized["dvf_mart"].table_ref
+    # L'engine stub a bien reçu le DataFrame
+    assert table_ref in registered
+    assert len(registered[table_ref]) == 3
+    assert list(registered[table_ref]["code_insee"]) == ["75056", "69123", "13055"]
+
+
+# ---------------------------------------------------------------------------
+# P2a — SourceResult tabulaire : geometry propagé à _result_to_gdf
+# ---------------------------------------------------------------------------
+
+
+def test_load_sourceresult_tabular_path_geometry_none_returns_dataframe(
+    tmp_path: Path, tabular_df: pd.DataFrame
+) -> None:
+    """SourceResult data=path vers un parquet non-géo, geometry=None → pd.DataFrame."""
+    from gispulse.core.plugin_model import Payload, SourceResult
+
+    parquet_path = tmp_path / "tab.parquet"
+    tabular_df.to_parquet(parquet_path, index=False)
+
+    result_obj = SourceResult(payload=Payload.VECTOR, data=str(parquet_path))
+    out = load(result_obj, geometry=None)
+    assert isinstance(out, pd.DataFrame)
+    assert not isinstance(out, gpd.GeoDataFrame)
+    assert len(out) == 3
+
+
+def test_load_sourceresult_tabular_path_geometry_true_raises(
+    tmp_path: Path, tabular_df: pd.DataFrame
+) -> None:
+    """SourceResult data=path vers un parquet non-géo, geometry=True → ValueError."""
+    from gispulse.core.plugin_model import Payload, SourceResult
+
+    parquet_path = tmp_path / "tab.parquet"
+    tabular_df.to_parquet(parquet_path, index=False)
+
+    result_obj = SourceResult(payload=Payload.VECTOR, data=str(parquet_path))
+    with pytest.raises((ValueError, Exception)) as exc_info:
+        load(result_obj, geometry=True)
+    msg = str(exc_info.value).lower()
+    assert any(kw in msg for kw in ("geo", "geometry", "metadata"))
+
+
+# ---------------------------------------------------------------------------
+# P2b — contrat public : défaut geometry=True (strict-géo)
+# ---------------------------------------------------------------------------
+
+
+def test_load_default_geometry_is_strict_geo(
+    tmp_path: Path, tabular_df: pd.DataFrame
+) -> None:
+    """Par défaut (geometry implicite), un parquet non-géo doit lever — pas retourner DataFrame."""
+    parquet_path = tmp_path / "tab.parquet"
+    tabular_df.to_parquet(parquet_path, index=False)
+    # Appel sans geometry= : doit se comporter comme geometry=True (strict)
+    with pytest.raises((ValueError, Exception)) as exc_info:
+        load(str(parquet_path))
+    msg = str(exc_info.value).lower()
+    assert any(kw in msg for kw in ("geo", "geometry", "metadata"))
+
+
+def test_load_csv_no_geo_default_raises(tmp_path: Path) -> None:
+    """CSV sans colonnes géo, appel sans geometry= → ValueError (strict-géo par défaut)."""
+    p = tmp_path / "nogeo.csv"
+    p.write_text("code_insee,valeur\n75056,100\n", encoding="utf-8")
+    with pytest.raises(ValueError) as exc_info:
+        load(str(p))
+    assert "detect geometry" in str(exc_info.value).lower() or "geometry" in str(exc_info.value).lower()
+
+
+def test_load_geo_parquet_default_returns_geodataframe(geo_parquet: Path) -> None:
+    """GeoParquet sans geometry= → GeoDataFrame (comportement historique inchangé)."""
+    result = load(str(geo_parquet))
+    assert isinstance(result, gpd.GeoDataFrame)
+    assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# P3a — détection structurelle pyarrow (remplace le match textuel)
+# ---------------------------------------------------------------------------
+
+
+def test_load_tabular_parquet_auto_structural_detection(
+    tmp_path: Path, tabular_df: pd.DataFrame
+) -> None:
+    """geometry=None détecte l'absence de méta-géo via pyarrow, pas via str du message."""
+    parquet_path = tmp_path / "structural.parquet"
+    tabular_df.to_parquet(parquet_path, index=False)
+
+    result = load(str(parquet_path), geometry=None)
+    assert isinstance(result, pd.DataFrame)
+    assert not isinstance(result, gpd.GeoDataFrame)
+    assert len(result) == 3
+
+
+def test_load_corrupted_parquet_geometry_none_raises(tmp_path: Path) -> None:
+    """Parquet corrompu + geometry=None → l'erreur pyarrow se propage (pas de DataFrame vide)."""
+    corrupt = tmp_path / "corrupt.parquet"
+    corrupt.write_bytes(b"PAR1" + b"\x00" * 20 + b"PAR1")
+
+    with pytest.raises(Exception) as exc_info:
+        load(str(corrupt), geometry=None)
+    # Doit être une vraie erreur de lecture, pas AssertionError
+    assert type(exc_info.value).__name__ != "AssertionError"
+
+
+# ---------------------------------------------------------------------------
+# P3b — collision sep dans geometry=False CSV
+# ---------------------------------------------------------------------------
+
+
+def test_load_csv_geometry_false_custom_sep(tmp_path: Path) -> None:
+    """load(csv, geometry=False, sep=';') ne doit pas lever TypeError 'multiple values'."""
+    p = tmp_path / "semi.csv"
+    p.write_text("code_insee;valeur\n75056;100\n69123;200\n", encoding="utf-8")
+
+    result = load(str(p), geometry=False, sep=";")
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) == 2
+    assert list(result.columns) == ["code_insee", "valeur"]
+
+
+def test_load_csv_geometry_none_custom_sep_no_geo(tmp_path: Path) -> None:
+    """load(csv, geometry=None, sep=';') fallback tabulaire avec séparateur custom."""
+    p = tmp_path / "semi.csv"
+    p.write_text("code_insee;valeur\n75056;100\n69123;200\n", encoding="utf-8")
+
+    result = load(str(p), geometry=None, sep=";")
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) == 2

--- a/tests/unit/test_manifests_router.py
+++ b/tests/unit/test_manifests_router.py
@@ -73,7 +73,7 @@ def test_runner_manifest_dispatch_completes(runner):
     def _fake_run_manifest(manifest, *, source_loader=None, materializer=None, event_sink=None, run_id=None):
         return ManifestRunResult(materialized={}, execution_order=[])
 
-    with patch("gispulse.orchestration.runner.run_manifest", side_effect=_fake_run_manifest):
+    with patch("gispulse.runtime.manifest_runner.run_manifest", side_effect=_fake_run_manifest):
         updated_job, result_gdf = runner.run(job, gdf)
 
     assert updated_job.status == JobStatus.COMPLETED
@@ -102,7 +102,7 @@ def test_runner_manifest_takes_priority_over_pipeline_config(runner):
         executed.append("manifest")
         return ManifestRunResult(materialized={}, execution_order=[])
 
-    with patch("gispulse.orchestration.runner.run_manifest", side_effect=_fake_run_manifest):
+    with patch("gispulse.runtime.manifest_runner.run_manifest", side_effect=_fake_run_manifest):
         updated_job, _ = runner.run(job, gdf)
 
     assert executed == ["manifest"]


### PR DESCRIPTION
Prerequisite for declarative pipelines over attribute-only sources (the code_insee join family): `load()` gains `geometry: bool | None` — **public default unchanged** (strict geo: an existing caller never silently receives a different return type), AUTO mode (structural pyarrow footer check, targeted fallback, corruption still raises) opted into explicitly by the manifest source_loader, and direct tabular mode (CSV through the core encoding cascade). Tabular models materialize for real (DuckDB native Arrow bridge, no WKB path) and a tabular source declaring capability transforms fails explicitly instead of silently skipping them. REMOTE_TABLE non-geo (s3 tabular parquet) noted as follow-up.

26 new tests; 69 across the touched suites; persistence suite 170 passed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)