### PR TITLE
fix(storage): make Garage backend explicit

### DIFF
--- a/docs/n3-bulk-garage-wiring.md
+++ b/docs/n3-bulk-garage-wiring.md
@@ -164,7 +164,11 @@ La precedence globale est : env `GISPULSE_*` > `gispulse.toml` > defauts.
 
 Deux chemins S3 coexistent :
 
-- `DatasetStorage` / `S3Storage` dans `src/gispulse/persistence/storage.py` : utilise boto3, active S3 seulement si `GISPULSE_S3_ENDPOINT` est defini et si `check_tier("pro")` passe; sinon fallback local.
+- `DatasetStorage` / `S3Storage` dans `src/gispulse/persistence/storage.py` :
+  utilise boto3. `create_storage(mode="auto")` choisit S3 si
+  `GISPULSE_S3_ENDPOINT` est defini, sinon local. `create_storage(mode="s3")`
+  refuse tout fallback local et leve `STORAGE_S3_NOT_CONFIGURED` si l'endpoint
+  manque. Diagnostiquer avec `gispulse storage status --json`.
 - `DuckDBSession` : configure le secret DuckDB si `settings.s3.endpoint` est defini. Ce chemin sert a `read_parquet`, `ST_Read`, `COPY ... TO 's3://...'`. Il ne passe pas par `create_storage()`.
 
 Inconnues runtime VPS a verifier plus tard, sans le faire dans ce cadrage :
@@ -173,7 +177,8 @@ Inconnues runtime VPS a verifier plus tard, sans le faire dans ce cadrage :
 - presence du bucket `gispulse`;
 - validite des credentials et de `GISPULSE_S3_REGION=garage`;
 - capacite DuckDB/httpfs sur le VPS a ecrire puis relire un Parquet de smoke test;
-- besoin ou non du tier Pro si le runner N3 utilise `S3Storage` pour uploader les archives brutes;
+- politique produit/licence a documenter au niveau offre si necessaire ; le
+  branchement technique `S3Storage` lui-meme n'impose plus de gate Pro;
 - comportement Caddy/Garage si endpoint public HTTPS est utilise pour de gros objets.
 
 ## 4. Plan de cablage par source bulk #356

--- a/docs/source-cli.md
+++ b/docs/source-cli.md
@@ -26,6 +26,20 @@ storage abstraction is used for local filesystem and S3/MinIO, so `source list`
 and `source delete` can enumerate artifacts from manifest records instead of
 guessing object prefixes.
 
+## Storage backend clarity
+
+Use `gispulse storage status --json` to inspect the backend that gispulse would
+select without uploading data. It reports `requested_mode`, `backend`,
+`storage_class`, `endpoint_configured`, `bucket`, `region`, `local_path`,
+`selection_reason`, and `fallback`.
+
+`create_storage(mode="auto")` preserves the historical behavior: if
+`GISPULSE_S3_ENDPOINT` is set, gispulse selects `S3Storage`; otherwise it selects
+`LocalStorage`. Explicit S3/Garage calls must use `mode="s3"` (or CLI
+`--dest s3`), which fails with `STORAGE_S3_NOT_CONFIGURED` instead of falling
+back to local storage when the endpoint is missing. Explicit local development
+must use `mode="local"` / `--dest local`.
+
 For S3 bulk entries currently supported by `BulkIngestRunner`
 (`TABLE_FILE` and `DOWNLOAD`), `source ingest --dest s3` delegates to that
 runner and persists its manifest output in the same inventory. Other entries

--- a/src/gispulse/adapters/rest/rest_table_fetcher.py
+++ b/src/gispulse/adapters/rest/rest_table_fetcher.py
@@ -24,7 +24,7 @@ from dataclasses import dataclass, field
 from os import PathLike
 import tempfile
 import time
-from typing import Any, BinaryIO
+from typing import Any, BinaryIO, cast
 from urllib.parse import urlencode, urljoin, urlsplit
 
 from gispulse.adapters.rest.retry import RetrySpec, get_json_with_retry, sleep as _sleep
@@ -232,9 +232,7 @@ def _upload_jsonl_to_s3(s3_uri: str, body: BinaryIO) -> None:
         raise ValueError("REST_TABLE S3 materialization requires GISPULSE_S3_ENDPOINT")
 
     from gispulse.persistence.storage import S3Storage
