### PR TITLE
fix(manifest): selectless models run in declaration order (#440)

### DIFF
--- a/src/gispulse/runtime/manifest_runner.py
+++ b/src/gispulse/runtime/manifest_runner.py
@@ -403,7 +403,11 @@ def run_manifest(
         materializer = Materializer(engine=engine)
 
     model_names = set(manifest.models)
-    order = topological_sort(list(model_names), _inter_model_edges(manifest))
+    # topological_sort is STABLE on input order for nodes sharing an
+    # in-degree of zero — feed it the DECLARATION order, never a set():
+    # edge-less (selectless) models must run in declaration order, the
+    # same contract the compile path (_topo_models) already honours.
+    order = topological_sort(list(manifest.models), _inter_model_edges(manifest))
     log.info(
         "manifest_run_start",
         manifest=manifest.name or "(unnamed)",

--- a/tests/unit/test_manifest_model_order.py
+++ b/tests/unit/test_manifest_model_order.py
@@ -1,0 +1,59 @@
+"""Deterministic model execution order for edge-less (selectless) models.
+
+Found in live B-lite validation (foncier): a manifest declaring
+stage -> build_core -> build_finalize (all selectless external models)
+executed build_finalize BEFORE build_core — run_manifest collapsed the
+model names into a set() before the (stable) topological sort, so
+edge-less models ran in hash order instead of declaration order.
+The compile path (manifest_v3._topo_models) already preserves
+declaration order; the runtime must honour the same contract.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from gispulse.core.manifest_v3 import ManifestV3, ModelSpec
+from gispulse.runtime.manifest_runner import run_manifest
+
+
+def _selectless_external(name: str, marker_path: str) -> ModelSpec:
+    return ModelSpec(
+        name=name,
+        select=None,
+        transform=[
+            {
+                "step": {
+                    "kind": "external",
+                    "argv": [
+                        sys.executable,
+                        "-c",
+                        f"open(r'{marker_path}', 'a').write('{name}\\n')",
+                    ],
+                }
+            }
+        ],
+    )
+
+
+class TestSelectlessModelOrder:
+    def test_declaration_order_is_execution_order(self, tmp_path):
+        """Many edge-less models run strictly in declaration order.
+
+        Uses enough models that an accidental hash-order pass is
+        overwhelmingly unlikely (12! orderings), and a marker file
+        appended by each subprocess proves the REAL execution order,
+        not just the reported one.
+        """
+        marker = tmp_path / "order.log"
+        names = [f"m_{i:02d}" for i in (9, 3, 11, 1, 7, 0, 5, 10, 2, 8, 4, 6)]
+        manifest = ManifestV3(
+            name="order_probe",
+            sources={},
+            models={n: _selectless_external(n, str(marker)) for n in names},
+        )
+
+        result = run_manifest(manifest, run_id="r-order")
+
+        assert result.execution_order == names
+        assert marker.read_text().splitlines() == names


### PR DESCRIPTION
## Quoi

Trouvé en validation live B-lite de la migration foncier : un manifest déclarant `stage → build_core → build_finalize` (modèles selectless external, aucun edge inter-modèles) a exécuté **build_finalize avant build_core** — la phase dbt finalize sur une scratch périmée = données silencieusement fausses.

`run_manifest` écrasait l'ordre de déclaration dans un `set()` avant le tri topologique ; le tri lui-même est **stable** sur l'ordre d'entrée pour les nœuds de degré entrant nul — le fix alimente le tri avec l'ordre de déclaration (`list(manifest.models)`). C'est le contrat que le chemin de compilation (`_topo_models`) honorait déjà, documenté dans #455.

## Test

12 modèles external selectless déclarés en ordre mélangé — asserte `execution_order` ET l'ordre d'exécution **réel** des subprocess (fichier marqueur appendé par chaque step) ; un passage accidentel en ordre de hash est improbable (12! ordres).

138 passed sur les suites manifest, ruff clean.

Refs #440 · #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)