### PR TITLE
feat(src-osm): expose PBF road tag extraction

### DIFF
--- a/plugins/gispulse-src-osm/gispulse_src_osm/__init__.py
+++ b/plugins/gispulse-src-osm/gispulse_src_osm/__init__.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from gispulse_src_osm.pbf import OsmPbfReadError, read_pbf_roads
+
 
 def register() -> None:
     """Entry-point hook for the ``gispulse.data_sources`` group."""
@@ -9,3 +11,6 @@ def register() -> None:
     from gispulse_src_osm.source import OsmSource
 
     SOURCES.register(OsmSource())
+
+
+__all__ = ["OsmPbfReadError", "read_pbf_roads", "register"]

--- a/plugins/gispulse-src-osm/gispulse_src_osm/pbf.py
+++ b/plugins/gispulse-src-osm/gispulse_src_osm/pbf.py
@@ -1,0 +1,164 @@
+"""DuckDB-backed helpers for local OSM PBF extracts.
+
+The source plugin declares where the PBF comes from; this module owns the
+generic PBF-to-GeoDataFrame extraction. Domain-specific harmonisation, for
+example mapping ``surface=*`` to a cost model, remains in consumers.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import Any
+
+import geopandas as gpd
+
+_SOURCE_CRS = "EPSG:4326"
+_DEFAULT_TAGS = ("highway", "surface", "footway")
+_TAG_RE = re.compile(r"^[A-Za-z0-9_:-]+$")
+
+
+class OsmPbfReadError(ValueError):
+    """Structured error raised when an OSM PBF cannot be read."""
+
+    def __init__(self, *, code: str, context: str, recovery: str) -> None:
+        self.code = code
+        self.context = context
+        self.recovery = recovery
+        super().__init__({"code": code, "context": context, "recovery": recovery})
+
+
+def read_pbf_roads(
+    pbf_path: str | Path,
+    *,
+    tags: Sequence[str] = _DEFAULT_TAGS,
+    target_crs: str | None = "EPSG:31370",
+    connection_factory: Callable[[], Any] | None = None,
+) -> gpd.GeoDataFrame:
+    """Read road ways and selected OSM tags from a local ``.osm.pbf`` extract.
+
+    Args:
+        pbf_path: Local PBF file path.
+        tags: OSM tag keys to flatten into columns. ``highway`` is always
+            included because it defines the road-way filter.
+        target_crs: Optional CRS for the returned GeoDataFrame. ``None`` keeps
+            the native OSM WGS84 geometry.
+        connection_factory: Test hook returning a DuckDB-like connection.
+
+    Returns:
+        GeoDataFrame with ``id``, one column per requested tag, and line geometry.
+
+    Raises:
+        FileNotFoundError: If ``pbf_path`` does not exist.
+        OsmPbfReadError: If tag keys are unsafe or DuckDB/spatial cannot read PBF.
+    """
+    path = Path(pbf_path)
+    if not path.exists():
+        raise FileNotFoundError(f"OSM PBF file not found: {path}")
+
+    tag_keys = _normalise_tags(tags)
+    sql = _roads_sql(tag_keys)
+
+    owns_connection = connection_factory is None
+    if connection_factory is None:
+        try:
+            import duckdb
+        except ImportError as exc:  # pragma: no cover - dependency is installed in gispulse
+            raise OsmPbfReadError(
+                code="OSM_PBF_DUCKDB_MISSING",
+                context="duckdb is required to read OSM PBF extracts",
+                recovery="install gispulse with its DuckDB dependency, then retry",
+            ) from exc
+
+        from gispulse.core.duckdb_limits import configure_duckdb_limits
+
+        conn = duckdb.connect(":memory:")
+        configure_duckdb_limits(conn)
+        conn.execute("INSTALL spatial; LOAD spatial;")
+    else:
+        conn = connection_factory()
+
+    try:
+        frame = conn.execute(sql, [str(path)]).fetchdf()
+    except Exception as exc:
+        raise OsmPbfReadError(
+            code="OSM_PBF_READ_FAILED",
+            context=f"failed to read OSM PBF roads from {path}",
+            recovery="verify the file is a valid .osm.pbf and DuckDB spatial can load ST_ReadOSM",
+        ) from exc
+    finally:
+        if owns_connection:
+            conn.close()
+
+    return _frame_to_gdf(frame, target_crs=target_crs)
+
+
+def _normalise_tags(tags: Sequence[str]) -> tuple[str, ...]:
+    keys = ["highway", *list(tags)]
+    normalised: list[str] = []
+    for raw in keys:
+        key = raw.strip()
+        if not key or not _TAG_RE.fullmatch(key):
+            raise OsmPbfReadError(
+                code="OSM_PBF_TAG_INVALID",
+                context=f"unsafe OSM tag key: {raw!r}",
+                recovery="use plain OSM tag keys containing only letters, digits, _, :, or -",
+            )
+        if key not in normalised:
+            normalised.append(key)
+    return tuple(normalised)
+
+
+def _roads_sql(tags: Sequence[str]) -> str:
+    tag_select = ",\n        ".join(
+        f"tags['{_sql_string(tag)}']::VARCHAR AS \"{_sql_identifier(tag)}\"" for tag in tags
+    )
+    return f"""
+    SELECT
+        id,
+        {tag_select},
+        ST_AsWKB(geom) AS geometry
+    FROM ST_ReadOSM(?)
+    WHERE kind = 'way'
+      AND tags['highway'] IS NOT NULL
+      AND geom IS NOT NULL
+    """
+
+
+def _frame_to_gdf(frame: Any, *, target_crs: str | None) -> gpd.GeoDataFrame:
+    if "geometry" not in frame:
+        raise OsmPbfReadError(
+            code="OSM_PBF_GEOMETRY_MISSING",
+            context="DuckDB ST_ReadOSM result did not include a geometry column",
+            recovery="keep ST_AsWKB(geom) in the PBF road extraction query",
+        )
+
+    data = frame.copy()
+    data["geometry"] = data["geometry"].map(_load_wkb)
+    gdf = gpd.GeoDataFrame(data, geometry="geometry", crs=_SOURCE_CRS)
+    gdf = gdf.loc[~(gdf.geometry.is_empty | gdf.geometry.isna())].reset_index(drop=True)
+    if target_crs and target_crs != _SOURCE_CRS:
+        gdf = gdf.to_crs(target_crs)
+    return gdf
+
+
+def _load_wkb(value: object) -> object:
+    from shapely import wkb
+
+    if value is None:
+        return None
+    if isinstance(value, memoryview):
+        return wkb.loads(value.tobytes())
+    return wkb.loads(bytes(value))
+
+
+def _sql_identifier(value: str) -> str:
+    return value.replace('"', '""')
+
+
+def _sql_string(value: str) -> str:
+    return value.replace("'", "''")
+
+
+__all__ = ["OsmPbfReadError", "read_pbf_roads"]

--- a/plugins/gispulse-src-osm/gispulse_src_osm/source.py
+++ b/plugins/gispulse-src-osm/gispulse_src_osm/source.py
@@ -29,6 +29,7 @@ _TARGET_CRS = "EPSG:31370"
 _SOURCE_CRS = "EPSG:4326"  # OSM/Geofabrik native
 
 GEOFABRIK_BE_SHP = "https://download.geofabrik.de/europe/belgium-latest-free.shp.zip"
+GEOFABRIK_BE_PBF = "https://download.geofabrik.de/europe/belgium-latest.osm.pbf"
 
 # Geofabrik *free* shapefile roads layer (gis_osm_roads_free_1) attributes.
 # Confirmé sur la doc/exports Geofabrik : osm_id, code, fclass, name, ref, oneway,
@@ -85,6 +86,36 @@ _ENTRIES: dict[str, dict[str, Any]] = {
         ),
         "schema": _ROADS_SCHEMA,
         "canonical_field_map": _ROADS_FIELD_MAP,
+        "source_crs": _SOURCE_CRS,
+    },
+    "osm-pbf-be": {
+        "label": "OSM full extract — Belgium (Geofabrik PBF)",
+        "provider": "Geofabrik / OpenStreetMap",
+        "platform": "Geofabrik download server (PBF)",
+        "region": "BE",
+        "endpoint": GEOFABRIK_BE_PBF,
+        "access": AccessSpec(
+            protocol=AccessProtocol.DOWNLOAD,
+            endpoint=GEOFABRIK_BE_PBF,
+            params={
+                "source_crs": _SOURCE_CRS,
+                "target_crs": _TARGET_CRS,
+                "reader": "duckdb.ST_ReadOSM",
+            },
+            format="application/x-osm-pbf",
+        ),
+        "schema": {
+            "id": "int",
+            "highway": "str",
+            "surface": "str",
+            "geometry": f"geometry[{_TARGET_CRS}]",
+        },
+        "canonical_field_map": {
+            "id": "id",
+            "highway": "tags.highway",
+            "surface": "tags.surface",
+            "geometry": "geom",
+        },
         "source_crs": _SOURCE_CRS,
     },
 }

--- a/tests/unit/test_src_osm.py
+++ b/tests/unit/test_src_osm.py
@@ -16,9 +16,11 @@ _PKG_PATH = str(_PKG)
 if _PKG_PATH in sys.path:
     sys.path.remove(_PKG_PATH)
 sys.path.insert(0, _PKG_PATH)
-for _module in ("gispulse_src_osm.source", "gispulse_src_osm"):
+for _module in ("gispulse_src_osm.pbf", "gispulse_src_osm.source", "gispulse_src_osm"):
     sys.modules.pop(_module, None)
 
+from gispulse_src_osm import read_pbf_roads  # noqa: E402
+from gispulse_src_osm.pbf import OsmPbfReadError  # noqa: E402
 from gispulse_src_osm.source import OsmSource  # noqa: E402
 
 from gispulse.core.plugin_model import AccessProtocol, Payload, SourceDomain  # noqa: E402
@@ -66,6 +68,7 @@ def test_roads_be_entry_targets_zip_member_via_download(source: OsmSource) -> No
 def test_entries_exposes_roads_be(source: OsmSource) -> None:
     ids = {entry.id for entry in source.entries()}
     assert "osm-roads-be" in ids
+    assert "osm-pbf-be" in ids
 
 
 def test_schema_has_fclass_not_surface(source: OsmSource) -> None:
@@ -74,3 +77,77 @@ def test_schema_has_fclass_not_surface(source: OsmSource) -> None:
     assert "fclass" in schema
     assert "geometry" in schema
     assert "surface" not in schema
+
+
+def test_pbf_entry_exposes_full_extract_and_reader_hint(source: OsmSource) -> None:
+    access = source.access_for("osm-pbf-be")
+
+    assert access.protocol is AccessProtocol.DOWNLOAD
+    assert access.endpoint.endswith("belgium-latest.osm.pbf")
+    assert access.format == "application/x-osm-pbf"
+    assert access.params["reader"] == "duckdb.ST_ReadOSM"
+    assert source.schema("osm-pbf-be")["surface"] == "str"
+
+
+def test_read_pbf_roads_builds_duckdb_query_and_flattens_tags(
+    tmp_path: Path,
+) -> None:
+    import pandas as pd
+    from shapely.geometry import LineString
+
+    pbf = tmp_path / "belgium-latest.osm.pbf"
+    pbf.write_bytes(b"fake")
+    road_wkb = LineString([(4.0, 50.0), (4.1, 50.1)]).wkb
+
+    class FakeCursor:
+        def fetchdf(self) -> pd.DataFrame:
+            return pd.DataFrame(
+                {
+                    "id": [42],
+                    "highway": ["residential"],
+                    "surface": ["sett"],
+                    "geometry": [road_wkb],
+                }
+            )
+
+    class FakeConnection:
+        sql: str | None = None
+        params: list[str] | None = None
+
+        def execute(self, sql: str, params: list[str]) -> FakeCursor:
+            self.sql = sql
+            self.params = params
+            return FakeCursor()
+
+    conn = FakeConnection()
+
+    gdf = read_pbf_roads(
+        pbf,
+        tags=("surface",),
+        target_crs=None,
+        connection_factory=lambda: conn,
+    )
+
+    assert len(gdf) == 1
+    assert gdf.crs == "EPSG:4326"
+    assert gdf.loc[0, "highway"] == "residential"
+    assert gdf.loc[0, "surface"] == "sett"
+    assert conn.params == [str(pbf)]
+    assert conn.sql is not None
+    assert "ST_ReadOSM(?)" in conn.sql
+    assert "tags['surface']::VARCHAR AS \"surface\"" in conn.sql
+    assert "tags['highway'] IS NOT NULL" in conn.sql
+
+
+def test_read_pbf_roads_rejects_unsafe_tag_key(tmp_path: Path) -> None:
+    pbf = tmp_path / "belgium-latest.osm.pbf"
+    pbf.write_bytes(b"fake")
+
+    with pytest.raises(OsmPbfReadError) as excinfo:
+        read_pbf_roads(
+            pbf,
+            tags=("surface']; DROP TABLE osm; --",),
+            connection_factory=lambda: object(),
+        )
+
+    assert excinfo.value.code == "OSM_PBF_TAG_INVALID"


### PR DESCRIPTION
## Summary
- add an explicit `osm-pbf-be` Geofabrik PBF entry to `gispulse-src-osm`
- expose `read_pbf_roads(...)` so consumers can extract road ways and selected OSM tags via DuckDB `ST_ReadOSM`
- keep source plumbing in gispulse while downstream projects map raw tags to their own domain classes

## Validation
- `uv run pytest tests/unit/test_src_osm.py -q` (8 passed)
- `uv run ruff check plugins/gispulse-src-osm/gispulse_src_osm tests/unit/test_src_osm.py`
- `uv run pytest tests/unit/test_src_osm.py tests/unit/test_plugin_sdk_exports.py -q` (53 passed)
- `git diff --check`

## Milou boundary
This is the gispulse-side split for Milou surface-costing work: Milou should consume this primitive instead of carrying its own generic PBF/DuckDB reader.