-    from gispulse.persistence.tier import check_tier
 
-    check_tier("pro")
     storage = S3Storage(
         endpoint_url=settings.s3.endpoint,
         bucket=bucket,
@@ -283,9 +281,12 @@ class RestTableFetcher:
         s3_uri = _resolve_s3_materialize_uri(params)
         local_path = params.get("local_path")
         if s3_uri:
-            fh: BinaryIO = tempfile.SpooledTemporaryFile(
-                max_size=64 * 1024 * 1024,
-                mode="w+b",
+            fh = cast(
+                BinaryIO,
+                tempfile.SpooledTemporaryFile(
+                    max_size=64 * 1024 * 1024,
+                    mode="w+b",
+                ),
             )
         else:
             if not local_path:

--- a/src/gispulse/cli.py
+++ b/src/gispulse/cli.py
@@ -1553,8 +1553,10 @@ app.command(name="mcp")(cmd_mcp)
 # ---------------------------------------------------------------------------
 
 from gispulse.cli_source import source_app  # noqa: E402
+from gispulse.cli_storage import storage_app  # noqa: E402
 
 app.add_typer(source_app, name="source")
+app.add_typer(storage_app, name="storage")
 
 
 # ---------------------------------------------------------------------------

--- a/src/gispulse/cli_source.py
+++ b/src/gispulse/cli_source.py
@@ -475,18 +475,12 @@ def _row_count(result: Any) -> int | None:
 
 
 def _storage_for_dest(dest: str) -> Any:
+    from gispulse.persistence.storage import create_storage
+
     if dest == "local":
-        from gispulse.core.config import settings
-        from gispulse.persistence.storage import LocalStorage
-
-        return LocalStorage(base_path=settings.storage.data_dir)
+        return create_storage(mode="local")
     if dest == "s3":
-        from gispulse.core.config import settings
-        from gispulse.persistence.storage import create_storage
-
-        if not settings.s3.endpoint:
-            raise ValueError("dest=s3 requires GISPULSE_S3_ENDPOINT")
-        return create_storage()
+        return create_storage(mode="s3")
     raise ValueError(f"Invalid --dest {dest!r}; expected local or s3")
 
 
@@ -881,6 +875,12 @@ def source_catalog(
             protocol_filter=protocol,
         )
     except Exception as exc:  # noqa: BLE001 - CLI boundary
+        to_dict = getattr(exc, "to_dict", None)
+        if json_output and callable(to_dict):
+            payload = {"status": "error"}
+            payload.update(to_dict())
+            typer.echo(json.dumps(payload, sort_keys=True))
+            raise typer.Exit(1) from exc
         typer.echo(f"Error: {exc}", err=True)
         raise typer.Exit(1) from exc
     for warning in payload["warnings"]:
@@ -931,6 +931,12 @@ def source_ingest(
             prefix=prefix,
         )
     except Exception as exc:  # noqa: BLE001 - CLI boundary
+        to_dict = getattr(exc, "to_dict", None)
+        if json_output and callable(to_dict):
+            payload = {"status": "error"}
+            payload.update(to_dict())
+            typer.echo(json.dumps(payload, sort_keys=True))
+            raise typer.Exit(1) from exc
         typer.echo(f"Error: {exc}", err=True)
         raise typer.Exit(1) from exc
 

--- a/src/gispulse/cli_storage.py
+++ b/src/gispulse/cli_storage.py
@@ -1,0 +1,47 @@
+"""Storage diagnostics CLI."""
+
+from __future__ import annotations
+
+import json
+
+import typer
+
+from gispulse.persistence.storage import describe_storage_backend
+
+
+storage_app = typer.Typer(
+    help="Inspect explicit local vs S3/Garage storage backend selection.",
+    add_completion=False,
+)
+
+
+@storage_app.command("status")
+def storage_status(
+    mode: str = typer.Option(
+        "auto",
+        "--mode",
+        help="Storage mode to explain: auto, local, or s3.",
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON."),
+) -> None:
+    """Report which storage backend gispulse would use, without uploading data."""
+    report = describe_storage_backend(mode)
+
+    if json_output:
+        typer.echo(json.dumps(report, sort_keys=True))
+    else:
+        typer.echo(f"requested_mode={report['requested_mode']}")
+        typer.echo(f"backend={report['backend']}")
+        typer.echo(f"storage_class={report['storage_class']}")
+        typer.echo(f"endpoint_configured={report['endpoint_configured']}")
+        typer.echo(f"bucket={report['bucket']}")
+        typer.echo(f"fallback={report['fallback']}")
+        typer.echo(f"selection_reason={report['selection_reason']}")
+        if "error" in report:
+            error = report["error"]
+            if isinstance(error, dict):
+                typer.echo(f"error_code={error.get('code')}", err=True)
+                typer.echo(f"recovery={error.get('recovery')}", err=True)
+
+    if report["backend"] == "unconfigured":
+        raise typer.Exit(1)

--- a/src/gispulse/core/config.py
+++ b/src/gispulse/core/config.py
@@ -301,7 +301,7 @@ class StorageSettings(BaseSettings):
 
 
 class S3Settings(BaseSettings):
-    """S3/MinIO object storage (Pro tier)."""
+    """S3/MinIO/Garage object storage configuration."""
 
     model_config = SettingsConfigDict(env_prefix="GISPULSE_S3_")
 

--- a/src/gispulse/persistence/storage.py
+++ b/src/gispulse/persistence/storage.py
@@ -1,5 +1,5 @@
 """
-Dataset storage abstraction — local filesystem (default) and S3/MinIO (Pro).
+Dataset storage abstraction — local filesystem (default) and S3/MinIO.
 
 Provides a unified interface for storing, retrieving, and managing dataset
 files regardless of the underlying storage backend.
@@ -27,8 +27,9 @@ import asyncio
 import functools
 import shutil
 from abc import ABC, abstractmethod
+from io import BytesIO
 from pathlib import Path
-from typing import BinaryIO
+from typing import BinaryIO, Literal, cast
 
 from gispulse.core.config import settings
 from gispulse.core.logging import get_logger
@@ -36,8 +37,38 @@ from gispulse.core.logging import get_logger
 log = get_logger(__name__)
 
 
+StorageMode = Literal["auto", "local", "s3"]
+
+
 class StorageError(Exception):
-    """Raised when a storage operation fails."""
+    """Raised when a storage operation fails.
+
+    The string message remains backward-compatible, while ``code``/``context``/
+    ``recovery`` give CLIs and agents a stable machine-readable surface.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str = "STORAGE_ERROR",
+        context: dict[str, object] | None = None,
+        recovery: str = "",
+    ) -> None:
+        self.code = code
+        self.context = context or {}
+        self.recovery = recovery
+        super().__init__(message)
+
+    def to_dict(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "code": self.code,
+            "message": str(self),
+            "context": self.context,
+        }
+        if self.recovery:
+            payload["recovery"] = self.recovery
+        return payload
 
 
 def _make_s3_boto_config(BotoConfig):
@@ -214,7 +245,7 @@ class LocalStorage(DatasetStorage):
 
 
 # ---------------------------------------------------------------------------
-# S3Storage — S3/MinIO backend (Pro tier)
+# S3Storage — S3/MinIO backend
 # ---------------------------------------------------------------------------
 
 
@@ -282,8 +313,7 @@ class S3Storage(DatasetStorage):
             extra["ContentType"] = content_type
 
         if isinstance(data, bytes):
-            from io import BytesIO
-            body = BytesIO(data)
+            body = cast(BinaryIO, BytesIO(data))
         else:
             body = data
 
@@ -363,36 +393,160 @@ class S3Storage(DatasetStorage):
 
 
 # ---------------------------------------------------------------------------
-# Factory
+# Factory / diagnostics
 # ---------------------------------------------------------------------------
 
 
-def create_storage() -> DatasetStorage:
-    """Create the appropriate storage backend based on environment variables.
+def _normalize_storage_mode(mode: str) -> StorageMode:
+    clean = mode.strip().lower()
+    if clean in {"auto", "local", "s3"}:
+        return clean  # type: ignore[return-value]
+    raise StorageError(
+        f"Invalid storage mode {mode!r}; expected auto, local, or s3",
+        code="STORAGE_MODE_INVALID",
+        context={"mode": mode},
+        recovery="Use mode='auto', mode='local', or mode='s3'.",
+    )
 
-    If ``GISPULSE_S3_ENDPOINT`` is set, returns an :class:`S3Storage`
-    (requires Pro tier). Otherwise returns a :class:`LocalStorage`.
+
+def _s3_not_configured_error(mode: StorageMode) -> StorageError:
+    return StorageError(
+        "S3/Garage storage was explicitly requested but GISPULSE_S3_ENDPOINT is not configured",
+        code="STORAGE_S3_NOT_CONFIGURED",
+        context={"mode": mode, "endpoint_configured": False},
+        recovery=(
+            "Set GISPULSE_S3_ENDPOINT plus GISPULSE_S3_BUCKET/"
+            "GISPULSE_S3_ACCESS_KEY/GISPULSE_S3_SECRET_KEY, or choose mode='local' "
+            "explicitly for local development."
+        ),
+    )
+
+
+def describe_storage_backend(mode: str = "auto") -> dict[str, object]:
+    """Describe the storage backend selection without opening network connections.
+
+    ``mode='auto'`` preserves the historical behavior: S3/Garage when
+    ``GISPULSE_S3_ENDPOINT`` is configured, local storage otherwise. Explicit
+    ``mode='s3'`` never falls back to local storage.
     """
+    requested_mode = _normalize_storage_mode(mode)
     s3_url = settings.s3.endpoint
-    if s3_url:
-        from gispulse.persistence.tier import check_tier, TierError
+    endpoint_configured = bool(s3_url)
+    local_path = str(Path(settings.storage.data_dir).expanduser().resolve())
 
-        try:
-            check_tier("pro")
-        except TierError:
-            log.warning(
-                "s3_tier_blocked",
-                msg="GISPULSE_S3_ENDPOINT is set but S3 storage requires Pro tier. "
-                "Falling back to local storage.",
-            )
-            return LocalStorage(base_path=settings.storage.data_dir)
+    if requested_mode == "local":
+        return {
+            "requested_mode": requested_mode,
+            "backend": "local",
+            "storage_class": "LocalStorage",
+            "endpoint_configured": endpoint_configured,
+            "bucket": None,
+            "region": None,
+            "local_path": local_path,
+            "selection_reason": "mode=local explicitly selected local storage.",
+            "fallback": False,
+        }
 
+    if requested_mode == "s3" and not endpoint_configured:
+        error = _s3_not_configured_error(requested_mode)
+        return {
+            "requested_mode": requested_mode,
+            "backend": "unconfigured",
+            "storage_class": None,
+            "endpoint_configured": False,
+            "bucket": settings.s3.bucket,
+            "region": settings.s3.region,
+            "local_path": None,
+            "selection_reason": "mode=s3 requires GISPULSE_S3_ENDPOINT.",
+            "fallback": False,
+            "error": error.to_dict(),
+        }
+
+    if endpoint_configured:
+        reason = (
+            "mode=s3 explicitly selected S3/Garage storage."
+            if requested_mode == "s3"
+            else "GISPULSE_S3_ENDPOINT is set; auto mode selected S3/Garage storage."
+        )
+        return {
+            "requested_mode": requested_mode,
+            "backend": "s3",
+            "storage_class": "S3Storage",
+            "endpoint_configured": True,
+            "endpoint": s3_url,
+            "bucket": settings.s3.bucket,
+            "region": settings.s3.region,
+            "local_path": None,
+            "selection_reason": reason,
+            "fallback": False,
+        }
+
+    return {
+        "requested_mode": requested_mode,
+        "backend": "local",
+        "storage_class": "LocalStorage",
+        "endpoint_configured": False,
+        "bucket": None,
+        "region": None,
+        "local_path": local_path,
+        "selection_reason": "GISPULSE_S3_ENDPOINT is not set; auto mode selected local storage.",
+        "fallback": False,
+    }
+
+
+def create_storage(mode: str = "auto") -> DatasetStorage:
+    """Create a storage backend from an explicit mode.
+
+    ``mode='auto'`` keeps backward compatibility: S3/Garage when
+    ``GISPULSE_S3_ENDPOINT`` is set, local storage otherwise. Explicit
+    ``mode='s3'`` refuses to fall back to local storage.
+    """
+    report = describe_storage_backend(mode)
+    backend = report["backend"]
+
+    if backend == "s3":
+        log.info(
+            "storage_backend_selected",
+            requested_mode=report["requested_mode"],
+            backend=backend,
+            storage_class=report["storage_class"],
+            endpoint_configured=report["endpoint_configured"],
+            bucket=report["bucket"],
+        )
         return S3Storage(
-            endpoint_url=s3_url,
+            endpoint_url=str(report["endpoint"]),
             bucket=settings.s3.bucket,
             access_key=settings.s3.access_key,
             secret_key=settings.s3.secret_key,
             region=settings.s3.region,
         )
 
-    return LocalStorage(base_path=settings.storage.data_dir)
+    if backend == "local":
+        log.info(
+            "storage_backend_selected",
+            requested_mode=report["requested_mode"],
+            backend=backend,
+            storage_class=report["storage_class"],
+            endpoint_configured=report["endpoint_configured"],
+            bucket=report["bucket"],
+        )
+        return LocalStorage(base_path=settings.storage.data_dir)
+
+    error_payload = report.get("error")
+    if isinstance(error_payload, dict):
+        raise StorageError(
+            str(error_payload.get("message", "Storage backend is not configured")),
+            code=str(error_payload.get("code", "STORAGE_BACKEND_UNCONFIGURED")),
+            context=(
+                error_payload.get("context")
+                if isinstance(error_payload.get("context"), dict)
+                else {}
+            ),
+            recovery=str(error_payload.get("recovery", "")),
+        )
+    raise StorageError(
+        "Storage backend is not configured",
+        code="STORAGE_BACKEND_UNCONFIGURED",
+        context={"mode": mode},
+        recovery="Check storage configuration and retry.",
+    )

--- a/tests/integration/test_full_pipeline.py
+++ b/tests/integration/test_full_pipeline.py
@@ -517,16 +517,42 @@ class TestStorageUploadDownloadDelete:
 class TestTierGatingAllFeatures:
     """Verify that each Pro feature is properly gated in Community tier."""
 
-    def test_community_blocks_s3_storage(self, monkeypatch):
-        """S3 storage is gated to Pro tier — Community gets LocalStorage fallback."""
-        from gispulse.persistence.storage import create_storage
+    def test_community_allows_s3_storage_when_endpoint_configured(self, monkeypatch):
+        """S3/Garage storage is community-usable when explicitly configured."""
+        import gispulse.persistence.storage as storage_module
+
+        captured: dict[str, object] = {}
+
+        class _FakeS3Storage:
+            def __init__(
+                self,
+                *,
+                endpoint_url: str,
+                bucket: str,
+                access_key: str,
+                secret_key: str,
+                region: str,
+            ) -> None:
+                captured.update(
+                    {
+                        "endpoint_url": endpoint_url,
+                        "bucket": bucket,
+                        "access_key": access_key,
+                        "secret_key": secret_key,
+                        "region": region,
+                    }
+                )
 
         monkeypatch.setenv("GISPULSE_S3_ENDPOINT", "http://minio:9000")
+        monkeypatch.setenv("GISPULSE_S3_BUCKET", "community-artifacts")
         monkeypatch.setenv("GISPULSE_TIER", "community")
         monkeypatch.delenv("GISPULSE_LICENSE_KEY", raising=False)
+        monkeypatch.setattr(storage_module, "S3Storage", _FakeS3Storage)
 
-        storage = create_storage()
-        assert isinstance(storage, LocalStorage)
+        storage = storage_module.create_storage()
+        assert isinstance(storage, _FakeS3Storage)
+        assert captured["endpoint_url"] == "http://minio:9000"
+        assert captured["bucket"] == "community-artifacts"
 
     def test_community_blocks_scheduler(self, monkeypatch):
         """PipelineScheduler.start() requires Pro tier."""

--- a/tests/unit/test_cli_source.py
+++ b/tests/unit/test_cli_source.py
@@ -432,6 +432,37 @@ def test_source_ingest_ambiguous_source_without_plugin_fails(
     assert "gispulse-src-rival:ax-source" in result.output
 
 
+def test_source_ingest_s3_without_endpoint_returns_structured_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fetcher = _JsonFetcher()
+    registry = ProtocolRegistry()
+    registry.register(fetcher)
+    _patch_source_hub(monkeypatch, registry=registry)
+    monkeypatch.delenv("GISPULSE_S3_ENDPOINT", raising=False)
+    monkeypatch.delenv("GISPULSE_S3_ACCESS_KEY", raising=False)
+    monkeypatch.delenv("GISPULSE_S3_SECRET_KEY", raising=False)
+
+    result = runner.invoke(
+        app,
+        [
+            "source",
+            "ingest",
+            "ax-source",
+            "parcelles",
+            "--dest",
+            "s3",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["status"] == "error"
+    assert payload["code"] == "STORAGE_S3_NOT_CONFIGURED"
+    assert "GISPULSE_S3_ENDPOINT" in payload["recovery"]
+
+
 def test_source_ingest_uses_bulk_runner_for_s3_table_entries(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/unit/test_cli_storage.py
+++ b/tests/unit/test_cli_storage.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+import os
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from gispulse.cli import app
+
+
+runner = CliRunner()
+
+
+def test_storage_status_reports_auto_local_json() -> None:
+    env = {k: v for k, v in os.environ.items() if not k.startswith("GISPULSE_S3_")}
+    with patch.dict(os.environ, env, clear=True):
+        result = runner.invoke(app, ["storage", "status", "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["requested_mode"] == "auto"
+    assert payload["backend"] == "local"
+    assert payload["storage_class"] == "LocalStorage"
+    assert payload["fallback"] is False
+
+
+def test_storage_status_s3_missing_endpoint_exits_1_json() -> None:
+    env = {k: v for k, v in os.environ.items() if not k.startswith("GISPULSE_S3_")}
+    with patch.dict(os.environ, env, clear=True):
+        result = runner.invoke(app, ["storage", "status", "--mode", "s3", "--json"])
+
+    assert result.exit_code == 1, result.output
+    payload = json.loads(result.output)
+    assert payload["backend"] == "unconfigured"
+    assert payload["error"]["code"] == "STORAGE_S3_NOT_CONFIGURED"
+    assert "GISPULSE_S3_ENDPOINT" in payload["error"]["recovery"]

--- a/tests/unit/test_rest_table_fetcher.py
+++ b/tests/unit/test_rest_table_fetcher.py
@@ -736,3 +736,73 @@ def test_rate_limit_retry_uses_retry_after_header(
 
     assert calls == 2
     assert sleeps == [0.25]
+
+
+def test_upload_jsonl_to_s3_does_not_require_paid_license(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from io import BytesIO
+
+    from gispulse.adapters.rest import rest_table_fetcher
+    from gispulse.persistence import storage as storage_module
+    from gispulse.persistence import tier as tier_module
+
+    captured: dict[str, object] = {}
+
+    class FakeS3Storage:
+        def __init__(
+            self,
+            *,
+            endpoint_url: str,
+            bucket: str,
+            access_key: str,
+            secret_key: str,
+            region: str,
+        ) -> None:
+            captured["init"] = {
+                "endpoint_url": endpoint_url,
+                "bucket": bucket,
+                "access_key": access_key,
+                "secret_key": secret_key,
+                "region": region,
+            }
+
+        async def upload(self, key: str, body, content_type: str) -> str:
+            captured["upload"] = {
+                "key": key,
+                "body": body.read(),
+                "content_type": content_type,
+            }
+            return key
+
+    def fail_if_called(*args: object, **kwargs: object) -> None:
+        raise AssertionError("S3/Garage upload must not require a paid-tier check")
+
+    monkeypatch.setenv("GISPULSE_S3_ENDPOINT", "http://garage:3900")
+    monkeypatch.setenv("GISPULSE_S3_ACCESS_KEY", "garage-key")
+    monkeypatch.setenv("GISPULSE_S3_SECRET_KEY", "garage-secret")
+    monkeypatch.setenv("GISPULSE_S3_REGION", "garage")
+    monkeypatch.setenv("GISPULSE_TIER", "community")
+    monkeypatch.delenv("GISPULSE_LICENSE_KEY", raising=False)
+    monkeypatch.setattr(storage_module, "S3Storage", FakeS3Storage)
+    monkeypatch.setattr(tier_module, "check_tier", fail_if_called)
+
+    rest_table_fetcher._upload_jsonl_to_s3(
+        "s3://milou-artifacts/raw/georisques/radon.jsonl",
+        BytesIO(b'{"code_insee":"63113"}\n'),
+    )
+
+    assert captured == {
+        "init": {
+            "endpoint_url": "http://garage:3900",
+            "bucket": "milou-artifacts",
+            "access_key": "garage-key",
+            "secret_key": "garage-secret",
+            "region": "garage",
+        },
+        "upload": {
+            "key": "raw/georisques/radon.jsonl",
+            "body": b'{"code_insee":"63113"}\n',
+            "content_type": "application/x-ndjson",
+        },
+    }

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -15,6 +15,7 @@ from gispulse.persistence.storage import (
     LocalStorage,
     StorageError,
     create_storage,
+    describe_storage_backend,
     _make_s3_boto_config,
     validate_storage_key,
 )
@@ -32,6 +33,14 @@ def _run(coro):
         return loop.run_until_complete(coro)
     finally:
         loop.close()
+
+
+class _CaptureLogger:
+    def __init__(self) -> None:
+        self.infos: list[dict[str, object]] = []
+
+    def info(self, event: str, **context: object) -> None:
+        self.infos.append({"event": event, **context})
 
 
 def _make_mock_boto3():
@@ -305,35 +314,88 @@ class TestS3Storage:
 
 
 class TestCreateStorage:
-    def test_default_local(self):
+    def test_default_local(self, monkeypatch: pytest.MonkeyPatch):
         """Without S3 env vars, create_storage returns LocalStorage."""
+        logger = _CaptureLogger()
+        monkeypatch.setattr("gispulse.persistence.storage.log", logger)
         env = {k: v for k, v in os.environ.items() if not k.startswith("GISPULSE_S3_")}
         with patch.dict(os.environ, env, clear=True):
             storage = create_storage()
         assert isinstance(storage, LocalStorage)
+        selected = [
+            entry for entry in logger.infos if entry["event"] == "storage_backend_selected"
+        ]
+        assert selected == [
+            {
+                "event": "storage_backend_selected",
+                "requested_mode": "auto",
+                "backend": "local",
+                "storage_class": "LocalStorage",
+                "endpoint_configured": False,
+                "bucket": None,
+            }
+        ]
 
-    def test_s3_without_pro_tier_falls_back(self):
-        """S3 endpoint set but tier is community => falls back to local."""
+    def test_explicit_s3_without_endpoint_fails_structured(self):
+        """Explicit S3 mode must not silently fall back to LocalStorage."""
+        env = {k: v for k, v in os.environ.items() if not k.startswith("GISPULSE_S3_")}
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(StorageError) as exc:
+                create_storage(mode="s3")
+        assert exc.value.code == "STORAGE_S3_NOT_CONFIGURED"
+        assert exc.value.context == {"mode": "s3", "endpoint_configured": False}
+        assert "GISPULSE_S3_ENDPOINT" in exc.value.recovery
+
+    def test_explicit_local_ignores_s3_endpoint(self):
+        """Local mode is an explicit opt-in, not an accidental S3 fallback."""
         env = {
             "GISPULSE_S3_ENDPOINT": "http://localhost:9000",
-            "GISPULSE_TIER": "community",
+            "GISPULSE_S3_BUCKET": "test",
         }
         with patch.dict(os.environ, env, clear=False):
-            storage = create_storage()
+            storage = create_storage(mode="local")
         assert isinstance(storage, LocalStorage)
 
-    def test_s3_with_pro_tier(self):
-        """S3 endpoint set with pro tier => creates S3Storage."""
+    def test_describe_storage_backend_auto_local(self):
+        env = {k: v for k, v in os.environ.items() if not k.startswith("GISPULSE_S3_")}
+        with patch.dict(os.environ, env, clear=True):
+            report = describe_storage_backend(mode="auto")
+        assert report == {
+            "requested_mode": "auto",
+            "backend": "local",
+            "storage_class": "LocalStorage",
+            "endpoint_configured": False,
+            "bucket": None,
+            "region": None,
+            "local_path": os.path.expanduser("~/.gispulse/data"),
+            "selection_reason": "GISPULSE_S3_ENDPOINT is not set; auto mode selected local storage.",
+            "fallback": False,
+        }
+
+    def test_describe_storage_backend_explicit_s3_missing_endpoint(self):
+        env = {k: v for k, v in os.environ.items() if not k.startswith("GISPULSE_S3_")}
+        with patch.dict(os.environ, env, clear=True):
+            report = describe_storage_backend(mode="s3")
+        assert report["backend"] == "unconfigured"
+        assert report["storage_class"] is None
+        assert report["error"]["code"] == "STORAGE_S3_NOT_CONFIGURED"
+        assert report["fallback"] is False
+
+    def test_s3_endpoint_uses_s3_storage_without_license_gate(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """S3 endpoint set => creates S3Storage without a paid-tier license."""
         from gispulse.persistence.storage import S3Storage
 
+        logger = _CaptureLogger()
+        monkeypatch.setattr("gispulse.persistence.storage.log", logger)
         env = {
             "GISPULSE_S3_ENDPOINT": "http://localhost:9000",
             "GISPULSE_S3_BUCKET": "test",
             "GISPULSE_S3_ACCESS_KEY": "admin",
             "GISPULSE_S3_SECRET_KEY": "secret",
-            "GISPULSE_TIER": "pro",
-            "GISPULSE_LICENCE_SKIP_VERIFY": "true",
-            "GISPULSE_LICENSE_KEY": "eyJvcmciOiAidGVzdCIsICJ0aWVyIjogInBybyIsICJleHAiOiAiMjAzMC0wMS0wMVQwMDowMDowMFoifQ.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "GISPULSE_TIER": "community",
+            "GISPULSE_LICENSE_KEY": "",
         }
         mock_boto3, mock_botocore_config, mock_client = _make_mock_boto3()
 
@@ -349,6 +411,21 @@ class TestCreateStorage:
             with patch.dict(os.environ, env, clear=False):
                 storage = create_storage()
             assert isinstance(storage, S3Storage)
+            selected = [
+                entry
+                for entry in logger.infos
+                if entry["event"] == "storage_backend_selected"
+            ]
+            assert selected == [
+                {
+                    "event": "storage_backend_selected",
+                    "requested_mode": "auto",
+                    "backend": "s3",
+                    "storage_class": "S3Storage",
+                    "endpoint_configured": True,
+                    "bucket": "test",
+                }
+            ]
         finally:
             if saved_boto3 is not None:
                 sys.modules["boto3"] = saved_boto3


### PR DESCRIPTION
## Summary

- make storage backend selection explicit with `create_storage(mode="auto|local|s3")`
- add `gispulse storage status --json` for agent/operator diagnostics
- remove the technical Pro-tier gate from S3/Garage plumbing while preserving no-fallback behavior for explicit S3
- return structured storage errors (`code`, `context`, `recovery`) and cover source-ingest JSON failures

## Why

MILOU needs Garage as a local S3-compatible object store for produced artifacts. That should be core gispulse storage plumbing, not a MILOU-specific writer shim. Explicit `mode="s3"` now fails fast with `STORAGE_S3_NOT_CONFIGURED` instead of silently returning `LocalStorage`.

Relates to #461.

## Test plan

- `uv run pytest tests/unit/test_storage.py tests/unit/test_cli_storage.py tests/unit/test_cli_source.py tests/unit/test_rest_table_fetcher.py tests/integration/test_full_pipeline.py::TestTierGatingAllFeatures::test_community_allows_s3_storage_when_endpoint_configured -q`
- `uv run ruff check src/gispulse/persistence/storage.py src/gispulse/cli_storage.py src/gispulse/cli_source.py src/gispulse/adapters/rest/rest_table_fetcher.py tests/unit/test_storage.py tests/unit/test_cli_storage.py tests/unit/test_cli_source.py tests/unit/test_rest_table_fetcher.py tests/integration/test_full_pipeline.py`
- `uv run mypy --config-file=/dev/null --ignore-missing-imports --follow-imports=skip src/gispulse/persistence/storage.py src/gispulse/cli_storage.py src/gispulse/cli_source.py src/gispulse/adapters/rest/rest_table_fetcher.py`
