### PR TITLE
chore(cap-h3): porter #457 (multi-metric H3) sur integration/v2.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
           tests/unit/test_plugin_hub_gate.py
           tests/unit/test_src_cadastre.py
           tests/unit/test_src_ocsge.py
+          tests/unit/test_cap_h3.py
 
   capability-matrix-drift:
     runs-on: ubuntu-latest

--- a/plugins/gispulse-cap-h3/gispulse_cap_h3/capabilities.py
+++ b/plugins/gispulse-cap-h3/gispulse_cap_h3/capabilities.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import geopandas as gpd
+import pandas as pd
 from shapely.geometry import Polygon
 
 from gispulse.plugins.api import Capability
 from gispulse.plugins.api import register_capability as register
+
+# Multi-metric spec: output column name -> (source column or None for count, func).
+AggSpec = dict[str, "tuple[str | None, str]"]
 
 
 def _h3_available() -> bool:
@@ -45,6 +49,14 @@ class H3AggregateCapability(Capability):
                     "default": "count",
                     "description": "Aggregation function",
                 },
+                "aggregations": {
+                    "type": "object",
+                    "description": (
+                        "Multi-metric aggregation: output column name -> [source column "
+                        "or null for count, function]. Computed in a single H3 pass. "
+                        "Overrides agg_column/agg_func when provided."
+                    ),
+                },
             },
             "additionalProperties": False,
         }
@@ -56,6 +68,7 @@ class H3AggregateCapability(Capability):
         resolution: int = 7,
         agg_column: str | None = None,
         agg_func: str = "count",
+        aggregations: AggSpec | None = None,
         **_kw,
     ) -> gpd.GeoDataFrame:
         if not _h3_available():
@@ -69,20 +82,37 @@ class H3AggregateCapability(Capability):
         if src.crs and src.crs.to_epsg() != 4326:
             src = src.to_crs(epsg=4326)
 
-        # Assign H3 index to each point
+        # Assign the H3 index to each point ONCE (shared by every metric).
         src["_h3_index"] = src.geometry.apply(
             lambda g: h3.latlng_to_cell(g.y, g.x, resolution)
         )
 
-        # Aggregate
-        if agg_column and agg_column in src.columns:
-            grouped = src.groupby("_h3_index")[agg_column].agg(agg_func).reset_index()
-            grouped.columns = ["h3_index", "value"]
+        # One groupby, one column per requested metric. Single-metric callers
+        # (agg_column/agg_func) keep the historical {"value": ...} shape and its
+        # lenient "missing column -> count" fallback. Explicit multi-metric specs
+        # are validated up front: a missing source column raises instead of
+        # silently producing a count where a sum/mean was asked.
+        if aggregations is None:
+            specs: AggSpec = {"value": (agg_column, agg_func)}
         else:
-            grouped = src.groupby("_h3_index").size().reset_index(name="value")
-            grouped.columns = ["h3_index", "value"]
+            if not aggregations:
+                raise ValueError(
+                    "aggregations must be a non-empty mapping {name: (column or None, func)}"
+                )
+            for name, (col, _func) in aggregations.items():
+                if col is not None and col not in src.columns:
+                    raise ValueError(
+                        f"aggregations[{name!r}]: source column {col!r} not found in input"
+                    )
+            specs = aggregations
+        groups = src.groupby("_h3_index")
+        columns = {
+            name: (groups[col].agg(func) if col and col in src.columns else groups.size())
+            for name, (col, func) in specs.items()
+        }
+        grouped = pd.DataFrame(columns).reset_index().rename(columns={"_h3_index": "h3_index"})
 
-        # Convert H3 cells to polygons
+        # Convert H3 cells to polygons ONCE (boundary is shared across metrics).
         def h3_to_polygon(h3_index):
             boundary = h3.cell_to_boundary(h3_index)
             return Polygon([(lng, lat) for lat, lng in boundary])

--- a/plugins/gispulse-cap-h3/pyproject.toml
+++ b/plugins/gispulse-cap-h3/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gispulse-cap-h3"
-version = "1.0.0"
+version = "1.1.0"
 description = "Uber H3 hexagonal grid aggregation for point datasets"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/tests/unit/test_cap_h3.py
