### PR TITLE
fix(orchestration): cancel, heartbeat and timeout elevation on the manifest path (#440)

### DIFF
--- a/src/gispulse/orchestration/runner.py
+++ b/src/gispulse/orchestration/runner.py
@@ -415,6 +415,8 @@ class JobRunner:
                             event_sink=event_sink,
                             run_id=run_id,
                             run_repo=run_repo,
+                            cancel_check=cancel_check,
+                            heartbeat=heartbeat,
                         )
                         steps_count = len(
                             job.parameters[_MANIFEST_KEY].get("models", {})
@@ -708,6 +710,8 @@ class JobRunner:
         event_sink: RunEventSink | None = None,
         run_id: str | None = None,
         run_repo: Any | None = None,
+        cancel_check: Any | None = None,
+        heartbeat: Any | None = None,
     ) -> gpd.GeoDataFrame:
         """Execute a job whose parameters contain a ``manifest`` dict (v3 ManifestV3).
 
@@ -891,6 +895,23 @@ class JobRunner:
         # --- Execute with timeout -----------------------------------------
         from gispulse.runtime.manifest_runner import run_manifest  # local to avoid circular import
 
+        # Per-step timeout elevation (#448) must apply on the manifest path
+        # too: a manifest external step declaring timeout_seconds=21600 was
+        # killed by the 300 s job default (found in live phase-A validation).
+        from gispulse.core.manifest_v3 import compile_to_pipeline as _compile_for_timeout
+
+        effective_timeout = _compute_effective_timeout(
+            timeout, _compile_for_timeout(manifest)
+        )
+        if effective_timeout != timeout:
+            log.info(
+                "job_timeout_elevated",
+                job_id=str(job.id),
+                original_timeout=timeout,
+                effective_timeout=effective_timeout,
+            )
+            timeout = effective_timeout
+
         pool = ThreadPoolExecutor(max_workers=1)
         try:
             future = pool.submit(
@@ -906,6 +927,8 @@ class JobRunner:
                 # or resume paths with a non-empty remaining list.
                 steps_filter=steps_filter_manifest or None,
                 resume_markers=manifest_resume_markers if manifest_resume_markers else None,
+                cancel_check=cancel_check,
+                heartbeat=heartbeat,
             )
             result = future.result(timeout=timeout)
         except FuturesTimeoutError:

--- a/src/gispulse/runtime/manifest_runner.py
+++ b/src/gispulse/runtime/manifest_runner.py
@@ -324,8 +324,16 @@ def run_manifest(
     run_id: str | None = None,
     steps_filter: list[str] | None = None,
     resume_markers: dict[str, str] | None = None,
+    cancel_check: Callable[[], bool] | None = None,
+    heartbeat: Callable[[], None] | None = None,
 ) -> ManifestRunResult:
     """Execute a v3 manifest end-to-end.
+
+    ``cancel_check``/``heartbeat`` are forwarded to every per-model
+    PipelineExecutor so long-running non-capability steps (external
+    subprocesses) can be cancelled mid-step and keep the worker's
+    stuck-recovery fed — without them a manifest job is only cancellable
+    between models.
 
     Walks the models in topological order and, for each one, resolves
     its ``select`` and any transform-level ``with:`` references into
