### PR TITLE
feat(sources): plugins OSM + GRB publics + lecture membre zip /vsizip

### DIFF
--- a/plugins/gispulse-src-grb/gispulse_src_grb/__init__.py
+++ b/plugins/gispulse-src-grb/gispulse_src_grb/__init__.py
@@ -1,0 +1,11 @@
+"""GISPulse data-source plugin — GRB Flanders (voirie/bâti)."""
+
+from __future__ import annotations
+
+
+def register() -> None:
+    """Entry-point hook for the ``gispulse.data_sources`` group."""
+    from gispulse.core.sources import SOURCES
+    from gispulse_src_grb.source import GrbSource
+
+    SOURCES.register(GrbSource())

--- a/plugins/gispulse-src-grb/gispulse_src_grb/source.py
+++ b/plugins/gispulse-src-grb/gispulse_src_grb/source.py
@@ -1,0 +1,135 @@
+"""GRB Flanders (Grootschalig Referentiebestand) DataSource.
+
+GRB is the Flemish large-scale topographic reference. This plugin declares its
+public WFS layers used for civil-works surface classification: ``WBN`` (chaussée
+/ wegbaan) and ``WGA`` (accotements / wegaanhorigheid). GISPulse core owns the
+WFS dispatch; harmonisation (GRB type → gc_surface) stays OUTSIDE this plugin.
+
+WFS native CRS is EPSG:31370 (Lambert 72) — no reprojection needed. Polygons
+carry a functional ``TYPE``/``LBLTYPE`` (carriageway zone, sidewalk…), the basis
+for the BOM cost tiers (sous revêtement / trottoir). Flanders only (PICC Wallonie
+has no WFS, UrbIS Brussels is a separate datastore).
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any
+
+from gispulse.plugins.api import (
+    AccessProtocol,
+    AccessSpec,
+    DeclarativeSource,
+    Payload,
+    SourceDomain,
+    SourceEntryRef,
+)
+
+GRB_WFS_ENDPOINT = "https://geo.api.vlaanderen.be/GRB/wfs"
+_TARGET_CRS = "EPSG:31370"  # GRB WFS native — no reprojection
+
+_SCHEMA = {
+    "source": "str",
+    "oidn": "int",
+    "uidn": "int",
+    "type": "int",
+    "label_type": "str",
+    "geometry": f"geometry[{_TARGET_CRS}]",
+}
+
+_FIELD_MAP = {
+    "source": "literal:GRB",
+    "oidn": "OIDN",
+    "uidn": "UIDN",
+    "type": "TYPE",
+    "label_type": "LBLTYPE",
+    "geometry": "geometry",
+}
+
+
+def _wfs_access(typename: str) -> AccessSpec:
+    return AccessSpec(
+        protocol=AccessProtocol.WFS,
+        endpoint=GRB_WFS_ENDPOINT,
+        params={
+            "typename": typename,
+            "version": "2.0.0",
+            "crs": _TARGET_CRS,
+        },
+        format="application/json",
+    )
+
+
+_ENTRIES: dict[str, dict[str, Any]] = {
+    "grb-wegbaan-vl": {
+        "label": "GRB wegbaan (chaussée) — Flandre",
+        "typename": "GRB:WBN",
+        "kind": "carriageway",
+    },
+    "grb-aanhorigheid-vl": {
+        "label": "GRB wegaanhorigheid (accotements) — Flandre",
+        "typename": "GRB:WGA",
+        "kind": "appurtenance",
+    },
+}
+
+_COMMON_METADATA = {
+    "license": "Gratis Open Data Licentie Vlaanderen",
+    "provider": "Digitaal Vlaanderen",
+    "platform": "GRB WFS (geo.api.vlaanderen.be)",
+    "jurisdiction": "BE",
+    "region": "VL",
+    "target_crs": _TARGET_CRS,
+    "source_crs": _TARGET_CRS,
+    "schema_columns": tuple(_SCHEMA),
+    "canonical_field_map": dict(_FIELD_MAP),
+}
+
+
+def _copy_params(params: dict[str, Any]) -> dict[str, Any]:
+    return dict(params)
+
+
+class GrbSource(DeclarativeSource):
+    """GRB Flanders WFS layers (carriageway + appurtenances)."""
+
+    name = "grb"
+    domain = SourceDomain.BASE
+    payload = Payload.VECTOR
+    jurisdiction = "BE"
+
+    def entries(self) -> list[SourceEntryRef]:
+        return [self._entry_ref(entry_id) for entry_id in _ENTRIES]
+
+    def _entry_ref(self, entry_id: str) -> SourceEntryRef:
+        spec = _ENTRIES[entry_id]
+        access = _wfs_access(spec["typename"])
+        return SourceEntryRef(
+            id=entry_id,
+            name=spec["label"],
+            access=access,
+            revision_token=None,
+            domain=self.domain,
+            payload=self.payload,
+            jurisdiction=self.jurisdiction,
+            metadata={
+                **_COMMON_METADATA,
+                "typename": spec["typename"],
+                "kind": spec["kind"],
+                "endpoint": GRB_WFS_ENDPOINT,
+            },
+        )
+
+    def access_for(self, entry_id: str) -> AccessSpec:
+        """Return the declared AccessSpec without network access."""
+        self._entry(entry_id)  # valide l'id (lève l'erreur canonique si inconnu)
+        access = _wfs_access(_ENTRIES[entry_id]["typename"])
+        return replace(access, params=_copy_params(access.params))
+
+    def schema(self, entry_id: str) -> dict[str, str]:
+        self._entry(entry_id)  # validates the id
+        return dict(_SCHEMA)
+
+    def revision(self, entry_id: str) -> str | None:
+        self._entry(entry_id)  # validates the id
+        return None

--- a/plugins/gispulse-src-grb/pyproject.toml
+++ b/plugins/gispulse-src-grb/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gispulse-src-grb"
+version = "0.1.0"
+description = "GRB Flanders (Grootschalig Referentiebestand) source for GISPulse"
+requires-python = ">=3.10"
+license = "AGPL-3.0-or-later"
+authors = [{ name = "GISPulse", email = "dev@gispulse.io" }]
+dependencies = [
+    "gispulse>=2.0.0,<3.0.0",
+]
+
+# Registered as a data source - discovered by core.plugin_hub.PluginHub.
+[project.entry-points."gispulse.data_sources"]
+grb = "gispulse_src_grb:register"
+
+[tool.gispulse.plugin]
+kind = "source"
+protocol = ">=1.0,<2.0"
+domain = "base"
+jurisdiction = "BE"
+display_name = "GRB Flanders (voirie/bâti)"

--- a/plugins/gispulse-src-osm/gispulse_src_osm/__init__.py
+++ b/plugins/gispulse-src-osm/gispulse_src_osm/__init__.py
@@ -1,0 +1,11 @@
+"""GISPulse data-source plugin — OpenStreetMap (Geofabrik) extracts."""
+
+from __future__ import annotations
+
+
+def register() -> None:
+    """Entry-point hook for the ``gispulse.data_sources`` group."""
+    from gispulse.core.sources import SOURCES
+    from gispulse_src_osm.source import OsmSource
+
+    SOURCES.register(OsmSource())

--- a/plugins/gispulse-src-osm/gispulse_src_osm/source.py
+++ b/plugins/gispulse-src-osm/gispulse_src_osm/source.py
@@ -1,0 +1,148 @@
+"""OpenStreetMap (Geofabrik) DataSource.
+
+This plugin declares Geofabrik thematic shapefile extracts. A single vector
+layer of the ``.shp.zip`` archive is read in place via the DOWNLOAD protocol +
+``archive_member`` (GDAL ``/vsizip/``) — no full extraction. GISPulse core owns
+HTTP download / VSI streaming; harmonisation/scoring stays OUTSIDE the source
+plugin (frontière ETL/métier).
+
+⚠️ The Geofabrik *free* shapefiles carry road TYPE (``fclass``) but **not** the
+OSM ``surface=*`` tag — geometry + coarse classification, not exact pavement.
+Generic by design: a new region or layer is a new entry, no code change.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any
+
+from gispulse.plugins.api import (
+    AccessProtocol,
+    AccessSpec,
+    DeclarativeSource,
+    Payload,
+    SourceDomain,
+    SourceEntryRef,
+)
+
+_TARGET_CRS = "EPSG:31370"
+_SOURCE_CRS = "EPSG:4326"  # OSM/Geofabrik native
+
+GEOFABRIK_BE_SHP = "https://download.geofabrik.de/europe/belgium-latest-free.shp.zip"
+
+# Geofabrik *free* shapefile roads layer (gis_osm_roads_free_1) attributes.
+# Confirmé sur la doc/exports Geofabrik : osm_id, code, fclass, name, ref, oneway,
+# maxspeed, layer, bridge, tunnel. PAS de `surface` (uniquement dans le .pbf complet
+# ou les shapefiles « tous attributs » payants) — `fclass`/`code` (type de voie) sont
+# le seul signal de revêtement disponible dans l'extrait gratuit.
+_ROADS_SCHEMA = {
+    "source": "str",
+    "osm_id": "str",
+    "code": "int",
+    "fclass": "str",
+    "name": "str",
+    "ref": "str",
+    "oneway": "str",
+    "maxspeed": "int",
+    "layer": "int",
+    "bridge": "str",
+    "tunnel": "str",
+    "geometry": f"geometry[{_TARGET_CRS}]",
+}
+
+_ROADS_FIELD_MAP = {
+    "source": "literal:OSM",
+    "osm_id": "osm_id",
+    "code": "code",
+    "fclass": "fclass",
+    "name": "name",
+    "ref": "ref",
+    "oneway": "oneway",
+    "maxspeed": "maxspeed",
+    "layer": "layer",
+    "bridge": "bridge",
+    "tunnel": "tunnel",
+    "geometry": "geometry",
+}
+
+_ENTRIES: dict[str, dict[str, Any]] = {
+    "osm-roads-be": {
+        "label": "OSM roads — Belgium (Geofabrik)",
+        "provider": "Geofabrik / OpenStreetMap",
+        "platform": "Geofabrik download server (thematic shapefile)",
+        "region": "BE",
+        "endpoint": GEOFABRIK_BE_SHP,
+        "access": AccessSpec(
+            protocol=AccessProtocol.DOWNLOAD,
+            endpoint=GEOFABRIK_BE_SHP,
+            params={
+                "archive_member": "gis_osm_roads_free_1.shp",
+                "archive_format": "zip",
+                "source_crs": _SOURCE_CRS,
+                "target_crs": _TARGET_CRS,
+            },
+            format="application/zip",
+        ),
+        "schema": _ROADS_SCHEMA,
+        "canonical_field_map": _ROADS_FIELD_MAP,
+        "source_crs": _SOURCE_CRS,
+    },
+}
+
+_COMMON_METADATA = {
+    "license": "ODbL (OpenStreetMap contributors)",
+    "jurisdiction": "BE",
+    "target_crs": _TARGET_CRS,
+}
+
+
+def _copy_params(params: dict[str, Any]) -> dict[str, Any]:
+    return dict(params)
+
+
+class OsmSource(DeclarativeSource):
+    """OpenStreetMap Geofabrik thematic extracts (vector)."""
+
+    name = "osm"
+    domain = SourceDomain.BASE
+    payload = Payload.VECTOR
+    jurisdiction = "BE"
+
+    def entries(self) -> list[SourceEntryRef]:
+        return [self._entry_ref(entry_id) for entry_id in _ENTRIES]
+
+    def _entry_ref(self, entry_id: str) -> SourceEntryRef:
+        spec = _ENTRIES[entry_id]
+        access = spec["access"]
+        return SourceEntryRef(
+            id=entry_id,
+            name=spec["label"],
+            access=replace(access, params=_copy_params(access.params)),
+            revision_token=None,
+            domain=self.domain,
+            payload=self.payload,
+            jurisdiction=self.jurisdiction,
+            metadata={
+                **_COMMON_METADATA,
+                "provider": spec["provider"],
+                "platform": spec["platform"],
+                "region": spec["region"],
+                "source_crs": spec["source_crs"],
+                "schema_columns": tuple(spec["schema"]),
+                "canonical_field_map": dict(spec["canonical_field_map"]),
+                "endpoint": spec["endpoint"],
+            },
+        )
+
+    def access_for(self, entry_id: str) -> AccessSpec:
+        """Return the declared AccessSpec without network access."""
+        entry = self._entry(entry_id)
+        return replace(entry.access, params=_copy_params(entry.access.params))
+
+    def schema(self, entry_id: str) -> dict[str, str]:
+        self._entry(entry_id)  # validates the id
+        return dict(_ENTRIES[entry_id]["schema"])
+
+    def revision(self, entry_id: str) -> str | None:
+        self._entry(entry_id)  # validates the id
+        return None