+++ b/tests/unit/test_cap_h3.py
@@ -1,0 +1,82 @@
+"""Tests for the H3 aggregation capability (gispulse-cap-h3).
+
+Covers the single-metric API (back-compat) and the multi-metric extension
+that aggregates several columns in a SINGLE H3 pass (one ``latlng_to_cell``
++ one ``cell_to_boundary``) — so a caller wanting ``count`` + ``sum`` no
+longer pays for two full passes.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Runtime needs the h3 lib (a plugin dep) — skip cleanly where it isn't installed
+# (e.g. the engine-only `unit` CI job). The `plugins` CI job installs it.
+pytest.importorskip("h3")
+
+# Make the bundled plugin importable without an editable install (same pattern
+# as test_src_cadastre.py), so this file runs under the `plugins` CI job.
+_PKG = Path(__file__).resolve().parents[2] / "plugins" / "gispulse-cap-h3"
+if str(_PKG) not in sys.path:
+    sys.path.insert(0, str(_PKG))
+
+import geopandas as gpd  # noqa: E402
+from shapely.geometry import Point  # noqa: E402
+
+from gispulse_cap_h3.capabilities import H3AggregateCapability  # noqa: E402
+
+
+def _toy_points() -> gpd.GeoDataFrame:
+    # Two co-located points (same r5 cell) + one distant point.
+    return gpd.GeoDataFrame(
+        {"weight": [1.0, 3.0, 5.0]},
+        geometry=[Point(4.3500, 50.8500), Point(4.3501, 50.8501), Point(3.2000, 51.2000)],
+        crs="EPSG:4326",
+    )
+
+
+def test_single_metric_is_backward_compatible() -> None:
+    out = H3AggregateCapability().execute(_toy_points(), resolution=5, agg_column="weight", agg_func="sum")
+    assert set(out.columns) >= {"h3_index", "value", "geometry"}
+    assert len(out) == 2
+    assert set(out["value"]) == {4.0, 5.0}  # 1+3 colocalisés, 5 isolé
+    assert out.geometry.iloc[0].geom_type == "Polygon"
+    assert out.crs is not None and out.crs.to_epsg() == 4326
+
+
+def test_count_without_column_uses_size() -> None:
+    out = H3AggregateCapability().execute(_toy_points(), resolution=5)
+    assert set(out["value"]) == {2, 1}
+
+
+def test_multi_metric_single_pass() -> None:
+    out = H3AggregateCapability().execute(
+        _toy_points(),
+        resolution=5,
+        aggregations={"count": (None, "count"), "weight_sum": ("weight", "sum")},
+    )
+    assert set(out.columns) >= {"h3_index", "count", "weight_sum", "geometry"}
+    assert len(out) == 2
+    big = out.sort_values("count", ascending=False).iloc[0]
+    assert big["count"] == 2
+    assert big["weight_sum"] == 4.0
+    assert out.geometry.iloc[0].geom_type == "Polygon"
+    assert out.crs is not None and out.crs.to_epsg() == 4326
+
+
+def test_multi_metric_missing_column_raises() -> None:
+    # A missing source column must NOT silently become a count (plausible-but-wrong).
+    with pytest.raises(ValueError, match="not found"):
+        H3AggregateCapability().execute(
+            _toy_points(),
+            resolution=5,
+            aggregations={"revenue_sum": ("revenue", "sum")},  # no 'revenue' column
+        )
+
+
+def test_empty_aggregations_raises() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        H3AggregateCapability().execute(_toy_points(), resolution=5, aggregations={})


### PR DESCRIPTION
## Pourquoi

`#457` (feat cap-h3 : agrégation multi-métrique en une passe H3) a été mergé sur **`main`**, alors que tout le chantier d'intégration actif (osm/grb/vsizip `#459`, orchestration, sécurité, universal loader…) vit sur **`integration/v2.4`**. Résultat : `main` et `integration/v2.4` divergent d'un seul commit (celui-ci), et un consommateur qui a besoin **à la fois** de la source OSM (`#459`, v2.4) **et** de cap-h3 1.1.0 (`#457`, main) est obligé de piner deux branches.

Cette PR **reporte `#457` sur `integration/v2.4`** (cherry-pick propre, zéro conflit) pour rendre la branche d'intégration cohérente : cap-h3 passe à **1.1.0** aux côtés du reste.

## Contenu
Cherry-pick de `7a8a622` (#457) — `plugins/gispulse-cap-h3/` (capabilities + pyproject 1.0.0→1.1.0), `tests/unit/test_cap_h3.py`, `.github/workflows/ci.yml` (auto-merge). Aucun nouveau code : c'est le commit déjà reviewé/mergé sur main, relocalisé.

## Après merge
`integration/v2.4` contient osm/grb/vsizip **+** cap-h3 1.1.0 → les consommateurs (MILOU) pinnent **une seule** branche.

🤖 Generated with [Claude Code](https://claude.com/claude-code)