### PR TITLE
feat(manifest): non-capability steps and selectless models in manifest v3 (#440 wave 6 prereq)

### DIFF
--- a/src/gispulse/adapters/http/routers/manifests_router.py
+++ b/src/gispulse/adapters/http/routers/manifests_router.py
@@ -177,7 +177,13 @@ def _validate_manifest_dict(raw: dict[str, Any]) -> tuple[bool, list[str], int]:
             f"unknown capability '{step.capability}' in step '{step.id}'. "
             f"Available: {sorted(known_caps)}."
             for step in compiled.steps
-            if step.type == "capability" and step.capability
+            # Skip non-capability steps: their kind is dispatched to the step-kind
+            # registry at execution time in the worker process. The HTTP boundary
+            # cannot know which application kinds are registered there. Validating
+            # step.kind existence here would produce false-positive 422s for any
+            # custom kind (e.g. "external") that is perfectly valid in the worker.
+            if step.kind == "capability"
+            and step.type == "capability" and step.capability
             and step.capability not in known_caps
         ]
         if cap_errors:

--- a/src/gispulse/core/manifest_v3.py
+++ b/src/gispulse/core/manifest_v3.py
@@ -94,10 +94,17 @@ class ModelSpec:
     Attributes:
         name:        Model name (the key under ``models:``). Also the
                      terminal step id after compilation.
-        select:      Upstream layer reference — a source name or
-                     another model.
+        select:      Upstream layer reference — a source name or another
+                     model. **Optional** when all transform items are
+                     non-capability (``kind`` key present and != "capability").
+                     Omitting ``select`` on a model that contains at least one
+                     capability step is a validation error raised by
+                     :func:`validate_manifest`.
         transform:   List of ``{capability: params}`` shorthand items.
-                     Compiles to a chain of :class:`StepSpec`.
+                     An item is non-capability when its params dict contains
+                     ``kind: <value>`` where *value* is a non-empty string
+                     that is not ``"capability"``. Compiles to a chain of
+                     :class:`StepSpec`.
         materialize: ``view`` (default), ``table``, ``incremental``.
         refresh:     ``manual`` (default), ``on_change``, ``schedule``.
         assertions:  Data-quality gates run after materialization —
@@ -107,7 +114,7 @@ class ModelSpec:
     """
 
     name: str
-    select: str
+    select: str | None = None
     transform: list[dict[str, Any]] = field(default_factory=list)
     materialize: str = "view"
     refresh: str = "manual"
@@ -178,7 +185,10 @@ def _parse_models(raw: dict[str, Any]) -> dict[str, ModelSpec]:
     for name, spec in (raw or {}).items():
         out[name] = ModelSpec(
             name=name,
-            select=spec["select"],
+            # ``select`` is optional for models whose every transform item is
+            # non-capability.  Semantic validation enforces this constraint in
+            # validate_manifest() after all models are parsed.
+            select=spec.get("select"),
             transform=list(spec.get("transform") or []),
             materialize=spec.get("materialize", "view"),
             refresh=spec.get("refresh", "manual"),
@@ -300,14 +310,56 @@ def _resolve_ref(
     )
 
 
-def _split_transform(item: dict[str, Any]) -> tuple[str, dict[str, Any]]:
-    """Pull the ``{capability_name: params}`` pair out of a transform item."""
+def _split_transform(
+    item: dict[str, Any],
+) -> tuple[str, dict[str, Any], str]:
+    """Pull the ``{item_name: params}`` pair out of a transform item.
+
+    Returns ``(item_name, params_without_kind, effective_kind)``.
+
+    The ``kind`` key in params is **reserved**: when present and non-empty
+    and not ``"capability"``, the item compiles to a non-capability
+    :class:`~gispulse.core.pipeline.StepSpec` and the kind value is
+    forwarded as both ``step.kind`` and ``step.type``.  ``kind:
+    capability`` explicit is treated as the default (capability path).
+
+    ``kind`` is always stripped from the returned params dict — it is
+    pipeline plumbing, not a capability parameter.
+    """
     if len(item) != 1:
         raise ValueError(
             f"transform step must have exactly one key, got {list(item)!r}"
         )
-    (cap_name, params), = item.items()
-    return cap_name, dict(params or {})
+    (item_name, raw_params), = item.items()
+    params = dict(raw_params or {})
+    kind_val = params.pop("kind", None)
+
+    # AX fast-fail: ``kind`` must be a non-empty string when present.
+    # - Absent (None after pop)   → capability path (default).
+    # - "capability"              → capability path (explicit).
+    # - Non-string (int, list, …) → ValueError immediately.
+    # - Empty string ""           → ValueError (ambiguous; authors must be
+    #                               explicit — either omit the key or set
+    #                               "capability"). Silently normalising "" to
+    #                               capability would hide typos.
+    if kind_val is None:
+        effective_kind = "capability"
+    elif not isinstance(kind_val, str):
+        raise ValueError(
+            f"transform '{item_name}': 'kind' must be a string, "
+            f"got {type(kind_val).__name__!r} ({kind_val!r})"
+        )
+    elif kind_val == "":
+        raise ValueError(
+            f"transform '{item_name}': 'kind' must be a non-empty string; "
+            "omit the key entirely or set 'kind: capability' to use the "
+            "capability path"
+        )
+    elif kind_val == "capability":
+        effective_kind = "capability"
+    else:
+        effective_kind = kind_val
+    return item_name, params, effective_kind
 
 
 def _compile_model_steps(
@@ -322,18 +374,36 @@ def _compile_model_steps(
     intermediate step is named ``<model>__t<index>``. A transform's
     ``with: <ref>`` is converted into a multi-input edge plus a
     ``ref_layer`` capability param for the legacy ref-layer plumbing.
+
+    Non-capability steps (``kind`` key present and != ``"capability"``):
+    - Compile to ``StepSpec(kind=<kind>, type=<kind>, capability="")``
+    - The ``kind`` key is stripped from ``params`` (pipeline plumbing).
+    - ``with:`` on a non-capability step is a validation error: there is
+      no GeoDataFrame data flow to secondary inputs for external steps.
+
+    When ``model.select`` is ``None`` (allowed only when every transform
+    item is non-capability), the first step gets ``input=None``; each
+    subsequent step chains to the previous step id as usual.
     """
-    primary, primary_is_model = _resolve_ref(model.select, sources, model_names)
+    # --- Resolve primary input ---
     prev_input: str | list[str] | None
-    prev_input = primary if primary_is_model else None
-    # For a source-rooted model, no upstream step exists; the first step
-    # reads the primary input set by the executor (the source registered
-    # in ref_layers).
+    if model.select is not None:
+        primary, primary_is_model = _resolve_ref(model.select, sources, model_names)
+        prev_input = primary if primary_is_model else None
+        # For a source-rooted model, no upstream step exists; the first step
+        # reads the primary input set by the executor (the source registered
+        # in ref_layers).
+    else:
+        # No select → no primary data source. Only valid for models where
+        # every transform item is non-capability (enforced by validate_manifest).
+        prev_input = None
 
     transforms = model.transform
     if not transforms:
         # Passthrough — an identity model. Compile to a single
         # filter-no-op step that simply forwards the input.