--- a/plugins/gispulse-src-osm/pyproject.toml
+++ b/plugins/gispulse-src-osm/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gispulse-src-osm"
+version = "0.1.0"
+description = "OpenStreetMap (Geofabrik) source for GISPulse"
+requires-python = ">=3.10"
+license = "AGPL-3.0-or-later"
+authors = [{ name = "GISPulse", email = "dev@gispulse.io" }]
+dependencies = [
+    "gispulse>=2.0.0,<3.0.0",
+]
+
+# Registered as a data source - discovered by core.plugin_hub.PluginHub.
+[project.entry-points."gispulse.data_sources"]
+osm = "gispulse_src_osm:register"
+
+[tool.gispulse.plugin]
+kind = "source"
+protocol = ">=1.0,<2.0"
+domain = "base"
+jurisdiction = "BE"
+display_name = "OpenStreetMap (Geofabrik)"

--- a/src/gispulse/core/fetchers/http_file.py
+++ b/src/gispulse/core/fetchers/http_file.py
@@ -48,6 +48,21 @@ def _vsicurl(endpoint: str) -> str:
     return endpoint
 
 
+def _resolve_vsi_uri(access: AccessSpec) -> str:
+    """GDAL virtual path for the scanned file, ``/vsizip/`` when targeting a zip member.
+
+    When ``access.params['archive_member']`` is set and the endpoint is a ``.zip``
+    archive (e.g. a Geofabrik ``.shp.zip``), build
+    ``/vsizip/<inner>/<member>`` where ``<inner>`` is the ``/vsicurl/``-wrapped
+    remote zip (or the local path). GDAL reads that single member in place — no
+    physical extraction of the whole archive. Otherwise, plain ``/vsicurl/``.
+    """
+    member = access.params.get("archive_member")
+    if member and access.endpoint.split("?")[0].lower().endswith(".zip"):
+        return f"/vsizip/{_vsicurl(access.endpoint)}/{member}"
+    return _vsicurl(access.endpoint)
+
+
 class HttpFileFetcher(LazyFetcher):
     """Remote single-file adapter — ``/vsicurl/`` lazy scan + streamed download.
 
@@ -56,6 +71,9 @@ class HttpFileFetcher(LazyFetcher):
     * ``lat`` / ``lon`` — column names for a point CSV (default
       ``"latitude"`` / ``"longitude"``); only consulted for ``.csv``.
     * ``layer`` — layer name for a multi-layer source (GPKG).
+    * ``archive_member`` — for a ``.zip`` endpoint, the single vector member to
+      read in place via ``/vsizip/`` (e.g. ``"gis_osm_roads_free_1.shp"``); no
+      full archive extraction.
     * ``local_path`` — materialise destination (default: a temp file).
     * ``s3_uri`` / ``s3_key`` — opt-in materialisation destination. When
       present, DuckDB writes the parsed scan to S3/Garage as Parquet.
@@ -92,8 +110,12 @@ class HttpFileFetcher(LazyFetcher):
         return f"(SELECT *, {geom} AS geometry FROM read_csv_auto('{uri}'){where})"
 
     def _spatial_scan(self, access: AccessSpec, extent: Any | None) -> str:
-        """Spatial-file scan via ``ST_Read`` (GeoJSON / GPKG / FGB / SHP)."""
-        uri = _vsicurl(access.endpoint).replace("'", "''")
+        """Spatial-file scan via ``ST_Read`` (GeoJSON / GPKG / FGB / SHP).
+
+        Supports a shapefile (or any GDAL vector) inside a remote ``.zip`` via the
+        ``archive_member`` param (``/vsizip/`` virtual path) — no full extraction.
+        """
+        uri = _resolve_vsi_uri(access).replace("'", "''")
         layer = access.params.get("layer")
         st_read = f"ST_Read('{uri}'"
         if layer:
@@ -149,6 +171,30 @@ class HttpFileFetcher(LazyFetcher):
             )
 
         local_path = access.params.get("local_path")
+
+        # Un membre d'archive (.zip) ne peut pas être streamé brut : read_vector ne lit
+        # pas un .zip. On matérialise le membre cible en Parquet LOCAL via le même scan
+        # /vsizip/ que le chemin S3/Garage — sortie lisible et cohérente.
+        if access.params.get("archive_member"):
+            from gispulse.persistence.duckdb_engine import DuckDBSession
+
+            if not local_path:
+                handle = tempfile.NamedTemporaryFile(suffix=".parquet", delete=False)
+                handle.close()
+                local_path = handle.name
+            select = self._reference_scan(access, extent)
+            dest = str(local_path).replace("'", "''")
+            copy_sql = f"COPY (SELECT * FROM {select}) TO '{dest}' (FORMAT PARQUET)"
+            with DuckDBSession() as session:
+                session.conn.execute(copy_sql)
+            log.info("http_file_materialized", path=local_path)
+            return SourceResult(
+                payload=self.payload,
+                mode=FetchMode.MATERIALIZE,
+                data=local_path,
+                metadata={"copy_sql": copy_sql, "archive_member": access.params["archive_member"]},
+            )
+
         if not local_path:
             suffix = "." + access.endpoint.split("?")[0].rsplit(".", 1)[-1]
             handle = tempfile.NamedTemporaryFile(suffix=suffix, delete=False)

--- a/tests/unit/test_http_file_fetcher.py
+++ b/tests/unit/test_http_file_fetcher.py
@@ -56,6 +56,31 @@ def test_reference_scan_gpkg_with_layer() -> None:
     assert "layer='parcels'" in scan
 
 
+def test_reference_scan_shapefile_inside_remote_zip_via_vsizip() -> None:
+    # Un .shp dans un .zip distant (ex. extrait Geofabrik) : on lit le seul membre
+    # cible via /vsizip//vsicurl/ sans extraire toute l'archive.
+    result = HttpFileFetcher().virtual_table(
+        _access(
+            "https://host.example.org/belgium-free.shp.zip",
+            archive_member="gis_osm_roads_free_1.shp",
+        )
+    )
+    assert result.metadata[DUCKDB_SCAN_KEY] == (
+        "ST_Read('/vsizip//vsicurl/https://host.example.org/"
+        "belgium-free.shp.zip/gis_osm_roads_free_1.shp')"
+    )
+
+
+def test_reference_scan_local_zip_member_via_vsizip() -> None:
+    # .zip local : /vsizip/ sans /vsicurl/ (sert les fixtures hors-ligne).
+    result = HttpFileFetcher().virtual_table(
+        _access("/tmp/belgium-free.shp.zip", archive_member="gis_osm_roads_free_1.shp")
+    )
+    assert result.metadata[DUCKDB_SCAN_KEY] == (
+        "ST_Read('/vsizip//tmp/belgium-free.shp.zip/gis_osm_roads_free_1.shp')"
+    )
+
+
 def test_reference_scan_pushdown_bbox_for_spatial_file() -> None:
     result = HttpFileFetcher().virtual_table(
         _access("https://host.example.org/cities.geojson"),
@@ -178,6 +203,46 @@ def test_fetch_materialize_can_copy_csv_directly_to_s3_uri(
     assert f"TO '{uri}' (FORMAT PARQUET)" in executed[0]
     assert "read_csv_auto('/vsicurl/https://host.example.org/sites.csv')" in executed[0]
     assert "ST_MakeEnvelope(0.0, 0.0, 1.0, 1.0)" in executed[0]
+
+
+def test_fetch_materialize_zip_member_writes_local_parquet_via_vsizip(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: object
+) -> None:
+    # Un .shp dans un .zip ne peut pas être streamé brut : le materialize local doit
+    # produire un Parquet via le scan /vsizip/ (même mécanisme que le chemin S3/Garage).
+    executed: list[str] = []
+
+    class _FakeConn:
+        def execute(self, sql: str) -> None:
+            executed.append(sql)
+
+    class _FakeSession:
+        conn = _FakeConn()
+
+        def __enter__(self) -> "_FakeSession":
+            return self
+
+        def __exit__(self, *exc: object) -> None:
+            return None
+
+    import gispulse.persistence.duckdb_engine as duckdb_engine
+
+    monkeypatch.setattr(duckdb_engine, "DuckDBSession", _FakeSession)
+
+    dest = str(tmp_path) + "/roads.parquet"  # type: ignore[operator]
+    result = HttpFileFetcher().fetch(
+        _access(
+            "https://host.example.org/belgium-free.shp.zip",
+            archive_member="gis_osm_roads_free_1.shp",
+            local_path=dest,
+        ),
+        mode=FetchMode.MATERIALIZE,
+    )
+
+    assert result.mode is FetchMode.MATERIALIZE
+    assert result.data == dest
+    assert f"TO '{dest}' (FORMAT PARQUET)" in executed[0]
+    assert "/vsizip//vsicurl/https://host.example.org/belgium-free.shp.zip/" in executed[0]
 
 
 def test_fetch_materialize_builds_s3_uri_from_configured_bucket(

--- a/tests/unit/test_src_grb.py
+++ b/tests/unit/test_src_grb.py
@@ -1,0 +1,71 @@
+"""Unit tests for the gispulse-src-grb plugin.
+
+Zero-network: the plugin only declares GRB Flanders WFS layers. Core fetchers own
+the WFS dispatch.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_PKG = Path(__file__).resolve().parents[2] / "plugins" / "gispulse-src-grb"
+_PKG_PATH = str(_PKG)
+if _PKG_PATH in sys.path:
+    sys.path.remove(_PKG_PATH)
+sys.path.insert(0, _PKG_PATH)
+for _module in ("gispulse_src_grb.source", "gispulse_src_grb"):
+    sys.modules.pop(_module, None)
+
+from gispulse_src_grb.source import GrbSource  # noqa: E402
+
+from gispulse.core.plugin_model import AccessProtocol, Payload, SourceDomain  # noqa: E402
+from gispulse.core.sources import DataSource  # noqa: E402
+
+pytestmark = pytest.mark.usefixtures("offline_ssrf")
+
+
+@pytest.fixture
+def source() -> GrbSource:
+    return GrbSource()
+
+
+def test_pyproject_declares_grb_entrypoint_and_manifest() -> None:
+    tomllib = pytest.importorskip("tomllib")
+    pyproject = tomllib.loads((_PKG / "pyproject.toml").read_text())
+
+    assert pyproject["project"]["entry-points"]["gispulse.data_sources"] == {
+        "grb": "gispulse_src_grb:register"
+    }
+    manifest = pyproject["tool"]["gispulse"]["plugin"]
+    assert manifest["kind"] == "source"
+    assert manifest["domain"] == "base"
+    assert manifest["jurisdiction"] == "BE"
+
+
+def test_is_a_base_vector_datasource(source: GrbSource) -> None:
+    assert isinstance(source, DataSource)
+    assert source.name == "grb"
+    assert source.domain is SourceDomain.BASE
+    assert source.payload is Payload.VECTOR
+
+
+def test_wegbaan_entry_is_wfs_in_lambert72(source: GrbSource) -> None:
+    access = source.access_for("grb-wegbaan-vl")
+    assert access.protocol is AccessProtocol.WFS
+    assert access.endpoint == "https://geo.api.vlaanderen.be/GRB/wfs"
+    assert access.params["typename"] == "GRB:WBN"
+    # GRB est nativement en Lambert 72 → pas de reprojection.
+    assert access.params["crs"] == "EPSG:31370"
+
+
+def test_exposes_both_carriageway_and_appurtenance(source: GrbSource) -> None:
+    ids = {entry.id for entry in source.entries()}
+    assert {"grb-wegbaan-vl", "grb-aanhorigheid-vl"} <= ids
+
+
+def test_aanhorigheid_targets_wga_layer(source: GrbSource) -> None:
+    access = source.access_for("grb-aanhorigheid-vl")
+    assert access.params["typename"] == "GRB:WGA"