@@ -503,6 +511,8 @@ def run_manifest(
             # to the step-kind registry; they don't consume GeoDataFrame inputs.
             model_executor = PipelineExecutor(
                 execution_context=None,
+                cancel_check=cancel_check,
+                heartbeat=heartbeat,
                 resume_markers=model_resume_markers if model_resume_markers else None,
             )
             # Provide a sentinel empty inputs dict; sub_spec only has non-capability
@@ -612,6 +622,8 @@ def run_manifest(
             # the current model's step IDs (no cross-model marker leakage).
             model_executor = PipelineExecutor(
                 execution_context=None,
+                cancel_check=cancel_check,
+                heartbeat=heartbeat,
                 resume_markers=model_resume_markers if model_resume_markers else None,
             )
             results = model_executor.execute(sub_spec, inputs, None, event_sink=_sink, run_id=run_id)  # type: ignore[arg-type]

--- a/tests/unit/test_manifest_cancel.py
+++ b/tests/unit/test_manifest_cancel.py
@@ -1,0 +1,203 @@
+"""Cancel + heartbeat propagation through the manifest execution path.
+
+Found during the live phase-A validation (foncier): POST /runs/{id}/cancel
+returned 202 but the external subprocess kept running — run_manifest built
+its per-model PipelineExecutor without cancel_check/heartbeat, so manifest
+jobs (the cockpit command surface) were not cancellable mid-step and never
+heartbeat during long external steps.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+
+import pytest
+
+from gispulse.core.manifest_v3 import ManifestV3, ModelSpec
+from gispulse.runtime.manifest_runner import run_manifest
+
+
+def _external_manifest(argv: list[str], name: str = "cancel_probe") -> ManifestV3:
+    return ManifestV3(
+        name=f"test_{name}",
+        sources={},
+        models={
+            name: ModelSpec(
+                name=name,
+                select=None,
+                transform=[
+                    {
+                        "step": {
+                            "kind": "external",
+                            "argv": argv,
+                            "timeout_seconds": 120,
+                        }
+                    }
+                ],
+            )
+        },
+    )
+
+
+class TestManifestCancelPropagation:
+    def test_cancel_check_kills_external_step(self, tmp_path):
+        """cancel_check=True → the external subprocess is terminated quickly.
+
+        Without propagation the sleep runs its full 60 s and the marker file
+        gets written by the subprocess.
+        """
+        marker = tmp_path / "never_written.txt"
+        code = f"import time; time.sleep(60); open(r'{marker}', 'w').write('x')"
+        manifest = _external_manifest([sys.executable, "-c", code])
+
+        t0 = time.monotonic()
+        # RuntimeError specifically: the executor's failed-step path. A
+        # TypeError ("unexpected keyword argument") would also contain
+        # "cancel" — do not let a signature mismatch pass as a cancel.
+        with pytest.raises(RuntimeError) as excinfo:
+            run_manifest(
+                manifest,
+                cancel_check=lambda: True,
+                run_id="r-cancel",
+            )
+        elapsed = time.monotonic() - t0
+        assert elapsed < 30, f"external step not cancelled (took {elapsed:.1f}s)"
+        assert "cancelled" in str(excinfo.value).lower()
+        assert not marker.exists(), "subprocess ran to completion despite cancel"
+
+    def test_heartbeat_called_during_external_step(self, monkeypatch):
+        """The heartbeat callable reaches the external step context.
+
+        The external kind beats every 25 s — shrink the interval so a
+        1 s subprocess is enough to observe propagation.
+        """
+        import gispulse.orchestration.external_step as ext
+
+        monkeypatch.setattr(ext, "_HEARTBEAT_INTERVAL_S", 0.05)
+        beats: list[float] = []
+        manifest = _external_manifest(
+            [sys.executable, "-c", "import time; time.sleep(1)"], name="hb_probe"
+        )
+        run_manifest(
+            manifest,
+            heartbeat=lambda: beats.append(time.monotonic()),
+            run_id="r-hb",
+        )
+        assert beats, "heartbeat never called on the manifest path"
+
+    def test_no_cancel_check_still_completes(self):
+        """Backward compat: omitting cancel_check/heartbeat changes nothing."""
+        manifest = _external_manifest(
+            [sys.executable, "-c", "print('ok')"], name="compat_probe"
+        )
+        result = run_manifest(manifest, run_id="r-compat")
+        assert "compat_probe" in result.execution_order
+
+
+class TestRunnerManifestCancelEndToEnd:
+    def test_jobrunner_threads_cancel_check_to_manifest_path(self, tmp_path):
+        """JobRunner.run(manifest job, cancel_check=True) fails fast as cancelled."""
+        from uuid import uuid4
+
+        import geopandas as gpd
+        from shapely.geometry import Point
+
+        from gispulse.core.models import Job, JobStatus
+        from gispulse.orchestration.runner import JobRunner
+        from gispulse.persistence.repository import InMemoryRepository
+        from gispulse.rules.engine import RuleEngine
+
+        marker = tmp_path / "never_written.txt"
+        code = f"import time; time.sleep(60); open(r'{marker}', 'w').write('x')"
+        manifest = {
+            "version": 3,
+            "name": "e2e_cancel",
+            "models": {
+                "e2e_cancel": {
+                    "transform": [
+                        {
+                            "step": {
+                                "kind": "external",
+                                "argv": [sys.executable, "-c", code],
+                                "timeout_seconds": 120,
+                            }
+                        }
+                    ]
+                }
+            },
+        }
+        job = Job(
+            id=uuid4(),
+            name="e2e-cancel",
+            parameters={"manifest": manifest, "max_retries": 0},
+        )
+        gdf = gpd.GeoDataFrame({"id": [1], "geometry": [Point(0, 0)]}, crs="EPSG:4326")
+        runner = JobRunner(repository=InMemoryRepository(), rule_engine=RuleEngine())
+
+        t0 = time.monotonic()
+        # runner.run raises after marking the job FAILED (same contract the
+        # timeout tests rely on).
+        with pytest.raises(RuntimeError, match="cancelled"):
+            runner.run(job, gdf, cancel_check=lambda: True)
+        elapsed = time.monotonic() - t0
+
+        assert job.status == JobStatus.FAILED
+        assert elapsed < 30, f"manifest job not cancelled mid-step ({elapsed:.1f}s)"
+        assert not marker.exists()
+
+
+class TestManifestTimeoutElevation:
+    def test_step_timeout_elevates_job_timeout_on_manifest_path(self):
+        """A step declaring timeout_seconds > job timeout is not killed early.
+
+        Found in live phase-A validation: job timeout default (300 s) was
+        applied raw on the manifest path — a dbt step declaring 21600 s
+        would die at 5 min. Here: job timeout=1 s, step declares 30 s,
+        subprocess sleeps 3 s → without elevation the future times out at
+        1 s; with elevation the run completes.
+        """
+        from uuid import uuid4
+
+        import geopandas as gpd
+        from shapely.geometry import Point
+
+        from gispulse.core.models import Job, JobStatus
+        from gispulse.orchestration.runner import JobRunner
+        from gispulse.persistence.repository import InMemoryRepository
+        from gispulse.rules.engine import RuleEngine
+
+        manifest = {
+            "version": 3,
+            "name": "timeout_probe",
+            "models": {
+                "timeout_probe": {
+                    "transform": [
+                        {
+                            "step": {
+                                "kind": "external",
+                                "argv": [
+                                    sys.executable,
+                                    "-c",
+                                    "import time; time.sleep(3); print('done')",
+                                ],
+                                "timeout_seconds": 30,
+                            }
+                        }
+                    ]
+                }
+            },
+        }
+        job = Job(
+            id=uuid4(),
+            name="timeout-elevation",
+            parameters={"manifest": manifest, "timeout": 1, "max_retries": 0},
+        )
+        gdf = gpd.GeoDataFrame({"id": [1], "geometry": [Point(0, 0)]}, crs="EPSG:4326")
+        runner = JobRunner(repository=InMemoryRepository(), rule_engine=RuleEngine())
+
+        updated_job, _ = runner.run(job, gdf)
+        assert updated_job.status == JobStatus.COMPLETED, (
+            f"job should complete via elevated timeout, got {updated_job.status} "
+            f"(error: {updated_job.error_message})"
+        )

--- a/tests/unit/test_manifests_router.py
+++ b/tests/unit/test_manifests_router.py
@@ -70,7 +70,7 @@ def test_runner_manifest_dispatch_completes(runner):
     gdf = _make_gdf()
     job = Job(name="test_manifest", parameters={"manifest": _minimal_manifest_dict()})
 
-    def _fake_run_manifest(manifest, *, source_loader=None, materializer=None, event_sink=None, run_id=None, steps_filter=None, resume_markers=None):
+    def _fake_run_manifest(manifest, *, source_loader=None, materializer=None, event_sink=None, run_id=None, steps_filter=None, resume_markers=None, cancel_check=None, heartbeat=None):
         return ManifestRunResult(materialized={}, execution_order=[])
 
     with patch("gispulse.runtime.manifest_runner.run_manifest", side_effect=_fake_run_manifest):
@@ -98,7 +98,7 @@ def test_runner_manifest_takes_priority_over_pipeline_config(runner):
 
     executed = []
 
-    def _fake_run_manifest(manifest, *, source_loader=None, materializer=None, event_sink=None, run_id=None, steps_filter=None, resume_markers=None):
+    def _fake_run_manifest(manifest, *, source_loader=None, materializer=None, event_sink=None, run_id=None, steps_filter=None, resume_markers=None, cancel_check=None, heartbeat=None):
         executed.append("manifest")
         return ManifestRunResult(materialized={}, execution_order=[])
 


### PR DESCRIPTION
## Quoi

Deux bugs trouvés en **validation live** de la phase A foncier (VPS) — invisibles des suites unitaires car les tests E2E cancel/timeout passaient par le chemin `pipeline_config` :

1. **Cancel inopérant sur le chemin manifest** : `POST /runs/{id}/cancel` → 202 mais le subprocess external continuait (observé : un `sleep 300` survivant 60 s+ au cancel). Cause : `run_manifest` construisait ses `PipelineExecutor` par modèle sans `cancel_check`/`heartbeat`. Fix : paramètres ajoutés à `run_manifest` (les 2 sites executor) et threadés depuis `JobRunner.run` → `_execute_manifest`.
2. **Élévation de timeout absente du chemin manifest** : un step déclarant `timeout_seconds=21600` était tué par le défaut job de 300 s (« Job timed out after 300s » observé live — un vrai build foncier de 3 h mourrait à 5 min). Fix : `_compute_effective_timeout` appliqué sur la spec aplatie compilée, même formule que le chemin pipeline_config (#450).

## Tests

`tests/unit/test_manifest_cancel.py` : cancel tue le subprocess vite (assert `RuntimeError` spécifiquement — un `TypeError` de signature contenant « cancel » ne peut PAS passer pour un cancel, faux positif réellement rencontré en l'écrivant), propagation heartbeat, compat ascendante, E2E JobRunner, élévation E2E (job 1 s + step 30 s + sleep 3 s → COMPLETED). 200 passed sur les suites manifest+orchestration, ruff clean.

## Review

Diff chirurgical auto-vérifié TDD (rouge→vert sur les deux bugs) ; review Codex lancée en parallèle — verdict posté en commentaire dès qu'il atterrit. Merge au vert demandé explicitement (validation live bloquée dessus).

Refs #440 · #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)