+        # (Only reaches here when select is not None; no-select + no-transform
+        # is rejected by validate_manifest before compilation.)
         return [
             StepSpec(
                 id=model.name,
@@ -348,41 +418,68 @@ def _compile_model_steps(
     steps: list[StepSpec] = []
     n = len(transforms)
     for i, item in enumerate(transforms):
-        cap_name, params = _split_transform(item)
-        # `with: <ref>` ⇒ multi-input edge + ref_layer capability param.
-        extra_ref = params.pop("with", None)
-        inputs: str | list[str] | None = prev_input
-        if extra_ref is not None:
-            resolved, is_model = _resolve_ref(
-                extra_ref, sources, model_names
-            )
-            # ref_layer carries the secondary input for the existing
-            # ref-layer plumbing (spatial_join, attribute_join, …).
-            params.setdefault("ref_layer", resolved)
-            # When the primary input is itself an upstream *step* AND the
-            # with-ref names another *model*, surface the dep as a
-            # multi-input edge so the DAG executor wires both branches.
-            # When the primary is a *source* (prev_input is None), the
-            # secondary stays on ref_layer alone — adding it to step.input
-            # would silently swap the primary with the secondary.
-            if is_model and prev_input is not None:
-                base = (
-                    [prev_input]
-                    if isinstance(prev_input, str)
-                    else list(prev_input)
-                )
-                inputs = base + [resolved]
+        item_name, params, effective_kind = _split_transform(item)
         step_id = model.name if i == n - 1 else f"{model.name}__t{i}"
-        steps.append(
-            StepSpec(
-                id=step_id,
-                type="capability",
-                capability=cap_name,
-                params=params,
-                input=inputs,
-                order=i,
+
+        if effective_kind != "capability":
+            # --- Non-capability step ---
+            # ``with:`` is illegal: non-capability steps produce no GeoDataFrame
+            # and cannot receive a secondary data flow.
+            if "with" in params:
+                raise ValueError(
+                    f"models.{model.name}.transform[{i}].{item_name}: "
+                    f"'with:' is not allowed on a non-capability step "
+                    f"(kind={effective_kind!r}); non-capability steps produce "
+                    "no GeoDataFrame data flow that a secondary input could consume"
+                )
+            steps.append(
+                StepSpec(
+                    id=step_id,
+                    type=effective_kind,
+                    capability="",
+                    kind=effective_kind,
+                    params=params,
+                    input=prev_input,
+                    order=i,
+                )
             )
-        )
+        else:
+            # --- Capability step (existing unchanged behaviour) ---
+            cap_name = item_name
+            # `with: <ref>` ⇒ multi-input edge + ref_layer capability param.
+            extra_ref = params.pop("with", None)
+            inputs: str | list[str] | None = prev_input
+            if extra_ref is not None:
+                resolved, is_model = _resolve_ref(
+                    extra_ref, sources, model_names
+                )
+                # ref_layer carries the secondary input for the existing
+                # ref-layer plumbing (spatial_join, attribute_join, …).
+                params.setdefault("ref_layer", resolved)
+                # When the primary input is itself an upstream *step* AND the
+                # with-ref names another *model*, surface the dep as a
+                # multi-input edge so the DAG executor wires both branches.
+                # When the primary is a *source* (prev_input is None), the
+                # secondary stays on ref_layer alone — adding it to step.input
+                # would silently swap the primary with the secondary.
+                if is_model and prev_input is not None:
+                    base = (
+                        [prev_input]
+                        if isinstance(prev_input, str)
+                        else list(prev_input)
+                    )
+                    inputs = base + [resolved]
+            steps.append(
+                StepSpec(
+                    id=step_id,
+                    type="capability",
+                    capability=cap_name,
+                    params=params,
+                    input=inputs,
+                    order=i,
+                )
+            )
+
         prev_input = step_id
     return steps
 
@@ -404,8 +501,9 @@ def _topo_models(models: dict[str, ModelSpec]) -> list[str]:
     while remaining and progress:
         progress = False
         for name in list(remaining):
-            ref = remaining[name].select
-            if ref not in remaining:
+            ref = remaining[name].select  # may be None for non-capability models
+            # A model with select=None has no inter-model dependency → ready.
+            if ref is None or ref not in remaining:
                 ordered.append(name)
                 del remaining[name]
                 progress = True
@@ -651,20 +749,42 @@ def _extract_with_ref(params: object) -> str | None:
     return None
 
 
+def _item_is_noncapability(item: dict[str, Any]) -> bool:
+    """Return True when a transform item's params contain a non-capability kind."""
+    if not isinstance(item, dict) or len(item) != 1:
+        return False
+    (_, params), = item.items()
+    if not isinstance(params, dict):
+        return False
+    kind_val = params.get("kind")
+    return bool(kind_val) and kind_val != "capability"
+
+
 def validate_manifest(manifest: ManifestV3) -> list[str]:
     """Validate a v3 manifest at load-time.
 
-    Catches the three load-time concerns ADR 0005 / #248 calls for:
+    Catches the following load-time concerns:
 
-    - Unresolved ``select:`` and transform-level ``with:`` references —
-      a ``ModelSpec`` selecting a name that is neither a declared source
-      nor another model. Error (blocking).
-    - Cycles in the inter-model dependency graph, detected by
-      :func:`~gispulse.core.dag.topological_sort` (Kahn's algorithm,
-      shared with :class:`GraphExecutor`). Error (blocking).
-    - Orphan models — models nobody else selects. They are often the
-      pipeline's terminal outputs (perfectly legitimate), so this is
-      surfaced as a warning, not an error.
+    - **select semantics** — ``select`` is required when a model contains
+      at least one capability transform step (or no transforms at all, since
+      the identity passthrough must read from somewhere). It is optional only
+      when every transform item is non-capability. Violations raise.
+    - **Unresolved references** — a ``ModelSpec`` selecting a name that is
+      neither a declared source nor another model. Error (blocking).
+    - **with: on non-capability** — ``with:`` delivers a secondary GeoDataFrame
+      to a capability step; it is illegal on a non-capability step. Error.
+    - **Cycles** in the inter-model dependency graph, detected by
+      :func:`~gispulse.core.dag.topological_sort`. Error (blocking).
+    - **Orphan models** — models nobody else selects. Often the pipeline's
+      terminal outputs (perfectly legitimate); surfaced as a warning.
+
+    Design note — step kind existence is NOT validated here:
+        Step kinds like ``"external"`` are registered in the worker process
+        via ``register_step_kind()``. At HTTP validation time the server may
+        not have the application kinds loaded. This boundary validates
+        *structure* only; the worker fails early on unknown kinds at execution
+        time with a clear ``"unknown step kind"`` error. This is documented
+        intentionally so readers understand the split.
 
     Returns the list of *warnings*. Errors raise
     :class:`ManifestValidationError`.
@@ -680,7 +800,34 @@ def validate_manifest(manifest: ManifestV3) -> list[str]:
     inter_model_edges: list[tuple[str, str]] = []
 
     for name, model in manifest.models.items():
-        if not isinstance(model.select, str) or not model.select:
+        transforms = list(model.transform or [])
+
+        # --- Determine whether all transforms are non-capability ---
+        all_noncap = bool(transforms) and all(
+            _item_is_noncapability(step) for step in transforms
+        )
+
+        # --- select validation ---
+        if model.select is None:
+            if not all_noncap:
+                # No select is only valid when 100 % of transforms are
+                # non-capability. Capability steps need a GeoDataFrame primary
+                # input from a declared source or upstream model. The passthrough
+                # identity model also requires a select (it reads primary).
+                if not transforms:
+                    errors.append(
+                        f"models.{name}: 'select' is required when the model "
+                        "has no transform steps (passthrough identity requires "
+                        "an input source)"
+                    )
+                else:
+                    errors.append(
+                        f"models.{name}: 'select' is required when the model "
+                        "contains capability transform steps; omit 'select' only "
+                        "when every transform item is non-capability "
+                        "(kind != 'capability')"
+                    )
+        elif not isinstance(model.select, str) or not model.select:
             errors.append(
                 f"models.{name}: missing or empty 'select' reference"
             )
@@ -693,7 +840,8 @@ def validate_manifest(manifest: ManifestV3) -> list[str]:
             inter_model_edges.append((model.select, name))
             referenced_models.add(model.select)
 
-        for i, step in enumerate(model.transform or []):
+        # --- Transform step validation ---
+        for i, step in enumerate(transforms):
             if not isinstance(step, dict) or len(step) != 1:
                 errors.append(
                     f"models.{name}.transform[{i}]: must be a single-key "
@@ -701,6 +849,40 @@ def validate_manifest(manifest: ManifestV3) -> list[str]:
                 )
                 continue
             (cap, params), = step.items()
+
+            # Validate ``kind`` type early — _split_transform will raise at
+            # compile time, but validate_manifest must surface it at load time
+            # so /manifests/validate returns 422 with an actionable message.
+            if isinstance(params, dict) and "kind" in params:
+                kind_raw = params["kind"]
+                if not isinstance(kind_raw, str):
+                    errors.append(
+                        f"models.{name}.transform[{i}].{cap}: "
+                        f"'kind' must be a string, got "
+                        f"{type(kind_raw).__name__!r} ({kind_raw!r})"
+                    )
+                    continue
+                if kind_raw == "":
+                    errors.append(
+                        f"models.{name}.transform[{i}].{cap}: "
+                        "'kind' must be a non-empty string; omit the key or "
+                        "set 'kind: capability' to use the capability path"
+                    )
+                    continue
+
+            # ``with:`` on non-capability step
+            is_noncap = _item_is_noncapability(step)
+            if is_noncap:
+                if isinstance(params, dict) and "with" in params:
+                    errors.append(
+                        f"models.{name}.transform[{i}].{cap}: "
+                        "'with:' is not allowed on a non-capability step; "
+                        "non-capability steps produce no GeoDataFrame data "
+                        "flow that a secondary input could consume"
+                    )
+                continue  # ref validation below is for capability steps only
+
+            # Capability step: validate ``with:`` ref
             with_ref = _extract_with_ref(params)
             if with_ref is None:
                 continue

--- a/src/gispulse/core/pipeline.py
+++ b/src/gispulse/core/pipeline.py
@@ -49,7 +49,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any
 
 from gispulse.core.predicates import AnyPredicate, AttrPredicate, CompoundPredicate, GeomPredicate
 
@@ -89,7 +89,7 @@ class StepSpec:
     """
 
     id: str = ""
-    type: Literal["capability", "filter", "spatial_op", "custom_sql"] = "capability"
+    type: str = "capability"  # "capability" | "filter" | "spatial_op" | "custom_sql" | <app-kind>
     capability: str | None = None
     params: dict[str, Any] = field(default_factory=dict)
     input: str | list[str] | None = None

--- a/src/gispulse/core/pipeline_schema.py
+++ b/src/gispulse/core/pipeline_schema.py
@@ -305,11 +305,16 @@ SCHEMA_V3: dict[str, Any] = {
         },
         "model": {
             "type": "object",
-            "required": ["select"],
             "properties": {
                 "select": {
                     "type": "string",
-                    "description": "Upstream layer reference — a source name or another model.",
+                    "description": (
+                        "Upstream layer reference — a source name or another model. "
+                        "Optional when all transform items are non-capability (kind != "
+                        "'capability'). Semantic validation of this constraint is performed "
+                        "by validate_manifest(), not by the JSON schema, because the schema "
+                        "cannot inspect transform item keys."
+                    ),
                 },
                 "transform": {
                     "type": "array",
@@ -555,8 +560,9 @@ def _validate_v3_basic(raw: dict[str, Any]) -> list[str]:
         if not isinstance(model, dict):
             errors.append(f"models.{name}: must be an object")
             continue
-        if "select" not in model:
-            errors.append(f"models.{name}: missing required field 'select'")
+        # 'select' is semantically required for capability models, but the basic
+        # structural check does not enforce it — validate_manifest() owns that
+        # constraint because it can inspect transform item kinds.
         transform = model.get("transform")
         if transform is not None:
             if not isinstance(transform, list):

--- a/src/gispulse/orchestration/pipeline_executor.py
+++ b/src/gispulse/orchestration/pipeline_executor.py
@@ -276,8 +276,11 @@ class PipelineExecutor:
         from datetime import datetime, timezone
 
         sink = event_sink if event_sink is not None else NoOpSink()
-        # Use the first input as the primary GeoDataFrame
-        gdf = next(iter(inputs.values()))
+        # Use the first input as the primary GeoDataFrame.
+        # For pipelines that contain only non-capability steps (e.g. manifests
+        # whose models have select=None), inputs may be empty — initialize gdf
+        # lazily so those pipelines don't raise here.
+        gdf: gpd.GeoDataFrame | None = next(iter(inputs.values()), None)
         results: dict[str, gpd.GeoDataFrame] = {}
 
         for step in spec.enabled_steps:

--- a/src/gispulse/orchestration/runner.py
+++ b/src/gispulse/orchestration/runner.py
@@ -866,6 +866,18 @@ class JobRunner:
                 steps_to_run=steps_filter_manifest,
                 resume_markers_count=len(manifest_resume_markers),
             )
+            # F1 guard: when the resume has already skipped ALL steps (the
+            # source run was fully COMPLETED), steps_filter_manifest is empty.
+            # Do NOT convert [] → None (= "no filter" = re-run everything).
+            # Short-circuit here: replay events have already been emitted by
+            # _replay_resume; there is nothing left to execute.
+            if not steps_filter_manifest:
+                log.info(
+                    "manifest_resume_nothing_to_execute",
+                    job_id=str(job.id),
+                    resume_from_run_id=resume_from_run_id,
+                )
+                return gdf
         elif resume_from_run_id and run_repo is None:
             # No run_repo available — cannot replay, raise explicit error
             # (never silent resume-from-scratch for manifest jobs).
@@ -887,7 +899,12 @@ class JobRunner:
                 source_loader=source_loader,
                 event_sink=event_sink,
                 run_id=run_id,
-                steps_filter=steps_filter_manifest if steps_filter_manifest else None,
+                # Preserve [] as [] — empty list means "nothing to run for this
+                # partial resume", not "run everything". None means no filter.
+                # The F1 guard above already returns early when the list is empty
+                # after a resume; this line is reached only for non-resume paths
+                # or resume paths with a non-empty remaining list.
+                steps_filter=steps_filter_manifest or None,
                 resume_markers=manifest_resume_markers if manifest_resume_markers else None,
             )
             result = future.result(timeout=timeout)

--- a/src/gispulse/runtime/manifest_runner.py
+++ b/src/gispulse/runtime/manifest_runner.py
@@ -194,7 +194,8 @@ def _inter_model_edges(manifest: ManifestV3) -> list[tuple[str, str]]:
     model_names = set(manifest.models)
     edges: list[tuple[str, str]] = []
     for name, model in manifest.models.items():
-        if model.select in model_names:
+        # select may be None for non-capability models
+        if model.select is not None and model.select in model_names:
             edges.append((model.select, name))
         for step in model.transform or []:
             if not isinstance(step, dict) or len(step) != 1:
@@ -226,6 +227,7 @@ def _build_sub_pipeline(
             StepSpec(
                 id=s.id,
                 type=s.type,
+                kind=s.kind,  # preserve non-capability kind (e.g. "external")
                 capability=s.capability,
                 params=dict(s.params),
                 input=inp,
@@ -292,7 +294,7 @@ def validate_steps_filter_models(
         }
         # Combine: select ref + all with: refs
         _all_upstream_refs: set[str] = set()
-        if _mdl.select in model_names:
+        if _mdl.select is not None and _mdl.select in model_names:
             _all_upstream_refs.add(_mdl.select)
         _all_upstream_refs.update(_ref_layer_refs)
 
@@ -353,15 +355,41 @@ def run_manifest(
     """
     validate_manifest(manifest)  # raises on cycles / unresolved refs
 
+    # Determine whether any model needs a source loader — specifically, a model
+    # whose ``select`` resolves to a *declared source* (not to another model).
+    # Models whose ``select`` points to another model never call source_loader
+    # directly; they call _resolve() which reads from the materializer cache.
+    # Models with select=None (non-capability) never call _resolve() at all.
+    #
+    # This guard prevents the misleading "requires engine or source_loader"
+    # error when the only non-None selects reference other models (including
+    # no-data models) rather than real data sources. The actionable error
+    # "produces no data output" surfaces later in the execution loop.
+    _declared_sources = set(manifest.sources)
+    _needs_loader = any(
+        m.select is not None and m.select in _declared_sources
+        for m in manifest.models.values()
+    )
+
     if source_loader is None:
-        if engine is None:
+        if engine is None and _needs_loader:
             raise RuntimeError(
                 "run_manifest requires either an engine (uses engine.load_layer) "
                 "or a source_loader callable"
             )
-
-        def source_loader(src: SourceSpec) -> gpd.GeoDataFrame:
-            return engine.load_layer(src.uri, layer=src.layer or "")
+        if engine is not None:
+            def source_loader(src: SourceSpec) -> gpd.GeoDataFrame:
+                return engine.load_layer(src.uri, layer=src.layer or "")
+        else:
+            # No engine, no loader — but _needs_loader is False so _resolve()
+            # will never be called for sources. Provide a sentinel that raises
+            # clearly if called anyway (defensive programming).
+            def source_loader(src: SourceSpec) -> gpd.GeoDataFrame:  # type: ignore[misc]
+                raise RuntimeError(
+                    f"run_manifest: no source_loader or engine provided, "
+                    f"but source '{src.name}' was requested — "
+                    "check the manifest's model dependencies"
+                )
 
     if materializer is None:
         materializer = Materializer(engine=engine)
@@ -422,8 +450,70 @@ def run_manifest(
     _resume_markers: dict[str, str] = resume_markers or {}
     executed_order: list[str] = []  # models actually materialized (filter-aware)
 
+    # Track which models have no data output (external / non-capability models
+    # without select). Downstream capability models that try to _resolve() these
+    # get a clear error rather than a silent KeyError.
+    _no_data_models: set[str] = set()
+
     for model_name in order:
         model = manifest.models[model_name]
+
+        # --- Non-capability model (select=None) — execute steps, no data output ---
+        # These are models whose every transform item is non-capability (kind !=
+        # "capability"). They launch external work (subprocess, dbt, …) but produce
+        # no GeoDataFrame.
+        # IMPORTANT: a non-capability model excluded by steps_filter must NOT
+        # run (no subprocess) and must NOT appear in executed_order — same
+        # contract as capability models. Check _included_models first.
+        if model.select is None:
+            if model_name not in _included_models:
+                # Excluded by steps_filter — skip entirely, no subprocess.
+                log.debug(
+                    "manifest_model_noncapability_skipped_by_filter",
+                    model=model_name,
+                    steps_filter=list(_effective_filter) if _effective_filter else [],
+                )
+                _no_data_models.add(model_name)
+                # Do NOT add to executed_order — the model was not run.
+                continue
+            log.debug(
+                "manifest_model_noncapability",
+                model=model_name,
+                mode=model.materialize,
+            )
+            sub_spec = _build_sub_pipeline(model, manifest.sources, model_names)
+            if _effective_filter is not None:
+                from gispulse.core.pipeline import PipelineSpec as _PS
+                filtered_steps = [s for s in sub_spec.steps if s.id in _effective_filter]
+                sub_spec = _PS(
+                    version=sub_spec.version,
+                    name=sub_spec.name,
+                    steps=filtered_steps,
+                    triggers=sub_spec.triggers,
+                    ref_layers=sub_spec.ref_layers,
+                )
+            model_step_ids_for_resume = {s.id for s in sub_spec.steps}
+            model_resume_markers = {
+                sid: marker
+                for sid, marker in _resume_markers.items()
+                if sid in model_step_ids_for_resume
+            }
+            # No primary data — pass an empty inputs dict. PipelineExecutor's
+            # _execute_linear/_execute_dag dispatch non-capability steps directly
+            # to the step-kind registry; they don't consume GeoDataFrame inputs.
+            model_executor = PipelineExecutor(
+                execution_context=None,
+                resume_markers=model_resume_markers if model_resume_markers else None,
+            )
+            # Provide a sentinel empty inputs dict; sub_spec only has non-capability
+            # steps so PipelineExecutor never tries to read from it as a GeoDataFrame.
+            model_executor.execute(
+                sub_spec, {}, None, event_sink=_sink, run_id=run_id  # type: ignore[arg-type]
+            )
+            _no_data_models.add(model_name)
+            executed_order.append(model_name)
+            # No assertions on non-capability models (no data to assert on).
+            continue
 
         if model_name not in _included_models:
             # --- Skipped model: materialise primary as passthrough, NO steps executed ---
@@ -447,6 +537,16 @@ def run_manifest(
             )
             # Do NOT add to executed_order — the model was not run.
             continue
+
+        # --- Included capability model: check upstream has data ---
+        if model.select in _no_data_models:
+            raise ValueError(
+                f"run_manifest: model '{model_name}' selects model "
+                f"'{model.select}' which produces no data output "
+                f"(it is a non-capability model with no select). "
+                f"Downstream capability models cannot receive GeoDataFrame "
+                f"data from a non-capability upstream."
+            )
 
         # --- Included model: build sub-spec, optionally filtered ---
         sub_spec = _build_sub_pipeline(model, manifest.sources, model_names)

--- a/tests/unit/test_manifest_external_steps.py
+++ b/tests/unit/test_manifest_external_steps.py
@@ -1,0 +1,701 @@
+"""Tests TDD — manifest v3 steps non-capability + select optionnel (issue #453).
+
+Volets :
+A. Compilation d'un transform item avec clé réservée ``kind``
+B. ``select`` optionnel pour les modèles 100 % non-capability
+C. Exécution bout-en-bout run_manifest d'un modèle external sans select
+D. Modèle downstream référençant un modèle sans select → erreur claire
+E. /manifests/validate accepte le manifest external
+F. steps_filter interaction
+G. POST /manifests/run 202 bout-en-bout
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# A. Compilation : transform item avec clé ``kind``
+# ---------------------------------------------------------------------------
+
+
+class TestCompileKindStep:
+    """_split_transform / _compile_model_steps avec un item non-capability."""
+
+    def _compile(self, item: dict, model_name: str = "m", source_name: str = "s"):
+        """Helper : compile un seul transform item vers une liste de StepSpec."""
+        from gispulse.core.manifest_v3 import _compile_model_steps, ModelSpec, SourceSpec
+
+        model = ModelSpec(
+            name=model_name,
+            select=source_name,
+            transform=[item],
+        )
+        sources = {source_name: SourceSpec(name=source_name, uri="memory://s")}
+        return _compile_model_steps(model, sources, {model_name})
+
+    def test_kind_external_produces_step_with_kind(self):
+        """Un item avec kind=external doit produire un StepSpec(kind='external')."""
+        steps = self._compile({
+            "shell_pipeline": {
+                "kind": "external",
+                "argv": ["python", "run.py"],
+                "timeout_seconds": 60,
+            }
+        })
+        assert len(steps) == 1
+        s = steps[0]
+        assert s.kind == "external"
+        assert s.type == "external"
+        assert s.capability == ""
+        assert "argv" in s.params
+        assert "kind" not in s.params  # clé réservée retirée des params
+        assert s.params["timeout_seconds"] == 60
+
+    def test_kind_external_id_equals_model_name_for_single_step(self):
+        """Le dernier (et unique) step = model name."""
+        steps = self._compile({
+            "shell_pipeline": {
+                "kind": "external",
+                "argv": ["uv", "run", "python", "ingest.py"],
+            }
+        })
+        assert steps[0].id == "m"
+
+    def test_kind_external_intermediate_id(self):
+        """Avec 2 transforms dont le 1er non-capability, id intermédiaire = m__t0."""
+        from gispulse.core.manifest_v3 import _compile_model_steps, ModelSpec, SourceSpec
+
+        model = ModelSpec(
+            name="m",
+            select="s",
+            transform=[
+                {"shell_step": {"kind": "external", "argv": ["step1.py"]}},
+                {"shell_step2": {"kind": "external", "argv": ["step2.py"]}},
+            ],
+        )
+        sources = {"s": SourceSpec(name="s", uri="memory://s")}
+        steps = _compile_model_steps(model, sources, {"m"})
+        assert steps[0].id == "m__t0"
+        assert steps[1].id == "m"
+
+    def test_kind_capability_explicit_keeps_capability_path(self):
+        """kind: capability explicite → comportement actuel (capability = nom de l'item)."""
+        steps = self._compile({
+            "filter": {
+                "kind": "capability",
+                "expression": "val > 0",
+            }
+        })
+        assert steps[0].kind == "capability"
+        assert steps[0].capability == "filter"
+        assert steps[0].type == "capability"
+        assert "kind" not in steps[0].params
+        assert "expression" in steps[0].params
+
+    def test_kind_absent_keeps_capability_path(self):
+        """Pas de clé kind → comportement actuel (capability)."""
+        steps = self._compile({
+            "filter": {"expression": "val > 0"}
+        })
+        assert steps[0].kind == "capability"
+        assert steps[0].capability == "filter"
+
+    def test_kind_empty_string_raises_value_error(self):
+        """kind='' (vide) → ValueError (F3 : pas de normalisation silencieuse)."""
+        from gispulse.core.manifest_v3 import _split_transform
+
+        with pytest.raises(ValueError, match="non-empty"):
+            _split_transform({"filter": {"kind": "", "expression": "val > 0"}})
+
+    def test_with_on_noncapability_raises(self):
+        """with: sur un item non-capability → ManifestValidationError explicite."""
+        from gispulse.core.manifest_v3 import _compile_model_steps, ModelSpec, SourceSpec
+
+        model = ModelSpec(
+            name="m",
+            select="s",
+            transform=[
+                {
+                    "shell_pipeline": {
+                        "kind": "external",
+                        "argv": ["ingest.py"],
+                        "with": "other",  # illégal sur non-capability
+                    }
+                }
+            ],
+        )
+        sources = {
+            "s": SourceSpec(name="s", uri="memory://s"),
+            "other": SourceSpec(name="other", uri="memory://other"),
+        }
+        with pytest.raises(ValueError, match="with.*non.capability|non.capability.*with"):
+            _compile_model_steps(model, sources, {"m"})
+
+    def test_intra_model_chaining_preserved_for_two_external_steps(self):
+        """Deux steps external : le second a input=m__t0 (chaînage intra-modèle)."""
+        from gispulse.core.manifest_v3 import _compile_model_steps, ModelSpec, SourceSpec
+
+        model = ModelSpec(
+            name="m",
+            select="s",
+            transform=[
+                {"step_a": {"kind": "external", "argv": ["a.py"]}},
+                {"step_b": {"kind": "external", "argv": ["b.py"]}},
+            ],
+        )
+        sources = {"s": SourceSpec(name="s", uri="memory://s")}
+        steps = _compile_model_steps(model, sources, {"m"})
+        # Le step_b (index 1, id=m) doit référencer step_a (m__t0)
+        assert steps[1].input == "m__t0"
+
+    def test_timeout_seconds_in_params(self):
+        """timeout_seconds passé dans params (le handler external le lit de là)."""
+        steps = self._compile({
+            "shell_pipeline": {
+                "kind": "external",
+                "argv": ["run.py"],
+                "timeout_seconds": 21600,
+            }
+        })
+        assert steps[0].params.get("timeout_seconds") == 21600
+
+
+# ---------------------------------------------------------------------------
+# B. select optionnel pour les modèles 100 % non-capability
+# ---------------------------------------------------------------------------
+
+
+class TestSelectOptional:
+    """ModelSpec.select peut être None quand tous les transforms sont non-capability."""
+
+    def _build_manifest(self, model_dict: dict) -> object:
+        """Helper : construit un ManifestV3 minimal via _parse_models."""
+        from gispulse.core.manifest_v3 import _parse_models, ManifestV3
+
+        # On injecte un modèle sans select
+        models = _parse_models({"ext_model": model_dict})
+        manifest = ManifestV3(
+            sources={},
+            models=models,
+        )
+        return manifest
+
+    def test_parse_model_without_select_succeeds(self):
+        """Un modèle sans select=... se parse sans lever d'exception."""
+        from gispulse.core.manifest_v3 import _parse_models
+
+        models = _parse_models({
+            "ext_model": {
+                "transform": [
+                    {"shell_pipeline": {"kind": "external", "argv": ["run.py"]}}
+                ]
+            }
+        })
+        m = models["ext_model"]
+        assert m.select is None
+
+    def test_modelspec_select_defaults_to_none(self):
+        """ModelSpec.select vaut None par défaut (optionnel)."""
+        from gispulse.core.manifest_v3 import ModelSpec
+
+        m = ModelSpec(name="x")
+        assert m.select is None
+
+    def test_validate_manifest_accepts_all_noncapability(self):
+        """validate_manifest ne lève pas quand tous les steps sont non-capability sans select."""
+        from gispulse.core.manifest_v3 import ManifestV3, ModelSpec, validate_manifest
+
+        manifest = ManifestV3(
+            sources={},
+            models={
+                "ext_model": ModelSpec(
+                    name="ext_model",
+                    select=None,
+                    transform=[
+                        {"shell_pipeline": {"kind": "external", "argv": ["run.py"]}}
+                    ],
+                )
+            },
+        )
+        # Ne doit pas lever
+        warnings = validate_manifest(manifest)
+        assert isinstance(warnings, list)
+
+    def test_validate_manifest_rejects_capability_without_select(self):
+        """Un step capability sans select → ManifestValidationError explicite."""
+        from gispulse.core.manifest_v3 import ManifestV3, ModelSpec, ManifestValidationError, validate_manifest
+
+        manifest = ManifestV3(
+            sources={"s": __import__("gispulse.core.manifest_v3", fromlist=["SourceSpec"]).SourceSpec(name="s", uri="m://s")},
+            models={
+                "bad": ModelSpec(
+                    name="bad",
+                    select=None,  # manquant mais transform capability
+                    transform=[{"filter": {"expression": "val > 0"}}],
+                )
+            },
+        )
+        with pytest.raises(ManifestValidationError, match="select.*required|capability.*select"):
+            validate_manifest(manifest)
+
+    def test_validate_manifest_rejects_no_transform_no_select(self):
+        """Modèle sans transform ET sans select → erreur (passthrough sans source)."""
+        from gispulse.core.manifest_v3 import ManifestV3, ModelSpec, ManifestValidationError, validate_manifest
+
+        manifest = ManifestV3(
+            sources={},
+            models={
+                "bad": ModelSpec(
+                    name="bad",
+                    select=None,
+                    transform=[],
+                )
+            },
+        )
+        with pytest.raises(ManifestValidationError):
+            validate_manifest(manifest)
+
+    def test_compile_noncapability_model_no_select(self):
+        """compile_to_pipeline sur un modèle external sans select produit des steps valides."""
+        from gispulse.core.manifest_v3 import ManifestV3, ModelSpec, compile_to_pipeline
+
+        manifest = ManifestV3(
+            sources={},
+            models={
+                "ext_model": ModelSpec(
+                    name="ext_model",
+                    select=None,
+                    transform=[
+                        {"shell_pipeline": {"kind": "external", "argv": ["run.py"]}}
+                    ],
+                )
+            },
+        )
+        spec = compile_to_pipeline(manifest)
+        assert len(spec.steps) == 1
+        s = spec.steps[0]
+        assert s.id == "ext_model"
+        assert s.kind == "external"
+        assert s.input is None  # pas de chaînage en amont
+
+    def test_compile_first_step_input_none_without_select(self):
+        """Premier step d'un modèle sans select a input=None."""
+        from gispulse.core.manifest_v3 import ManifestV3, ModelSpec, compile_to_pipeline
+
+        manifest = ManifestV3(
+            sources={},
+            models={
+                "m": ModelSpec(
+                    name="m",
+                    select=None,
+                    transform=[
+                        {"s1": {"kind": "external", "argv": ["a.py"]}},
+                        {"s2": {"kind": "external", "argv": ["b.py"]}},
+                    ],
+                )
+            },
+        )
+        spec = compile_to_pipeline(manifest)
+        assert spec.steps[0].input is None
+        assert spec.steps[1].input == "m__t0"
+
+
+# ---------------------------------------------------------------------------
+# C. Exécution bout-en-bout run_manifest — modèle external sans select
+# ---------------------------------------------------------------------------
+
+
+class TestRunManifestExternal:
+    """run_manifest avec un modèle 100 % external sans select."""
+
+    def _make_manifest_external(self, script_content: str, model_name: str = "run_dept"):
+        """Construit un ManifestV3 avec un seul modèle external qui exécute un script Python."""
+        from gispulse.core.manifest_v3 import ManifestV3, ModelSpec
+
+        return ManifestV3(
+            name="test_external",
+            sources={},
+            models={
+                model_name: ModelSpec(
+                    name=model_name,
+                    select=None,
+                    transform=[
+                        {
+                            "shell_pipeline": {
+                                "kind": "external",
+                                "argv": [sys.executable, "-c", script_content],
+                                "timeout_seconds": 30,
+                            }
+                        }
+                    ],
+                )
+            },
+        )
+
+    def test_run_completed_status(self):
+        """run_manifest d'un modèle external → execution_order contient le modèle."""
+        from gispulse.runtime.manifest_runner import run_manifest
+
+        manifest = self._make_manifest_external("print('hello')")
+        result = run_manifest(manifest)
+        assert "run_dept" in result.execution_order
+
+    def test_run_no_data_materialized(self):
+        """Un modèle external ne produit pas de GeoDataFrame — pas dans materialized."""
+        from gispulse.runtime.manifest_runner import run_manifest
+
+        manifest = self._make_manifest_external("import sys; sys.exit(0)")
+        result = run_manifest(manifest)
+        # Le modèle est dans executed_order mais materialized ne contient pas de
+        # GeoDataFrame (le modèle external ne matérialise rien)
+        assert "run_dept" not in result.materialized
+
+    def test_run_step_artifacts_log_tail(self):
+        """artifacts du step external contiennent log_tail."""
+        from gispulse.runtime.manifest_runner import run_manifest
+
+        class _SpySink:
+            def __init__(self):
+                self.events: list[tuple[str, dict]] = []
+            def emit(self, t, d):
+                self.events.append((t, d))
+
+        manifest = self._make_manifest_external("print('output line')")
+        spy = _SpySink()
+        run_manifest(manifest, event_sink=spy)
+
+        completed = [d for t, d in spy.events if t == "run.step.completed"]
+        assert completed, "Aucun événement run.step.completed émis"
+        artifacts = completed[-1].get("artifacts", {})
+        assert "log_tail" in artifacts
+
+    def test_run_failing_script_raises(self):
+        """Un script qui retourne exit 1 → RuntimeError remontée par run_manifest."""
+        from gispulse.runtime.manifest_runner import run_manifest
+
+        manifest = self._make_manifest_external("import sys; sys.exit(1)")
+        with pytest.raises(RuntimeError, match="failed"):
+            run_manifest(manifest)
+
+    def test_run_print_hello_completed(self):
+        """Subprocess réel `python -c print` → run COMPLETED, no exception."""
+        from gispulse.runtime.manifest_runner import run_manifest
+
+        manifest = self._make_manifest_external("print('hello from external')")
+        result = run_manifest(manifest)
+        assert result.execution_order == ["run_dept"]
+
+
+# ---------------------------------------------------------------------------
+# D. Modèle downstream référençant un modèle sans select → erreur claire
+# ---------------------------------------------------------------------------
+
+
+class TestDownstreamNoSelectError:
+    """Un modèle downstream qui sélectionne un modèle sans select (external) → erreur."""
+
+    def test_downstream_select_raises_on_resolve(self):
+        """_resolve d'un modèle external (sans données) → ValueError explicite."""
+        from gispulse.core.manifest_v3 import ManifestV3, ModelSpec
+        from gispulse.runtime.manifest_runner import run_manifest
+
+        manifest = ManifestV3(
+            sources={"s": __import__("gispulse.core.manifest_v3", fromlist=["SourceSpec"]).SourceSpec(name="s", uri="m://s")},
+            models={
+                "ext": ModelSpec(
+                    name="ext",
+                    select=None,
+                    transform=[
+                        {"shell": {"kind": "external", "argv": [sys.executable, "-c", "print('done')"]}}
+                    ],
+                ),
+                "downstream": ModelSpec(
+                    name="downstream",
+                    select="ext",  # référence un modèle sans données
+                    transform=[{"filter": {"expression": "val > 0"}}],
+                ),
+            },
+        )
+
+        import geopandas as gpd
+        from shapely.geometry import Point
+
+        def _loader(src):
+            return gpd.GeoDataFrame(
+                {"id": [1], "val": [10]},
+                geometry=[Point(0, 0)],
+                crs="EPSG:4326",
+            )
+
+        with pytest.raises((ValueError, RuntimeError, KeyError), match="no data|produces no data|external|non.capability"):
+            run_manifest(manifest, source_loader=_loader)
+
+
+# ---------------------------------------------------------------------------
+# E. /manifests/validate accepte le manifest external
+# ---------------------------------------------------------------------------
+
+
+class TestManifestValidateEndpoint:
+    """POST /manifests/validate avec un manifest external."""
+
+    @pytest.fixture(autouse=True)
+    def _disable_rate_limiter(self):
+        from gispulse.adapters.http.rate_limit import limiter
+        limiter.enabled = False
+
+    @pytest.fixture
+    def client(self):
+        from fastapi.testclient import TestClient
+        from gispulse.adapters.http.app import create_app
+        import warnings
+        warnings.filterwarnings("ignore")
+        app = create_app()
+        with TestClient(app) as c:
+            yield c
+
+    def _external_manifest(self):
+        return {
+            "version": 3,
+            "name": "ext_manifest",
+            "sources": {},
+            "models": {
+                "run_dept_63": {
+                    "transform": [
+                        {
+                            "shell_pipeline": {
+                                "kind": "external",
+                                "argv": [sys.executable, "-c", "print('ok')"],
+                                "timeout_seconds": 21600,
+                            }
+                        }
+                    ]
+                }
+            },
+        }
+
+    def test_validate_external_manifest_returns_valid(self, client):
+        """POST /manifests/validate avec manifest external → valid=True."""
+        resp = client.post(
+            "/manifests/validate",
+            json={"manifest": self._external_manifest()},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["valid"] is True, f"Errors: {body.get('errors')}"
+
+    def test_validate_external_manifest_compiled_steps(self, client):
+        """compiled_steps_count == 1 pour un manifest avec 1 modèle 1 transform."""
+        resp = client.post(
+            "/manifests/validate",
+            json={"manifest": self._external_manifest()},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["compiled_steps_count"] == 1
+
+    def test_validate_known_capabilities_not_checked_for_external(self, client):
+        """Les steps non-capability ne sont pas soumis au check de capabilities."""
+        # Un nom de step arbitraire non enregistré comme capability → OK pour external
+        manifest = {
+            "version": 3,
+            "sources": {},
+            "models": {
+                "m": {
+                    "transform": [
+                        {
+                            "completely_unknown_capability_xyz": {
+                                "kind": "external",
+                                "argv": ["run.py"],
+                            }
+                        }
+                    ]
+                }
+            },
+        }
+        resp = client.post(
+            "/manifests/validate",
+            json={"manifest": manifest},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["valid"] is True, f"Errors: {body.get('errors')}"
+
+
+# ---------------------------------------------------------------------------
+# F. steps_filter interaction avec modèle sans select
+# ---------------------------------------------------------------------------
+
+
+class TestStepsFilterInteractionExternal:
+    """validate_steps_filter_models : un modèle sans select est skippable trivialement."""
+
+    def test_filter_including_external_model_no_error(self):
+        """steps_filter incluant un modèle external ne produit pas d'erreur orphan."""
+        from gispulse.core.manifest_v3 import ManifestV3, ModelSpec
+        from gispulse.runtime.manifest_runner import validate_steps_filter_models
+
+        manifest = ManifestV3(
+            sources={},
+            models={
+                "ext": ModelSpec(
+                    name="ext",
+                    select=None,
+                    transform=[
+                        {"shell": {"kind": "external", "argv": ["run.py"]}}
+                    ],
+                )
+            },
+        )
+        # ne doit pas lever
+        validate_steps_filter_models(manifest, ["ext"])
+
+    def test_filter_excluding_external_upstream_no_error(self):
+        """Un modèle capability downstream dont l'upstream external est exclu → OK
+        (pas de GeoDataFrame à propager depuis external)."""
+        from gispulse.core.manifest_v3 import ManifestV3, ModelSpec, SourceSpec
+        from gispulse.runtime.manifest_runner import validate_steps_filter_models
+
+        manifest = ManifestV3(
+            sources={"s": SourceSpec(name="s", uri="memory://s")},
+            models={
+                "ext": ModelSpec(
+                    name="ext",
+                    select=None,
+                    transform=[{"shell": {"kind": "external", "argv": ["run.py"]}}],
+                ),
+                # Note: ce downstream doit avoir une source valide pour se compiler
+                "cap": ModelSpec(
+                    name="cap",
+                    select="s",
+                    transform=[{"filter": {"expression": "val > 0"}}],
+                ),
+            },
+        )
+        # filter = seulement "cap" (ext exclu) → OK car ext est non-capability
+        validate_steps_filter_models(manifest, ["cap"])
+
+
+# ---------------------------------------------------------------------------
+# G. POST /manifests/run 202 bout-en-bout
+# ---------------------------------------------------------------------------
+
+
+class TestManifestRunEndpointExternal:
+    """POST /manifests/run avec manifest external → 202 Accepted."""
+
+    @pytest.fixture(autouse=True)
+    def _disable_rate_limiter(self):
+        from gispulse.adapters.http.rate_limit import limiter
+        limiter.enabled = False
+
+    @pytest.fixture
+    def client(self, tmp_path):
+        from fastapi.testclient import TestClient
+        from gispulse.adapters.http.app import create_app
+        import warnings
+        warnings.filterwarnings("ignore")
+        app = create_app()
+        with TestClient(app) as c:
+            yield c
+
+    def _external_manifest(self):
+        return {
+            "version": 3,
+            "name": "ext_run_test",
+            "sources": {},
+            "models": {
+                "run_dept_63": {
+                    "transform": [
+                        {
+                            "shell_pipeline": {
+                                "kind": "external",
+                                "argv": [sys.executable, "-c", "print('done')"],
+                                "timeout_seconds": 30,
+                            }
+                        }
+                    ]
+                }
+            },
+        }
+
+    def test_post_run_returns_202(self, client):
+        """POST /manifests/run manifest external → 202 avec job_id."""
+        resp = client.post(
+            "/manifests/run",
+            json={"manifest": self._external_manifest()},
+        )
+        assert resp.status_code == 202, resp.text
+        body = resp.json()
+        assert "job_id" in body
+        assert body["status"] == "pending"
+
+    def test_post_run_returns_manifest_name(self, client):
+        """manifest_name dans la réponse 202 correspond au name du manifest."""
+        resp = client.post(
+            "/manifests/run",
+            json={"manifest": self._external_manifest()},
+        )
+        assert resp.status_code == 202
+        body = resp.json()
+        assert body["manifest_name"] == "ext_run_test"
+
+    def test_post_run_invalid_manifest_returns_422(self, client):
+        """Un manifest invalide retourne 422 sans créer de job."""
+        resp = client.post(
+            "/manifests/run",
+            json={"manifest": {"version": 3, "models": {"bad": {"select": "nonexistent_source"}}}},
+        )
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# H. Schema v3 — model sans select accepté par SCHEMA_V3
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaV3SelectOptional:
+    """SCHEMA_V3 doit accepter un model sans la clé select quand il a des transforms."""
+
+    def test_schema_accepts_model_without_select_with_transform(self):
+        """SCHEMA_V3 accepte un modèle sans select si il a un transform."""
+        from gispulse.core.pipeline_schema import validate_pipeline_json
+
+        raw = {
+            "version": 3,
+            "sources": {},
+            "models": {
+                "ext_model": {
+                    "transform": [
+                        {"shell_pipeline": {"kind": "external", "argv": ["run.py"]}}
+                    ]
+                }
+            },
+        }
+        errors = validate_pipeline_json(raw)
+        assert errors == [], f"Schema errors: {errors}"
+
+    def test_schema_still_requires_select_for_capability_model(self):
+        """SCHEMA_V3 est inchangé pour les modèles capability (select toujours obligatoire
+        via la validation sémantique, pas nécessairement le schéma JSON)."""
+        # Note: le schéma JSON devient permissif sur select, c'est validate_manifest
+        # qui impose la contrainte sémantique. Ce test vérifie simplement que le
+        # schéma JSON accepte les manifests existants (rétrocompatibilité).
+        from gispulse.core.pipeline_schema import validate_pipeline_json
+
+        raw = {
+            "version": 3,
+            "sources": {"s": {"uri": "memory://s"}},
+            "models": {
+                "m": {
+                    "select": "s",
+                    "transform": [{"filter": {"expression": "val > 0"}}],
+                }
+            },
+        }
+        errors = validate_pipeline_json(raw)
+        assert errors == [], f"Schema errors: {errors}"

--- a/tests/unit/test_manifest_kinds_fixes.py
+++ b/tests/unit/test_manifest_kinds_fixes.py
@@ -1,0 +1,435 @@
+"""Tests TDD — fixes F1/F2/F3/F4 (review Codex issue #453).
+
+F1 (P1): runner.py — resume avec liste steps vide = None = re-exécution totale
+F2 (P2): manifest_runner.py — execution_order pollué par external exclu du filtre
+F3 (P2): manifest_v3.py — kind non-string / string vide silencieusement normalisé
+F4 (P3): manifest_runner.py — pré-check loader masque « produces no data output »
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# F3 — _split_transform : kind doit être une string non-vide
+# ---------------------------------------------------------------------------
+
+
+class TestSplitTransformKindValidation:
+    """F3 : kind non-string → ValueError ; string vide → ValueError."""
+
+    def test_kind_int_raises_value_error(self):
+        """kind: 123 (int) doit lever ValueError, pas normaliser en '123'."""
+        from gispulse.core.manifest_v3 import _split_transform
+
+        with pytest.raises(ValueError, match="kind.*string|string.*kind"):
+            _split_transform({"step": {"kind": 123, "argv": ["run.py"]}})
+
+    def test_kind_empty_string_raises_value_error(self):
+        """kind: '' (string vide) doit lever ValueError, pas silencieusement→capability."""
+        from gispulse.core.manifest_v3 import _split_transform
+
+        with pytest.raises(ValueError, match="kind.*empty|empty.*kind|kind.*non.empty"):
+            _split_transform({"step": {"kind": "", "argv": ["run.py"]}})
+
+    def test_kind_none_absent_is_capability(self):
+        """Absence de kind (pas de clé) → capability (comportement existant inchangé)."""
+        from gispulse.core.manifest_v3 import _split_transform
+
+        _, params, effective_kind = _split_transform({"filter": {"expression": "val > 0"}})
+        assert effective_kind == "capability"
+
+    def test_kind_none_key_absent_is_capability(self):
+        """kind: null (clé absente) → capability."""
+        from gispulse.core.manifest_v3 import _split_transform
+
+        _, params, effective_kind = _split_transform({"filter": {}})
+        assert effective_kind == "capability"
+
+    def test_kind_float_raises_value_error(self):
+        """kind: 1.5 (float) doit lever ValueError."""
+        from gispulse.core.manifest_v3 import _split_transform
+
+        with pytest.raises(ValueError, match="kind.*string|string.*kind"):
+            _split_transform({"step": {"kind": 1.5, "argv": ["run.py"]}})
+
+    def test_kind_list_raises_value_error(self):
+        """kind: ['x'] (list) doit lever ValueError."""
+        from gispulse.core.manifest_v3 import _split_transform
+
+        with pytest.raises(ValueError, match="kind.*string|string.*kind"):
+            _split_transform({"step": {"kind": ["external"], "argv": ["run.py"]}})
+
+    def test_kind_external_string_ok(self):
+        """kind: 'external' (string non-vide) → effective_kind='external'."""
+        from gispulse.core.manifest_v3 import _split_transform
+
+        _, params, effective_kind = _split_transform(
+            {"shell": {"kind": "external", "argv": ["run.py"]}}
+        )
+        assert effective_kind == "external"
+
+    def test_validate_manifest_rejects_kind_int(self):
+        """validate_manifest remonte l'erreur kind non-string en ManifestValidationError."""
+        from gispulse.core.manifest_v3 import (
+            ManifestV3,
+            ModelSpec,
+            ManifestValidationError,
+            validate_manifest,
+        )
+
+        manifest = ManifestV3(
+            sources={},
+            models={
+                "bad": ModelSpec(
+                    name="bad",
+                    select=None,
+                    transform=[{"shell": {"kind": 42, "argv": ["run.py"]}}],
+                )
+            },
+        )
+        with pytest.raises((ManifestValidationError, ValueError), match="kind"):
+            validate_manifest(manifest)
+
+
+# ---------------------------------------------------------------------------
+# F2 — execution_order ne doit pas contenir les external exclus du filtre
+# ---------------------------------------------------------------------------
+
+
+class TestExecutionOrderFilterExternal:
+    """F2 : modèle external exclu du steps_filter ne doit pas apparaître dans execution_order."""
+
+    def _make_two_external_manifest(self):
+        from gispulse.core.manifest_v3 import ManifestV3, ModelSpec
+
+        return ManifestV3(
+            sources={},
+            models={
+                "a": ModelSpec(
+                    name="a",
+                    select=None,
+                    transform=[
+                        {
+                            "shell_a": {
+                                "kind": "external",
+                                "argv": [sys.executable, "-c", "print('a')"],
+                            }
+                        }
+                    ],
+                ),
+                "b": ModelSpec(
+                    name="b",
+                    select=None,
+                    transform=[
+                        {
+                            "shell_b": {
+                                "kind": "external",
+                                "argv": [sys.executable, "-c", "print('b')"],
+                            }
+                        }
+                    ],
+                ),
+            },
+        )
+
+    def test_filter_a_only_execution_order(self):
+        """steps_filter=['a'] → execution_order=['a'] uniquement, 'b' absent."""
+        from gispulse.runtime.manifest_runner import run_manifest
+
+        manifest = self._make_two_external_manifest()
+        result = run_manifest(manifest, steps_filter=["a"])
+        assert result.execution_order == ["a"], (
+            f"Expected ['a'] but got {result.execution_order!r} — "
+            "excluded external model 'b' should not appear"
+        )
+
+    def test_filter_b_only_execution_order(self):
+        """steps_filter=['b'] → execution_order=['b'] uniquement, 'a' absent."""
+        from gispulse.runtime.manifest_runner import run_manifest
+
+        manifest = self._make_two_external_manifest()
+        result = run_manifest(manifest, steps_filter=["b"])
+        assert result.execution_order == ["b"], (
+            f"Expected ['b'] but got {result.execution_order!r}"
+        )
+
+    def test_filter_none_runs_both(self):
+        """Pas de filtre → les deux modèles s'exécutent (régression: ne pas briser)."""
+        from gispulse.runtime.manifest_runner import run_manifest
+
+        manifest = self._make_two_external_manifest()
+        result = run_manifest(manifest)
+        assert set(result.execution_order) == {"a", "b"}
+
+    def test_excluded_external_does_not_run_subprocess(self, tmp_path):
+        """Un external exclu du filtre ne doit PAS lancer de subprocess (marqueur fichier)."""
+        from gispulse.runtime.manifest_runner import run_manifest
+        from gispulse.core.manifest_v3 import ManifestV3, ModelSpec
+
+        marker = tmp_path / "ran.txt"
+        # Le script crée le fichier s'il tourne
+        script = f"open({str(marker)!r}, 'w').write('ran')"
+
+        manifest = ManifestV3(
+            sources={},
+            models={
+                "a": ModelSpec(
+                    name="a",
+                    select=None,
+                    transform=[
+                        {
+                            "shell_a": {
+                                "kind": "external",
+                                "argv": [sys.executable, "-c", "print('a')"],
+                            }
+                        }
+                    ],
+                ),
+                "should_not_run": ModelSpec(
+                    name="should_not_run",
+                    select=None,
+                    transform=[
+                        {
+                            "shell_marker": {
+                                "kind": "external",
+                                "argv": [sys.executable, "-c", script],
+                            }
+                        }
+                    ],
+                ),
+            },
+        )
+        run_manifest(manifest, steps_filter=["a"])
+        assert not marker.exists(), (
+            "should_not_run subprocess was executed despite being excluded from steps_filter"
+        )
+
+
+# ---------------------------------------------------------------------------
+# F4 — pré-check loader : erreur claire « produces no data » > « requires engine »
+# ---------------------------------------------------------------------------
+
+
+class TestNoDataDownstreamErrorMessage:
+    """F4 : ext(select=None) + downstream(select='ext') sans source_loader → erreur claire."""
+
+    def test_downstream_no_data_error_is_clear(self):
+        """L'erreur doit mentionner 'no data' ou 'non-capability', pas 'requires engine'."""
+        from gispulse.core.manifest_v3 import ManifestV3, ModelSpec
+        from gispulse.runtime.manifest_runner import run_manifest
+
+        manifest = ManifestV3(
+            sources={},  # pas de source déclarée
+            models={
+                "ext": ModelSpec(
+                    name="ext",
+                    select=None,
+                    transform=[
+                        {
+                            "shell": {
+                                "kind": "external",
+                                "argv": [sys.executable, "-c", "print('done')"],
+                            }
+                        }
+                    ],
+                ),
+                "downstream": ModelSpec(
+                    name="downstream",
+                    select="ext",  # ref vers un modèle no-data
+                    transform=[{"filter": {"expression": "val > 0"}}],
+                ),
+            },
+        )
+        with pytest.raises((ValueError, RuntimeError, KeyError)) as exc_info:
+            # Aucun source_loader ni engine : le seul « select » non-None
+            # pointe vers un modèle sans données.
+            run_manifest(manifest)
+
+        error_msg = str(exc_info.value).lower()
+        assert (
+            "no data" in error_msg
+            or "non-capability" in error_msg
+            or "produces no data" in error_msg
+            or "no data output" in error_msg
+        ), (
+            f"Expected a clear 'no data' error, got: {exc_info.value!r}\n"
+            "This should NOT be 'requires either an engine' — that masks the real issue."
+        )
+
+    def test_no_false_engine_error_when_only_model_refs(self):
+        """run_manifest ne doit pas exiger engine/source_loader quand tous
+        les selects pointent vers d'autres modèles (pas vers des sources déclarées)."""
+        from gispulse.core.manifest_v3 import ManifestV3, ModelSpec
+        from gispulse.runtime.manifest_runner import run_manifest
+
+        # Ce manifest n'a pas de sources déclarées, uniquement des modèles external.
+        # Il ne doit pas lever « requires engine or source_loader ».
+        manifest = ManifestV3(
+            sources={},
+            models={
+                "ext": ModelSpec(
+                    name="ext",
+                    select=None,
+                    transform=[
+                        {
+                            "shell": {
+                                "kind": "external",
+                                "argv": [sys.executable, "-c", "print('ok')"],
+                            }
+                        }
+                    ],
+                ),
+            },
+        )
+        # Ne doit PAS lever RuntimeError("requires engine")
+        result = run_manifest(manifest)
+        assert "ext" in result.execution_order
+
+
+# ---------------------------------------------------------------------------
+# F1 — resume manifest : liste vide → rien à exécuter, pas de re-run total
+# ---------------------------------------------------------------------------
+
+
+class TestManifestResumeNothingToExecute:
+    """F1 : quand _replay_resume retourne liste vide, run_manifest N'EST PAS appelé."""
+
+    def _make_ext_manifest_dict(self, marker_path: str | None = None):
+        """Manifest avec 1 modèle external qui crée un fichier marqueur si lancé."""
+        if marker_path:
+            script = f"open({marker_path!r}, 'w').write('ran')"
+        else:
+            script = "print('hello')"
+        return {
+            "version": 3,
+            "name": "resume_test",
+            "sources": {},
+            "models": {
+                "run_dept_63": {
+                    "transform": [
+                        {
+                            "shell_pipeline": {
+                                "kind": "external",
+                                "argv": [sys.executable, "-c", script],
+                                "timeout_seconds": 30,
+                            }
+                        }
+                    ]
+                }
+            },
+        }
+
+    def _make_completed_source_run(self, run_repo, step_id: str = "run_dept_63"):
+        """Crée et persiste un run source COMPLETED avec 1 step COMPLETED."""
+        from datetime import datetime, timezone
+        from gispulse.core.run_models import PipelineRun, PipelineRunStep
+        from gispulse.core.enums import JobStatus
+
+        source_run = PipelineRun(source="job", spec_ref="resume_test", scope="")
+        source_run.status = JobStatus.COMPLETED
+        source_run.ended_at = datetime.now(timezone.utc)
+        source_run.steps = [
+            PipelineRunStep(
+                step_id=step_id,
+                status=JobStatus.COMPLETED,
+                ended_at=datetime.now(timezone.utc),
+                artifacts={"log_tail": "done"},
+            )
+        ]
+        run_repo.save(source_run)
+        return source_run
+
+    def test_resume_empty_steps_does_not_call_run_manifest(self, tmp_path):
+        """Quand tous les steps sont COMPLETED dans la source run, run_manifest NE TOURNE PAS."""
+        from gispulse.orchestration.runner import JobRunner
+        from gispulse.core.models import Job, JobStatus
+        from gispulse.persistence.repository import InMemoryRepository
+        from gispulse.rules.engine import RuleEngine
+        from gispulse.persistence.run_repository import RunRepository
+        import geopandas as gpd
+        from shapely.geometry import Point
+
+        marker = tmp_path / "ran.txt"
+        manifest_dict = self._make_ext_manifest_dict(str(marker))
+
+        run_repo = RunRepository(db_path=tmp_path / "runs.db")
+        source_run = self._make_completed_source_run(run_repo)
+
+        job = Job(
+            name="resume_test",
+            parameters={
+                "manifest": manifest_dict,
+                "resume_from_run_id": str(source_run.run_id),
+            },
+        )
+
+        repo = InMemoryRepository()
+        engine = RuleEngine(repository=repo)
+        runner = JobRunner(repository=repo, rule_engine=engine)
+        gdf = gpd.GeoDataFrame({"id": [1]}, geometry=[Point(0, 0)], crs="EPSG:4326")
+
+        updated_job, _ = runner.run(job, gdf, run_repo=run_repo)
+
+        assert updated_job.status == JobStatus.COMPLETED, (
+            f"Job should be COMPLETED, got {updated_job.status}: {updated_job.error_message}"
+        )
+        assert not marker.exists(), (
+            "The subprocess ran again despite all steps being COMPLETED in source run. "
+            "This is F1: empty steps_filter list was converted to None = no filter = re-run."
+        )
+
+    def test_resume_empty_steps_run_manifest_not_called_at_all(self, tmp_path):
+        """Quand tous les steps sont COMPLETED, run_manifest NE DOIT PAS être appelé."""
+        from unittest.mock import patch, MagicMock
+        from gispulse.orchestration.runner import JobRunner
+        from gispulse.core.models import Job, JobStatus
+        from gispulse.persistence.repository import InMemoryRepository
+        from gispulse.rules.engine import RuleEngine
+        from gispulse.persistence.run_repository import RunRepository
+        from gispulse.runtime.manifest_runner import ManifestRunResult
+        import geopandas as gpd
+        from shapely.geometry import Point
+
+        run_repo = RunRepository(db_path=tmp_path / "runs.db")
+        source_run = self._make_completed_source_run(run_repo)
+
+        job = Job(
+            name="resume_test",
+            parameters={
+                "manifest": self._make_ext_manifest_dict(),
+                "resume_from_run_id": str(source_run.run_id),
+            },
+        )
+
+        repo = InMemoryRepository()
+        engine = RuleEngine(repository=repo)
+        runner = JobRunner(repository=repo, rule_engine=engine)
+        gdf = gpd.GeoDataFrame({"id": [1]}, geometry=[Point(0, 0)], crs="EPSG:4326")
+
+        # Mock run_manifest pour qu'il ne fasse rien (évite la récursion)
+        mock_rm = MagicMock(return_value=ManifestRunResult(
+            materialized={}, execution_order=[]
+        ))
+
+        with patch("gispulse.runtime.manifest_runner.run_manifest", mock_rm):
+            updated_job, _ = runner.run(job, gdf, run_repo=run_repo)
+
+        assert updated_job.status == JobStatus.COMPLETED
+
+        # Vérifie que mock_rm n'a PAS été appelé, ou si appelé, pas avec None/[]
+        for call in mock_rm.call_args_list:
+            sf = call.kwargs.get("steps_filter")
+            if sf is None:
+                pytest.fail(
+                    "run_manifest called with steps_filter=None — "
+                    "converted from empty list, re-runs everything (F1)"
+                )
+            if sf == []:
+                pytest.fail(
+                    "run_manifest called with steps_filter=[] — "
+                    "should skip the call entirely when nothing to execute (F1)"
+                )


### PR DESCRIPTION
## Quoi

Prérequis de la vague 6 du chantier orchestration (#440), implémente la design issue #453 : le manifest v3 — **seule surface de commande HTTP** (`POST /manifests/run`) — sait maintenant exprimer des **steps non-capability** (kind `external` de #450 et futurs kinds applicatifs), ce qui débloque les migrations d'orchestrateurs applicatifs en wrap-then-replace (foncier phase A).

## Contenu

- **Clé réservée `kind`** sur les transform items :
  ```yaml
  models:
    run_dept_63:
      transform:
        - shell_pipeline:
            kind: external
            argv: ["uv", "run", "python", "scripts/run_pipeline.py", "--departement", "63"]
            timeout_seconds: 21600
  ```
  compile en `StepSpec(kind="external", type="external", capability="")`. Explicite > implicite : seule la clé `kind` bascule le dispatch, pas de résolution magique par nom. `kind` non-string ou vide → rejeté à la validation, jamais normalisé silencieusement.
- **`select` optionnel** uniquement quand TOUS les items du modèle sont non-capability (une chaîne subprocess opaque n'a pas d'entrée de données — exiger une source no-op serait un mensonge déclaratif). Step capability sans `select` = toujours une erreur. Les modèles sans select ne sont pas matérialisés ; un modèle d'aval qui en consomme un échoue avec « produces no data output » (ordonné AVANT le pré-check engine/loader pour que le message actionnable gagne).
- **`with:` interdit** sur un item non-capability (aucun flux de données n'entre dans un step external).
- **`/manifests/validate`** : structure seule pour les kinds non-capability — les kinds applicatifs sont enregistrés dans le worker, valider leur existence à la frontière HTTP produirait des 422 sur des manifests valides ; le worker échoue explicitement (« unknown step kind ») à l'exécution. Choix documenté en docstring.
- **Interactions vague 5 durcies** : la compilation des sub-pipelines propage `kind` (perdu avant — cassait la détection non-capability de `validate_steps_filter_models`) ; un resume manifest sans rien à exécuter ne relance plus le subprocess (filtre vide ≠ pas de filtre) ; les modèles exclus par `steps_filter` n'apparaissent plus dans `execution_order`.

## Tests

`test_manifest_external_steps.py` (32) + `test_manifest_kinds_fixes.py` (16) — 238 passed / 2 skipped sur les suites manifest+orchestration, ruff check clean.

## Review

Review Codex pré-commit : 4 findings (1 P1 : le filtre vide du resume qui ré-exécutait tout), tous corrigés — trail en commentaire.

Refs #440 · Closes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)