--- a/tests/unit/test_src_osm.py
+++ b/tests/unit/test_src_osm.py
@@ -1,0 +1,76 @@
+"""Unit tests for the gispulse-src-osm plugin.
+
+Zero-network: the plugin only declares Geofabrik OSM extracts. Core fetchers own
+HTTP download and VSI streaming (incl. /vsizip/ for a single archive member).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_PKG = Path(__file__).resolve().parents[2] / "plugins" / "gispulse-src-osm"
+_PKG_PATH = str(_PKG)
+if _PKG_PATH in sys.path:
+    sys.path.remove(_PKG_PATH)
+sys.path.insert(0, _PKG_PATH)
+for _module in ("gispulse_src_osm.source", "gispulse_src_osm"):
+    sys.modules.pop(_module, None)
+
+from gispulse_src_osm.source import OsmSource  # noqa: E402
+
+from gispulse.core.plugin_model import AccessProtocol, Payload, SourceDomain  # noqa: E402
+from gispulse.core.sources import DataSource  # noqa: E402
+
+pytestmark = pytest.mark.usefixtures("offline_ssrf")
+
+
+@pytest.fixture
+def source() -> OsmSource:
+    return OsmSource()
+
+
+def test_pyproject_declares_osm_entrypoint_and_manifest() -> None:
+    tomllib = pytest.importorskip("tomllib")
+    pyproject = tomllib.loads((_PKG / "pyproject.toml").read_text())
+
+    assert pyproject["project"]["entry-points"]["gispulse.data_sources"] == {
+        "osm": "gispulse_src_osm:register"
+    }
+    manifest = pyproject["tool"]["gispulse"]["plugin"]
+    assert manifest["kind"] == "source"
+    assert manifest["domain"] == "base"
+    assert manifest["jurisdiction"] == "BE"
+
+
+def test_is_a_base_vector_datasource(source: OsmSource) -> None:
+    assert isinstance(source, DataSource)
+    assert source.name == "osm"
+    assert source.domain is SourceDomain.BASE
+    assert source.payload is Payload.VECTOR
+
+
+def test_roads_be_entry_targets_zip_member_via_download(source: OsmSource) -> None:
+    access = source.access_for("osm-roads-be")
+    assert access.protocol is AccessProtocol.DOWNLOAD
+    assert access.endpoint.endswith("belgium-latest-free.shp.zip")
+    # le membre routes est ciblé pour une lecture /vsizip/ (pas d'extraction totale)
+    assert access.params["archive_member"] == "gis_osm_roads_free_1.shp"
+    assert access.params["archive_format"] == "zip"
+    assert access.params["source_crs"] == "EPSG:4326"
+    assert access.params["target_crs"] == "EPSG:31370"
+
+
+def test_entries_exposes_roads_be(source: OsmSource) -> None:
+    ids = {entry.id for entry in source.entries()}
+    assert "osm-roads-be" in ids
+
+
+def test_schema_has_fclass_not_surface(source: OsmSource) -> None:
+    # Le shapefile gratuit Geofabrik porte fclass (type de voie), PAS le tag surface.
+    schema = source.schema("osm-roads-be")
+    assert "fclass" in schema
+    assert "geometry" in schema
+    assert "surface" not in schema


### PR DESCRIPTION
## Quoi
Deux sources open data publiques (Belgique) + l'extension fetch qui les rend déclaratives.

- **core `http_file.py`** : `_resolve_vsi_uri` — lit un membre `.shp` d'un `.zip` distant via `/vsizip//vsicurl/<url>/<member>` (param `archive_member`), scan lazy ET materialize (Parquet local + S3/Garage). Chemin existant inchangé sans `archive_member`.
- **`gispulse-src-osm`** : routes Geofabrik (`.shp.zip` → membre roads ; schéma réel osm_id/code/fclass/.../layer, pas de `surface`).
- **`gispulse-src-grb`** : GRB Flandre WFS (WBN chaussée + WGA accotements), EPSG:31370 natif.

## Qualité
Review stratégique Codex (vérifs runtime : `ST_Read /vsizip/` réel OK, GRB `GetFeature` OK, 3 findings corrigés). 26 tests, ruff clean. Plugins discoverables via entry-points (CI installe `plugins/*/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)