### PR TITLE
fix(capabilities): steiner_tree KeyError on graph with terminal-less component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   undersized cluster when `len(gdf) < min_size`). Pure numpy, seeded
   (`random_state`), with a stable size-descending relabel.
 
+### Fixed
+
+- **`steiner_tree` on a graph with a terminal-less component.** The Mehlhorn
+  heuristic (networkx's default since 3.2) indexes every node of the graph
+  after a multi-source Dijkstra from the terminals, so a disconnected
+  component without any terminal — common in a raw OSM road network — raised
+  `KeyError`. The solve is now restricted to the terminals' connected
+  component (already computed for the connectivity guard); unchanged for a
+  fully connected network.
+
 ## [2.3.0] - 2026-06-14
 
 ### Added

--- a/src/gispulse/capabilities/network.py
+++ b/src/gispulse/capabilities/network.py
@@ -1010,7 +1010,14 @@ class SteinerTreeCapability(Capability):
                 "network (no path between some of them)."
             )
 
-        tree = steiner_tree(G, terminal_nodes, weight="weight")
+        # Restrict the solve to the terminals' connected component. Mehlhorn
+        # (networkx's default heuristic since 3.2) runs a multi_source_dijkstra
+        # from the terminals and then indexes EVERY node of the graph; a
+        # component with no terminal (common in a raw OSM road network) is
+        # unreachable from all sources and raises KeyError. ``reachable`` is
+        # exactly that component (already computed above) and holds every
+        # terminal, so the tree is unchanged for a fully connected network.
+        tree = steiner_tree(G.subgraph(reachable), terminal_nodes, weight="weight")
 
         rows: list[dict[str, Any]] = []
         for u, v, data in tree.edges(data=True):

--- a/tests/unit/test_steiner_tree.py
+++ b/tests/unit/test_steiner_tree.py
@@ -72,6 +72,25 @@ def test_disconnected_terminals_raise(network):
         _run(isolated, _terminals([(0, 0), (100, 100)]))
 
 
+def test_disconnected_island_without_terminal_does_not_crash():
+    # Network = main A-B-C component + an extra island with NO terminal
+    # (common in a raw OSM road network: an isolated service-road stub). The
+    # terminals (A, C) are connected to each other; the solver must NOT raise
+    # KeyError on the island's nodes — regression guard for the Mehlhorn bug
+    # (multi_source_dijkstra from the terminals then indexing every graph node).
+    net = gpd.GeoDataFrame(
+        geometry=[
+            LineString([(0, 0), (10, 0)]),         # A-B
+            LineString([(10, 0), (20, 0)]),        # B-C
+            LineString([(100, 100), (110, 100)]),  # disconnected island, no terminal
+        ],
+        crs="EPSG:3857",
+    )
+    tree = _run(net, _terminals([(0, 0), (20, 0)]))  # A and C, connected
+    assert len(tree) == 2  # A-B, B-C
+    assert tree["weight"].sum() == pytest.approx(20.0)
+
+
 def test_fewer_than_two_terminals_returns_empty(network):
     tree = _run(network, _terminals([(0, 0)]))
     assert len(tree) == 0


### PR DESCRIPTION
## Problem

`SteinerTreeCapability` handed the **whole** graph to `networkx.steiner_tree`. Mehlhorn (networkx's default heuristic since 3.2) runs a `multi_source_dijkstra` from the terminals and then indexes *every* node of the graph — so any connected component with **no terminal** (endemic in a raw OSM road network: isolated service-road stubs, mis-connected segments) raises `KeyError`. The existing guard verified that the *terminals* share one component, but still passed the full graph to the solver.

## Fix

Restrict the solve to the terminals' connected component:

```python
tree = steiner_tree(G.subgraph(reachable), terminal_nodes, weight="weight")
```

`reachable` is already computed for the connectivity guard, and every terminal is proven to be in it, so the returned tree is **unchanged for a fully connected network**. This is the same `G.subgraph(component)` idiom already used by `ConnectivityCheckCapability` in the same module.

`method` is left at its default (mehlhorn) on purpose — `kou` would `raise NetworkXError("G is not a connected graph")` on exactly this terminal-less-island case, so the subgraph restriction is required regardless of algorithm.

## Validation

- New regression test `test_disconnected_island_without_terminal_does_not_crash` — verified **discriminating** (reproduces the original `KeyError` against pre-fix code, passes with the fix).
- `tests/unit/test_steiner_tree.py`: **9/9 pass**. Full network-capability suite: **152 pass**, no new failures.
- `CHANGELOG.md` updated under `[Unreleased] → Fixed`.

## Why it matters

The default routing path on raw OSM data crashes today. Downstream consumers that pin this branch (`integration/v2.4`) hit it as soon as they route via `apply("steiner_tree")` on real voirie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R96nGzo5mNi732BYduWwfT
